### PR TITLE
🛡️ Sentinel: Fix mass assignment vulnerability in User model

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Mass Assignment of Admin Status]
+**Vulnerability:** The `is_admin` attribute was included in the `User` model's `$fillable` array.
+**Learning:** This allowed anyone with access to a user creation or update flow (if not strictly guarded) to potentially escalate their privileges by including `is_admin: true` in the request payload. In this codebase, even administrative Livewire components were relying on this mass-assignment, making the attribute "intentionally" vulnerable for convenience.
+**Prevention:** Always exclude high-privilege attributes from `$fillable`. Use explicit property assignment ($user->is_admin = true) in controlled administrative contexts to update such fields.

--- a/app/Livewire/Admin/Users/CreateUser.php
+++ b/app/Livewire/Admin/Users/CreateUser.php
@@ -39,13 +39,16 @@ class CreateUser extends Component
     {
         $validated = $this->validate();
 
-        $user = User::create([
+        $user = new User([
             'name' => $validated['name'],
             'email' => $validated['email'],
             'password' => Hash::make($validated['password']),
-            'is_admin' => $validated['isAdmin'],
-            'email_verified_at' => $this->sendVerification ? null : now(),
         ]);
+
+        // Set sensitive attributes via explicit assignment to bypass mass-assignment protection
+        $user->is_admin = $validated['isAdmin'];
+        $user->email_verified_at = $this->sendVerification ? null : now();
+        $user->save();
 
         if ($this->sendVerification) {
             $user->sendEmailVerificationNotification();

--- a/app/Livewire/Admin/Users/EditUser.php
+++ b/app/Livewire/Admin/Users/EditUser.php
@@ -59,17 +59,17 @@ class EditUser extends Component
 
         $validated = $this->validate();
 
-        $data = [
-            'name' => $validated['name'],
-            'email' => $validated['email'],
-            'is_admin' => $validated['isAdmin'],
-        ];
+        $this->user->name = $validated['name'];
+        $this->user->email = $validated['email'];
+
+        // Set sensitive attributes via explicit assignment to bypass mass-assignment protection
+        $this->user->is_admin = $validated['isAdmin'];
 
         if ($this->changePassword) {
-            $data['password'] = Hash::make($validated['password']);
+            $this->user->password = Hash::make($validated['password']);
         }
 
-        $this->user->update($data);
+        $this->user->save();
 
         $this->success('User updated');
         $this->changePassword = false;

--- a/app/Livewire/Admin/Users/ListUsers.php
+++ b/app/Livewire/Admin/Users/ListUsers.php
@@ -56,7 +56,10 @@ class ListUsers extends Component
             return;
         }
 
-        $user->update(['is_admin' => ! $user->is_admin]);
+        // Set sensitive attributes via explicit assignment to bypass mass-assignment protection
+        $user->is_admin = ! $user->is_admin;
+        $user->save();
+
         $this->success($user->is_admin ? 'Admin granted' : 'Admin revoked');
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -46,7 +46,6 @@ class User extends Authenticatable implements MustVerifyEmail
         'name',
         'email',
         'password',
-        'is_admin', // Added is_admin to fillable if it can be mass assigned
     ];
 
     /**

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -13,15 +13,13 @@ class UserSeeder extends Seeder
         $adminEmail = 'admin@crockenhill.org';
 
         // Ensure the admin user exists and stays up to date without duplicate key errors.
-        User::updateOrCreate(
-            ['email' => $adminEmail],
-            [
-                'name' => 'Admin User',
-                'password' => Hash::make('password'),
-                'is_admin' => true,
-                'email_verified_at' => now(),
-            ]
-        );
+        // Using firstOrNew and explicit assignment to bypass mass-assignment protection on is_admin.
+        $admin = User::firstOrNew(['email' => $adminEmail]);
+        $admin->name = 'Admin User';
+        $admin->password = Hash::make('password');
+        $admin->is_admin = true;
+        $admin->email_verified_at = now();
+        $admin->save();
 
         // Keep a stable baseline of seeded non-admin users.
         $targetRegularUsers = 9;


### PR DESCRIPTION
Identified and fixed a high-priority mass assignment vulnerability in the `User` model. 

The `is_admin` attribute was previously mass-assignable, which could allow a malicious actor to escalate their privileges by including `is_admin: true` in a request (e.g., during registration if not carefully filtered, or in future profile update features).

Changes:
1.  **User Model**: Removed `is_admin` from `$fillable`.
2.  **Administrative Components**: Updated `CreateUser`, `EditUser`, and `ListUsers` Livewire components to set the `is_admin` status via explicit property assignment.
3.  **User Seeder**: Updated `UserSeeder` to use secure explicit assignment when creating the initial admin user.
4.  **Security Journal**: Added a new entry to `.jules/sentinel.md` documenting this vulnerability and its prevention.

This fix adheres to the principle of least privilege and follows Laravel security best practices.

---
*PR created automatically by Jules for task [12976323951998639937](https://jules.google.com/task/12976323951998639937) started by @GarethClarridge*