### PR TITLE
🛡️ Sentinel: Harden authorization on administrative and API routes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The `is_admin` attribute was included in the `User` model's `$fillable` array.
 **Learning:** This allowed anyone with access to a user creation or update flow (if not strictly guarded) to potentially escalate their privileges by including `is_admin: true` in the request payload. In this codebase, even administrative Livewire components were relying on this mass-assignment, making the attribute "intentionally" vulnerable for convenience.
 **Prevention:** Always exclude high-privilege attributes from `$fillable`. Use explicit property assignment ($user->is_admin = true) in controlled administrative contexts to update such fields.
+## 2026-02-21 - [Insufficient Authorization on Admin/API Endpoints]
+**Vulnerability:** Administrative API endpoints for media processing and web-based calendar management were only protected by authentication (`auth` or `auth:sanctum`), allowing any registered user to perform privileged actions.
+**Learning:** Route-level authorization (`admin` middleware) should always be applied to all administrative surfaces, even if individual controllers or requests perform their own checks, to ensure defense in depth and consistent protection.
+**Prevention:** Audit all routes prefixed with `admin` or serving administrative functions to ensure the `admin` middleware is consistently applied at the route group level.

--- a/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -11,9 +11,9 @@ class EnsureUserIsAdmin
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
-    public function handle(Request $request, Closure $next): \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+    public function handle(Request $request, Closure $next): \Symfony\Component\HttpFoundation\Response
     {
         if (! Auth::check() || ! Auth::user()->is_admin) {
             abort(403, 'Unauthorized action.');

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,24 +21,24 @@ Route::prefix('sermons')->name('api.sermons.')->middleware('cors')->group(functi
         ->name('show');
 });
 
-// Unified media processing endpoints
-Route::prefix('media')->name('api.media.')->group(function () {
+// Unified media processing endpoints - restricted to admins
+Route::prefix('media')->name('api.media.')->middleware(['auth:sanctum', 'admin'])->group(function () {
     // Upload endpoints for each type
     Route::post('{type}', [MediaController::class, 'upload'])
         ->where('type', 'audio|video|livestream')
-        ->middleware(['cors', 'auth:sanctum', 'throttle:media-upload'])
+        ->middleware(['cors', 'throttle:media-upload'])
         ->name('upload');
+
+    // Processing management routes
+    Route::get('processing/{processingId}/status', [MediaController::class, 'status'])
+        ->middleware('throttle:api')
+        ->name('processing.status');
+
+    Route::delete('processing/{processingId}', [MediaController::class, 'cancel'])
+        ->middleware('throttle:api')
+        ->name('processing.cancel');
+
+    Route::post('processing/{processingId}/retry', [MediaController::class, 'retry'])
+        ->middleware('throttle:media-retry')
+        ->name('processing.retry');
 });
-
-// Processing management routes - defined separately to avoid nested group issues
-Route::get('media/processing/{processingId}/status', [MediaController::class, 'status'])
-    ->middleware(['auth:sanctum', 'throttle:api'])
-    ->name('api.media.processing.status');
-
-Route::delete('media/processing/{processingId}', [MediaController::class, 'cancel'])
-    ->middleware(['auth:sanctum', 'throttle:api'])
-    ->name('api.media.processing.cancel');
-
-Route::post('media/processing/{processingId}/retry', [MediaController::class, 'retry'])
-    ->middleware(['auth:sanctum', 'throttle:media-retry'])
-    ->name('api.media.processing.retry');

--- a/routes/web.php
+++ b/routes/web.php
@@ -75,15 +75,15 @@ Route::group(['prefix' => 'christ/sermons'], function () {
         ->name('showSermonWithDate');
     Route::get('/{year}/{month}/{sermon:slug}/edit', [SermonAdminController::class, 'editWithDate'])
         ->where(['year' => '[0-9]{4}', 'month' => '[0-9]{2}'])
-        ->middleware('auth')
+        ->middleware(['auth', 'admin'])
         ->name('editSermonWithDate');
     Route::post('/{year}/{month}/{sermon:slug}/edit', [SermonAdminController::class, 'updateWithDate'])
         ->where(['year' => '[0-9]{4}', 'month' => '[0-9]{2}'])
-        ->middleware('auth')
+        ->middleware(['auth', 'admin'])
         ->name('updateSermonWithDate');
     Route::post('/{year}/{month}/{sermon:slug}/delete', [SermonAdminController::class, 'destroyWithDate'])
         ->where(['year' => '[0-9]{4}', 'month' => '[0-9]{2}'])
-        ->middleware('auth')
+        ->middleware(['auth', 'admin'])
         ->name('destroySermonWithDate');
 
     // Audio serving route
@@ -94,9 +94,9 @@ Route::group(['prefix' => 'christ/sermons'], function () {
 
     // Fallback slug-only routes
     Route::get('/{sermon:slug}', [SermonController::class, 'show'])->name('showSermon');
-    Route::get('/{sermon:slug}/edit', [SermonAdminController::class, 'edit'])->middleware('auth')->name('editSermon');
-    Route::post('/{sermon:slug}/edit', [SermonAdminController::class, 'update'])->middleware('auth')->name('updateSermon');
-    Route::post('/{sermon:slug}/delete', [SermonAdminController::class, 'destroy'])->middleware('auth')->name('destroySermon');
+    Route::get('/{sermon:slug}/edit', [SermonAdminController::class, 'edit'])->middleware(['auth', 'admin'])->name('editSermon');
+    Route::post('/{sermon:slug}/edit', [SermonAdminController::class, 'update'])->middleware(['auth', 'admin'])->name('updateSermon');
+    Route::post('/{sermon:slug}/delete', [SermonAdminController::class, 'destroy'])->middleware(['auth', 'admin'])->name('destroySermon');
 });
 
 // Members routes
@@ -160,18 +160,19 @@ Route::middleware('auth')->group(function () {
 
 Route::group(['middleware' => 'auth', 'prefix' => 'church/members'], function () {
     Route::get('', MemberController::class)->name('memberHome');
-    // Pages resource removed - now handled by Filament at /admin/pages
-    // Meetings resource removed - now handled by Filament at /admin/meetings
 
-    // Calendar admin routes
-    Route::get('calendar/uncategorized', [CalendarAdminController::class, 'uncategorizedEvents'])->name('admin.calendar.uncategorized');
-    Route::post('calendar/categorize', [CalendarAdminController::class, 'categorizeEvent'])->name('admin.calendar.categorize');
-    Route::get('calendar/patterns', [CalendarAdminController::class, 'patternManagement'])->name('admin.calendar.patterns');
-    Route::post('calendar/sync', [CalendarAdminController::class, 'syncCalendar'])->name('admin.calendar.sync');
+    // Admin-only routes within members area
+    Route::middleware('admin')->group(function () {
+        // Calendar admin routes
+        Route::get('calendar/uncategorized', [CalendarAdminController::class, 'uncategorizedEvents'])->name('admin.calendar.uncategorized');
+        Route::post('calendar/categorize', [CalendarAdminController::class, 'categorizeEvent'])->name('admin.calendar.categorize');
+        Route::get('calendar/patterns', [CalendarAdminController::class, 'patternManagement'])->name('admin.calendar.patterns');
+        Route::post('calendar/sync', [CalendarAdminController::class, 'syncCalendar'])->name('admin.calendar.sync');
 
-    // Unified media upload route (replaces smart-upload)
-    Route::get('sermon-upload', [SermonAdminController::class, 'upload'])->name('admin.sermon-upload.create');
-    Route::post('sermon-upload', [SermonAdminController::class, 'processMedia'])->name('admin.sermon-upload.store');
+        // Unified media upload route (replaces smart-upload)
+        Route::get('sermon-upload', [SermonAdminController::class, 'upload'])->name('admin.sermon-upload.create');
+        Route::post('sermon-upload', [SermonAdminController::class, 'processMedia'])->name('admin.sermon-upload.store');
+    });
 });
 
 Route::get('phpinfo', fn () => app()->isLocal() ? phpinfo() : abort(404))->middleware('admin');

--- a/tests/Feature/Api/MediaSecurityTest.php
+++ b/tests/Feature/Api/MediaSecurityTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class MediaSecurityTest extends TestCase
+{
+    // No database traits
+
+    public function test_non_admin_user_cannot_upload_media_via_api()
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->make(['id' => 1, 'is_admin' => false]);
+
+        $file = UploadedFile::fake()->create('sermon.mp3', 100);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson(route('api.media.upload', ['type' => 'audio']), [
+                'file' => $file,
+            ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_user_can_upload_media_via_api()
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->make(['id' => 2, 'is_admin' => true]);
+
+        $file = UploadedFile::fake()->create('sermon.mp3', 100);
+
+        // Mock the media processor to avoid actual processing
+        $this->mock(\App\Services\UnifiedMediaProcessor::class, function ($mock) {
+            $mock->shouldReceive('process')->andReturn(
+                \App\Services\ProcessingResult::success('test-uuid', 'Success')
+            );
+        });
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson(route('api.media.upload', ['type' => 'audio']), [
+                'file' => $file,
+            ]);
+
+        $response->assertStatus(202);
+    }
+}

--- a/tests/Feature/CalendarSecurityTest.php
+++ b/tests/Feature/CalendarSecurityTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Tests\TestCase;
+
+class CalendarSecurityTest extends TestCase
+{
+    public function test_non_admin_user_cannot_access_calendar_admin_routes()
+    {
+        $user = User::factory()->make(['id' => 1, 'is_admin' => false]);
+
+        $this->actingAs($user)
+            ->get(route('admin.calendar.uncategorized'))
+            ->assertStatus(403);
+
+        $this->actingAs($user)
+            ->get(route('admin.calendar.patterns'))
+            ->assertStatus(403);
+
+        $this->actingAs($user)
+            ->post(route('admin.calendar.sync'))
+            ->assertStatus(403);
+    }
+
+    public function test_admin_user_can_access_calendar_admin_routes()
+    {
+        $user = User::factory()->make(['id' => 2, 'is_admin' => true]);
+
+        // We expect it to try to render but fail with 500 because of missing DB tables for View Composer,
+        // but if it reaches the View Composer, it means it passed the 'admin' middleware!
+        // A 403 would mean it failed the middleware.
+
+        $response = $this->actingAs($user)->get(route('admin.calendar.uncategorized'));
+        $this->assertNotEquals(403, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
Identified and fixed a high-priority security issue where several administrative routes were accessible to any authenticated user. Applied the 'admin' middleware to Media API endpoints, Calendar management routes, and Sermon editing/deletion routes to ensure proper authorization. Also updated the 'EnsureUserIsAdmin' middleware to support both Web and API responses. Verified the fix with new security-focused feature tests.

---
*PR created automatically by Jules for task [6089090219171010891](https://jules.google.com/task/6089090219171010891) started by @GarethClarridge*