### PR TITLE
⚡ Bolt: Database Query Optimizations (Eager Loading)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,11 @@
 - In `SitemapService@generate`, the number of queries is reduced from `1 + N + M` to `3` (for sermons and pages), where `N` is sermons and `M` is pages.
 - Measurably faster page loads for sermon listings and faster sitemap generation.
 **Action:** Always check if relationships used in components (like sermon-card) or sitemap generation are eager-loaded in the controller or service.
+
+## 2026-02-19 - [N+1 Optimizations in Podcast Feeds and Page Views]
+**Learning:** Identified N+1 query patterns in `PodcastFeedService` (preacherProfile) and `ViewServiceProvider` (media relationship for Page models used in related links).
+**Impact:**
+- `PodcastFeedService@fetchSermons`: Reduced queries from 100+ to 2 per feed load.
+- `ViewServiceProvider`: Reduced queries for every page with related links from 6 to 2.
+- Added mandatory PHPDoc explaining these optimizations.
+**Action:** Be cautious when removing view composers during optimization as they may be required by legacy templates not easily found by grep. Always add descriptive PHPDoc to explain why an eager load was added.

--- a/app/Http/Controllers/SermonController.php
+++ b/app/Http/Controllers/SermonController.php
@@ -24,7 +24,9 @@ class SermonController extends Controller
             ->pluck('date');
 
         if ($distinct_dates->isNotEmpty()) {
-            // Eager load preacherProfile to prevent N+1 queries in sermon-card components
+            /**
+             * Performance Optimization: Eager load preacherProfile to prevent N+1 queries in sermon-card components
+             */
             $latest_sermons = Sermon::with('preacherProfile')
                 ->whereIn('date', $distinct_dates)
                 ->orderBy('date', 'desc')
@@ -42,7 +44,9 @@ class SermonController extends Controller
 
     public function getAll(): View
     {
-        // Eager load preacherProfile to prevent N+1 queries in sermon-card components
+        /**
+         * Performance Optimization: Eager load preacherProfile to prevent N+1 queries in sermon-card components
+         */
         $sermons = Sermon::with('preacherProfile')
             ->orderBy('date', 'desc')
             ->orderBy('service', 'asc')
@@ -101,9 +105,16 @@ class SermonController extends Controller
         ]);
     }
 
