### PR TITLE
Add tests for CalendarController and refactor for cross-database compatibility

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -1,0 +1,7 @@
+## 2026-02-21 - SQLite Compatibility and View Composers
+**Learning:** Raw MySQL syntax like `DB::raw('RAND()')` or `SHOW INDEX FROM...` in migrations prevents tests from running in SQLite environments. Using `inRandomOrder()` is the standard Laravel way to ensure cross-database compatibility.
+**Action:** Always prefer `inRandomOrder()` and wrap driver-specific migration logic in driver checks (`DB::getDriverName() === 'mysql'`).
+
+## 2026-02-21 - Parallel Testing Artifacts
+**Learning:** Running parallel tests with SQLite in Laravel creates local database files (e.g., `crockenhill_test_1`) in the root directory.
+**Action:** Ensure these artifacts and any temporary `.env` files are removed before committing to avoid polluting the repository with binary data.

--- a/app/Providers/ViewServiceProvider.php
+++ b/app/Providers/ViewServiceProvider.php
@@ -9,7 +9,6 @@ use App\Models\Page;
 use App\Models\Sermon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 
@@ -80,7 +79,7 @@ class ViewServiceProvider extends ServiceProvider
                     ->where('slug', '!=', $slug)
                     ->where('slug', '!=', 'privacy-policy')
                     ->where('admin', '!=', 'yes')
-                    ->orderBy(DB::raw('RAND()'))
+                    ->inRandomOrder()
                     ->take(5)
                     ->get();
 
@@ -148,7 +147,7 @@ class ViewServiceProvider extends ServiceProvider
                             ->where('area', $slug)
                             ->where('slug', '!=', $slug)
                             ->where('slug', '!=', 'homepage')
-                            ->orderBy(DB::raw('RAND()'))
+                            ->inRandomOrder()
                             ->take(5)
                             ->get();
 
@@ -175,7 +174,7 @@ class ViewServiceProvider extends ServiceProvider
                         ->where('area', $area)
                         ->where('slug', '!=', $area)
                         ->where('slug', '!=', 'homepage')
-                        ->orderBy(DB::raw('RAND()'))
+                        ->inRandomOrder()
                         ->take(5)
                         ->get();
 
@@ -324,7 +323,7 @@ class ViewServiceProvider extends ServiceProvider
                         ->where('slug', '!=', $area)
                         ->where('slug', '!=', 'privacy-policy')
                         ->where('admin', '!=', 'yes')
-                        ->orderBy(DB::raw('RAND()'))
+                        ->inRandomOrder()
                         ->take(5)
                         ->get();
                 }

