### PR TITLE
⚡ Bolt: Optimize sitemap generation and service efficiency

### DIFF
--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -134,6 +134,8 @@ class Sermon extends Model implements Sitemapable
     {
         return [
             'date' => 'date',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
             'points' => 'array',
             'service' => SermonService::class,
             'segment_start_time' => 'float',
@@ -173,7 +175,7 @@ class Sermon extends Model implements Sitemapable
 
         $disk = config('thumbnail-generation.storage.disk', 'public');
 
-        return \Illuminate\Support\Facades\Storage::disk($disk)->url($this->thumbnail_file_path);
+        return \Illuminate\Support\Facades\Storage::disk((string) $disk)->url($this->thumbnail_file_path);
     }
 
     public function getPlainThumbnailFilePathAttribute(): ?string
@@ -585,7 +587,9 @@ class Sermon extends Model implements Sitemapable
             return null;
         }
 
-        return \Illuminate\Support\Facades\Storage::disk(config('media-processing.storage.sermon_disk'))->url($this->video_file_path);
+        $disk = config('media-processing.storage.sermon_disk', 'public');
+
+        return \Illuminate\Support\Facades\Storage::disk((string) $disk)->url($this->video_file_path);
     }
 
     /**
@@ -730,17 +734,21 @@ class Sermon extends Model implements Sitemapable
 
     /**
      * Convert the sermon to a sitemap tag.
+     *
+     * Performance Optimization: Uses casted updated_at and avoids redundant method calls
+     * to resolve storage URLs during bulk sitemap generation.
      */
     /**
      * @return Url|string|array<string, mixed>
      */
     public function toSitemapTag(): Url|string|array
     {
-        $year = $this->date->format('Y');
-        $month = $this->date->format('m');
+        $date = $this->date;
+        $year = $date->format('Y');
+        $month = $date->format('m');
 
         // Calculate priority based on recency (use absolute value for past dates)
-        $daysOld = abs(now()->diffInDays($this->date, false));
+        $daysOld = abs(now()->diffInDays($date, false));
         $priority = $daysOld < 30 ? 0.8 : 0.6;
 
         // Change frequency based on age
@@ -748,43 +756,38 @@ class Sermon extends Model implements Sitemapable
             ? Url::CHANGE_FREQUENCY_MONTHLY
             : Url::CHANGE_FREQUENCY_YEARLY;
 
-        // Use updated_at if valid, otherwise fall back to date
-        // Note: old records may have invalid updated_at values (0000-00-00) that aren't null
-        // Also, timestamps are disabled so updated_at returns as string, not Carbon
-        $lastModified = $this->date;
-        if ($this->updated_at) {
-            $updatedAt = \Carbon\Carbon::parse($this->updated_at);
-            if ($updatedAt->year > 0) {
-                $lastModified = $updatedAt;
-            }
-        }
+        // Use casted updated_at if valid (year > 0), otherwise fall back to date
+        /** @var ?Carbon $updatedAt */
+        $updatedAt = $this->updated_at;
+        $lastModified = ($updatedAt && $updatedAt->year > 0) ? $updatedAt : $date;
 
         $url = Url::create("/christ/sermons/{$year}/{$month}/{$this->slug}")
             ->setLastModificationDate($lastModified)
             ->setChangeFrequency($changeFreq)
             ->setPriority($priority);
 
-        if ($this->hasVideo() && $this->video_url) {
-            $thumbnailUrl = $this->thumbnail_url;
-            if ($thumbnailUrl) {
-                $videoOptions = [];
-                if ($this->duration && $this->duration > 0) {
-                    $videoOptions['duration'] = (int) $this->duration;
-                }
-                $url->addVideo(
-                    $thumbnailUrl,
-                    $this->title,
-                    $this->summary ?? $this->title,
-                    $this->video_url,
-                    null,
-                    $videoOptions
-                );
+        // Access properties directly if possible to avoid multiple accessor calls
+        $videoUrl = $this->video_url;
+        $thumbnailUrl = $this->thumbnail_url;
+
+        if ($videoUrl && $thumbnailUrl) {
+            $videoOptions = [];
+            if ($this->duration && $this->duration > 0) {
+                $videoOptions['duration'] = (int) $this->duration;
             }
+            $url->addVideo(
+                $thumbnailUrl,
+                $this->title,
+                $this->summary ?? $this->title,
+                $videoUrl,
+                null,
+                $videoOptions
+            );
         }
 
-        if ($this->hasThumbnail() && $this->thumbnail_url) {
+        if ($thumbnailUrl) {
             $url->addImage(
-                $this->thumbnail_url,
+                $thumbnailUrl,
                 $this->meta_description, // Caption
                 '', // Geo location
                 $this->title // Title

--- a/app/Services/BritishEnglishConverter.php
+++ b/app/Services/BritishEnglishConverter.php
@@ -12,6 +12,16 @@ class BritishEnglishConverter
     private const CACHE_TTL = 86400; // 24 hours
 
     /**
+     * @var array<int, string>|null Cached regex patterns
+     */
+    private ?array $patterns = null;
+
+    /**
+     * @var array<int, string>|null Cached replacements
+     */
+    private ?array $replacements = null;
+
+    /**
      * Convert American English text to British English
      *
      * Performance Optimization: Uses array-based preg_replace to process all corrections
@@ -24,13 +34,18 @@ class BritishEnglishConverter
      */
     public function convert(string $text): string
     {
-        $corrections = $this->getCorrections();
+        if ($this->patterns === null || $this->replacements === null) {
+            $corrections = $this->getCorrections();
 
-        if (empty($corrections)) {
-            return $text;
+            if (empty($corrections)) {
+                return $text;
+            }
+
+            $this->patterns = array_keys($corrections);
+            $this->replacements = array_values($corrections);
         }
 
-        return (string) preg_replace(array_keys($corrections), array_values($corrections), $text);
+        return (string) preg_replace($this->patterns, $this->replacements, $text);
     }
 
     /**

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -43,7 +43,7 @@ class SitemapService
             ->add(
                 Page::query()
                     ->select(['id', 'slug', 'area', 'updated_at', 'description', 'heading'])
-                    ->with(['media', 'meeting'])
+                    ->with(['media'])
                     ->where('admin', 'no')
                     ->get()
             )

--- a/database/migrations/2026_02_28_190200_create_song_author_song_table.php
+++ b/database/migrations/2026_02_28_190200_create_song_author_song_table.php
@@ -43,6 +43,10 @@ return new class extends Migration
 
     private function songsIdColumnType(): string
     {
+        if (DB::getDriverName() === 'sqlite') {
+            return 'unsignedBigInteger';
+        }
+
         $songsIdColumn = DB::selectOne(
             'SELECT COLUMN_TYPE AS column_type
                 FROM information_schema.columns

--- a/database/migrations/2026_02_28_190400_create_song_book_song_table.php
+++ b/database/migrations/2026_02_28_190400_create_song_book_song_table.php
@@ -43,6 +43,10 @@ return new class extends Migration
 
     private function songsIdColumnType(): string
     {
+        if (DB::getDriverName() === 'sqlite') {
+            return 'unsignedBigInteger';
+        }
+
         $songsIdColumn = DB::selectOne(
             'SELECT COLUMN_TYPE AS column_type
                 FROM information_schema.columns

--- a/database/migrations/2026_02_28_190500_add_song_id_to_church_service_items_table.php
+++ b/database/migrations/2026_02_28_190500_add_song_id_to_church_service_items_table.php
@@ -59,6 +59,10 @@ return new class extends Migration
 
     private function songsIdColumnType(): string
     {
+        if (DB::getDriverName() === 'sqlite') {
+            return 'unsignedBigInteger';
+        }
+
         $songsIdColumn = DB::selectOne(
             'SELECT COLUMN_TYPE AS column_type
                 FROM information_schema.columns


### PR DESCRIPTION
This PR implements several performance optimizations targeted at bulk data processing paths, specifically sitemap generation and transcript conversion.

### Changes:
- **Sermon Model**: Added explicit casts for timestamps and optimized the `toSitemapTag` method. By using casted dates and memoizing accessor results into local variables, we avoid repeated configuration lookups and Carbon object instantiation for every sermon in the sitemap.
- **Sitemap Service**: Removed an unnecessary `with('meeting')` eager load when fetching pages for the sitemap, reducing database I/O and memory usage.
- **British English Converter**: Added local property caching for regex patterns and replacements. This ensures that the overhead of `array_keys` and `array_values` on the large corrections array only occurs once per request/job cycle.
- **Test Compatibility**: Fixed three migrations that used MySQL-specific `information_schema` queries without SQLite fallbacks, allowing the test suite to run in the sandbox environment.

### Impact:
- **Sitemap Generation**: Significant reduction in CPU cycles and memory allocation when generating sitemaps with hundreds of sermons.
- **Transcript Conversion**: Improved throughput for bulk transcript processing by caching regex structures.
- **Testing**: Improved developer experience by enabling a functional SQLite-based test environment.

---
*PR created automatically by Jules for task [10223237652367948213](https://jules.google.com/task/10223237652367948213) started by @GarethClarridge*