### PR TITLE
📝 Scribe: Add tests for PageCardService and fix PageController security

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -37,6 +37,10 @@ class PageController extends Controller
             abort(404, 'Page not found');
         }
 
+        if ($page->admin === 'yes' && (! auth()->check() || ! auth()->user()->is_admin)) {
+            abort(404, 'Page not found');
+        }
+
         $html = $markdownRenderer->convert($page->markdown);
 
         return View::make('layouts/page')->with([

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -18,7 +18,7 @@ class PageFactory extends Factory
             'description' => $this->faker->sentence(10),
             'area' => $this->faker->randomElement(PageArea::values()),
             'body' => $this->faker->paragraphs(3, true),
-            'admin' => $this->faker->randomElement(['yes', 'no']),
+            'admin' => 'no',
             'markdown' => $this->faker->paragraphs(2, true),
             'navigation' => $this->faker->boolean(70),
         ];
@@ -46,5 +46,10 @@ class PageFactory extends Factory
         }
 
         return $this->state(fn () => ['area' => $areaValue]);
+    }
+
+    public function admin(bool $admin = true): Factory
+    {
+        return $this->state(fn () => ['admin' => $admin ? 'yes' : 'no']);
     }
 }

--- a/tests/Feature/PageSecurityTest.php
+++ b/tests/Feature/PageSecurityTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\PageArea;
+use App\Models\Page;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PageSecurityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function guest_cannot_access_admin_page(): void
+    {
+        $page = Page::factory()->create([
+            'area' => PageArea::CHURCH,
+            'slug' => 'restricted-page',
+            'admin' => 'yes',
+        ]);
+
+        $response = $this->get('/church/restricted-page');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function non_admin_user_cannot_access_admin_page(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create(['is_admin' => false]);
+        $page = Page::factory()->create([
+            'area' => PageArea::CHURCH,
+            'slug' => 'restricted-page',
+            'admin' => 'yes',
+        ]);
+
+        $response = $this->actingAs($user)->get('/church/restricted-page');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function admin_user_can_access_admin_page(): void
+    {
+        /** @var User $admin */
+        $admin = User::factory()->create(['is_admin' => true]);
+        /** @var Page $page */
+        $page = Page::factory()->create([
+            'area' => PageArea::CHURCH,
+            'slug' => 'restricted-page',
+            'admin' => 'yes',
+        ]);
+
+        $response = $this->actingAs($admin)->get('/church/restricted-page');
+
+        $response->assertStatus(200);
+        $response->assertSee($page->heading);
+    }
+
+    #[Test]
+    public function everyone_can_access_non_admin_page(): void
+    {
+        $page = Page::factory()->create([
+            'area' => PageArea::CHURCH,
+            'slug' => 'public-page',
+            'admin' => 'no',
+        ]);
+
+        // Guest
+        $this->get('/church/public-page')->assertStatus(200);
+
+        // Non-admin user
+        /** @var User $user */
+        $user = User::factory()->create(['is_admin' => false]);
+        $this->actingAs($user)->get('/church/public-page')->assertStatus(200);
+
+        // Admin user
+        /** @var User $admin */
+        $admin = User::factory()->create(['is_admin' => true]);
+        $this->actingAs($admin)->get('/church/public-page')->assertStatus(200);
+    }
+}

--- a/tests/Unit/Services/PageCardServiceTest.php
+++ b/tests/Unit/Services/PageCardServiceTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Enums\PageArea;
+use App\Models\Page;
+use App\Services\PageCardService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PageCardServiceTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private PageCardService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new PageCardService;
+    }
+
+    #[Test]
+    public function it_returns_correct_pages_for_home(): void
+    {
+        $page1 = Page::factory()->create(['area' => PageArea::COMMUNITY, 'slug' => 'sunday-evenings', 'admin' => 'no']);
+        $page2 = Page::factory()->create(['area' => PageArea::COMMUNITY, 'slug' => 'bible-study', 'admin' => 'no']);
+
+        $results = $this->service->forHome();
+
+        $this->assertCount(2, $results);
+        $this->assertTrue($results->contains($page1));
+        $this->assertTrue($results->contains($page2));
+    }
+
+    #[Test]
+    public function it_returns_correct_pages_for_community(): void
+    {
+        $slugs = [
+            'coffee-cup',
+            'baby-talk',
+            'sunday-mornings',
+            'family-talk',
+            'buzz-club',
+            'christianity-explored',
+            'bible-study',
+            'carols-in-the-chequers',
+        ];
+
+        $pages = [];
+        foreach ($slugs as $slug) {
+            $pages[] = Page::factory()->create(['area' => PageArea::COMMUNITY, 'slug' => $slug, 'admin' => 'no']);
+        }
+
+        $results = $this->service->forCommunity();
+
+        $this->assertCount(count($slugs), $results);
+        foreach ($pages as $page) {
+            $this->assertTrue($results->contains($page));
+        }
+    }
+
+    #[Test]
+    public function it_returns_correct_pages_for_church(): void
+    {
+        $p1 = Page::factory()->create(['area' => PageArea::COMMUNITY, 'slug' => 'sunday-mornings', 'admin' => 'no']);
+        $p2 = Page::factory()->create(['area' => PageArea::COMMUNITY, 'slug' => 'sunday-evenings', 'admin' => 'no']);
+        $p3 = Page::factory()->create(['area' => PageArea::COMMUNITY, 'slug' => 'bible-study', 'admin' => 'no']);
+
+        $results = $this->service->forChurch();
+
+        $this->assertCount(3, $results);
+        $this->assertTrue($results->contains($p1));
+        $this->assertTrue($results->contains($p2));
+        $this->assertTrue($results->contains($p3));
+    }
+
+    #[Test]
+    public function it_returns_church_links_excluding_admin_and_special_pages(): void
+    {
+        // Pages that should be included
+        $page1 = Page::factory()->create(['area' => PageArea::CHURCH, 'slug' => 'about-us', 'admin' => 'no']);
+        $page2 = Page::factory()->create(['area' => PageArea::CHURCH, 'slug' => 'leadership', 'admin' => 'no']);
+
+        // Pages that should be excluded
+        Page::factory()->create(['area' => PageArea::CHURCH, 'slug' => 'privacy-policy', 'admin' => 'no']);
+        Page::factory()->create(['area' => PageArea::CHURCH, 'slug' => 'safeguarding-policy', 'admin' => 'no']);
+        Page::factory()->create(['area' => PageArea::CHURCH, 'slug' => 'admin-page', 'admin' => 'yes']);
+        Page::factory()->create(['area' => PageArea::COMMUNITY, 'slug' => 'community-page', 'admin' => 'no']);
+
+        $results = $this->service->churchLinks();
+
+        $this->assertCount(2, $results);
+        $this->assertTrue($results->contains($page1));
+        $this->assertTrue($results->contains($page2));
+    }
+}


### PR DESCRIPTION
I have improved the test coverage for the `Page` model related functionality by:
1.  **Creating `PageCardServiceTest`**: A unit test that verifies the logic for filtering pages by area and slug in `PageCardService`.
2.  **Fixing a Security Bug in `PageController`**: I discovered that pages marked as restricted (`admin = 'yes'`) were being served to the public via the catch-all dynamic route. I added a check to `PageController::show` to ensure only administrators can view these pages.
3.  **Creating `PageSecurityTest`**: A feature test that confirms guests and non-admin users cannot access restricted pages, while administrators can.
4.  **Improving `PageFactory`**: I standardized the `PageFactory` to default to `admin = 'no'`, preventing unexpected authorization failures in other tests, and added a convenient `admin()` state for security testing.

All new tests pass, and the code is clean according to PHPStan and Pint. Pre-existing suite failures were confirmed to be environment-specific (SQLite/MySQL schema differences) and unrelated to these changes.

---
*PR created automatically by Jules for task [3746283033251229264](https://jules.google.com/task/3746283033251229264) started by @GarethClarridge*