### PR TITLE
📝 Scribe: Add tests for User management Livewire components

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -37,3 +37,7 @@
 ## 2026-04-09 - [S3 Disk Mocking Gotcha]
 **Learning:** `AwsS3V3Adapter` constructor enforces that the bucket name is a string. Setting it to `null` in `config()` during tests (even if mocking local disks) can cause a `TypeError` if the S3 disk is instantiated by Laravel's filesystem manager during a request cycle.
 **Action:** Always provide a dummy string (e.g., 'fake-bucket') for the bucket configuration when testing components that might trigger disk resolution, even if the test is intended to exercise a different disk.
+
+## 2026-05-15 - [Testing Admin Actions and Password Complexity]
+**Learning:** Admin user management tests must account for strict `Password::defaults()` (12+ chars, letters, numbers, symbols, uncompromised). Using `Log::shouldReceive` is an effective way to verify that critical administrative actions (deletions, permission changes) are being audited as required.
+**Action:** Use complex strings (e.g., `C0mplex_Passw0rd!`) for test passwords to avoid validation failures. Mock `Log` to assert that `Log::warning` is called with correct metadata for audit trails.

--- a/tests/Feature/Livewire/Admin/Users/CreateUserTest.php
+++ b/tests/Feature/Livewire/Admin/Users/CreateUserTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire\Admin\Users;
+
+use App\Livewire\Admin\Users\CreateUser;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CreateUserTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::factory()->crockenhillAdmin()->create(['is_admin' => true]);
+    }
+
+    #[Test]
+    public function it_authorizes_admin_access(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($user);
+
+        Livewire::test(CreateUser::class)
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_renders_successfully_for_admin(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(CreateUser::class)
+            ->assertStatus(200)
+            ->assertSee('Create User');
+    }
+
+    #[Test]
+    public function it_can_create_a_user(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(CreateUser::class)
+            ->set('name', 'New User')
+            ->set('email', 'newuser@example.com')
+            ->set('password', 'C0mplex_Passw0rd!')
+            ->set('passwordConfirmation', 'C0mplex_Passw0rd!')
+            ->set('isAdmin', true)
+            ->set('sendVerification', false)
+            ->call('save')
+            ->assertHasNoErrors()
+            ->assertRedirect(route('admin.users.index'));
+
+        $this->assertDatabaseHas('users', [
+            'name' => 'New User',
+            'email' => 'newuser@example.com',
+            'is_admin' => true,
+        ]);
+
+        $user = User::where('email', 'newuser@example.com')->first();
+        $this->assertTrue(Hash::check('C0mplex_Passw0rd!', $user->password));
+        $this->assertNotNull($user->email_verified_at);
+    }
+
+    #[Test]
+    public function it_sends_verification_email_when_requested(): void
+    {
+        Notification::fake();
+        $this->actingAs($this->admin);
+
+        Livewire::test(CreateUser::class)
+            ->set('name', 'Verify Me')
+            ->set('email', 'verify@example.com')
+            ->set('password', 'C0mplex_Passw0rd!')
+            ->set('passwordConfirmation', 'C0mplex_Passw0rd!')
+            ->set('sendVerification', true)
+            ->call('save');
+
+        $user = User::where('email', 'verify@example.com')->first();
+        $this->assertNotNull($user);
+        $this->assertNull($user->email_verified_at);
+        Notification::assertSentTo($user, VerifyEmail::class);
+    }
+
+    #[Test]
+    public function it_validates_required_fields(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(CreateUser::class)
+            ->set('name', '')
+            ->set('email', '')
+            ->set('password', '')
+            ->call('save')
+            ->assertHasErrors(['name', 'email', 'password']);
+    }
+
+    #[Test]
+    public function it_validates_email_uniqueness(): void
+    {
+        User::factory()->create(['email' => 'existing@example.com']);
+        $this->actingAs($this->admin);
+
+        Livewire::test(CreateUser::class)
+            ->set('email', 'existing@example.com')
+            ->call('save')
+            ->assertHasErrors(['email' => 'unique']);
+    }
+
+    #[Test]
+    public function it_validates_password_confirmation(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(CreateUser::class)
+            ->set('password', 'C0mplex_Passw0rd!')
+            ->set('passwordConfirmation', 'Different!')
+            ->call('save')
+            ->assertHasErrors(['password' => 'same']);
+    }
+
+    #[Test]
+    public function it_enforces_password_complexity(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(CreateUser::class)
+            ->set('password', 'short')
+            ->set('passwordConfirmation', 'short')
+            ->call('save')
+            ->assertHasErrors(['password']);
+    }
+}

