### PR TITLE
📝 Scribe: Add tests for sermon audio serving

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -13,3 +13,7 @@
 ## 2026-02-21 - Parallel Testing Artifacts
 **Learning:** Running parallel tests with SQLite in Laravel creates local database files (e.g., `crockenhill_test_1`) in the root directory.
 **Action:** Ensure these artifacts and any temporary `.env` files are removed before committing to avoid polluting the repository with binary data.
+
+## 2026-02-28 - [Testing BinaryFileResponse and Naming Conventions]
+**Learning:** `BinaryFileResponse` (returned by `response()->file()`) can be verified in feature tests using `assertStatus` and `assertHeader`. When using PHPUnit `#[Test]` attributes, method names should not have the `test_` prefix to avoid redundancy and follow strict project conventions.
+**Action:** Use `#[Test]` with descriptive, non-prefixed method names like `can_serve_audio_locally`.

--- a/tests/Feature/SermonAudioServingTest.php
+++ b/tests/Feature/SermonAudioServingTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Sermon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonAudioServingTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Mock the storage disks
+        Storage::fake('public');
+        Storage::fake('do_spaces');
+
+        // Set default disks
+        Config::set('media-processing.storage.sermon_disk', 'public');
+        Config::set('media-processing.storage.legacy_disk', 'public');
+    }
+
+    #[Test]
+    public function can_serve_audio_file_locally(): void
+    {
+        /** @var Sermon $sermon */
+        $sermon = Sermon::factory()->create([
+            'slug' => 'test-sermon',
+            'audio_file_path' => 'sermons/test.mp3',
+        ]);
+
+        // Create a fake audio file
+        Storage::disk('public')->put('sermons/test.mp3', 'fake audio content');
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/audio");
+
+        $response->assertStatus(200)
+            ->assertHeader('Content-Type', 'audio/mpeg')
+            ->assertHeader('Content-Disposition', 'inline; filename="test.mp3"');
+    }
+
+    #[Test]
+    public function returns_404_when_sermon_has_no_audio_file_path(): void
+    {
+        /** @var Sermon $sermon */
+        $sermon = Sermon::factory()->create([
+            'slug' => 'test-sermon',
+            'audio_file_path' => '',
+        ]);
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/audio");
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function returns_404_when_audio_file_does_not_exist(): void
+    {
+        /** @var Sermon $sermon */
+        $sermon = Sermon::factory()->create([
+            'slug' => 'test-sermon',
+            'audio_file_path' => 'sermons/nonexistent.mp3',
+        ]);
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/audio");
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function redirects_to_cdn_for_do_spaces_storage(): void
+    {
+        Config::set('media-processing.storage.sermon_disk', 'do_spaces');
+        Config::set('filesystems.disks.do_spaces.cdn_endpoint', 'https://cdn.example.com');
+
+        /** @var Sermon $sermon */
+        $sermon = Sermon::factory()->create([
+            'slug' => 'test-sermon',
+            'audio_file_path' => 'sermons/cdn-test.mp3',
+        ]);
+
+        // Create a fake audio file on do_spaces
+        Storage::disk('do_spaces')->put('sermons/cdn-test.mp3', 'fake audio content');
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/audio");
+
+        $response->assertRedirect('https://cdn.example.com/sermons/cdn-test.mp3');
+    }
+
+    #[Test]
+    public function serves_audio_file_directly_for_do_spaces_without_cdn(): void
+    {
+        Config::set('media-processing.storage.sermon_disk', 'do_spaces');
+        Config::set('filesystems.disks.do_spaces.cdn_endpoint', null);
+
+        /** @var Sermon $sermon */
+        $sermon = Sermon::factory()->create([
+            'slug' => 'test-sermon',
+            'audio_file_path' => 'sermons/direct-test.mp3',
+        ]);
+
+        // Create a fake audio file on do_spaces
+        Storage::disk('do_spaces')->put('sermons/direct-test.mp3', 'fake audio content');
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/audio");
+
+        $response->assertStatus(200)
+            ->assertHeader('Content-Type', 'audio/mpeg');
+    }
+}


### PR DESCRIPTION
Identified that `SermonAssetController::serveAudio` was untested. Added `SermonAudioServingTest` to cover various scenarios including local serving, 404 handling, and CDN redirection. Followed all project conventions and quality standards.

---
*PR created automatically by Jules for task [10340043604493983148](https://jules.google.com/task/10340043604493983148) started by @GarethClarridge*