### PR TITLE
Implement audit logging for destructive administrative actions

### DIFF
--- a/app/Http/Controllers/Admin/SermonAdminController.php
+++ b/app/Http/Controllers/Admin/SermonAdminController.php
@@ -26,6 +26,12 @@ class SermonAdminController extends Controller
     {
         $this->authorize('delete', $sermon);
 
+        Log::warning('Sermon deleted by admin (via controller)', [
+            'admin_id' => auth()->id(),
+            'sermon_id' => $sermon->id,
+            'title' => $sermon->title,
+        ]);
+
         $sermon->delete();
 
         return redirect()->route('sermons.index')->with('message', 'Sermon successfully deleted!');

--- a/app/Http/Controllers/Admin/SermonAdminController.php
+++ b/app/Http/Controllers/Admin/SermonAdminController.php
@@ -26,7 +26,7 @@ class SermonAdminController extends Controller
     {
         $this->authorize('delete', $sermon);
 
-        Log::warning('Sermon deleted by admin (via controller)', [
+        Log::warning('Sermon deleted by admin', [
             'admin_id' => auth()->id(),
             'sermon_id' => $sermon->id,
             'title' => $sermon->title,

--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -99,7 +99,7 @@ class MeetingController extends Controller
     {
         $this->authorize('delete', $meeting);
 
-        Log::warning('Meeting deleted by admin (via controller)', [
+        Log::warning('Meeting deleted by admin', [
             'admin_id' => auth()->id(),
             'meeting_id' => $meeting->id,
             'slug' => $meeting->slug,

--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -11,6 +11,7 @@ use App\Services\PublicMeetingReadModelCache;
 use App\Services\PublicPageVisibilityGuard;
 use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\View;
@@ -97,6 +98,12 @@ class MeetingController extends Controller
     public function destroy(Meeting $meeting): RedirectResponse
     {
         $this->authorize('delete', $meeting);
+
+        Log::warning('Meeting deleted by admin (via controller)', [
+            'admin_id' => auth()->id(),
+            'meeting_id' => $meeting->id,
+            'slug' => $meeting->slug,
+        ]);
 
         $meetingSlug = $meeting->slug;
         $meeting->delete();

--- a/app/Livewire/Admin/ChurchServices/ReviewInboundEmails.php
+++ b/app/Livewire/Admin/ChurchServices/ReviewInboundEmails.php
@@ -15,6 +15,7 @@ use App\Models\InboundEmail;
 use App\Traits\EscapesLikeWildcards;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -147,6 +148,14 @@ class ReviewInboundEmails extends Component
 
             return;
         }
+
+        Log::warning('Inbound email rejected by admin', [
+            'admin_id' => $userId,
+            'inbound_email_id' => $inboundEmail->id,
+            'message_id' => $inboundEmail->message_id,
+            'from' => $inboundEmail->from,
+            'subject' => $inboundEmail->subject,
+        ]);
 
         $action->execute($inboundEmail, $userId);
 

--- a/app/Livewire/Admin/ChurchServices/ShowChurchService.php
+++ b/app/Livewire/Admin/ChurchServices/ShowChurchService.php
@@ -21,6 +21,7 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Component;
 
@@ -74,6 +75,12 @@ class ShowChurchService extends Component
     {
 
         $this->authorizeAdmin();
+
+        Log::warning('Media processing log deleted by admin', [
+            'admin_id' => auth()->id(),
+            'processing_log_id' => $processingLogId,
+            'church_service_id' => $this->churchService->id,
+        ]);
 
         $processingLog = MediaProcessingLog::query()->find($processingLogId);
         if (! $processingLog instanceof MediaProcessingLog) {

--- a/app/Livewire/Admin/ChurchServices/ShowChurchService.php
+++ b/app/Livewire/Admin/ChurchServices/ShowChurchService.php
@@ -76,12 +76,6 @@ class ShowChurchService extends Component
 
         $this->authorizeAdmin();
 
-        Log::warning('Media processing log deleted by admin', [
-            'admin_id' => auth()->id(),
-            'processing_log_id' => $processingLogId,
-            'church_service_id' => $this->churchService->id,
-        ]);
-
         $processingLog = MediaProcessingLog::query()->find($processingLogId);
         if (! $processingLog instanceof MediaProcessingLog) {
             $this->error('Processing run not found.');
@@ -100,6 +94,12 @@ class ShowChurchService extends Component
 
             return;
         }
+
+        Log::warning('Media processing run reclassification requested by admin', [
+            'admin_id' => auth()->id(),
+            'processing_log_id' => $processingLogId,
+            'church_service_id' => $this->churchService->id,
+        ]);
 
         // Resolve on demand because Livewire serializes component state between requests.
         app(\App\Services\ProcessingRunOrchestrator::class)->reclassify($processingLog);
@@ -140,6 +140,12 @@ class ShowChurchService extends Component
 
             return null;
         }
+
+        Log::warning('Media processing log deleted by admin', [
+            'admin_id' => auth()->id(),
+            'processing_log_id' => $processingLogId,
+            'church_service_id' => $this->churchService->id,
+        ]);
 
         try {
             $result = app(DeleteLivestreamUpload::class)->execute($processingLog);

--- a/app/Livewire/Admin/ChurchServices/ShowSong.php
+++ b/app/Livewire/Admin/ChurchServices/ShowSong.php
@@ -10,6 +10,7 @@ use App\Models\Song;
 use App\Models\SongVideo;
 use App\Services\SongVideoService;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Component;
 
@@ -92,6 +93,14 @@ class ShowSong extends Component
     public function deleteVideo(int $videoId): void
     {
         $video = SongVideo::query()->where('song_id', $this->song->id)->findOrFail($videoId);
+
+        Log::warning('Song video deleted by admin', [
+            'admin_id' => auth()->id(),
+            'video_id' => $video->id,
+            'song_id' => $this->song->id,
+            'song_title' => $this->song->title,
+        ]);
+
         app(SongVideoService::class)->deleteVideo($video);
     }
 

--- a/app/Livewire/Admin/Meetings/ListMeetings.php
+++ b/app/Livewire/Admin/Meetings/ListMeetings.php
@@ -11,6 +11,7 @@ use App\Livewire\Traits\WithNotifications;
 use App\Livewire\Traits\WithSortableListing;
 use App\Models\Meeting;
 use App\Traits\EscapesLikeWildcards;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -81,6 +82,12 @@ class ListMeetings extends Component
     {
 
         $this->authorizeAdmin();
+
+        Log::warning('Meeting deleted by admin', [
+            'admin_id' => auth()->id(),
+            'meeting_id' => $meeting->id,
+            'slug' => $meeting->slug,
+        ]);
 
         $meeting->delete();
         $this->success('Meeting deleted');

--- a/app/Livewire/Admin/Pages/ListPages.php
+++ b/app/Livewire/Admin/Pages/ListPages.php
@@ -11,6 +11,7 @@ use App\Livewire\Traits\WithNotifications;
 use App\Livewire\Traits\WithSortableListing;
 use App\Models\Page;
 use App\Traits\EscapesLikeWildcards;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -80,6 +81,12 @@ class ListPages extends Component
 
         $this->authorizeAdmin();
 
+        Log::warning('Page deleted by admin', [
+            'admin_id' => auth()->id(),
+            'page_id' => $page->id,
+            'heading' => $page->heading,
+        ]);
+
         $page->delete();
         $this->success('Page deleted');
     }
@@ -88,6 +95,11 @@ class ListPages extends Component
     {
 
         $this->authorizeAdmin();
+
+        Log::warning('Pages deleted by admin (batch)', [
+            'admin_id' => auth()->id(),
+            'page_ids' => $this->selected,
+        ]);
 
         Page::whereIn('id', $this->selected)->delete();
         $this->selected = [];

--- a/app/Livewire/Admin/Preachers/EditPreacher.php
+++ b/app/Livewire/Admin/Preachers/EditPreacher.php
@@ -11,6 +11,7 @@ use App\Models\Preacher;
 use App\Models\PreacherAlias;
 use App\Models\SpeakerProfile;
 use App\Models\SpeakerSample;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
 use Livewire\Component;
@@ -106,9 +107,21 @@ class EditPreacher extends Component
 
         $this->authorizeAdmin();
 
-        PreacherAlias::where('id', $aliasId)
+        $alias = PreacherAlias::where('id', $aliasId)
             ->where('preacher_id', $this->preacher->id)
-            ->delete();
+            ->first();
+
+        if ($alias) {
+            Log::warning('Preacher alias removed by admin', [
+                'admin_id' => auth()->id(),
+                'preacher_id' => $this->preacher->id,
+                'preacher_name' => $this->preacher->name,
+                'alias_id' => $alias->id,
+                'alias' => $alias->alias,
+            ]);
+
+            $alias->delete();
+        }
 
         $this->preacher->refresh();
     }
@@ -157,9 +170,20 @@ class EditPreacher extends Component
 
         $this->authorizeAdmin();
 
-        SpeakerProfile::where('id', $profileId)
+        $profile = SpeakerProfile::where('id', $profileId)
             ->where('preacher_id', $this->preacher->id)
-            ->update(['is_active' => false]);
+            ->first();
+
+        if ($profile) {
+            Log::warning('Speaker profile deactivated by admin', [
+                'admin_id' => auth()->id(),
+                'preacher_id' => $this->preacher->id,
+                'preacher_name' => $this->preacher->name,
+                'profile_id' => $profile->id,
+            ]);
+
+            $profile->update(['is_active' => false]);
+        }
 
         $this->success('Speaker profile deactivated. This preacher will no longer be matched automatically.');
         $this->preacher->refresh();

--- a/app/Livewire/Admin/Preachers/ListPreachers.php
+++ b/app/Livewire/Admin/Preachers/ListPreachers.php
@@ -10,6 +10,7 @@ use App\Livewire\Traits\WithNotifications;
 use App\Livewire\Traits\WithSortableListing;
 use App\Models\Preacher;
 use App\Traits\EscapesLikeWildcards;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -67,6 +68,12 @@ class ListPreachers extends Component
     {
 
         $this->authorizeAdmin();
+
+        Log::warning('Preacher deleted by admin', [
+            'admin_id' => auth()->id(),
+            'preacher_id' => $preacher->id,
+            'name' => $preacher->name,
+        ]);
 
         $preacher->delete();
 

--- a/app/Livewire/Admin/Sermons/ListSermons.php
+++ b/app/Livewire/Admin/Sermons/ListSermons.php
@@ -14,6 +14,7 @@ use App\Models\Sermon;
 use App\Repositories\SermonRepository;
 use App\Traits\EscapesLikeWildcards;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -117,6 +118,12 @@ class ListSermons extends Component
     {
 
         $this->authorizeAdmin();
+
+        Log::warning('Sermon deleted by admin', [
+            'admin_id' => auth()->id(),
+            'sermon_id' => $sermon->id,
+            'title' => $sermon->title,
+        ]);
 
         $sermon->delete();
 

--- a/app/Livewire/Admin/Users/CreateUser.php
+++ b/app/Livewire/Admin/Users/CreateUser.php
@@ -8,6 +8,7 @@ use App\Livewire\Traits\WithAdminAuthorization;
 use App\Livewire\Traits\WithNotifications;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\View\View;
 use Livewire\Component;
@@ -71,6 +72,14 @@ class CreateUser extends Component
         $user->is_admin = $validated['isAdmin'];
         $user->email_verified_at = $this->sendVerification ? null : now();
         $user->save();
+
+        if ($user->is_admin) {
+            Log::warning('New admin user created', [
+                'admin_id' => auth()->id(),
+                'target_user_id' => $user->id,
+                'target_user_email' => $user->email,
+            ]);
+        }
 
         if ($this->sendVerification) {
             $user->sendEmailVerificationNotification();

--- a/tests/Feature/Security/AuditLoggingTest.php
+++ b/tests/Feature/Security/AuditLoggingTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use App\Enums\InboundEmailStatus;
+use App\Livewire\Admin\ChurchServices\ReviewInboundEmails;
+use App\Livewire\Admin\Meetings\ListMeetings;
+use App\Livewire\Admin\Pages\ListPages;
+use App\Livewire\Admin\Preachers\EditPreacher;
+use App\Livewire\Admin\Preachers\ListPreachers;
+use App\Livewire\Admin\Sermons\ListSermons;
+use App\Models\InboundEmail;
+use App\Models\Meeting;
+use App\Models\Page;
+use App\Models\Preacher;
+use App\Models\PreacherAlias;
+use App\Models\Sermon;
+use App\Models\SpeakerProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Log;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AuditLoggingTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
+    }
+
+    #[Test]
+    public function it_logs_sermon_deletion_via_livewire(): void
+    {
+        Log::spy();
+        $sermon = Sermon::factory()->create(['title' => 'Sermon to delete']);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListSermons::class)
+            ->call('delete', $sermon);
+
+        $this->assertDatabaseMissing('sermons', ['id' => $sermon->id]);
+
+        Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Sermon deleted by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['sermon_id'] === $sermon->id &&
+            $context['title'] === 'Sermon to delete'
+        );
+    }
+
+    #[Test]
+    public function it_logs_sermon_deletion_via_controller(): void
+    {
+        Log::spy();
+        $sermon = Sermon::factory()->create(['title' => 'Sermon Title']);
+
+        $this->actingAs($this->admin)
+            ->post(route('sermons.destroy', $sermon->slug))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('sermons', ['id' => $sermon->id]);
+
+        Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Sermon deleted by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['sermon_id'] === $sermon->id &&
+            $context['title'] === 'Sermon Title'
+        );
+    }
+
+    #[Test]
+    public function it_logs_page_deletion_via_livewire(): void
+    {
+        Log::spy();
+        $page = Page::factory()->create(['heading' => 'Page to delete']);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPages::class)
+            ->call('delete', $page);
+
+        $this->assertDatabaseMissing('pages', ['id' => $page->id]);
+
+        Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Page deleted by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['page_id'] === $page->id &&
+            $context['heading'] === 'Page to delete'
+        );
+    }
+
+    #[Test]
+    public function it_logs_bulk_page_deletion_via_livewire(): void
+    {
+        Log::spy();
+        $pages = Page::factory()->count(3)->create();
+        $ids = $pages->pluck('id')->all();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPages::class)
+            ->set('selected', $ids)
+            ->call('deleteSelected');
+
+        foreach ($ids as $id) {
+            $this->assertDatabaseMissing('pages', ['id' => $id]);
+        }
+
+        Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Pages deleted by admin (batch)' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['page_ids'] === $ids
+        );
+    }
+
+    #[Test]
+    public function it_logs_meeting_deletion_via_livewire(): void
+    {
+        Log::spy();
+        $meeting = Meeting::factory()->create(['slug' => 'meeting-slug']);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListMeetings::class)
+            ->call('delete', $meeting);
+
+        $this->assertDatabaseMissing('meetings', ['id' => $meeting->id]);
+
+        Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Meeting deleted by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['meeting_id'] === $meeting->id &&
+            $context['slug'] === 'meeting-slug'
+        );
+    }
+
+    #[Test]
+    public function it_logs_meeting_deletion_via_controller(): void
+    {
+        Log::spy();
+        $meeting = Meeting::factory()->create(['slug' => 'meeting-slug']);
+
+        $this->actingAs($this->admin)
+            ->delete(route('meetings.destroy', $meeting))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('meetings', ['id' => $meeting->id]);
+
+        Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Meeting deleted by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['meeting_id'] === $meeting->id &&
+            $context['slug'] === 'meeting-slug'
+        );
+    }
+
+    #[Test]
+    public function it_logs_preacher_deletion_via_livewire(): void
+    {
+        Log::spy();
+        $preacher = Preacher::factory()->create(['name' => 'Preacher Name']);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPreachers::class)
+            ->call('delete', $preacher);
+
+        $this->assertDatabaseMissing('preachers', ['id' => $preacher->id]);
+
+        Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Preacher deleted by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['preacher_id'] === $preacher->id &&
+            $context['name'] === 'Preacher Name'
+        );
+    }
+
+    #[Test]
+    public function it_logs_preacher_alias_removal(): void
+    {
+        Log::spy();
+        $preacher = Preacher::factory()->create(['name' => 'Preacher Name']);
+        $alias = PreacherAlias::create(['preacher_id' => $preacher->id, 'alias' => 'old alias']);
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPreacher::class, ['preacher' => $preacher])
+            ->call('removeAlias', $alias->id);
+
+        $this->assertDatabaseMissing('preacher_aliases', ['id' => $alias->id]);
+
+        Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Preacher alias removed by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['preacher_id'] === $preacher->id &&
+            $context['alias_id'] === $alias->id &&
+            $context['alias'] === 'old alias'
+        );
+    }
+
+    #[Test]
+    public function it_logs_speaker_profile_deactivation(): void
+    {
+        Log::spy();
+        $preacher = Preacher::factory()->create(['name' => 'Preacher Name']);
+        $profile = SpeakerProfile::factory()->create([
+            'preacher_id' => $preacher->id,
+            'is_active' => true,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPreacher::class, ['preacher' => $preacher])
+            ->call('removeProfile', $profile->id);
+
+        $this->assertDatabaseHas('speaker_profiles', [
+            'id' => $profile->id,
+            'is_active' => false,
+        ]);
+
+        Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Speaker profile deactivated by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['preacher_id'] === $preacher->id &&
+            $context['profile_id'] === $profile->id
+        );
+    }
+
+    #[Test]
+    public function it_logs_inbound_email_rejection_via_livewire(): void
+    {
+        Log::spy();
+        $email = InboundEmail::factory()->create([
+            'status' => InboundEmailStatus::PENDING->value,
+            'subject' => 'Suspicious Email',
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(ReviewInboundEmails::class)
+            ->call('reject', $email->id);
+
+        $email->refresh();
+        $this->assertSame(InboundEmailStatus::REJECTED, $email->status);
+
+        Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Inbound email rejected by admin' &&
+            $context['inbound_email_id'] === $email->id &&
+            $context['subject'] === 'Suspicious Email'
+        );
+    }
+}


### PR DESCRIPTION
Added audit logging (`Log::warning`) for several destructive administrative actions to enhance accountability and security. 

Actions logged include:
- Sermon deletion (via Livewire and Controller)
- Page deletion (individual and batch via Livewire)
- Meeting deletion (via Livewire and Controller)
- Preacher deletion
- Song video deletion
- Media processing log deletion
- Inbound email rejection
- Preacher alias removal
- Speaker profile deactivation
- Admin user creation

Logs include actor ID, target ID, and descriptive identifiers (e.g., title, slug, or name). Logic was added to ensure records exist before logging.

---
*PR created automatically by Jules for task [18112366536372841711](https://jules.google.com/task/18112366536372841711) started by @GarethClarridge*