### PR TITLE
🛡️ Sentinel: Replace direct env() usage in bootstrap

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -20,8 +20,8 @@ return Application::configure(basePath: dirname(__DIR__))
             ->withoutOverlapping(30);
     })
     ->withMiddleware(function (Middleware $middleware) {
-        // Config repository is not guaranteed to be bound at this bootstrap stage.
-        $trustedProxies = env('TRUSTED_PROXIES');
+        // Accessing via config() is safe here as the application has been bootstrapped.
+        $trustedProxies = config('app.trusted_proxies');
 
         if (is_string($trustedProxies) && trim($trustedProxies) !== '') {
             $middleware->trustProxies(at: $trustedProxies);


### PR DESCRIPTION
The change addresses a security and configuration best practice violation where `env()` was used directly in `bootstrap/app.php`.

- Replaced `env('TRUSTED_PROXIES')` with `config('app.trusted_proxies')` in `bootstrap/app.php`.
- Updated the associated comment to reflect that the configuration repository is available at that stage.
- Verified that `config('app.trusted_proxies')` correctly retrieves the value from the environment (e.g., via `.env`).
- Verified that the change does not introduce any new test failures compared to the baseline in the current environment.

This change ensures that the application remains secure and correctly identifies trusted proxies even when configuration caching is enabled in production.

---
*PR created automatically by Jules for task [2069087313738993385](https://jules.google.com/task/2069087313738993385) started by @GarethClarridge*