--- a/tests/Feature/Livewire/Admin/Users/EditUserTest.php
+++ b/tests/Feature/Livewire/Admin/Users/EditUserTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire\Admin\Users;
+
+use App\Livewire\Admin\Users\EditUser;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class EditUserTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::factory()->crockenhillAdmin()->create(['is_admin' => true]);
+    }
+
+    #[Test]
+    public function it_authorizes_admin_access(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+        $target = User::factory()->create();
+
+        $this->actingAs($user);
+
+        Livewire::test(EditUser::class, ['user' => $target])
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_renders_successfully_for_admin(): void
+    {
+        $target = User::factory()->create(['name' => 'Target User']);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(EditUser::class, ['user' => $target])
+            ->assertStatus(200)
+            ->assertSee('Edit User')
+            ->assertSet('name', 'Target User')
+            ->assertSet('email', $target->email);
+    }
+
+    #[Test]
+    public function it_can_update_user_details(): void
+    {
+        $target = User::factory()->create(['name' => 'Old Name']);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(EditUser::class, ['user' => $target])
+            ->set('name', 'New Name')
+            ->set('email', 'newemail@example.com')
+            ->call('save')
+            ->assertDispatched('notify');
+
+        $this->assertDatabaseHas('users', [
+            'id' => $target->id,
+            'name' => 'New Name',
+            'email' => 'newemail@example.com',
+        ]);
+    }
+
+    #[Test]
+    public function it_can_change_admin_status_and_logs_it(): void
+    {
+        $target = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($this->admin);
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->with('User admin status changed via edit form', \Mockery::on(function ($args) use ($target) {
+                return $args['target_user_id'] === $target->id &&
+                       $args['old_is_admin'] === false &&
+                       $args['new_is_admin'] === true;
+            }));
+
+        Livewire::test(EditUser::class, ['user' => $target])
+            ->set('isAdmin', true)
+            ->call('save')
+            ->assertDispatched('notify');
+
+        $this->assertTrue($target->fresh()->is_admin);
+    }
+
+    #[Test]
+    public function it_cannot_remove_own_admin_status(): void
+    {
+        $this->actingAs($this->admin);
+
+        Log::shouldReceive('warning')->never();
+
+        Livewire::test(EditUser::class, ['user' => $this->admin])
+            ->set('isAdmin', false)
+            ->call('save')
+            ->assertDispatched('notify', function ($name, $params) {
+                return $params['type'] === 'error' && $params['message'] === 'Cannot remove your own admin status';
+            });
+
+        $this->assertTrue($this->admin->fresh()->is_admin);
+    }
+
+    #[Test]
+    public function it_can_change_password(): void
+    {
+        $target = User::factory()->create();
+        $oldPassword = $target->password;
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(EditUser::class, ['user' => $target])
+            ->set('changePassword', true)
+            ->set('password', 'C0mplex_Passw0rd!')
+            ->set('passwordConfirmation', 'C0mplex_Passw0rd!')
+            ->call('save')
+            ->assertDispatched('notify')
+            ->assertSet('changePassword', false)
+            ->assertSet('password', '')
+            ->assertSet('passwordConfirmation', '');
+
+        $this->assertNotEquals($oldPassword, $target->fresh()->password);
+        $this->assertTrue(Hash::check('C0mplex_Passw0rd!', $target->fresh()->password));
+    }
+
+    #[Test]
+    public function it_validates_password_when_changing(): void
+    {
+        $target = User::factory()->create();
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(EditUser::class, ['user' => $target])
+            ->set('changePassword', true)
+            ->set('password', 'short')
+            ->set('passwordConfirmation', 'short')
+            ->call('save')
+            ->assertHasErrors(['password']);
+    }
+
+    #[Test]
+    public function it_validates_email_uniqueness_excluding_current_user(): void
+    {
+        $target = User::factory()->create(['email' => 'target@example.com']);
+        User::factory()->create(['email' => 'other@example.com']);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(EditUser::class, ['user' => $target])
+            ->set('email', 'other@example.com')
+            ->call('save')
+            ->assertHasErrors(['email' => 'unique'])
+            ->set('email', 'target@example.com')
+            ->call('save')
+            ->assertHasNoErrors(['email']);
+    }
+}

