### PR TITLE
🧹 Tidy: Improve Job Type Safety and Property Visibility

### DIFF
--- a/app/Jobs/AnalyzeSegments.php
+++ b/app/Jobs/AnalyzeSegments.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Jobs;
 
 use App\Data\LivestreamSegment;

--- a/app/Jobs/CleanupTemporaryFiles.php
+++ b/app/Jobs/CleanupTemporaryFiles.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Jobs;
 
 use App\Enums\MediaType;

--- a/app/Jobs/CreateSermonRecord.php
+++ b/app/Jobs/CreateSermonRecord.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Jobs;
 
 use App\Data\SermonCreationOptions;

--- a/app/Jobs/ExtractSermon.php
+++ b/app/Jobs/ExtractSermon.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Jobs;
 
 use App\Data\LivestreamSegment;

--- a/app/Jobs/GenerateRmsLog.php
+++ b/app/Jobs/GenerateRmsLog.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Jobs;
 
 use App\Models\MediaProcessingLog;

--- a/app/Jobs/IdentifySpeaker.php
+++ b/app/Jobs/IdentifySpeaker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Jobs;
 
 use App\Contracts\SpeakerIdentificationInterface;

--- a/app/Jobs/PerformVisualAnalysis.php
+++ b/app/Jobs/PerformVisualAnalysis.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Jobs;
 
 use App\Models\MediaProcessingLog;

--- a/app/Jobs/ProcessTranscriptWithAI.php
+++ b/app/Jobs/ProcessTranscriptWithAI.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Jobs;
 
 use App\Actions\QueueScriptureEnrichment;
@@ -33,7 +35,7 @@ class ProcessTranscriptWithAI extends ProcessingJob implements ShouldQueue
      * Create a new job instance.
      */
     public function __construct(
-        private MediaProcessingLog $processingLog,
+        private readonly MediaProcessingLog $processingLog,
     ) {}
 
     /**

--- a/app/Jobs/ProcessingJob.php
+++ b/app/Jobs/ProcessingJob.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Jobs;
 
 use App\Enums\ProcessingStatus;

--- a/app/Jobs/SendCompletionNotification.php
+++ b/app/Jobs/SendCompletionNotification.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Jobs;
 
 use App\Models\MediaProcessingLog;

--- a/app/Jobs/SubmitToProcessing.php
+++ b/app/Jobs/SubmitToProcessing.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Jobs;
 
 use App\Data\SermonCreationOptions;

--- a/app/Jobs/TranscribeAudio.php
+++ b/app/Jobs/TranscribeAudio.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Jobs;
 
 use App\Contracts\TranscriptionServiceInterface;
@@ -32,7 +34,7 @@ class TranscribeAudio extends ProcessingJob implements ShouldQueue
      * Create a new job instance.
      */
     public function __construct(
-        public MediaProcessingLog $processingLog,
+        public readonly MediaProcessingLog $processingLog,
     ) {}
 
     /**


### PR DESCRIPTION
This PR improves the code quality and type safety of background jobs in the `app/Jobs` directory. 

Specifically:
- **Strict Types**: Added `declare(strict_types=1);` to 12 Job classes (`ProcessingJob`, `TranscribeAudio`, `ExtractSermon`, `IdentifySpeaker`, `ProcessTranscriptWithAI`, `CleanupTemporaryFiles`, `CreateSermonRecord`, `GenerateRmsLog`, `SendCompletionNotification`, `SubmitToProcessing`, `PerformVisualAnalysis`, and `AnalyzeSegments`) to align with project conventions and prevent accidental type coercion.
- **Readonly Properties**: Applied the `readonly` keyword to constructor-promoted properties in `TranscribeAudio` and `ProcessTranscriptWithAI`. 
- **Refinement**: Other jobs initially targeted for `readonly` properties were kept mutable because they reassign their state via `$this->processingLog->fresh()` or through the `ChecksCancellation` trait.

**Behavior**: No functional changes.
**Verification**: 
- Static analysis: `composer phpstan` returned 0 errors.
- Formatting: `bin/pint --dirty` verified project style compliance.
- Tests: Ran all tests in `tests/Unit/Jobs` and `tests/Feature/Jobs`. All relevant tests passed. Pre-existing failures in the environment (e.g. `AutoPublishServiceSectionTest`) were confirmed to be unrelated to these changes.

---
*PR created automatically by Jules for task [1000279455376556917](https://jules.google.com/task/1000279455376556917) started by @GarethClarridge*