### PR TITLE
📝 Scribe: Add tests for User Management Livewire components

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -15,8 +15,9 @@ class UserFactory extends Factory
         return [
             'name' => $this->faker->name(),
             'email' => $this->faker->unique()->safeEmail(),
-            // 'email_verified_at' => now(), // Reverted: column does not exist
+            'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'is_admin' => false,
             'remember_token' => Str::random(10),
         ];
     }

--- a/tests/Feature/Livewire/AdminUserTest.php
+++ b/tests/Feature/Livewire/AdminUserTest.php
@@ -1,0 +1,321 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\Admin\Users\CreateUser;
+use App\Livewire\Admin\Users\EditUser;
+use App\Livewire\Admin\Users\ListUsers;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AdminUserTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function list_users_component_renders_successfully_for_admin(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin);
+
+        Livewire::test(ListUsers::class)
+            ->assertStatus(200)
+            ->assertSee('Users');
+    }
+
+    #[Test]
+    public function list_users_component_aborts_for_non_admin(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($user);
+
+        Livewire::test(ListUsers::class)
+            ->assertStatus(403);
+    }
+
+    #[Test]
+    public function list_users_component_aborts_for_guest(): void
+    {
+        Livewire::test(ListUsers::class)
+            ->assertStatus(403);
+    }
+
+    #[Test]
+    public function it_can_search_users_by_name_or_email(): void
+    {
+        $admin = User::factory()->admin()->create();
+        User::factory()->create(['name' => 'John Doe', 'email' => 'john@example.com']);
+        User::factory()->create(['name' => 'Jane Smith', 'email' => 'jane@example.com']);
+
+        $this->actingAs($admin);
+
+        Livewire::test(ListUsers::class)
+            ->set('search', 'John')
+            ->assertSee('John Doe')
+            ->assertDontSee('Jane Smith')
+            ->set('search', 'jane@example.com')
+            ->assertSee('Jane Smith')
+            ->assertDontSee('John Doe');
+    }
+
+    #[Test]
+    public function it_can_filter_users_by_verification_status(): void
+    {
+        $admin = User::factory()->admin()->create();
+        User::factory()->create(['name' => 'Verified User', 'email_verified_at' => now()]);
+        User::factory()->create(['name' => 'Unverified User', 'email_verified_at' => null]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(ListUsers::class)
+            ->set('verifiedFilter', true)
+            ->assertSee('Verified User')
+            ->assertDontSee('Unverified User')
+            ->set('verifiedFilter', false)
+            ->assertSee('Unverified User')
+            ->assertDontSee('Verified User');
+    }
+
+    #[Test]
+    public function it_can_filter_users_by_admin_status(): void
+    {
+        $admin = User::factory()->admin()->create(['name' => 'Admin User']);
+        User::factory()->create(['name' => 'Regular User', 'is_admin' => false]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(ListUsers::class)
+            ->set('adminFilter', true)
+            ->assertSee('Admin User')
+            ->assertDontSee('Regular User')
+            ->set('adminFilter', false)
+            ->assertSee('Regular User')
+            ->assertDontSee('Admin User');
+    }
+
+    #[Test]
+    public function it_can_toggle_admin_status(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(ListUsers::class)
+            ->call('toggleAdmin', $user->id)
+            ->assertDispatched('notify', type: 'success', message: 'Admin granted');
+
+        $this->assertTrue($user->fresh()->is_admin);
+
+        Livewire::test(ListUsers::class)
+            ->call('toggleAdmin', $user->id)
+            ->assertDispatched('notify', type: 'success', message: 'Admin revoked');
+
+        $this->assertFalse($user->fresh()->is_admin);
+    }
+
+    #[Test]
+    public function it_cannot_toggle_own_admin_status(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin);
+
+        Livewire::test(ListUsers::class)
+            ->call('toggleAdmin', $admin->id)
+            ->assertDispatched('notify', type: 'error', message: 'Cannot modify your own admin status');
+
+        $this->assertTrue($admin->fresh()->is_admin);
+    }
+
+    #[Test]
+    public function it_can_delete_user(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create();
+
+        $this->actingAs($admin);
+
+        Livewire::test(ListUsers::class)
+            ->call('delete', $user->id)
+            ->assertDispatched('notify', type: 'success', message: 'User deleted');
+
+        $this->assertModelMissing($user);
+    }
+
+    #[Test]
+    public function it_cannot_delete_self(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin);
+
+        Livewire::test(ListUsers::class)
+            ->call('delete', $admin->id)
+            ->assertDispatched('notify', type: 'error', message: 'Cannot delete yourself');
+
+        $this->assertModelExists($admin);
+    }
+
+    #[Test]
+    public function create_user_validation_rules(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $this->actingAs($admin);
+
+        Livewire::test(CreateUser::class)
+            ->set('name', '')
+            ->set('email', '')
+            ->set('password', '')
+            ->call('save')
+            ->assertHasErrors(['name', 'email', 'password'])
+            ->set('email', 'not-an-email')
+            ->set('password', 'short')
+            ->call('save')
+            ->assertHasErrors(['email', 'password'])
+            ->set('password', 'password123')
+            ->set('passwordConfirmation', 'different')
+            ->call('save')
+            ->assertHasErrors(['password']);
+    }
+
+    #[Test]
+    public function it_can_create_a_standard_user(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $this->actingAs($admin);
+
+        Livewire::test(CreateUser::class)
+            ->set('name', 'New User')
+            ->set('email', 'new@example.com')
+            ->set('password', 'password123')
+            ->set('passwordConfirmation', 'password123')
+            ->set('isAdmin', false)
+            ->set('sendVerification', true)
+            ->call('save')
+            ->assertRedirect(route('admin.users.index'));
+
+        $this->assertDatabaseHas('users', [
+            'name' => 'New User',
+            'email' => 'new@example.com',
+            'is_admin' => false,
+            'email_verified_at' => null,
+        ]);
+    }
+
+    #[Test]
+    public function it_can_create_an_admin_user_without_verification(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $this->actingAs($admin);
+
+        Livewire::test(CreateUser::class)
+            ->set('name', 'New Admin')
+            ->set('email', 'admin_new@example.com')
+            ->set('password', 'password123')
+            ->set('passwordConfirmation', 'password123')
+            ->set('isAdmin', true)
+            ->set('sendVerification', false)
+            ->call('save')
+            ->assertRedirect(route('admin.users.index'));
+
+        $user = User::where('email', 'admin_new@example.com')->first();
+        $this->assertTrue($user->is_admin);
+        $this->assertNotNull($user->email_verified_at);
+    }
+
+    #[Test]
+    public function edit_user_component_renders_with_user_data(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create(['name' => 'Existing User', 'email' => 'existing@example.com']);
+
+        $this->actingAs($admin);
+
+        Livewire::test(EditUser::class, ['user' => $user])
+            ->assertSet('name', 'Existing User')
+            ->assertSet('email', 'existing@example.com')
+            ->assertSet('isAdmin', false);
+    }
+
+    #[Test]
+    public function it_can_update_user_name_and_email(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create(['name' => 'Old Name', 'email' => 'old@example.com']);
+
+        $this->actingAs($admin);
+
+        Livewire::test(EditUser::class, ['user' => $user])
+            ->set('name', 'New Name')
+            ->set('email', 'new_email@example.com')
+            ->call('save')
+            ->assertDispatched('notify', type: 'success', message: 'User updated');
+
+        $this->assertEquals('New Name', $user->fresh()->name);
+        $this->assertEquals('new_email@example.com', $user->fresh()->email);
+    }
+
+    #[Test]
+    public function it_can_update_user_password(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create();
+        $oldPassword = $user->password;
+
+        $this->actingAs($admin);
+
+        Livewire::test(EditUser::class, ['user' => $user])
+            ->set('changePassword', true)
+            ->set('password', 'new_password123')
+            ->set('passwordConfirmation', 'new_password123')
+            ->call('save')
+            ->assertDispatched('notify', type: 'success', message: 'User updated');
+
+        $this->assertNotEquals($oldPassword, $user->fresh()->password);
+        $this->assertTrue(\Hash::check('new_password123', $user->fresh()->password));
+    }
+
+    #[Test]
+    public function it_can_toggle_admin_status_in_edit_mode(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(EditUser::class, ['user' => $user])
+            ->set('isAdmin', true)
+            ->call('save')
+            ->assertDispatched('notify', type: 'success', message: 'User updated');
+
+        $this->assertTrue($user->fresh()->is_admin);
+
+        Livewire::test(EditUser::class, ['user' => $user])
+            ->set('isAdmin', false)
+            ->call('save')
+            ->assertDispatched('notify', type: 'success', message: 'User updated');
+
+        $this->assertFalse($user->fresh()->is_admin);
+    }
+
+    #[Test]
+    public function it_cannot_remove_own_admin_status_in_edit_mode(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin);
+
+        Livewire::test(EditUser::class, ['user' => $admin])
+            ->set('isAdmin', false)
+            ->call('save')
+            ->assertDispatched('notify', type: 'error', message: 'Cannot remove your own admin status');
+
+        $this->assertTrue($admin->fresh()->is_admin);
+    }
+}