--- a/tests/Feature/Livewire/Admin/Users/ListUsersTest.php
+++ b/tests/Feature/Livewire/Admin/Users/ListUsersTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire\Admin\Users;
+
+use App\Livewire\Admin\Users\ListUsers;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Log;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ListUsersTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::factory()->crockenhillAdmin()->create(['is_admin' => true]);
+    }
+
+    #[Test]
+    public function it_authorizes_admin_access(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($user);
+
+        Livewire::test(ListUsers::class)
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_renders_successfully_for_admin(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListUsers::class)
+            ->assertStatus(200)
+            ->assertSee('Users')
+            ->assertSee($this->admin->email);
+    }
+
+    #[Test]
+    public function it_lists_multiple_users(): void
+    {
+        User::factory()->count(5)->create();
+
+        $this->actingAs($this->admin);
+
+        $test = Livewire::test(ListUsers::class);
+
+        foreach (User::all() as $user) {
+            $test->assertSee($user->name);
+        }
+    }
+
+    #[Test]
+    public function it_filters_by_search_term(): void
+    {
+        $user1 = User::factory()->create(['name' => 'John Doe', 'email' => 'john@example.com']);
+        $user2 = User::factory()->create(['name' => 'Jane Smith', 'email' => 'jane@example.com']);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListUsers::class)
+            ->set('search', 'John')
+            ->assertSee($user1->name)
+            ->assertDontSee($user2->name)
+            ->set('search', 'jane@example.com')
+            ->assertSee($user2->name)
+            ->assertDontSee($user1->name);
+    }
+
+    #[Test]
+    public function it_filters_by_verified_status(): void
+    {
+        $verifiedUser = User::factory()->create(['email_verified_at' => now()]);
+        $unverifiedUser = User::factory()->create(['email_verified_at' => null]);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListUsers::class)
+            ->set('verifiedFilter', true)
+            ->assertSee($verifiedUser->email)
+            ->assertDontSee($unverifiedUser->email)
+            ->set('verifiedFilter', false)
+            ->assertSee($unverifiedUser->email)
+            ->assertDontSee($verifiedUser->email);
+    }
+
+    #[Test]
+    public function it_filters_by_admin_status(): void
+    {
+        $anotherAdmin = User::factory()->admin()->create(['email' => 'another-admin@example.com']);
+        $regularUser = User::factory()->create(['email' => 'regular@example.com']);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListUsers::class)
+            ->set('adminFilter', true)
+            ->assertSee($anotherAdmin->email)
+            ->assertDontSee($regularUser->email)
+            ->set('adminFilter', false)
+            ->assertSee($regularUser->email)
+            ->assertDontSee($anotherAdmin->email);
+    }
+
+    #[Test]
+    public function it_sorts_users(): void
+    {
+        User::query()->delete(); // Clear for predictable sorting
+        $this->admin = User::factory()->crockenhillAdmin()->create(['name' => 'B Admin', 'email' => 'b@example.com']);
+        $userA = User::factory()->create(['name' => 'A User', 'email' => 'a@example.com']);
+        $userC = User::factory()->create(['name' => 'C User', 'email' => 'c@example.com']);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListUsers::class)
+            ->set('sortBy', 'name')
+            ->set('sortDirection', 'asc')
+            ->assertSeeInOrder(['A User', 'B Admin', 'C User'])
+            ->set('sortDirection', 'desc')
+            ->assertSeeInOrder(['C User', 'B Admin', 'A User']);
+    }
+
+    #[Test]
+    public function it_can_delete_a_user(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($this->admin);
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->with('User deleted by admin', \Mockery::on(function ($args) use ($user) {
+                return $args['admin_id'] === $this->admin->id &&
+                       $args['deleted_user_id'] === $user->id &&
+                       $args['deleted_user_email'] === $user->email;
+            }));
+
+        Livewire::test(ListUsers::class)
+            ->call('delete', $user->id)
+            ->assertDispatched('notify');
+
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+    }
+
+    #[Test]
+    public function it_cannot_delete_self(): void
+    {
+        $this->actingAs($this->admin);
+
+        Log::shouldReceive('warning')->never();
+
+        Livewire::test(ListUsers::class)
+            ->call('delete', $this->admin->id)
+            ->assertDispatched('notify', function ($name, $params) {
+                return $params['type'] === 'error' && $params['message'] === 'Cannot delete yourself';
+            });
+
+        $this->assertDatabaseHas('users', ['id' => $this->admin->id]);
+    }
+
+    #[Test]
+    public function it_can_toggle_admin_status(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($this->admin);
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->with('User admin status toggled', \Mockery::on(function ($args) use ($user) {
+                return $args['admin_id'] === $this->admin->id &&
+                       $args['target_user_id'] === $user->id &&
+                       $args['new_is_admin'] === true;
+            }));
+
+        Livewire::test(ListUsers::class)
+            ->call('toggleAdmin', $user->id)
+            ->assertDispatched('notify');
+
+        $this->assertTrue($user->fresh()->is_admin);
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->with('User admin status toggled', \Mockery::on(function ($args) use ($user) {
+                return $args['new_is_admin'] === false;
+            }));
+
+        Livewire::test(ListUsers::class)
+            ->call('toggleAdmin', $user->id)
+            ->assertDispatched('notify');
+
+        $this->assertFalse($user->fresh()->is_admin);
+    }
+
+    #[Test]
+    public function it_cannot_toggle_own_admin_status(): void
+    {
+        $this->actingAs($this->admin);
+
+        Log::shouldReceive('warning')->never();
+
+        Livewire::test(ListUsers::class)
+            ->call('toggleAdmin', $this->admin->id)
+            ->assertDispatched('notify', function ($name, $params) {
+                return $params['type'] === 'error' && $params['message'] === 'Cannot modify your own admin status';
+            });
+
+        $this->assertTrue($this->admin->fresh()->is_admin);
+    }
+}