--- a/tests/Feature/CalendarControllerTest.php
+++ b/tests/Feature/CalendarControllerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\CalendarEvent;
+use App\Models\Meeting;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CalendarControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function calendar_index_shows_upcoming_confirmed_events(): void
+    {
+        $meeting = Meeting::factory()->create(['slug' => 'test-meeting']);
+
+        // Upcoming confirmed event
+        $upcoming = CalendarEvent::factory()->create([
+            'meeting_slug' => 'test-meeting',
+            'start_datetime' => now()->addDays(1),
+            'status' => 'confirmed',
+            'title' => 'Upcoming Event',
+        ]);
+
+        // Past event
+        $past = CalendarEvent::factory()->create([
+            'meeting_slug' => 'test-meeting',
+            'start_datetime' => now()->subDays(1),
+            'status' => 'confirmed',
+            'title' => 'Past Event',
+        ]);
+
+        // Unconfirmed event (tentative)
+        $unconfirmed = CalendarEvent::factory()->create([
+            'meeting_slug' => 'test-meeting',
+            'start_datetime' => now()->addDays(2),
+            'status' => 'tentative',
+            'title' => 'Unconfirmed Event',
+        ]);
+
+        // Too far in the future (> 6 months)
+        $farFuture = CalendarEvent::factory()->create([
+            'meeting_slug' => 'test-meeting',
+            'start_datetime' => now()->addMonths(7),
+            'status' => 'confirmed',
+            'title' => 'Far Future Event',
+        ]);
+
+        $response = $this->get(route('calendar.index'));
+
+        $response->assertStatus(200);
+        $response->assertSee('Upcoming Event');
+        $response->assertDontSee('Past Event');
+        $response->assertDontSee('Unconfirmed Event');
+        $response->assertDontSee('Far Future Event');
+    }
+
+    #[Test]
+    public function events_for_meeting_shows_events_for_that_meeting_not_cancelled(): void
+    {
+        $meeting = Meeting::factory()->create(['slug' => 'specific-meeting']);
+        $otherMeeting = Meeting::factory()->create(['slug' => 'other-meeting']);
+
+        $event1 = CalendarEvent::factory()->create([
+            'meeting_slug' => 'specific-meeting',
+            'title' => 'Meeting Event 1',
+            'status' => 'confirmed',
+        ]);
+
+        $event2 = CalendarEvent::factory()->create([
+            'meeting_slug' => 'specific-meeting',
+            'title' => 'Meeting Event 2',
+            'status' => 'tentative', // Should be shown as it's not 'cancelled'
+        ]);
+
+        $cancelledEvent = CalendarEvent::factory()->create([
+            'meeting_slug' => 'specific-meeting',
+            'title' => 'Cancelled Event',
+            'status' => 'cancelled', // Should NOT be shown
+        ]);
+
+        $otherEvent = CalendarEvent::factory()->create([
+            'meeting_slug' => 'other-meeting',
+            'title' => 'Other Meeting Event',
+            'status' => 'confirmed',
+        ]);
+
+        $response = $this->get(route('meetings.events', $meeting));
+
+        $response->assertStatus(200);
+        $response->assertSee('Meeting Event 1');
+        $response->assertSee('Meeting Event 2');
+        $response->assertDontSee('Cancelled Event');
+        $response->assertDontSee('Other Meeting Event');
+    }
+
+    #[Test]
+    public function uncategorized_calendar_shows_upcoming_uncategorized_events(): void
+    {
+        config(['calendar.uncategorized_slug' => 'uncategorized']);
+
+        $uncategorizedUpcoming = CalendarEvent::factory()->create([
+            'meeting_slug' => 'uncategorized',
+            'start_datetime' => now()->addDays(1),
+            'title' => 'Uncategorized Upcoming',
+        ]);
+
+        $uncategorizedPast = CalendarEvent::factory()->create([
+            'meeting_slug' => 'uncategorized',
+            'start_datetime' => now()->subDays(1),
+            'title' => 'Uncategorized Past',
+        ]);
+
+        $categorizedUpcoming = CalendarEvent::factory()->create([
+            'meeting_slug' => 'some-meeting',
+            'start_datetime' => now()->addDays(1),
+            'title' => 'Categorized Upcoming',
+        ]);
+
+        $response = $this->get(route('calendar.uncategorized'));
+
+        $response->assertStatus(200);
+        $response->assertSee('Uncategorized Upcoming');
+        $response->assertDontSee('Uncategorized Past');
+        $response->assertDontSee('Categorized Upcoming');
+    }
+
+    #[Test]
+    public function calendar_index_handles_no_events_gracefully(): void
+    {
+        // Ensure no events exist
+        CalendarEvent::query()->delete();
+
+        $response = $this->get(route('calendar.index'));
+
+        $response->assertStatus(200);
+        $response->assertSee('No upcoming events');
+    }
+}


### PR DESCRIPTION
I have added a new feature test `tests/Feature/CalendarControllerTest.php` that provides full coverage for the public-facing `CalendarController` routes. 

Additionally, I've refactored several queries in `app/Providers/ViewServiceProvider.php` to use Eloquent's `inRandomOrder()` instead of raw MySQL `RAND()`, which improves compatibility with other database drivers like SQLite and follows Laravel best practices.

I also addressed environment-specific issues encountered during testing by documenting the necessary fixes and ensuring that no local database artifacts are included in the submission.

---
*PR created automatically by Jules for task [13362549533388262022](https://jules.google.com/task/13362549533388262022) started by @GarethClarridge*