### PR TITLE
🎨 Palette: UX and accessibility improvements for core Blade components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -47,3 +47,7 @@
 ## 2026-04-09 - Accessible Smooth Scrolling and Navigation
 **Learning:** Large pages (like date-grouped sermon lists) benefit from "Back to top" functionality to reduce scroll fatigue. Implementing this with `scroll-behavior: smooth` provides a pleasant transition, but it MUST be wrapped in a `@media (prefers-reduced-motion: no-preference)` block to respect accessibility settings for users with motion sensitivities. Using Alpine.js to show/hide the button based on a scroll threshold (e.g., 400px) keeps the UI clean and ensures the button is only present when useful.
 **Action:** Always wrap `scroll-behavior: smooth` in a media query checking for `no-preference`. Use Alpine.js for scroll-based visibility transitions and ensure the button is fully keyboard accessible with proper ARIA labels.
+
+## 2026-04-10 - Refined Focus States and Form Accessibility Fallbacks
+**Learning:** Transitioning from 'focus:ring' to 'focus-visible:ring' in core interactive components (buttons, toggles) significantly improves UX for mouse users by removing the distracting blue outlines during clicks, while maintaining full accessibility for keyboard users. Additionally, ensuring all form components (like textarea) have an 'aria-label' fallback derived from placeholders ensures that screen reader users can understand the context of an input even when a visual label is absent.
+**Action:** Use 'focus-visible' for all focus rings. Implement 'aria-label' fallbacks in all custom form components where a visual label is optional but a placeholder is present.

--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -11,7 +11,7 @@
 ])
 
 @php
-$baseClasses = 'no-underline rounded-md focus:outline-none focus:ring-2 focus:ring-cbc-teal focus:ring-offset-2 transition-all inline-flex items-center justify-center gap-2';
+$baseClasses = 'no-underline rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 transition-all inline-flex items-center justify-center gap-2';
 
 $sizeClasses = [
     'xs' => 'px-2 py-1 text-xs',

--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -3,7 +3,7 @@
     'prose' => false,
 ])
 
-<div {{ $attributes->merge(['class' => 'rounded-lg shadow bg-white border-1 border-gray-300']) }}>
+<div {{ $attributes->merge(['class' => 'rounded-lg shadow bg-white border border-gray-300']) }}>
     <div class="p-6">
         @isset($heading)
             <h3 class="mb-3 font-display text-2xl">

--- a/resources/views/components/checkbox.blade.php
+++ b/resources/views/components/checkbox.blade.php
@@ -6,6 +6,11 @@ $id = $attributes->get('id', $modelName
     ? str_replace(['.', ' ', '[', ']'], '-', $modelName)
     : ($label ? \Illuminate\Support\Str::slug($label) : 'checkbox-' . \Illuminate\Support\Str::random(8)));
 $hasError = $modelName && $errors->has($modelName);
+
+$describedBy = [];
+if ($hint) $describedBy[] = $id . '-hint';
+if ($hasError) $describedBy[] = $id . '-error';
+$describedBy = implode(' ', $describedBy);
 @endphp
 
 <div class="flex items-start gap-3">
@@ -15,16 +20,17 @@ $hasError = $modelName && $errors->has($modelName);
             @if($id) id="{{ $id }}" @endif
             {{ $attributes->merge(['class' => 'h-4 w-4 rounded border-gray-300 text-cbc-teal focus:ring-cbc-teal' . ($hasError ? ' border-red-300' : '')]) }}
             @checked($checked)
-            @if($hasError) aria-invalid="true" aria-describedby="{{ $id }}-error" @endif
+            @if($hasError) aria-invalid="true" @endif
+            @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
         />
     </div>
     @if($label)
         <div class="text-sm leading-5">
-            <label @if($id) for="{{ $id }}" @endif class="cursor-pointer font-medium text-gray-700">
+            <label @if($id) id="{{ $id }}-label" for="{{ $id }}" @endif class="cursor-pointer font-medium text-gray-700">
                 {{ $label }}
             </label>
             @if($hint)
-                <p class="text-gray-500">{{ $hint }}</p>
+                <p @if($id) id="{{ $id }}-hint" @endif class="text-gray-500">{{ $hint }}</p>
             @endif
         </div>
     @endif

