### PR TITLE
🛡️ Sentinel: Fix information leakage and enhance route security

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,13 @@
 **Vulnerability:** Registration, forgot password, and reset password flows were missing rate limiting, making them vulnerable to automated registration spam and brute-force password reset attempts.
 **Learning:** While the login flow was protected, other authentication-related entry points were overlooked. Livewire components require manual implementation of the `RateLimiter` logic as they don't automatically inherit route-level throttling in some configurations.
 **Prevention:** Ensure all public-facing authentication and sensitive data entry points implement throttling. Use a combination of user identifier (e.g., email) and IP address for the throttle key to prevent targeted and distributed attacks.
+
+## 2026-02-23 - [Information Leakage in Error Responses]
+**Vulnerability:** Exception messages were being returned directly to users in redirect messages, potentially leaking internal details like file paths or database structure.
+**Learning:** Catching exceptions and displaying `$e->getMessage()` is a common developer habit for debugging but dangerous in production.
+**Prevention:** Always log the full exception for developers and return a generic, friendly message to the user.
+
+## 2026-02-23 - [Under-protected Administrative Routes]
+**Vulnerability:** Several routes for editing sermons and managing meetings relied solely on `auth` middleware or controller-level authorization, missing route-level `admin` middleware for defense-in-depth.
+**Learning:** Relying only on policy checks in controllers is technically correct but less robust than combining it with route-level middleware.
+**Prevention:** Apply administrative middleware (`admin`) to all routes that perform administrative actions, even if they are already guarded by policies.

--- a/app/Http/Controllers/Admin/SermonAdminController.php
+++ b/app/Http/Controllers/Admin/SermonAdminController.php
@@ -14,6 +14,7 @@ use App\Models\PreacherAlias;
 use App\Models\Sermon;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
 
@@ -141,9 +142,15 @@ class SermonAdminController extends Controller
             }
 
         } catch (\Exception $e) {
+            Log::error('Sermon upload failed', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+                'user_id' => $request->user()?->id,
+            ]);
+
             return redirect()
                 ->back()
-                ->with('error', 'An error occurred during upload: '.$e->getMessage());
+                ->with('error', 'An error occurred during upload. Please try again.');
         }
     }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,7 +43,7 @@ Route::permanentRedirect('whats-on/buzz-club', '/community/buzz-club');
 // Meeting routes
 Route::resource('meetings', MeetingController::class)
     ->except(['show'])
-    ->middleware('auth');
+    ->middleware(['auth', 'admin']);
 
 // Calendar routes
 Route::get('/calendar', [CalendarController::class, 'index'])->name('calendar.index');
@@ -75,15 +75,15 @@ Route::group(['prefix' => 'christ/sermons'], function () {
         ->name('showSermonWithDate');
     Route::get('/{year}/{month}/{sermon:slug}/edit', [SermonAdminController::class, 'editWithDate'])
         ->where(['year' => '[0-9]{4}', 'month' => '[0-9]{2}'])
-        ->middleware('auth')
+        ->middleware(['auth', 'admin'])
         ->name('editSermonWithDate');
     Route::post('/{year}/{month}/{sermon:slug}/edit', [SermonAdminController::class, 'updateWithDate'])
         ->where(['year' => '[0-9]{4}', 'month' => '[0-9]{2}'])
-        ->middleware('auth')
+        ->middleware(['auth', 'admin'])
         ->name('updateSermonWithDate');
     Route::post('/{year}/{month}/{sermon:slug}/delete', [SermonAdminController::class, 'destroyWithDate'])
         ->where(['year' => '[0-9]{4}', 'month' => '[0-9]{2}'])
-        ->middleware('auth')
+        ->middleware(['auth', 'admin'])
         ->name('destroySermonWithDate');
 
     // Audio serving route
@@ -94,9 +94,9 @@ Route::group(['prefix' => 'christ/sermons'], function () {
 
     // Fallback slug-only routes
     Route::get('/{sermon:slug}', [SermonController::class, 'show'])->name('showSermon');
-    Route::get('/{sermon:slug}/edit', [SermonAdminController::class, 'edit'])->middleware('auth')->name('editSermon');
-    Route::post('/{sermon:slug}/edit', [SermonAdminController::class, 'update'])->middleware('auth')->name('updateSermon');
-    Route::post('/{sermon:slug}/delete', [SermonAdminController::class, 'destroy'])->middleware('auth')->name('destroySermon');
+    Route::get('/{sermon:slug}/edit', [SermonAdminController::class, 'edit'])->middleware(['auth', 'admin'])->name('editSermon');
+    Route::post('/{sermon:slug}/edit', [SermonAdminController::class, 'update'])->middleware(['auth', 'admin'])->name('updateSermon');
+    Route::post('/{sermon:slug}/delete', [SermonAdminController::class, 'destroy'])->middleware(['auth', 'admin'])->name('destroySermon');
 });
 
 // Members routes
@@ -167,11 +167,11 @@ Route::group(['middleware' => 'auth', 'prefix' => 'church/members'], function ()
         Route::post('calendar/categorize', [CalendarAdminController::class, 'categorizeEvent'])->name('admin.calendar.categorize');
         Route::get('calendar/patterns', [CalendarAdminController::class, 'patternManagement'])->name('admin.calendar.patterns');
         Route::post('calendar/sync', [CalendarAdminController::class, 'syncCalendar'])->name('admin.calendar.sync');
-    });
 
-    // Unified media upload route (replaces smart-upload)
-    Route::get('sermon-upload', [SermonAdminController::class, 'upload'])->name('admin.sermon-upload.create');
-    Route::post('sermon-upload', [SermonAdminController::class, 'processMedia'])->name('admin.sermon-upload.store');
+        // Unified media upload route (replaces smart-upload)
+        Route::get('sermon-upload', [SermonAdminController::class, 'upload'])->name('admin.sermon-upload.create');
+        Route::post('sermon-upload', [SermonAdminController::class, 'processMedia'])->name('admin.sermon-upload.store');
+    });
 });
 
 Route::get('phpinfo', fn () => app()->isLocal() ? phpinfo() : abort(404))->middleware('admin');

