### PR TITLE
⚡ Bolt: optimize BritishEnglishConverter and migrations

### DIFF
--- a/app/Services/BritishEnglishConverter.php
+++ b/app/Services/BritishEnglishConverter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services;
 
 use Illuminate\Support\Facades\Cache;
@@ -11,26 +13,37 @@ class BritishEnglishConverter
 
     private const CACHE_TTL = 86400; // 24 hours
 
+    /** @var array<int, string>|null */
+    private ?array $patterns = null;
+
+    /** @var array<int, string>|null */
+    private ?array $replacements = null;
+
     /**
      * Convert American English text to British English
      *
      * Performance Optimization: Uses array-based preg_replace to process all corrections
-     * in a single pass through the regex engine, rather than looping and calling
-     * preg_replace multiple times. This is significantly more efficient when
-     * dealing with large word lists or long transcripts.
+     * in a single pass through the regex engine. Patterns and replacements are memoized
+     * in class properties after the first load to avoid redundant cache hits and
+     * array_keys/array_values operations during bulk processing.
      *
      * @param  string  $text  Text to convert
      * @return string Converted text
      */
     public function convert(string $text): string
     {
-        $corrections = $this->getCorrections();
+        if ($this->patterns === null || $this->replacements === null) {
+            $corrections = $this->getCorrections();
 
-        if (empty($corrections)) {
-            return $text;
+            if (empty($corrections)) {
+                return $text;
+            }
+
+            $this->patterns = array_keys($corrections);
+            $this->replacements = array_values($corrections);
         }
 
-        return (string) preg_replace(array_keys($corrections), array_values($corrections), $text);
+        return (string) preg_replace($this->patterns, $this->replacements, $text);
     }
 
     /**
@@ -185,6 +198,8 @@ class BritishEnglishConverter
     public function clearCache(): void
     {
         Cache::forget(self::CACHE_KEY);
+        $this->patterns = null;
+        $this->replacements = null;
     }
 
     /**

--- a/database/migrations/2026_02_28_190200_create_song_author_song_table.php
+++ b/database/migrations/2026_02_28_190200_create_song_author_song_table.php
@@ -43,6 +43,10 @@ return new class extends Migration
 
     private function songsIdColumnType(): string
     {
+        if (DB::getDriverName() === 'sqlite') {
+            return 'unsignedBigInteger';
+        }
+
         $songsIdColumn = DB::selectOne(
             'SELECT COLUMN_TYPE AS column_type
                 FROM information_schema.columns

--- a/database/migrations/2026_02_28_190400_create_song_book_song_table.php
+++ b/database/migrations/2026_02_28_190400_create_song_book_song_table.php
@@ -43,6 +43,10 @@ return new class extends Migration
 
     private function songsIdColumnType(): string
     {
+        if (DB::getDriverName() === 'sqlite') {
+            return 'unsignedBigInteger';
+        }
+
         $songsIdColumn = DB::selectOne(
             'SELECT COLUMN_TYPE AS column_type
                 FROM information_schema.columns

--- a/database/migrations/2026_02_28_190500_add_song_id_to_church_service_items_table.php
+++ b/database/migrations/2026_02_28_190500_add_song_id_to_church_service_items_table.php
@@ -59,6 +59,10 @@ return new class extends Migration
 
     private function songsIdColumnType(): string
     {
+        if (DB::getDriverName() === 'sqlite') {
+            return 'unsignedBigInteger';
+        }
+
         $songsIdColumn = DB::selectOne(
             'SELECT COLUMN_TYPE AS column_type
                 FROM information_schema.columns


### PR DESCRIPTION
Implemented property-based memoization in `BritishEnglishConverter` to significantly reduce overhead during bulk processing of sermon transcripts. By caching derived regex patterns and replacements in class properties after the first load, we avoid redundant `Cache::get()` calls and expensive `array_keys`/`array_values` operations on every `convert()` call.

Additionally, updated multiple migrations to bypass `information_schema` lookups when running on SQLite. This eliminates unnecessary database overhead and prevents migration failures in SQLite-based testing environments, resulting in faster and more reliable test cycles.

💡 **What:** Added class-property memoization to `BritishEnglishConverter` and optimized migration schema checks for SQLite.
🎯 **Why:** `BritishEnglishConverter::convert()` was hitting the cache and performing redundant array manipulations on every call, which adds up during bulk transcript formatting. Migrations were performing expensive and incompatible schema queries on SQLite.
📊 **Impact:** Reduces CPU and memory overhead during bulk text processing. Speeds up the migration phase of the test suite by avoiding complex schema lookups.
🔬 **Measurement:** Verified with `BritishEnglishConverterTest` and full test suite execution.

---
*PR created automatically by Jules for task [915425269948044028](https://jules.google.com/task/915425269948044028) started by @GarethClarridge*