--- a/resources/views/components/checkbox.blade.php
+++ b/resources/views/components/checkbox.blade.php
@@ -17,8 +17,10 @@ $describedBy = implode(' ', $describedBy);
     <div class="flex h-5 items-center">
         <input
             type="checkbox"
-            @if($id) id="{{ $id }}" @endif
-            {{ $attributes->merge(['class' => 'h-4 w-4 rounded border-gray-300 text-cbc-teal focus:ring-cbc-teal' . ($hasError ? ' border-red-300' : '')]) }}
+            {{ $attributes->merge([
+                'class' => 'h-4 w-4 rounded border-gray-300 text-cbc-teal focus:ring-cbc-teal focus-visible:ring-2' . ($hasError ? ' border-red-300' : ''),
+                'id' => $id
+            ]) }}
             @checked($checked)
             @if($hasError) aria-invalid="true" @endif
             @if($describedBy) aria-describedby="{{ $describedBy }}" @endif

--- a/resources/views/components/form-button.blade.php
+++ b/resources/views/components/form-button.blade.php
@@ -1,7 +1,7 @@
 @props(['variant' => 'primary', 'size' => 'md', 'type' => 'submit', 'icon' => null])
 
 @php
-$baseClasses = 'inline-flex items-center justify-center font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-cbc-teal focus:ring-offset-2 transition-colors duration-200';
+$baseClasses = 'inline-flex items-center justify-center font-medium rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 transition-colors duration-200';
 
 $sizeClasses = [
     'xs' => 'px-2 py-1 text-xs',

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -4,7 +4,7 @@
 $modelName = $attributes->wire('model')->value();
 $id = $attributes->get('id', $modelName ? str_replace(['.', ' ', '[', ']'], '-', $modelName) : ($label ? \Illuminate\Support\Str::slug($label) : null));
 $hasError = $modelName && $errors->has($modelName);
-$inputClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal'
+$inputClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2'
     . ($icon ? ' pl-10' : '')
     . ($hasError ? ' border-red-300' : ' border-gray-300')
     . ($clearable ? ' pr-10' : '');
@@ -33,14 +33,17 @@ $describedBy = implode(' ', $describedBy);
         @endif
 
         <input
-            @if($id) id="{{ $id }}" @endif
             x-ref="input"
             @input="count = $el.value.length"
             @focus="focused = true"
             @blur="focused = false"
-            {{ $attributes->merge(['type' => 'text', 'class' => $inputClasses]) }}
+            {{ $attributes->merge([
+                'type' => 'text',
+                'class' => $inputClasses,
+                'id' => $id,
+                'aria-label' => (!$label && $attributes->get('placeholder')) ? $attributes->get('placeholder') : null
+            ]) }}
             @if($maxlength) maxlength="{{ $maxlength }}" @endif
-            @if(!$label && $attributes->get('placeholder')) aria-label="{{ $attributes->get('placeholder') }}" @endif
             @if($hasError) aria-invalid="true" @endif
             @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
             @if($clearable && $modelName)

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -4,7 +4,7 @@
 $modelName = $attributes->wire('model')->value();
 $id = $attributes->get('id', $modelName ? str_replace(['.', ' ', '[', ']'], '-', $modelName) : ($label ? \Illuminate\Support\Str::slug($label) : null));
 $hasError = $modelName && $errors->has($modelName);
-$selectClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal'
+$selectClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2'
     . ($hasError ? ' border-red-300' : ' border-gray-300');
 
 $describedBy = [];
@@ -23,9 +23,11 @@ $describedBy = implode(' ', $describedBy);
 
     <div class="relative">
         <select
-            @if($id) id="{{ $id }}" @endif
-            {{ $attributes->merge(['class' => $selectClasses]) }}
-            @if(!$label && $placeholder) aria-label="{{ $placeholder }}" @endif
+            {{ $attributes->merge([
+                'class' => $selectClasses,
+                'id' => $id,
+                'aria-label' => (!$label && $placeholder) ? $placeholder : null
+            ]) }}
             @if($hasError) aria-invalid="true" @endif
             @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
         >

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -4,7 +4,7 @@
 $modelName = $attributes->wire('model')->value();
 $id = $attributes->get('id', $modelName ? str_replace(['.', ' ', '[', ']'], '-', $modelName) : ($label ? \Illuminate\Support\Str::slug($label) : null));
 $hasError = $modelName && $errors->has($modelName);
-$textareaClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal'
+$textareaClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2'
     . ($hasError ? ' border-red-300' : ' border-gray-300');
 
 $describedBy = [];
@@ -23,12 +23,15 @@ $describedBy = implode(' ', $describedBy);
 
     <div class="relative">
         <textarea
-            @if($id) id="{{ $id }}" @endif
             x-ref="textarea"
             @input="count = $el.value.length"
-            {{ $attributes->merge(['rows' => 3, 'class' => $textareaClasses]) }}
+            {{ $attributes->merge([
+                'rows' => 3,
+                'class' => $textareaClasses,
+                'id' => $id,
+                'aria-label' => (!$label && $attributes->get('placeholder')) ? $attributes->get('placeholder') : null
+            ]) }}
             @if($maxlength) maxlength="{{ $maxlength }}" @endif
-            @if(!$label && $attributes->get('placeholder')) aria-label="{{ $attributes->get('placeholder') }}" @endif
             @if($hasError) aria-invalid="true" @endif
             @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
         >{{ $slot }}</textarea>

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -28,6 +28,7 @@ $describedBy = implode(' ', $describedBy);
             @input="count = $el.value.length"
             {{ $attributes->merge(['rows' => 3, 'class' => $textareaClasses]) }}
             @if($maxlength) maxlength="{{ $maxlength }}" @endif
+            @if(!$label && $attributes->get('placeholder')) aria-label="{{ $attributes->get('placeholder') }}" @endif
             @if($hasError) aria-invalid="true" @endif
             @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
         >{{ $slot }}</textarea>

--- a/resources/views/components/toggle.blade.php
+++ b/resources/views/components/toggle.blade.php
@@ -19,7 +19,7 @@
             @click="checked = !checked"
             wire:loading.attr="disabled"
             wire:target="{{ $modelName }}"
-            {{ $attributes->merge(['class' => 'relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-cbc-teal focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed']) }}
+            {{ $attributes->merge(['class' => 'relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed']) }}
             :class="checked ? 'bg-cbc-teal' : 'bg-gray-200'">
             <span :class="checked ? 'translate-x-5' : 'translate-x-0'"
                 class="pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out">
@@ -38,7 +38,7 @@
             x-data="{ checked: {{ $checked ? 'true' : 'false' }} }"
             :aria-checked="checked"
             @click="checked = !checked"
-            {{ $attributes->except(['name', 'checked'])->merge(['class' => 'relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-cbc-teal focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed']) }}
+            {{ $attributes->except(['name', 'checked'])->merge(['class' => 'relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed']) }}
             :class="checked ? 'bg-cbc-teal' : 'bg-gray-200'">
             <span :class="checked ? 'translate-x-5' : 'translate-x-0'"
                 class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"></span>


### PR DESCRIPTION
🎨 Palette: UX and accessibility improvements for core Blade components

This PR implements several micro-UX and accessibility enhancements across the project's base Blade components:

- **Focus States**: Switched from `focus:ring-2` to `focus-visible:ring-2` in `button`, `form-button`, and `toggle` components. This provides a cleaner experience for mouse users while maintaining full accessibility for keyboard users.
- **Checkbox ARIA**: Improved `checkbox` accessibility by linking hints and error messages to the input via `aria-describedby` and ensuring consistent ID application.
- **Textarea ARIA**: Added `aria-label` fallback to the `textarea` component when no label is present but a placeholder exists, matching the pattern used in other input components.
- **Card Styling**: Corrected a non-standard `border-1` class to the standard Tailwind `border` class in the `card` component.

These changes ensure a more polished and accessible interface across the entire application.

---
*PR created automatically by Jules for task [726125262169663444](https://jules.google.com/task/726125262169663444) started by @GarethClarridge*