### PR TITLE
🎨 Palette: Accessible Smooth Scroll and Back-to-Top Button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,7 @@
 ## 2026-04-02 - Centralized Filter Bar UX
 **Learning:** Centralizing the "Clear Filters" logic into the base `x-admin.filter-bar` component ensures consistent positioning and behavior across all admin listings. By leveraging `$wire.hasFilters`, the component can automatically provide feedback and an escape hatch for filtered states without per-view boilerplate. This reduces maintenance overhead and ensures a predictable UX for administrators navigating different data types.
 **Action:** Use the `x-admin.filter-bar` to automatically handle filter-clearing logic. Provide a `resetAction` prop to allow customization when the default `resetFilters` method is not used.
+
+## 2026-04-09 - Accessible Smooth Scrolling and Navigation
+**Learning:** Large pages (like date-grouped sermon lists) benefit from "Back to top" functionality to reduce scroll fatigue. Implementing this with `scroll-behavior: smooth` provides a pleasant transition, but it MUST be wrapped in a `@media (prefers-reduced-motion: no-preference)` block to respect accessibility settings for users with motion sensitivities. Using Alpine.js to show/hide the button based on a scroll threshold (e.g., 400px) keeps the UI clean and ensures the button is only present when useful.
+**Action:** Always wrap `scroll-behavior: smooth` in a media query checking for `no-preference`. Use Alpine.js for scroll-based visibility transitions and ensure the button is fully keyboard accessible with proper ARIA labels.

--- a/resources/css/app.scss
+++ b/resources/css/app.scss
@@ -14,6 +14,12 @@
     [x-cloak] {
         display: none !important;
     }
+
+    @media (prefers-reduced-motion: no-preference) {
+        html {
+            scroll-behavior: smooth;
+        }
+    }
 }
 
 @font-face { 

--- a/resources/views/components/back-to-top.blade.php
+++ b/resources/views/components/back-to-top.blade.php
@@ -13,7 +13,7 @@
 >
     <button
         type="button"
-        @click="window.scrollTo(0, 0)"
+        @click="window.scrollTo({ top: 0, behavior: 'smooth' })"
         aria-label="Back to top"
         title="Back to top"
         class="flex h-12 w-12 items-center justify-center rounded-full bg-cbc-teal text-white shadow-lg transition-all hover:bg-cbc-teal-dark hover:shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 active:scale-95"

--- a/resources/views/components/back-to-top.blade.php
+++ b/resources/views/components/back-to-top.blade.php
@@ -1,7 +1,7 @@
 <div
     x-data="{ show: false }"
-    x-on:scroll.window="show = window.scrollY > 400"
-    class="fixed bottom-8 right-8 z-40"
+    x-on:scroll.window.throttle.100ms="show = window.scrollY > 400"
+    class="fixed bottom-4 right-4 z-40 sm:bottom-8 sm:right-8"
     x-show="show"
     x-transition:enter="transition ease-out duration-300"
     x-transition:enter-start="opacity-0 translate-y-10"
@@ -13,7 +13,7 @@
 >
     <button
         type="button"
-        @click="window.scrollTo({ top: 0, behavior: 'smooth' })"
+        @click="window.scrollTo(0, 0)"
         aria-label="Back to top"
         title="Back to top"
         class="flex h-12 w-12 items-center justify-center rounded-full bg-cbc-teal text-white shadow-lg transition-all hover:bg-cbc-teal-dark hover:shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 active:scale-95"

--- a/resources/views/components/back-to-top.blade.php
+++ b/resources/views/components/back-to-top.blade.php
@@ -1,0 +1,23 @@
+<div
+    x-data="{ show: false }"
+    x-on:scroll.window="show = window.scrollY > 400"
+    class="fixed bottom-8 right-8 z-40"
+    x-show="show"
+    x-transition:enter="transition ease-out duration-300"
+    x-transition:enter-start="opacity-0 translate-y-10"
+    x-transition:enter-end="opacity-100 translate-y-0"
+    x-transition:leave="transition ease-in duration-300"
+    x-transition:leave-start="opacity-100 translate-y-0"
+    x-transition:leave-end="opacity-0 translate-y-10"
+    x-cloak
+>
+    <button
+        type="button"
+        @click="window.scrollTo({ top: 0, behavior: 'smooth' })"
+        aria-label="Back to top"
+        title="Back to top"
+        class="flex h-12 w-12 items-center justify-center rounded-full bg-cbc-teal text-white shadow-lg transition-all hover:bg-cbc-teal-dark hover:shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 active:scale-95"
+    >
+        <x-heroicon-o-chevron-up class="h-6 w-6" aria-hidden="true" />
+    </button>
+</div>

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -98,6 +98,8 @@
     <x-layout.footer />
   </footer>
 
+  <x-back-to-top />
+
   {{-- Livewire Scripts --}}
   @livewireScripts
 </body>

--- a/tests/Feature/Components/BackToTopTest.php
+++ b/tests/Feature/Components/BackToTopTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Components;
+
+use Illuminate\Support\Facades\Blade;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class BackToTopTest extends TestCase
+{
+    #[Test]
+    public function it_exists_as_a_file(): void
+    {
+        $this->assertTrue(file_exists(resource_path('views/components/back-to-top.blade.php')));
+    }
+
+    #[Test]
+    public function it_renders_the_correct_alpine_directives(): void
+    {
+        $rendered = Blade::render('<x-back-to-top />');
+
+        $this->assertStringContainsString('x-on:scroll.window.throttle.100ms="show = window.scrollY > 400"', $rendered);
+        $this->assertStringContainsString('aria-label="Back to top"', $rendered);
+        $this->assertStringContainsString('window.scrollTo(0, 0)', $rendered);
+    }
+}

--- a/tests/Feature/Components/BackToTopTest.php
+++ b/tests/Feature/Components/BackToTopTest.php
@@ -23,6 +23,6 @@ class BackToTopTest extends TestCase
 
         $this->assertStringContainsString('x-on:scroll.window.throttle.100ms="show = window.scrollY > 400"', $rendered);
         $this->assertStringContainsString('aria-label="Back to top"', $rendered);
-        $this->assertStringContainsString('window.scrollTo(0, 0)', $rendered);
+        $this->assertStringContainsString('window.scrollTo({ top: 0, behavior: \'smooth\' })', $rendered);
     }
 }


### PR DESCRIPTION
💡 **What:** Added global smooth scrolling for anchor links and a reactive "Back to top" button that appears after scrolling down 400px.

🎯 **Why:** Improves navigation on long pages (like sermon lists and transcripts), reducing scroll fatigue for users.

♿ **Accessibility:**
- Smooth scroll is only enabled for users who do not prefer reduced motion (`@media (prefers-reduced-motion: no-preference)`).
- The "Back to top" button is fully keyboard-accessible, has a clear `aria-label`, and includes focus-visible styling.
- Visibility transitions use `x-transition` for a non-jarring experience.

📱 **Responsive:** The button is fixed to the bottom right and maintains its position across all screen sizes.

---
*PR created automatically by Jules for task [12031151427364780044](https://jules.google.com/task/12031151427364780044) started by @GarethClarridge*