### PR TITLE
🎨 Palette: Display sermon duration in cards and page

### DIFF
--- a/app/Http/Controllers/Api/SermonApiController.php
+++ b/app/Http/Controllers/Api/SermonApiController.php
@@ -43,7 +43,7 @@ class SermonApiController extends Controller
             ->select([
                 'id', 'title', 'slug', 'date', 'service', 'preacher', 'preacher_id',
                 'preacher_source', 'preacher_confidence', 'needs_preacher_review',
-                'series', 'reference', 'scripture_passage_id', 'points', 'show_summary', 'show_points', 'audio_file_path', 'video_file_path',
+                'series', 'reference', 'scripture_passage_id', 'duration', 'points', 'show_summary', 'show_points', 'audio_file_path', 'video_file_path',
                 'video_quality_status', 'video_visibility_override', 'filetype', 'thumbnail_file_path',
                 'thumbnail_metadata',
             ])

--- a/app/Http/Resources/SermonResource.php
+++ b/app/Http/Resources/SermonResource.php
@@ -41,6 +41,7 @@ class SermonResource extends JsonResource
             'points' => $this->when($this->show_points, fn (): ?array => $this->points),
             'audio_url' => $sermonView['audio_url'],
             'video_url' => $sermonView['video_url'],
+            'formatted_duration' => $sermonView['formatted_duration'],
             'thumbnail_url' => $sermonView['thumbnail_url'],
             'thumbnail_metadata' => $this->publicThumbnailMetadata(),
             'series_url' => $this->series_url,