--- a/tests/Feature/SentinelSecurityTest.php
+++ b/tests/Feature/SentinelSecurityTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Sermon;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class SentinelSecurityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_sermon_upload_route_requires_admin(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+
+        // Attempt to access upload page as non-admin
+        $response = $this->actingAs($user)->get('/church/members/sermon-upload');
+        $response->assertStatus(403);
+
+        // Attempt to post upload as non-admin
+        $response = $this->actingAs($user)->post('/church/members/sermon-upload', [
+            'type' => 'audio',
+            'file' => UploadedFile::fake()->create('sermon.mp3', 100),
+        ]);
+        $response->assertStatus(403);
+    }
+
+    public function test_sermon_edit_route_requires_admin(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+        $sermon = Sermon::factory()->create(['date' => now()]);
+
+        $response = $this->actingAs($user)->get("/christ/sermons/{$sermon->slug}/edit");
+        $response->assertStatus(403);
+
+        $response = $this->actingAs($user)->post("/christ/sermons/{$sermon->slug}/edit", []);
+        $response->assertStatus(403);
+    }
+
+    public function test_sermon_upload_leaks_no_information_on_error(): void
+    {
+        Log::spy();
+        Storage::fake('public');
+
+        $admin = User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
+
+        // We'll mock the processor to throw an exception with sensitive info
+        $this->mock(\App\Services\UnifiedMediaProcessor::class, function ($mock) {
+            $mock->shouldReceive('process')
+                ->andThrow(new \Exception('Sensitive database error or path: /secret/path'));
+        });
+
+        $response = $this->actingAs($admin)->post('/church/members/sermon-upload', [
+            'type' => 'audio',
+            'file' => UploadedFile::fake()->create('sermon.mp3', 100),
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error', 'An error occurred during upload. Please try again.');
+
+        Log::shouldHaveReceived('error')
+            ->once()
+            ->with('Sermon upload failed', \Mockery::on(function ($data) {
+                return str_contains($data['error'], 'Sensitive database error');
+            }));
+    }
+}

--- a/tests/Feature/UnifiedMediaProcessingTest.php
+++ b/tests/Feature/UnifiedMediaProcessingTest.php
@@ -135,6 +135,7 @@ class UnifiedMediaProcessingTest extends TestCase
         $user = User::factory()->create([
             'email' => 'test@crockenhill.org',
             'email_verified_at' => now(),
+            'is_admin' => true,
         ]);
         $this->actingAs($user);
 


### PR DESCRIPTION
This PR addresses security concerns by:
1. Preventing information leakage: Updating `SermonAdminController::processMedia` to log detailed errors but show only generic messages to users.
2. Enhancing route security: Applying `admin` middleware to several administrative routes that previously only used `auth` middleware or relied solely on controller-level policies.
3. Adding verification tests: A new `SentinelSecurityTest` ensures these protections are working as expected.

---
*PR created automatically by Jules for task [2684181196521766376](https://jules.google.com/task/2684181196521766376) started by @GarethClarridge*