### PR TITLE
🎨 Palette: Enhance form components with accessibility and loading states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-17 - [Accessible and Feedback-rich Form Components]
+**Learning:** Core form components in the TALL stack benefit significantly from automated accessibility (ID/label association, aria-describedby) and interaction feedback (wire:loading on buttons). By baking these into the base components, we ensure a consistent and accessible UX across the entire application without extra developer effort.
+**Action:** Always check base UI components for missing accessibility relationships and loading states when starting work on a new project.

--- a/resources/views/components/form-button.blade.php
+++ b/resources/views/components/form-button.blade.php
@@ -22,9 +22,13 @@ $variantClasses = [
 $classes = $baseClasses . ' ' . $sizeClasses[$size] . ' ' . $variantClasses[$variant];
 @endphp
 
-<button {{ $attributes->merge(['class' => $classes, 'type' => $type]) }}>
+<button {{ $attributes->merge(['class' => $classes, 'type' => $type]) }} wire:loading.attr="disabled">
     @if($icon)
-      <x-dynamic-component :component="'heroicon-o-' . $icon" class="w-4 h-4 {{ $slot->isNotEmpty() ? 'mr-2' : '' }}" />
+      <x-dynamic-component :component="'heroicon-o-' . $icon" class="w-4 h-4 {{ $slot->isNotEmpty() ? 'mr-2' : '' }}" wire:loading.remove />
     @endif
+    <svg wire:loading class="animate-spin h-4 w-4 {{ $slot->isNotEmpty() ? 'mr-2' : '' }}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+    </svg>
     {{ $slot }}
 </button>

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -2,15 +2,21 @@
 
 @php
 $modelName = $attributes->wire('model')->value();
+$id = $attributes->get('id', $modelName ? str_replace(['.', ' ', '[', ']'], '-', $modelName) : ($label ? \Illuminate\Support\Str::slug($label) : null));
 $hasError = $modelName && $errors->has($modelName);
 $inputClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-green-500 focus:ring-green-500'
     . ($icon ? ' pl-10' : '')
     . ($hasError ? ' border-red-300' : ' border-gray-300');
+
+$describedBy = [];
+if ($hint) $describedBy[] = $id . '-hint';
+if ($hasError) $describedBy[] = $id . '-error';
+$describedBy = implode(' ', $describedBy);
 @endphp
 
 <div>
     @if($label)
-        <label class="block text-sm font-medium text-gray-700 mb-1">
+        <label @if($id) for="{{ $id }}" @endif class="block text-sm font-medium text-gray-700 mb-1">
             {{ $label }}
             @if($required) <span class="text-red-500">*</span> @endif
         </label>
@@ -23,10 +29,16 @@ $inputClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-green
             </div>
         @endif
 
-        <input {{ $attributes->merge(['type' => 'text', 'class' => $inputClasses]) }} />
+        <input
+            @if($id) id="{{ $id }}" @endif
+            {{ $attributes->merge(['type' => 'text', 'class' => $inputClasses]) }}
+            @if($hasError) aria-invalid="true" @endif
+            @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
+        />
 
         @if($clearable && $modelName)
             <button type="button"
+                aria-label="Clear input"
                 wire:click="$set('{{ $modelName }}', '')"
                 class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600"
                 x-show="$wire.{{ $modelName }}">
@@ -36,12 +48,12 @@ $inputClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-green
     </div>
 
     @if($hint)
-        <p class="mt-1 text-sm text-gray-500">{{ $hint }}</p>
+        <p @if($id) id="{{ $id }}-hint" @endif class="mt-1 text-sm text-gray-500">{{ $hint }}</p>
     @endif
 
     @if($modelName)
         @error($modelName)
-            <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+            <p @if($id) id="{{ $id }}-error" @endif class="mt-1 text-sm text-red-600">{{ $message }}</p>
         @enderror
     @endif
 </div>

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -2,20 +2,31 @@
 
 @php
 $modelName = $attributes->wire('model')->value();
+$id = $attributes->get('id', $modelName ? str_replace(['.', ' ', '[', ']'], '-', $modelName) : ($label ? \Illuminate\Support\Str::slug($label) : null));
 $hasError = $modelName && $errors->has($modelName);
 $selectClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-green-500 focus:ring-green-500'
     . ($hasError ? ' border-red-300' : ' border-gray-300');
+
+$describedBy = [];
+if ($hint) $describedBy[] = $id . '-hint';
+if ($hasError) $describedBy[] = $id . '-error';
+$describedBy = implode(' ', $describedBy);
 @endphp
 
 <div>
     @if($label)
-        <label class="block text-sm font-medium text-gray-700 mb-1">
+        <label @if($id) for="{{ $id }}" @endif class="block text-sm font-medium text-gray-700 mb-1">
             {{ $label }}
             @if($required) <span class="text-red-500">*</span> @endif
         </label>
     @endif
 
-    <select {{ $attributes->merge(['class' => $selectClasses]) }}>
+    <select
+        @if($id) id="{{ $id }}" @endif
+        {{ $attributes->merge(['class' => $selectClasses]) }}
+        @if($hasError) aria-invalid="true" @endif
+        @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
+    >
         @if($placeholder)
             <option value="">{{ $placeholder }}</option>
         @endif
@@ -25,12 +36,12 @@ $selectClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-gree
     </select>
 
     @if($hint)
-        <p class="mt-1 text-sm text-gray-500">{{ $hint }}</p>
+        <p @if($id) id="{{ $id }}-hint" @endif class="mt-1 text-sm text-gray-500">{{ $hint }}</p>
     @endif
 
     @if($modelName)
         @error($modelName)
-            <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+            <p @if($id) id="{{ $id }}-error" @endif class="mt-1 text-sm text-red-600">{{ $message }}</p>
         @enderror
     @endif
 </div>

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -2,28 +2,39 @@
 
 @php
 $modelName = $attributes->wire('model')->value();
+$id = $attributes->get('id', $modelName ? str_replace(['.', ' ', '[', ']'], '-', $modelName) : ($label ? \Illuminate\Support\Str::slug($label) : null));
 $hasError = $modelName && $errors->has($modelName);
 $textareaClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-green-500 focus:ring-green-500'
     . ($hasError ? ' border-red-300' : ' border-gray-300');
+
+$describedBy = [];
+if ($hint) $describedBy[] = $id . '-hint';
+if ($hasError) $describedBy[] = $id . '-error';
+$describedBy = implode(' ', $describedBy);
 @endphp
 
 <div>
     @if($label)
-        <label class="block text-sm font-medium text-gray-700 mb-1">
+        <label @if($id) for="{{ $id }}" @endif class="block text-sm font-medium text-gray-700 mb-1">
             {{ $label }}
             @if($required) <span class="text-red-500">*</span> @endif
         </label>
     @endif
 
-    <textarea {{ $attributes->merge(['rows' => 3, 'class' => $textareaClasses]) }}></textarea>
+    <textarea
+        @if($id) id="{{ $id }}" @endif
+        {{ $attributes->merge(['rows' => 3, 'class' => $textareaClasses]) }}
+        @if($hasError) aria-invalid="true" @endif
+        @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
+    ></textarea>
 
     @if($hint)
-        <p class="mt-1 text-sm text-gray-500">{{ $hint }}</p>
+        <p @if($id) id="{{ $id }}-hint" @endif class="mt-1 text-sm text-gray-500">{{ $hint }}</p>
     @endif
 
     @if($modelName)
         @error($modelName)
-            <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+            <p @if($id) id="{{ $id }}-error" @endif class="mt-1 text-sm text-red-600">{{ $message }}</p>
         @enderror
     @endif
 </div>


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility improvements to the core form components:

1. **Visual Feedback:** The `form-button` component now automatically shows a spinner and becomes disabled during Livewire requests, providing immediate feedback that an action is in progress and preventing double-submissions.
2. **Accessibility (ARIA):** 
   - Labels are now properly associated with their inputs/textareas/selects using `for` and `id` attributes.
   - Stable IDs are automatically generated from `wire:model` or slugged labels if not explicitly provided.
   - `aria-invalid="true"` is added to elements with validation errors.
   - `aria-describedby` links inputs to their hints and error messages.
   - The "clear" button in the `input` component now has an `aria-label`.

These changes ensure a more accessible and delightful experience across all forms in the application.

---
*PR created automatically by Jules for task [50111037575581410](https://jules.google.com/task/50111037575581410) started by @GarethClarridge*