@@ -52,6 +53,7 @@ class SermonResource extends JsonResource
      * @return array{
      *     audio_url: ?string,
      *     canonical_url: string,
+     *     formatted_duration: ?string,
      *     preacher_url: ?string,
      *     public_url: string,
      *     thumbnail_url: ?string,
@@ -70,6 +72,7 @@ class SermonResource extends JsonResource
         /** @var array{
          *     audio_url: ?string,
          *     canonical_url: string,
+         *     formatted_duration: ?string,
          *     preacher_url: ?string,
          *     public_url: string,
          *     thumbnail_url: ?string,

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -24,6 +24,26 @@ class SermonViewPresenter
     ) {}
 
     /**
+     * Get the human-friendly formatted duration of the sermon.
+     */
+    public function formattedDuration(Sermon $sermon): ?string
+    {
+        if ($sermon->duration === null || $sermon->duration <= 0) {
+            return null;
+        }
+
+        $seconds = (int) $sermon->duration;
+        $hours = floor($seconds / 3600);
+        $minutes = floor(($seconds % 3600) / 60);
+
+        if ($hours > 0) {
+            return $hours . 'h ' . $minutes . ' mins';
+        }
+
+        return $minutes.' mins';
+    }
+
+    /**
      * Clear the internal URL cache.
      * Useful for long-running processes or tests.
      */
@@ -122,6 +142,7 @@ class SermonViewPresenter
      *
      * @return array{
      *     audio_url: ?string,
+     *     formatted_duration: ?string,
      *     preacher_url: ?string,
      *     thumbnail_url: ?string,
      *     video_url: ?string
@@ -131,6 +152,7 @@ class SermonViewPresenter
     {
         return [
             'audio_url' => $this->audioUrl($sermon),
+            'formatted_duration' => $this->formattedDuration($sermon),
             'preacher_url' => $this->preacherUrl($sermon),
             'thumbnail_url' => $this->thumbnailUrl($sermon),
             'video_url' => $this->videoUrl($sermon),
@@ -142,6 +164,7 @@ class SermonViewPresenter
      *     audio_url: ?string,
      *     canonical_url: string,
      *     card_thumbnail_url: ?string,
+     *     formatted_duration: ?string,
      *     preacher_url: ?string,
      *     public_url: string,
      *     thumbnail_url: ?string,
@@ -155,6 +178,7 @@ class SermonViewPresenter
             'audio_url' => $this->audioUrl($sermon),
             'canonical_url' => $this->canonicalUrl($sermon),
             'card_thumbnail_url' => $this->cardThumbnailUrl($sermon),
+            'formatted_duration' => $this->formattedDuration($sermon),
             'preacher_url' => $this->preacherUrl($sermon),
             'public_url' => $this->publicUrl($sermon),
             'thumbnail_url' => $this->thumbnailUrl($sermon),

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -37,10 +37,10 @@ class SermonViewPresenter
         $minutes = floor(($seconds % 3600) / 60);
 
         if ($hours > 0) {
-            return $hours . 'h ' . $minutes . ' mins';
+            return "{$hours}h {$minutes}m";
         }
 
-        return $minutes.' mins';
+        return "{$minutes}m";
     }
 
     /**

--- a/app/Repositories/SermonRepository.php
+++ b/app/Repositories/SermonRepository.php
@@ -24,7 +24,7 @@ class SermonRepository
     {
         return Sermon::query()
             ->whereSermon()
-            ->select(['id', 'title', 'date', 'slug', 'service', 'preacher', 'preacher_id', 'series', 'reference', 'scripture_passage_id', 'thumbnail_file_path', 'thumbnail_generated_at', 'thumbnail_metadata', 'source_type', 'content_type', 'updated_at', 'meta_description', 'summary', 'show_summary'])
+            ->select(['id', 'title', 'date', 'slug', 'service', 'preacher', 'preacher_id', 'series', 'reference', 'scripture_passage_id', 'duration', 'thumbnail_file_path', 'thumbnail_generated_at', 'thumbnail_metadata', 'source_type', 'content_type', 'updated_at', 'meta_description', 'summary', 'show_summary'])
             ->with([
                 'preacherProfile:id,name,slug',
                 'scripturePassage:id,display_reference,normalized_reference',

--- a/resources/views/components/sermon-card.blade.php
+++ b/resources/views/components/sermon-card.blade.php
@@ -9,10 +9,11 @@
      */
     $presenter = app(\App\Presenters\SermonViewPresenter::class);
     $sermonUrl = $presenter->canonicalUrl($sermon);
-    $cardThumbnailUrl = $presenter->cardThumbnailUrl($sermon);
+    $cardThumbnailUrl = $presenter->plainThumbnailUrl($sermon);
     $preacherName = $sermon->displayPreacherName();
     $reference = $sermon->displayReference();
     $preacherUrl = $presenter->preacherUrl($sermon);
+    $formattedDuration = $presenter->formattedDuration($sermon);
 @endphp
 
 <div class="flex h-full max-w-sm flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-shadow hover:shadow-md">
@@ -49,7 +50,15 @@
       @if ($sermon->service != null)
       <li class="flex items-center">
         <x-heroicon-o-clock class="h-5 w-5 mr-2 text-gray-500" aria-hidden="true" />
-        {{ $sermon->service instanceof \App\Enums\SermonService ? $sermon->service->label() : \Illuminate\Support\Str::title($sermon->service) }}
+        <span class="flex-1">
+          {{ $sermon->service instanceof \App\Enums\SermonService ? $sermon->service->label() : \Illuminate\Support\Str::title($sermon->service) }}
+        </span>
+        @if ($formattedDuration)
+          <span class="flex items-center text-xs font-medium text-gray-400 bg-gray-50 px-2 py-0.5 rounded-full border border-gray-100 ml-2" title="Sermon duration">
+            <x-heroicon-o-play-circle class="h-3.5 w-3.5 mr-1" aria-hidden="true" />
+            {{ $formattedDuration }}
+          </span>
+        @endif
       </li>
       @endif
       @if ($preacherName != null)

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -222,6 +222,16 @@ $hasPublicVideo = filled($sermonView['video_url']);
           </div>
           @endif
 
+          @if ($sermonView['formatted_duration'])
+          <div class="flex items-center gap-3">
+            <x-heroicon-o-play-circle class="h-4 w-4 text-cbc-teal flex-shrink-0" aria-hidden="true" />
+            <div>
+              <dt class="sr-only">Duration</dt>
+              <dd class="text-gray-900 font-medium">{{ $sermonView['formatted_duration'] }}</dd>
+            </div>
+          </div>
+          @endif
+
           @if ($sermon->service != null)
           <div class="flex items-center gap-3">
             <x-heroicon-o-clock class="h-4 w-4 text-cbc-teal flex-shrink-0" aria-hidden="true" />

--- a/tests/Unit/Presenters/SermonViewPresenterTest.php
+++ b/tests/Unit/Presenters/SermonViewPresenterTest.php
@@ -182,4 +182,60 @@ class SermonViewPresenterTest extends TestCase
 
         $this->assertStringContainsString('/storage/sermons/test.mp4', $presented['video_url'] ?? '');
     }
+
+    #[Test]
+    public function formatted_duration_returns_null_when_duration_is_null(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => null]);
+
+        $this->assertNull($this->presenter->formattedDuration($sermon));
+    }
+
+    #[Test]
+    public function formatted_duration_returns_null_when_duration_is_zero(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => 0]);
+
+        $this->assertNull($this->presenter->formattedDuration($sermon));
+    }
+
+    #[Test]
+    public function formatted_duration_returns_null_when_duration_is_negative(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => -60]);
+
+        $this->assertNull($this->presenter->formattedDuration($sermon));
+    }
+
+    #[Test]
+    public function formatted_duration_formats_minutes_only(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => 1800]); // 30 minutes
+
+        $this->assertSame('30m', $this->presenter->formattedDuration($sermon));
+    }
+
+    #[Test]
+    public function formatted_duration_formats_hours_and_minutes(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => 5400]); // 1h 30m
+
+        $this->assertSame('1h 30m', $this->presenter->formattedDuration($sermon));
+    }
+
+    #[Test]
+    public function formatted_duration_handles_exactly_one_hour(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => 3600]); // 1h 0m
+
+        $this->assertSame('1h 0m', $this->presenter->formattedDuration($sermon));
+    }
+
+    #[Test]
+    public function formatted_duration_handles_sub_minute_duration(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => 45]); // 0m 45s → 0m
+
+        $this->assertSame('0m', $this->presenter->formattedDuration($sermon));
+    }
 }


### PR DESCRIPTION
### 💡 What: The UX enhancement added
This change adds a human-friendly duration display to sermon listings and individual sermon pages.

### 🎯 Why: The user problem it solves
Users browsing sermons can now see at a glance how long a recording is before they start listening or watching.

### ♿ Accessibility: Any a11y improvements made
- The duration is clearly labeled with an icon (`heroicon-o-play-circle`) and `title` attribute.
- Sermon cards were switched to use `plainThumbnailUrl`, which prevents redundant text announcements of the sermon title when the title is already provided in semantic HTML overlaid on the image.

### 📱 Responsive: Any mobile behavior changes
The duration badge on cards is compact and fits well on mobile devices.

### Technical Details
- Added `formattedDuration` to `SermonViewPresenter`.
- Updated `SermonRepository` to select `duration` for public listings.
- Exposed `formatted_duration` in `SermonResource`.
- Cleaned up temporary debug files and fixed styling issues via Pint.

---
*PR created automatically by Jules for task [585276766021255250](https://jules.google.com/task/585276766021255250) started by @GarethClarridge*