### PR TITLE
🛡️ Sentinel: Secure admin-only pages and fix insecure Blade output

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -37,6 +37,14 @@ class PageController extends Controller
             abort(404, 'Page not found');
         }
 
+        /**
+         * Security check: If the page is marked as an admin-only page,
+         * ensure the current user has administrative privileges.
+         */
+        if ($page->admin === 'yes' && (! auth()->check() || ! auth()->user()->is_admin)) {
+            abort(403, 'Unauthorized action.');
+        }
+
         $html = $markdownRenderer->convert($page->markdown);
 
         return View::make('layouts/page')->with([

--- a/app/View/Composers/LayoutPageComposer.php
+++ b/app/View/Composers/LayoutPageComposer.php
@@ -32,6 +32,14 @@ class LayoutPageComposer
 
     private function composeUsingProvidedPage(View $view, Page $page): void
     {
+        /**
+         * Security check: If the page is marked as an admin-only page,
+         * ensure the current user has administrative privileges.
+         */
+        if ($page->admin === 'yes' && (! auth()->check() || ! auth()->user()->is_admin)) {
+            abort(403, 'Unauthorized action.');
+        }
+
         $viewData = $view->getData();
         $content = array_key_exists('content', $viewData)
             ? (string) $viewData['content']
@@ -140,6 +148,14 @@ class LayoutPageComposer
                 ->first();
 
             if ($page) {
+                /**
+                 * Security check: If the page is marked as an admin-only page,
+                 * ensure the current user has administrative privileges.
+                 */
+                if ($page->admin === 'yes' && (! auth()->check() || ! auth()->user()->is_admin)) {
+                    abort(403, 'Unauthorized action.');
+                }
+
                 $description = '<meta name="description" content="'.$page->description.'">';
                 $heading = $page->heading;
                 $content = htmlspecialchars_decode($page->body);
@@ -187,6 +203,14 @@ class LayoutPageComposer
                 ->first();
 
             if ($page) {
+                /**
+                 * Security check: If the page is marked as an admin-only page,
+                 * ensure the current user has administrative privileges.
+                 */
+                if ($page->admin === 'yes' && (! auth()->check() || ! auth()->user()->is_admin)) {
+                    abort(403, 'Unauthorized action.');
+                }
+
                 $description = '<meta name="description" content="'.$page->description.'">';
                 $heading = $page->heading;
                 $content = htmlspecialchars_decode($page->body);

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -18,7 +18,7 @@ class PageFactory extends Factory
             'description' => $this->faker->sentence(10),
             'area' => $this->faker->randomElement(PageArea::values()),
             'body' => $this->faker->paragraphs(3, true),
-            'admin' => $this->faker->randomElement(['yes', 'no']),
+            'admin' => 'no',
             'markdown' => $this->faker->paragraphs(2, true),
             'navigation' => $this->faker->boolean(70),
         ];
@@ -36,6 +36,15 @@ class PageFactory extends Factory
     public function isNotNavigation(): Factory
     {
         return $this->isNavigation(false);
+    }
+
+    public function admin(bool $isAdmin = true): Factory
+    {
+        return $this->state(function (array $attributes) use ($isAdmin) {
+            return [
+                'admin' => $isAdmin ? 'yes' : 'no',
+            ];
+        });
     }
 
     public function inArea(string|\App\Enums\PageArea $area): Factory

--- a/resources/views/sermons/preachers.blade.php
+++ b/resources/views/sermons/preachers.blade.php
@@ -12,7 +12,7 @@
                 {{ $preacher->name }}
             </h5>
           <small class="bg-slate-800 text-white rounded-full py-1 px-2 ms-2">
-            {!! $preacher->sermons_count !!}
+            {{ $preacher->sermons_count }}
           </small>
         </x-clickable-card>
       </li>

--- a/resources/views/sermons/serieses.blade.php
+++ b/resources/views/sermons/serieses.blade.php
@@ -8,7 +8,7 @@
       <li class="text-center p-3">
         <x-clickable-card 
           heading="{{$series->series}}" 
-          link="series/{!! \Illuminate\Support\Str::slug($series->series) !!}"
+          link="series/{{ \Illuminate\Support\Str::slug($series->series) }}"
           content="" />
       </li>
     @endisset

--- a/tests/Feature/AdminPageSecurityTest.php
+++ b/tests/Feature/AdminPageSecurityTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Page;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class AdminPageSecurityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function guest_cannot_view_admin_page()
+    {
+        // Create an admin page
+        $page = Page::factory()->admin()->create([
+            'slug' => 'secret-admin-page',
+            'area' => 'church',
+        ]);
+
+        $response = $this->get('/church/secret-admin-page');
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function non_admin_user_cannot_view_admin_page()
+    {
+        // Create an admin page
+        $page = Page::factory()->admin()->create([
+            'slug' => 'secret-admin-page',
+            'area' => 'church',
+        ]);
+
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $response = $this->actingAs($user)->get('/church/secret-admin-page');
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function admin_user_can_view_admin_page()
+    {
+        // Create an admin page
+        $page = Page::factory()->admin()->create([
+            'slug' => 'secret-admin-page',
+            'area' => 'church',
+        ]);
+
+        $admin = User::factory()->create(['is_admin' => true]);
+
+        $response = $this->actingAs($admin)->get('/church/secret-admin-page');
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
Identified and fixed security vulnerabilities related to unauthorized access to administrative pages and insecure data output in Blade templates.

Key changes:
- Added authorization checks in `PageController::show` and `LayoutPageComposer` to block non-admin access to pages where `admin === 'yes'`.
- Replaced `{!! !!}` with `{{ }}` in `serieses.blade.php` and `preachers.blade.php` to prevent potential XSS.
- Modified `PageFactory` to default `admin` to `'no'` and added an `admin()` state, stabilizing the test suite after the security changes.
- Added `AdminPageSecurityTest` to ensure robust protection of sensitive pages.

---
*PR created automatically by Jules for task [6966219842422316141](https://jules.google.com/task/6966219842422316141) started by @GarethClarridge*