### PR DESCRIPTION
I have added thorough PHPUnit tests for the admin User management Livewire components (`CreateUser`, `EditUser`, and `ListUsers`). 

### 🎯 Coverage:
The newly added tests cover:
- **Authorization**: Ensuring only admins can access these components.
- **CRUD Operations**: Listing, creating, updating, and deleting users.
- **Security Logic**: Verifying that admins cannot delete themselves or remove their own admin status through the UI.
- **Validation**: Enforcing required fields, unique emails, and strict password complexity rules.
- **Audit Logging**: Confirming that sensitive actions like user deletion and admin status changes are recorded in the logs.

### 📋 Tests added:
- `tests/Feature/Livewire/Admin/Users/ListUsersTest.php` (11 tests)
- `tests/Feature/Livewire/Admin/Users/CreateUserTest.php` (8 tests)
- `tests/Feature/Livewire/Admin/Users/EditUserTest.php` (8 tests)

### 🔍 Why:
User management is a critical administrative feature. Previously, these code paths were largely untested, posing a risk to data integrity and security logic. These tests provide a safety net for future refactoring and ensure that security constraints (like self-demotion prevention) are always enforced.

### ✅ Results:
- All 27 new tests pass.
- PHPStan and Pint (dirty) are clean.
- Updated `.jules/scribe.md` with learnings about password complexity and audit log mocking.

---
*PR created automatically by Jules for task [10505741110515964145](https://jules.google.com/task/10505741110515964145) started by @GarethClarridge*