### PR TITLE
⚡ Bolt: Performance optimizations for BritishEnglishConverter and SitemapService

### DIFF
--- a/app/Services/BritishEnglishConverter.php
+++ b/app/Services/BritishEnglishConverter.php
@@ -11,6 +11,12 @@ class BritishEnglishConverter
 
     private const CACHE_TTL = 86400; // 24 hours
 
+    /** @var array<int, string>|null */
+    private ?array $patterns = null;
+
+    /** @var array<int, string>|null */
+    private ?array $replacements = null;
+
     /**
      * Convert American English text to British English
      *
@@ -19,18 +25,27 @@ class BritishEnglishConverter
      * preg_replace multiple times. This is significantly more efficient when
      * dealing with large word lists or long transcripts.
      *
+     * Derived regex patterns and replacements are cached in local class properties
+     * after the first extraction to avoid redundant array operations and cache
+     * lookups across multiple calls in the same request or job.
+     *
      * @param  string  $text  Text to convert
      * @return string Converted text
      */
     public function convert(string $text): string
     {
-        $corrections = $this->getCorrections();
+        if ($this->patterns === null || $this->replacements === null) {
+            $corrections = $this->getCorrections();
 
-        if (empty($corrections)) {
-            return $text;
+            if (empty($corrections)) {
+                return $text;
+            }
+
+            $this->patterns = array_keys($corrections);
+            $this->replacements = array_values($corrections);
         }
 
-        return (string) preg_replace(array_keys($corrections), array_values($corrections), $text);
+        return (string) preg_replace($this->patterns, $this->replacements, $text);
     }
 
     /**
@@ -185,6 +200,8 @@ class BritishEnglishConverter
     public function clearCache(): void
     {
         Cache::forget(self::CACHE_KEY);
+        $this->patterns = null;
+        $this->replacements = null;
     }
 
     /**

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -43,7 +43,11 @@ class SitemapService
             ->add(
                 Page::query()
                     ->select(['id', 'slug', 'area', 'updated_at', 'description', 'heading'])
-                    ->with(['media', 'meeting'])
+                    /**
+                     * Performance Optimization: Only eager load 'media' (needed for images),
+                     * and remove 'meeting' as it is not utilized in sitemap generation.
+                     */
+                    ->with(['media'])
                     ->where('admin', 'no')
                     ->get()
             )

--- a/database/migrations/2026_02_28_190200_create_song_author_song_table.php
+++ b/database/migrations/2026_02_28_190200_create_song_author_song_table.php
@@ -43,6 +43,10 @@ return new class extends Migration
 
     private function songsIdColumnType(): string
     {
+        if (DB::getDriverName() === 'sqlite') {
+            return 'unsignedBigInteger';
+        }
+
         $songsIdColumn = DB::selectOne(
             'SELECT COLUMN_TYPE AS column_type
                 FROM information_schema.columns

--- a/database/migrations/2026_02_28_190400_create_song_book_song_table.php
+++ b/database/migrations/2026_02_28_190400_create_song_book_song_table.php
@@ -43,6 +43,10 @@ return new class extends Migration
 
     private function songsIdColumnType(): string
     {
+        if (DB::getDriverName() === 'sqlite') {
+            return 'unsignedBigInteger';
+        }
+
         $songsIdColumn = DB::selectOne(
             'SELECT COLUMN_TYPE AS column_type
                 FROM information_schema.columns

--- a/database/migrations/2026_02_28_190500_add_song_id_to_church_service_items_table.php
+++ b/database/migrations/2026_02_28_190500_add_song_id_to_church_service_items_table.php
@@ -59,6 +59,10 @@ return new class extends Migration
 
     private function songsIdColumnType(): string
     {
+        if (DB::getDriverName() === 'sqlite') {
+            return 'unsignedBigInteger';
+        }
+
         $songsIdColumn = DB::selectOne(
             'SELECT COLUMN_TYPE AS column_type
                 FROM information_schema.columns


### PR DESCRIPTION
I have implemented two key performance optimizations:

1. **BritishEnglishConverter Memoization**: The service now caches its compiled regex patterns and replacements in private class properties after the first load. This significantly reduces redundant cache lookups and array operations (`array_keys`, `array_values`) when processing multiple transcript paragraphs within a single request or background job.

2. **SitemapService Eager Loading**: Removed the `'meeting'` relationship from the eager-loading call in the `Page` query. This relationship is not used in sitemap generation, so removing it eliminates an unnecessary database query and reduces memory usage.

Additionally, I fixed three migrations (`create_song_author_song_table`, `create_song_book_song_table`, `add_song_id_to_church_service_items_table`) that were crashing in SQLite environments (used for testing) due to MySQL-specific `information_schema` queries. These now correctly fall back to `unsignedBigInteger` when using the SQLite driver.

Verification:
- Ran `tests/Unit/Services/BritishEnglishConverterTest.php` (passed).
- Ran `tests/Feature/SitemapTest.php` (passed after environment fixes).
- Verified with `phpstan` and `pint`.

---
*PR created automatically by Jules for task [18005318142132830122](https://jules.google.com/task/18005318142132830122) started by @GarethClarridge*