### PR DESCRIPTION
🎯 **Coverage:** Added comprehensive test coverage for User Management Livewire components (`ListUsers`, `CreateUser`, `EditUser`).

📋 **Tests added:**
- `list_users_component_renders_successfully_for_admin`
- `list_users_component_aborts_for_non_admin`
- `list_users_component_aborts_for_guest`
- `it_can_search_users_by_name_or_email`
- `it_can_filter_users_by_verification_status`
- `it_can_filter_users_by_admin_status`
- `it_can_toggle_admin_status`
- `it_cannot_toggle_own_admin_status`
- `it_can_delete_user`
- `it_cannot_delete_self`
- `create_user_validation_rules`
- `it_can_create_a_standard_user`
- `it_can_create_an_admin_user_without_verification`
- `edit_user_component_renders_with_user_data`
- `it_can_update_user_name_and_email`
- `it_can_update_user_password`
- `it_can_toggle_admin_status_in_edit_mode`
- `it_cannot_remove_own_admin_status_in_edit_mode`

🔍 **Why:** These admin components were previously untested, representing a high-risk area for authorization and data integrity.

✅ **Results:** 
- 18 new tests passing.
- UserFactory updated to avoid null property issues and correct outdated comments.
- PHPStan 0 errors, Pint clean.

---
*PR created automatically by Jules for task [17351943202557746828](https://jules.google.com/task/17351943202557746828) started by @GarethClarridge*