+    /**
+     * Display sermons for a specific preacher.
+     *
+     * Performance Optimization: Eager loads 'preacherProfile' to prevent N+1 queries
+     * when displaying sermon cards that access the preacher's name.
+     */
     public function getPreacher(Preacher $preacher): View
     {
         $sermons = $preacher->sermons()
+            ->with('preacherProfile')
             ->orderBy('date', 'desc')
             ->get();
 
@@ -125,7 +136,9 @@ class SermonController extends Controller
     public function getSeries(string $series): View
     {
         $series_name = str_replace('-', ' ', Str::title($series));
-        // Eager load preacherProfile to prevent N+1 queries in sermon-card components
+        /**
+         * Performance Optimization: Eager load preacherProfile to prevent N+1 queries in sermon-card components
+         */
         $sermons = Sermon::with('preacherProfile')
             ->where('series', $series_name)
             ->orderBy('date', 'desc')
@@ -138,7 +151,9 @@ class SermonController extends Controller
 
     public function getService(string $service): View
     {
-        // Eager load preacherProfile to prevent N+1 queries in sermon-card components
+        /**
+         * Performance Optimization: Eager load preacherProfile to prevent N+1 queries in sermon-card components
+         */
         $sermons = Sermon::with('preacherProfile')
             ->where('service', $service)
             ->orderBy('date', 'desc')

--- a/app/Providers/ViewServiceProvider.php
+++ b/app/Providers/ViewServiceProvider.php
@@ -30,6 +30,9 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function boot(Request $request): void
     {
+        /**
+         * Provide the latest morning and evening sermons to the footer.
+         */
         View::composer('includes.footer', function ($view) {
             // get the latest sermons
             $morning = Sermon::where('service', SermonService::MORNING->value)
@@ -51,6 +54,10 @@ class ViewServiceProvider extends ServiceProvider
             $view->with('photos', $photos);
         });
 
+        /**
+         * Performance Optimization: Eager load 'media' relationship on Page queries
+         * used for related links and page cards to prevent N+1 query issues.
+         */
         View::composer('layouts/page', function ($view) {
             // User
             $user = Auth::user();
@@ -66,13 +73,17 @@ class ViewServiceProvider extends ServiceProvider
                 $headingpicture = $page->heading_image_url;
                 $area = $page->area->value;
                 $slug = $page->slug;
-                $links = Page::where('area', $area)
+
+                // Eager load media to prevent N+1 queries in page-card components
+                $links = Page::with('media')
+                    ->where('area', $area)
                     ->where('slug', '!=', $slug)
                     ->where('slug', '!=', 'privacy-policy')
                     ->where('admin', '!=', 'yes')
                     ->orderBy(DB::raw('RAND()'))
                     ->take(5)
                     ->get();
+
                 $view->with([
                     'description' => $description,
                     'heading' => $heading,
@@ -132,8 +143,9 @@ class ViewServiceProvider extends ServiceProvider
                         // Heading picture
                         $headingpicture = '/images/headings/large/'.$sermon_slug.'.webp';
 
-                        // Find relevant links
-                        $links = Page::where('area', $slug)
+                        // Find relevant links - eager load media for page-cards
+                        $links = Page::with('media')
+                            ->where('area', $slug)
                             ->where('slug', '!=', $slug)
                             ->where('slug', '!=', 'homepage')
                             ->orderBy(DB::raw('RAND()'))
@@ -158,8 +170,9 @@ class ViewServiceProvider extends ServiceProvider
                     // Heading picture
                     $headingpicture = '/images/headings/large/'.$area.'.webp';
 
-                    // Find relevant links
-                    $links = Page::where('area', $area)
+                    // Find relevant links - eager load media for page-cards
+                    $links = Page::with('media')
+                        ->where('area', $area)
                         ->where('slug', '!=', $area)
                         ->where('slug', '!=', 'homepage')
                         ->orderBy(DB::raw('RAND()'))
@@ -186,22 +199,25 @@ class ViewServiceProvider extends ServiceProvider
                     // Heading picture
                     $headingpicture = '/images/headings/large/'.$slug.'.webp';
 
-                    // Links
+                    // Links - eager load media for page-cards
                     if (request()->segment(2) == 'sermons') {
-                        $links = Page::where('area', 'sermons')
+                        $links = Page::with('media')
+                            ->where('area', 'sermons')
                             ->where('slug', '!=', $slug)
                             ->where('slug', '!=', $area)
                             ->orderBy('slug', 'asc')
                             ->get();
                     } elseif (request()->segment(2) == 'members') {
-                        $links = Page::where('area', 'sermons')
+                        $links = Page::with('media')
+                            ->where('area', 'sermons')
                             ->where('slug', '!=', $slug)
                             ->where('slug', '!=', $area)
                             ->where('admin', '!=', 'yes')
                             ->orderBy('slug', 'asc')
                             ->get();
                     } else {
-                        $links = Page::where('area', $area)
+                        $links = Page::with('media')
+                            ->where('area', $area)
                             ->where('slug', '!=', $slug)
                             ->where('slug', '!=', $area)
                             ->where('slug', '!=', 'privacy-policy')
@@ -236,16 +252,18 @@ class ViewServiceProvider extends ServiceProvider
                         $headingpicture = '/images/headings/large/'.$slug.'.webp';
                     }
 
-                    // Links
+                    // Links - eager load media for page-cards
                     if (request()->segment(2) == 'sermons') {
-                        $links = Page::where('area', 'sermons')
+                        $links = Page::with('media')
+                            ->where('area', 'sermons')
                             ->where('slug', '!=', $slug)
                             ->where('slug', '!=', $area)
                             ->where('admin', '!=', 'yes')
                             ->orderBy('slug', 'asc')
                             ->get();
                     } elseif (request()->segment(2) == 'members') {
-                        $links = Page::where('area', 'sermons')
+                        $links = Page::with('media')
+                            ->where('area', 'sermons')
                             ->where('slug', '!=', $slug)
                             ->where('slug', '!=', $area)
                             ->where('admin', '!=', 'yes')
@@ -254,14 +272,16 @@ class ViewServiceProvider extends ServiceProvider
                     } elseif (request()->segment(1) == 'community') {
                         // Community pages - meetings now pass page data directly from controller
                         // This block is now only used for non-meeting community pages
-                        $links = Page::where('area', $area)
+                        $links = Page::with('media')
+                            ->where('area', $area)
                             ->where('slug', '!=', $slug)
                             ->where('slug', '!=', $area)
                             ->where('admin', '!=', 'yes')
                             ->orderBy('slug', 'asc')
                             ->get();
                     } else {
-                        $links = Page::where('area', $area)
+                        $links = Page::with('media')
+                            ->where('area', $area)
                             ->where('slug', '!=', $slug)
                             ->where('slug', '!=', $area)
                             ->where('slug', '!=', 'privacy-policy')
@@ -298,8 +318,9 @@ class ViewServiceProvider extends ServiceProvider
                     // Heading picture
                     $headingpicture = '/images/headings/large/'.$area.'.webp';
 
-                    // Links
-                    $links = Page::where('area', $area)
+                    // Links - eager load media for page-cards
+                    $links = Page::with('media')
+                        ->where('area', $area)
                         ->where('slug', '!=', $area)
                         ->where('slug', '!=', 'privacy-policy')
                         ->where('admin', '!=', 'yes')
@@ -320,22 +341,33 @@ class ViewServiceProvider extends ServiceProvider
             }
         });
 
+        /**
+         * Performance Optimization: Eager load 'media' relationship for Page models
+         * in home and community pages to prevent N+1 query issues in page-card components.
+         */
         View::composer(['full-width-pages.home', 'full-width-pages.community'], function ($view) {
-            $pages = Page::all();
+            // Eager load media for components (like page-cards) that use images
+            $pages = Page::with('media')->get();
 
             $view->with([
                 'pages' => $pages,
             ]);
         });
 
+        /**
+         * Performance Optimization: Eager load 'media' relationship for Page models
+         * in church page to prevent N+1 query issues in page-card components.
+         */
         View::composer('full-width-pages.church', function ($view) {
-            $links = Page::where('area', 'church')
+            // Eager load media for page-cards
+            $links = Page::with('media')
+                ->where('area', 'church')
                 ->where('slug', '!=', 'privacy-policy')
                 ->where('slug', '!=', 'safeguarding-policy')
                 ->where('admin', '!=', 'yes')
                 ->get();
 
-            $pages = Page::all();
+            $pages = Page::with('media')->get();
 
             $view->with([
                 'pages' => $pages,

--- a/app/Services/PodcastFeedService.php
+++ b/app/Services/PodcastFeedService.php
@@ -44,7 +44,10 @@ class PodcastFeedService
     }
 
     /**
-     * Fetch sermons from database and enrich for feed
+     * Fetch sermons from database and enrich for feed.
+     *
+     * Performance Optimization: Eager loads 'preacherProfile' to prevent N+1 queries
+     * when generating the podcast summary for each sermon in the feed.
      *
      * @return Collection<int, Sermon>
      */
@@ -54,6 +57,7 @@ class PodcastFeedService
         $limit = config('podcast.items_limit', 100);
 
         return Sermon::forPodcast()
+            ->with('preacherProfile')
             ->forService($serviceType)
             ->limit($limit)
             ->get()


### PR DESCRIPTION
Implemented several performance optimizations targeting N+1 query bottlenecks in the church website:

1. **PodcastFeedService**: Eager loaded the 'preacherProfile' relationship in the `fetchSermons` method. This prevents 100+ individual queries to the preachers table when generating the podcast RSS feed, as the `podcast_summary` accessor uses this relationship.
2. **SermonController**: Added eager loading for 'preacherProfile' in the `getPreacher` method to optimize the preacher's individual sermon listing.
3. **ViewServiceProvider**: Eager loaded the 'media' relationship (Spatie Media Library) for all Page collection queries. This prevents N+1 queries when displaying page cards (related links), which use the media relationship to fetch heading images.
4. **Documentation**: Added PHPDoc comments explaining the rationale and expected impact of these optimizations, as per project standards.

These changes significantly reduce the total query count for RSS feeds and many common page views without altering any business logic.

---
*PR created automatically by Jules for task [282700475869434339](https://jules.google.com/task/282700475869434339) started by @GarethClarridge*