### PR TITLE
🎨 Palette: Enhanced form components with loading feedback and accessibility improvements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,6 @@
 ## 2026-03-05 - Semantic Switches and Connectivity Feedback
 **Learning:** For interactive switches, wrapping everything in a `<label>` is not enough for modern accessibility standards. Using a `<button role="switch">` with an explicit `aria-labelledby` pointing to a descriptive label provides much clearer intent to assistive technologies. Additionally, global connectivity indicators like `wire:offline` are critical for TALL stack applications where many interactions depend on a stable server connection; providing this feedback at the layout level ensures users are never left wondering why a button isn't responding.
 **Action:** Always prefer `<button role="switch">` for toggles and ensure they are correctly labeled. Include a global `wire:offline` indicator in the main layout for all Livewire-heavy applications.
+## 2026-02-13 - Integrated Loading States for Form Components
+**Learning:** Adding automated loading indicators to base form components (input, select) that target their `wire:model` provides immediate feedback for debounced search and live validation without requiring per-instance configuration. Fallback `aria-label` from placeholders ensures accessibility when formal labels are missing.
+**Action:** Use `wire:loading` with `wire:target` in base components and ensure conflicting elements (like clear buttons) use `wire:loading.remove`.

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -32,16 +32,27 @@ $describedBy = implode(' ', $describedBy);
         <input
             @if($id) id="{{ $id }}" @endif
             {{ $attributes->merge(['type' => 'text', 'class' => $inputClasses]) }}
+            @if(!$label && $attributes->get('placeholder')) aria-label="{{ $attributes->get('placeholder') }}" @endif
             @if($hasError) aria-invalid="true" @endif
             @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
         />
+
+        @if($modelName)
+            <div wire:loading wire:target="{{ $modelName }}" class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+                <svg class="animate-spin h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+            </div>
+        @endif
 
         @if($clearable && $modelName)
             <button type="button"
                 aria-label="Clear input"
                 wire:click="$set('{{ $modelName }}', '')"
                 class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600"
-                x-show="$wire.{{ $modelName }}">
+                x-show="$wire.{{ $modelName }}"
+                wire:loading.remove wire:target="{{ $modelName }}">
                 <x-heroicon-o-x-mark class="h-4 w-4" />
             </button>
         @endif

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -21,19 +21,31 @@ $describedBy = implode(' ', $describedBy);
         </label>
     @endif
 
-    <select
-        @if($id) id="{{ $id }}" @endif
-        {{ $attributes->merge(['class' => $selectClasses]) }}
-        @if($hasError) aria-invalid="true" @endif
-        @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
-    >
-        @if($placeholder)
-            <option value="">{{ $placeholder }}</option>
+    <div class="relative">
+        <select
+            @if($id) id="{{ $id }}" @endif
+            {{ $attributes->merge(['class' => $selectClasses]) }}
+            @if(!$label && $placeholder) aria-label="{{ $placeholder }}" @endif
+            @if($hasError) aria-invalid="true" @endif
+            @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
+        >
+            @if($placeholder)
+                <option value="">{{ $placeholder }}</option>
+            @endif
+            @foreach($options as $option)
+                <option value="{{ $option['id'] }}">{{ $option['name'] }}</option>
+            @endforeach
+        </select>
+
+        @if($modelName)
+            <div wire:loading wire:target="{{ $modelName }}" class="absolute inset-y-0 right-0 pr-8 flex items-center pointer-events-none">
+                <svg class="animate-spin h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+            </div>
         @endif
-        @foreach($options as $option)
-            <option value="{{ $option['id'] }}">{{ $option['name'] }}</option>
-        @endforeach
-    </select>
+    </div>
 
     @if($hint)
         <p @if($id) id="{{ $id }}-hint" @endif class="mt-1 text-sm text-gray-500">{{ $hint }}</p>


### PR DESCRIPTION
This PR enhances the core Blade form components (\`x-input\` and \`x-select\`) to provide better visual feedback and accessibility.

### 💡 What:
- **Loading Feedback**: Added \`wire:loading\` spinners that automatically appear when the component's Livewire model is being updated (e.g., during debounced searches).
- **Accessibility**: Added fallback \`aria-label\` attributes derived from placeholders when a visible \`label\` is not provided.

### 🎯 Why:
- Many admin list views use debounced search inputs which currently offer no visual feedback while the server is processing the search. These changes provide immediate "active" states.
- Screen readers often miss the context of search inputs if they lack formal labels; the fallback \`aria-label\` ensures they remain accessible.

### ♿ Accessibility:
- Fallback \`aria-label\` improves compliance for inputs/selects without explicit labels.
- Loading states provide cognitive feedback that an action is in progress.

### 📱 Responsive:
- Spinners are absolutely positioned and do not affect layout flow or responsiveness.
- \`x-select\` spinner is offset to avoid overlapping with standard dropdown chevrons.

---
*PR created automatically by Jules for task [2598634979768005470](https://jules.google.com/task/2598634979768005470) started by @GarethClarridge*