### PR TITLE
📝 Scribe: Add tests for MediaProcessingIdentityResolver

### DIFF
--- a/app/Services/MediaProcessingIdentityResolver.php
+++ b/app/Services/MediaProcessingIdentityResolver.php
@@ -100,7 +100,7 @@ class MediaProcessingIdentityResolver
 
         return $query->where(function (Builder $query) use ($date, $serviceValue): void {
             $query->where(function (Builder $query) use ($date, $serviceValue): void {
-                $query->where('extracted_date', $date)
+                $query->whereDate('extracted_date', $date)
                     ->where('extracted_service', $serviceValue);
             })->orWhere(function (Builder $query) use ($date, $serviceValue): void {
                 $query->where(function (Builder $query): void {

--- a/database/migrations/2026_02_28_190200_create_song_author_song_table.php
+++ b/database/migrations/2026_02_28_190200_create_song_author_song_table.php
@@ -43,6 +43,10 @@ return new class extends Migration
 
     private function songsIdColumnType(): string
     {
+        if (DB::getDriverName() === 'sqlite') {
+            return 'unsignedBigInteger';
+        }
+
         $songsIdColumn = DB::selectOne(
             'SELECT COLUMN_TYPE AS column_type
                 FROM information_schema.columns

--- a/database/migrations/2026_02_28_190400_create_song_book_song_table.php
+++ b/database/migrations/2026_02_28_190400_create_song_book_song_table.php
@@ -43,6 +43,10 @@ return new class extends Migration
 
     private function songsIdColumnType(): string
     {
+        if (DB::getDriverName() === 'sqlite') {
+            return 'unsignedBigInteger';
+        }
+
         $songsIdColumn = DB::selectOne(
             'SELECT COLUMN_TYPE AS column_type
                 FROM information_schema.columns

--- a/database/migrations/2026_02_28_190500_add_song_id_to_church_service_items_table.php
+++ b/database/migrations/2026_02_28_190500_add_song_id_to_church_service_items_table.php
@@ -59,6 +59,10 @@ return new class extends Migration
 
     private function songsIdColumnType(): string
     {
+        if (DB::getDriverName() === 'sqlite') {
+            return 'unsignedBigInteger';
+        }
+
         $songsIdColumn = DB::selectOne(
             'SELECT COLUMN_TYPE AS column_type
                 FROM information_schema.columns

--- a/tests/Feature/MediaProcessingIdentityResolverTest.php
+++ b/tests/Feature/MediaProcessingIdentityResolverTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\SermonService;
+use App\Models\MediaProcessingLog;
+use App\Services\MediaProcessingIdentityResolver;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MediaProcessingIdentityResolverTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private MediaProcessingIdentityResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resolver = new MediaProcessingIdentityResolver;
+    }
+
+    #[Test]
+    public function it_resolves_identity_from_explicit_columns(): void
+    {
+        $log = MediaProcessingLog::factory()->create([
+            'extracted_date' => '2024-05-12',
+            'extracted_service' => SermonService::MORNING,
+            'processing_metadata' => [
+                'extracted_date' => '2024-05-13', // Should be ignored
+                'extracted_service' => SermonService::EVENING->value, // Should be ignored
+            ],
+        ]);
+
+        $identity = $this->resolver->resolve($log);
+
+        $this->assertNotNull($identity);
+        $this->assertEquals('2024-05-12', $identity['date']);
+        $this->assertEquals(SermonService::MORNING, $identity['service']);
+    }
+
+    #[Test]
+    public function it_resolves_identity_from_metadata_when_columns_are_null(): void
+    {
+        $log = MediaProcessingLog::factory()->create([
+            'extracted_date' => null,
+            'extracted_service' => null,
+            'processing_metadata' => [
+                'extracted_date' => '2024-05-13',
+                'extracted_service' => SermonService::EVENING->value,
+            ],
+        ]);
+
+        $identity = $this->resolver->resolve($log);
+
+        $this->assertNotNull($identity);
+        $this->assertEquals('2024-05-13', $identity['date']);
+        $this->assertEquals(SermonService::EVENING, $identity['service']);
+    }
+
+    #[Test]
+    public function it_returns_null_when_identity_cannot_be_resolved(): void
+    {
+        $log = MediaProcessingLog::factory()->create([
+            'extracted_date' => null,
+            'extracted_service' => null,
+            'processing_metadata' => [],
+        ]);
+
+        $this->assertNull($this->resolver->resolve($log));
+    }
+
+    #[Test]
+    public function it_parses_valid_date(): void
+    {
+        $this->assertEquals('2024-05-12', $this->resolver->parseDate('2024-05-12'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_invalid_date_format(): void
+    {
+        $this->assertNull($this->resolver->parseDate('12-05-2024'));
+        $this->assertNull($this->resolver->parseDate('2024-05-32'));
+        $this->assertNull($this->resolver->parseDate('not-a-date'));
+        $this->assertNull($this->resolver->parseDate(''));
+        $this->assertNull($this->resolver->parseDate(null));
+    }
+
+    #[Test]
+    public function it_parses_valid_service(): void
+    {
+        $this->assertEquals(SermonService::MORNING, $this->resolver->parseService('morning'));
+        $this->assertEquals(SermonService::EVENING, $this->resolver->parseService('evening'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_invalid_service(): void
+    {
+        $this->assertNull($this->resolver->parseService('invalid'));
+        $this->assertNull($this->resolver->parseService(''));
+        $this->assertNull($this->resolver->parseService(null));
+    }
+
+    #[Test]
+    public function it_checks_if_log_matches_identity(): void
+    {
+        $log = MediaProcessingLog::factory()->create([
+            'extracted_date' => '2024-05-12',
+            'extracted_service' => SermonService::MORNING,
+        ]);
+
+        $this->assertTrue($this->resolver->matchesService($log, '2024-05-12', SermonService::MORNING));
+        $this->assertFalse($this->resolver->matchesService($log, '2024-05-13', SermonService::MORNING));
+        $this->assertFalse($this->resolver->matchesService($log, '2024-05-12', SermonService::EVENING));
+    }
+
+    #[Test]
+    public function it_scopes_query_to_match_identity_via_columns(): void
+    {
+        MediaProcessingLog::factory()->create([
+            'extracted_date' => '2024-05-12',
+            'extracted_service' => SermonService::MORNING,
+        ]);
+
+        MediaProcessingLog::factory()->create([
+            'extracted_date' => '2024-05-13',
+            'extracted_service' => SermonService::MORNING,
+        ]);
+
+        $query = MediaProcessingLog::query();
+        $this->resolver->scopeMatchesIdentity($query, '2024-05-12', SermonService::MORNING);
+
+        $results = $query->get();
+        $this->assertCount(1, $results);
+        $this->assertEquals('2024-05-12', $results->first()->extracted_date->toDateString());
+    }
+
+    #[Test]
+    public function it_scopes_query_to_match_identity_via_metadata(): void
+    {
+        MediaProcessingLog::factory()->create([
+            'extracted_date' => null,
+            'extracted_service' => null,
+            'processing_metadata' => [
+                'extracted_date' => '2024-05-12',
+                'extracted_service' => SermonService::MORNING->value,
+            ],
+        ]);
+
+        MediaProcessingLog::factory()->create([
+            'extracted_date' => null,
+            'extracted_service' => null,
+            'processing_metadata' => [
+                'extracted_date' => '2024-05-13',
+                'extracted_service' => SermonService::MORNING->value,
+            ],
+        ]);
+
+        $query = MediaProcessingLog::query();
+        $this->resolver->scopeMatchesIdentity($query, '2024-05-12', SermonService::MORNING);
+
+        $results = $query->get();
+        $this->assertCount(1, $results);
+        $this->assertEquals('2024-05-12', $results->first()->processing_metadata['extracted_date']);
+    }
+}


### PR DESCRIPTION
This PR adds comprehensive test coverage for the `MediaProcessingIdentityResolver` service, which was previously untested. 

Key changes:
- **New Test**: Added `tests/Feature/MediaProcessingIdentityResolverTest.php` covering `resolve()`, `parseDate()`, `parseService()`, and the `scopeMatchesIdentity()` query scope.
- **Bug Fix**: Fixed `MediaProcessingIdentityResolver::scopeMatchesIdentity` to use `whereDate` instead of a raw `where` clause. This ensures that date comparisons work correctly across different database drivers (especially SQLite which often stores dates as strings).
- **SQLite Compatibility**: Patched three migrations that were using raw MySQL queries to inspect column types. These now have a fallback for SQLite, allowing the full migration suite to run in memory or on a local SQLite file during testing.

These changes improve both the reliability of the media processing pipeline and the maintainability of the test suite.

---
*PR created automatically by Jules for task [16968397592269122758](https://jules.google.com/task/16968397592269122758) started by @GarethClarridge*