### PR TITLE
🧹 Tidy: refactor PageArea enum keys to TitleCase

### DIFF
--- a/app/Enums/PageArea.php
+++ b/app/Enums/PageArea.php
@@ -10,20 +10,20 @@ enum PageArea: string
 {
     use HasValues;
 
-    case CHRIST = 'christ';
-    case CHURCH = 'church';
-    case COMMUNITY = 'community';
-    case MEMBERS = 'members';
-    case SERMONS = 'sermons';
+    case Christ = 'christ';
+    case Church = 'church';
+    case Community = 'community';
+    case Members = 'members';
+    case Sermons = 'sermons';
 
     public function label(): string
     {
         return match ($this) {
-            self::CHRIST => 'Christ',
-            self::CHURCH => 'Church',
-            self::COMMUNITY => 'Community',
-            self::MEMBERS => 'Members',
-            self::SERMONS => 'Sermons',
+            self::Christ => 'Christ',
+            self::Church => 'Church',
+            self::Community => 'Community',
+            self::Members => 'Members',
+            self::Sermons => 'Sermons',
         };
     }
 }

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -38,7 +38,7 @@ class PageController extends Controller
         // Fetch the landing page for this area (where slug equals area)
         $page = Page::query()->where('slug', $area)->where('area', $area)->first();
         if (! $page instanceof Page) {
-            if ($area === PageArea::MEMBERS->value && ! Auth::check()) {
+            if ($area === PageArea::Members->value && ! Auth::check()) {
                 // Even if no landing page exists, protect the members area by default
                 return redirect()->guest(route('login'));
             }

--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -179,7 +179,7 @@ class Meeting extends Model implements HasMedia, Sitemapable
         return $query->whereDoesntHave('page', function (Builder $query): void {
             $query
                 ->where('admin', 'yes')
-                ->orWhere('area', PageArea::MEMBERS->value);
+                ->orWhere('area', PageArea::Members->value);
         });
     }
 

--- a/app/Services/PageCardService.php
+++ b/app/Services/PageCardService.php
@@ -65,7 +65,7 @@ class PageCardService
         /**
          * Performance Optimization: Use PageRepository to fetch cached area links.
          */
-        $pages = $this->pageRepository->getAllLinksForArea(PageArea::CHURCH)
+        $pages = $this->pageRepository->getAllLinksForArea(PageArea::Church)
             ->filter(function (Page $page) {
                 return $page->slug !== 'privacy-policy'
                     && $page->slug !== 'safeguarding-policy'
@@ -85,7 +85,7 @@ class PageCardService
         /**
          * Performance Optimization: Use PageRepository to fetch cached area links.
          */
-        $pages = $this->pageRepository->getAllLinksForArea(PageArea::COMMUNITY)
+        $pages = $this->pageRepository->getAllLinksForArea(PageArea::Community)
             ->filter(function (Page $page) use ($slugs) {
                 return in_array($page->slug, $slugs, true);
             })

--- a/app/Services/PublicPageVisibilityGuard.php
+++ b/app/Services/PublicPageVisibilityGuard.php
@@ -25,7 +25,7 @@ class PublicPageVisibilityGuard
 
         // Members-area pages follow the same rule as the rest of the members area:
         // any authenticated account may view them.
-        if ($page->area === PageArea::MEMBERS && $user === null) {
+        if ($page->area === PageArea::Members && $user === null) {
             return redirect()->guest(route('login'));
         }
 

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -79,7 +79,7 @@ class SitemapService
             ->add(
                 Page::query()
                     ->public()
-                    ->where('area', '!=', PageArea::MEMBERS->value)
+                    ->where('area', '!=', PageArea::Members->value)
                     ->select(['id', 'slug', 'area', 'updated_at', 'description', 'heading'])
                     /**
                      * Performance Optimization: Only eager load 'media' (needed for images),

--- a/resources/views/livewire/admin/pages/list-pages.blade.php
+++ b/resources/views/livewire/admin/pages/list-pages.blade.php
@@ -90,11 +90,11 @@
                     {{-- Area --}}
                     <td class="px-4 py-3">
                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ match($page->area) {
-                            \App\Enums\PageArea::CHRIST => 'bg-green-100 text-green-800',
-                            \App\Enums\PageArea::CHURCH => 'bg-blue-100 text-blue-800',
-                            \App\Enums\PageArea::COMMUNITY => 'bg-amber-100 text-amber-800',
-                            \App\Enums\PageArea::MEMBERS => 'bg-purple-100 text-purple-800',
-                            \App\Enums\PageArea::SERMONS => 'bg-rose-100 text-rose-800',
+                            \App\Enums\PageArea::Christ => 'bg-green-100 text-green-800',
+                            \App\Enums\PageArea::Church => 'bg-blue-100 text-blue-800',
+                            \App\Enums\PageArea::Community => 'bg-amber-100 text-amber-800',
+                            \App\Enums\PageArea::Members => 'bg-purple-100 text-purple-800',
+                            \App\Enums\PageArea::Sermons => 'bg-rose-100 text-rose-800',
                         } }}">
                             {{ $page->area->label() }}
                         </span>

--- a/tests/Feature/DataIntegrity/PageIntegrityTest.php
+++ b/tests/Feature/DataIntegrity/PageIntegrityTest.php
@@ -20,21 +20,21 @@ class PageIntegrityTest extends TestCase
     public function it_allows_same_slug_in_different_areas(): void
     {
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'about',
         ]);
 
         $page2 = Page::factory()->create([
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'slug' => 'about',
         ]);
 
         $this->assertDatabaseHas('pages', [
-            'area' => PageArea::CHURCH->value,
+            'area' => PageArea::Church->value,
             'slug' => 'about',
         ]);
         $this->assertDatabaseHas('pages', [
-            'area' => PageArea::COMMUNITY->value,
+            'area' => PageArea::Community->value,
             'slug' => 'about',
         ]);
     }
@@ -43,7 +43,7 @@ class PageIntegrityTest extends TestCase
     public function it_prevents_duplicate_slug_in_same_area_at_database_level(): void
     {
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'about',
         ]);
 
@@ -51,7 +51,7 @@ class PageIntegrityTest extends TestCase
 
         // Bypass Eloquent and validation to test database constraint directly
         \Illuminate\Support\Facades\DB::table('pages')->insert([
-            'area' => PageArea::CHURCH->value,
+            'area' => PageArea::Church->value,
             'slug' => 'about',
             'heading' => 'Another About',
             'description' => 'Desc',
@@ -68,13 +68,13 @@ class PageIntegrityTest extends TestCase
         $admin = User::factory()->create(['is_admin' => true]);
 
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'about',
         ]);
 
         Livewire::actingAs($admin)
             ->test(CreatePage::class)
-            ->set('form.area', PageArea::CHURCH->value)
+            ->set('form.area', PageArea::Church->value)
             ->set('form.slug', 'about')
             ->set('form.heading', 'New About')
             ->set('form.description', 'Test Description')
@@ -88,13 +88,13 @@ class PageIntegrityTest extends TestCase
         $admin = User::factory()->create(['is_admin' => true]);
 
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'about',
         ]);
 
         Livewire::actingAs($admin)
             ->test(CreatePage::class)
-            ->set('form.area', PageArea::COMMUNITY->value)
+            ->set('form.area', PageArea::Community->value)
             ->set('form.slug', 'about')
             ->set('form.heading', 'Community About')
             ->set('form.description', 'Test Description')
@@ -102,7 +102,7 @@ class PageIntegrityTest extends TestCase
             ->assertHasNoErrors();
 
         $this->assertDatabaseHas('pages', [
-            'area' => PageArea::COMMUNITY->value,
+            'area' => PageArea::Community->value,
             'slug' => 'about',
         ]);
     }

--- a/tests/Feature/HomepageContentTest.php
+++ b/tests/Feature/HomepageContentTest.php
@@ -67,7 +67,7 @@ class HomepageContentTest extends TestCase
             [
                 'heading' => 'Sunday evenings',
                 'description' => 'Sunday evening service information.',
-                'area' => PageArea::COMMUNITY,
+                'area' => PageArea::Community,
                 'body' => 'Sunday evening service information.',
                 'markdown' => 'Sunday evening service information.',
                 'navigation' => true,
@@ -79,7 +79,7 @@ class HomepageContentTest extends TestCase
             [
                 'heading' => 'Bible study',
                 'description' => 'Bible study information.',
-                'area' => PageArea::COMMUNITY,
+                'area' => PageArea::Community,
                 'body' => 'Bible study information.',
                 'markdown' => 'Bible study information.',
                 'navigation' => true,

--- a/tests/Feature/Livewire/Admin/AdminUrlStateTest.php
+++ b/tests/Feature/Livewire/Admin/AdminUrlStateTest.php
@@ -110,31 +110,31 @@ class AdminUrlStateTest extends TestCase
         Page::factory()->create([
             'heading' => 'About Community Life',
             'description' => 'Community information',
-            'area' => PageArea::COMMUNITY->value,
+            'area' => PageArea::Community->value,
             'navigation' => false,
         ]);
 
         Page::factory()->create([
             'heading' => 'About Church Life',
             'description' => 'Church information',
-            'area' => PageArea::CHURCH->value,
+            'area' => PageArea::Church->value,
             'navigation' => false,
         ]);
 
         Page::factory()->create([
             'heading' => 'About Community Events',
             'description' => 'Community events',
-            'area' => PageArea::COMMUNITY->value,
+            'area' => PageArea::Community->value,
             'navigation' => true,
         ]);
 
         Livewire::withQueryParams([
             'search' => 'About',
-            'areaFilter' => PageArea::COMMUNITY->value,
+            'areaFilter' => PageArea::Community->value,
             'navigationFilter' => '0',
         ])->test(ListPages::class)
             ->assertSet('search', 'About')
-            ->assertSet('areaFilter', PageArea::COMMUNITY->value)
+            ->assertSet('areaFilter', PageArea::Community->value)
             ->assertSet('navigationFilter', false)
             ->assertSee('About Community Life')
             ->assertDontSee('About Church Life')

--- a/tests/Feature/Livewire/AdminPageTest.php
+++ b/tests/Feature/Livewire/AdminPageTest.php
@@ -137,7 +137,7 @@ class AdminPageTest extends TestCase
         Livewire::test(CreatePage::class)
             ->set('form.heading', 'About Crockenhill')
             ->set('form.description', 'Information about our church and mission.')
-            ->set('form.area', PageArea::CHURCH->value)
+            ->set('form.area', PageArea::Church->value)
             ->set('form.admin', true)
             ->set('form.navigation', true)
             ->set('form.markdown', '# Welcome to Crockenhill')
@@ -147,7 +147,7 @@ class AdminPageTest extends TestCase
         $page = Page::query()->where('slug', 'about-crockenhill')->firstOrFail();
 
         $this->assertSame('About Crockenhill', $page->heading);
-        $this->assertSame(PageArea::CHURCH, $page->area);
+        $this->assertSame(PageArea::Church, $page->area);
         $this->assertSame('yes', $page->admin);
         $this->assertTrue($page->navigation);
         $this->assertStringContainsString('<h1>Welcome to Crockenhill</h1>', $page->body);
@@ -161,7 +161,7 @@ class AdminPageTest extends TestCase
         Livewire::test(CreatePage::class)
             ->set('form.heading', 'Welcome')
             ->set('form.description', 'Welcome page description.')
-            ->set('form.area', PageArea::CHURCH->value)
+            ->set('form.area', PageArea::Church->value)
             ->set('form.navigation', false)
             ->set('form.markdown', 'Welcome page copy')
             ->call('save')
@@ -204,7 +204,7 @@ class AdminPageTest extends TestCase
         $page = Page::factory()->create([
             'heading' => 'Existing Page',
             'slug' => 'existing-page',
-            'area' => PageArea::COMMUNITY->value,
+            'area' => PageArea::Community->value,
             'admin' => 'yes',
             'navigation' => true,
             'description' => 'Existing page description.',
@@ -214,7 +214,7 @@ class AdminPageTest extends TestCase
         Livewire::test(EditPage::class, ['page' => $page])
             ->assertSet('form.heading', 'Existing Page')
             ->assertSet('form.slug', 'existing-page')
-            ->assertSet('form.area', PageArea::COMMUNITY->value)
+            ->assertSet('form.area', PageArea::Community->value)
             ->assertSet('form.admin', true)
             ->assertSet('form.navigation', true)
             ->assertSet('form.description', 'Existing page description.')
@@ -229,7 +229,7 @@ class AdminPageTest extends TestCase
         $page = Page::factory()->create([
             'heading' => 'Old Heading',
             'slug' => 'old-heading',
-            'area' => PageArea::CHURCH->value,
+            'area' => PageArea::Church->value,
             'admin' => 'no',
             'navigation' => false,
             'description' => 'Old description.',
@@ -239,7 +239,7 @@ class AdminPageTest extends TestCase
         Livewire::test(EditPage::class, ['page' => $page])
             ->set('form.heading', 'Updated Heading')
             ->set('form.slug', 'updated-heading')
-            ->set('form.area', PageArea::MEMBERS->value)
+            ->set('form.area', PageArea::Members->value)
             ->set('form.admin', true)
             ->set('form.navigation', true)
             ->set('form.description', 'Updated page description.')
@@ -251,7 +251,7 @@ class AdminPageTest extends TestCase
 
         $this->assertSame('Updated Heading', $page->heading);
         $this->assertSame('updated-heading', $page->slug);
-        $this->assertSame(PageArea::MEMBERS, $page->area);
+        $this->assertSame(PageArea::Members, $page->area);
         $this->assertSame('yes', $page->admin);
         $this->assertTrue($page->navigation);
         $this->assertSame('Updated page description.', $page->description);
@@ -284,8 +284,8 @@ class AdminPageTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $existing = Page::factory()->create(['slug' => 'existing-slug', 'area' => PageArea::CHURCH->value]);
-        $editable = Page::factory()->create(['slug' => 'editable-slug', 'area' => PageArea::CHURCH->value]);
+        $existing = Page::factory()->create(['slug' => 'existing-slug', 'area' => PageArea::Church->value]);
+        $editable = Page::factory()->create(['slug' => 'editable-slug', 'area' => PageArea::Church->value]);
 
         Livewire::test(EditPage::class, ['page' => $editable])
             ->set('form.slug', $existing->slug)

--- a/tests/Feature/MeetingSeoTest.php
+++ b/tests/Feature/MeetingSeoTest.php
@@ -27,7 +27,7 @@ class MeetingSeoTest extends TestCase
             'heading' => 'Buzz Club',
             'slug' => 'buzz-club',
             'description' => 'A fun club for kids.',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
         ]);
 
         $meeting = Meeting::factory()->create([
@@ -58,7 +58,7 @@ class MeetingSeoTest extends TestCase
         $page = Page::factory()->create([
             'heading' => 'Test Meeting',
             'slug' => 'test-meeting',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
         ]);
 
         Meeting::factory()->create([
@@ -88,7 +88,7 @@ class MeetingSeoTest extends TestCase
         $page = Page::factory()->create([
             'heading' => 'Test Meeting',
             'slug' => 'test-meeting',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
         ]);
 
         $meeting = Meeting::factory()->create([
@@ -126,7 +126,7 @@ class MeetingSeoTest extends TestCase
             'heading' => 'Buzz Club',
             'slug' => 'buzz-club',
             'description' => 'A fun club for kids.',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
         ]);
 
         $meeting = Meeting::factory()->create([
@@ -159,7 +159,7 @@ class MeetingSeoTest extends TestCase
         $page = Page::factory()->create([
             'heading' => 'One-off Event',
             'slug' => 'one-off',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
         ]);
 
         $meeting = Meeting::factory()->create([

--- a/tests/Feature/MembersAreaAccessModelTest.php
+++ b/tests/Feature/MembersAreaAccessModelTest.php
@@ -40,7 +40,7 @@ class MembersAreaAccessModelTest extends TestCase
         ]);
 
         $membersPage = Page::factory()->create([
-            'area' => PageArea::MEMBERS,
+            'area' => PageArea::Members,
             'slug' => 'members-only-page',
             'admin' => 'no',
         ]);
@@ -93,7 +93,7 @@ class MembersAreaAccessModelTest extends TestCase
         ]);
 
         $membersPage = Page::factory()->create([
-            'area' => PageArea::MEMBERS,
+            'area' => PageArea::Members,
             'slug' => 'guest-blocked-members-page',
             'admin' => 'no',
         ]);

--- a/tests/Feature/PageEditorPreviewSecurityTest.php
+++ b/tests/Feature/PageEditorPreviewSecurityTest.php
@@ -35,7 +35,7 @@ class PageEditorPreviewSecurityTest extends TestCase
         $this->actingAs($this->admin);
 
         $page = Page::factory()->create([
-            'area' => PageArea::CHURCH->value,
+            'area' => PageArea::Church->value,
             'slug' => 'preview-script-tag',
             'heading' => 'Preview Script Tag',
             'markdown' => '',
@@ -59,7 +59,7 @@ class PageEditorPreviewSecurityTest extends TestCase
         $this->actingAs($this->admin);
 
         $page = Page::factory()->create([
-            'area' => PageArea::CHURCH->value,
+            'area' => PageArea::Church->value,
             'slug' => 'preview-javascript-link',
             'heading' => 'Preview Javascript Link',
             'markdown' => '',

--- a/tests/Feature/PageSecurityTest.php
+++ b/tests/Feature/PageSecurityTest.php
@@ -17,7 +17,7 @@ class PageSecurityTest extends TestCase
     public function test_admin_pages_are_restricted_to_admins(): void
     {
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'admin-only-page',
             'admin' => 'yes',
         ]);
@@ -34,7 +34,7 @@ class PageSecurityTest extends TestCase
     public function test_non_admin_pages_remain_publicly_accessible(): void
     {
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'public-page',
             'admin' => 'no',
         ]);
@@ -48,7 +48,7 @@ class PageSecurityTest extends TestCase
     public function test_members_area_pages_require_authentication(): void
     {
         Page::factory()->create([
-            'area' => PageArea::MEMBERS,
+            'area' => PageArea::Members,
             'slug' => 'members-only-page',
             'admin' => 'no',
         ]);
@@ -66,7 +66,7 @@ class PageSecurityTest extends TestCase
             [
                 'heading' => 'Members',
                 'description' => 'Members landing page',
-                'area' => PageArea::MEMBERS,
+                'area' => PageArea::Members,
                 'body' => 'Members landing page',
                 'admin' => 'yes',
                 'markdown' => '# Members',
@@ -85,7 +85,7 @@ class PageSecurityTest extends TestCase
 
     public function test_landing_page_falls_back_to_body_content_when_markdown_is_missing(): void
     {
-        $area = PageArea::SERMONS->value;
+        $area = PageArea::Sermons->value;
 
         Page::unguarded(fn (): Page => Page::query()->updateOrCreate(
             ['slug' => $area],
@@ -108,7 +108,7 @@ class PageSecurityTest extends TestCase
 
     public function test_non_members_area_without_landing_page_returns_404(): void
     {
-        Page::query()->where('area', PageArea::SERMONS)->delete();
+        Page::query()->where('area', PageArea::Sermons)->delete();
 
         $this->get('/sermons')->assertNotFound();
     }

--- a/tests/Feature/PublicPageReadModelCacheTest.php
+++ b/tests/Feature/PublicPageReadModelCacheTest.php
@@ -17,7 +17,7 @@ class PublicPageReadModelCacheTest extends TestCase
     public function public_page_read_model_cache_is_populated_and_invalidated_on_page_update(): void
     {
         $page = Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'cached-public-page',
             'heading' => 'Original heading',
             'admin' => 'no',

--- a/tests/Feature/PublicReadSideInvariantsTest.php
+++ b/tests/Feature/PublicReadSideInvariantsTest.php
@@ -65,7 +65,7 @@ class PublicReadSideInvariantsTest extends TestCase
     public function meeting_linked_to_admin_page_returns_403_to_guests(): void
     {
         $adminPage = Page::factory()->create([
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'slug' => 'restricted-meeting-page',
             'admin' => 'yes',
         ]);
@@ -82,7 +82,7 @@ class PublicReadSideInvariantsTest extends TestCase
     public function meeting_linked_to_admin_page_is_accessible_to_admin_users(): void
     {
         $adminPage = Page::factory()->create([
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'slug' => 'admin-only-meeting-page',
             'admin' => 'yes',
         ]);
@@ -103,7 +103,7 @@ class PublicReadSideInvariantsTest extends TestCase
     public function meeting_linked_to_public_page_is_accessible_to_guests(): void
     {
         $publicPage = Page::factory()->create([
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'slug' => 'open-meeting-page',
             'admin' => 'no',
         ]);
@@ -139,7 +139,7 @@ class PublicReadSideInvariantsTest extends TestCase
     public function navigation_header_does_not_expose_admin_only_pages(): void
     {
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'secret-admin-nav-page',
             'heading' => 'Secret Admin Page',
             'navigation' => true,
@@ -158,7 +158,7 @@ class PublicReadSideInvariantsTest extends TestCase
     public function navigation_header_shows_public_navigation_pages(): void
     {
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'visible-nav-page',
             'heading' => 'Visible Nav Page',
             'navigation' => true,
@@ -176,7 +176,7 @@ class PublicReadSideInvariantsTest extends TestCase
     public function sitemap_does_not_include_meetings_linked_to_admin_pages(): void
     {
         $adminPage = Page::factory()->create([
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'slug' => 'restricted-community-page',
             'admin' => 'yes',
         ]);
@@ -199,7 +199,7 @@ class PublicReadSideInvariantsTest extends TestCase
     public function sitemap_does_not_include_members_area_pages(): void
     {
         Page::factory()->create([
-            'area' => PageArea::MEMBERS,
+            'area' => PageArea::Members,
             'slug' => 'members-only-page',
             'admin' => 'no',
         ]);
@@ -218,7 +218,7 @@ class PublicReadSideInvariantsTest extends TestCase
     public function sitemap_does_not_include_meetings_linked_to_members_pages(): void
     {
         $membersPage = Page::factory()->create([
-            'area' => PageArea::MEMBERS,
+            'area' => PageArea::Members,
             'slug' => 'members-meeting-page',
             'admin' => 'no',
         ]);

--- a/tests/Feature/RouteTest.php
+++ b/tests/Feature/RouteTest.php
@@ -37,7 +37,7 @@ class RouteTest extends TestCase
     {
         // Create test pages
         $christPage = Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => 'test-page',
             'heading' => 'Test Page',
             'markdown' => '# Test Content',
@@ -48,7 +48,7 @@ class RouteTest extends TestCase
         ]);
 
         $churchPage = Page::factory()->create([
-            'area' => PageArea::CHURCH->value,
+            'area' => PageArea::Church->value,
             'slug' => 'about-us',
             'heading' => 'About Us',
             'markdown' => '# About Us',
@@ -85,7 +85,7 @@ class RouteTest extends TestCase
     {
         // Create a page in 'christ' area
         Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => 'test-page',
             'heading' => 'Test Page',
             'markdown' => '# Test Content',
@@ -107,7 +107,7 @@ class RouteTest extends TestCase
     {
         // Create a page with special characters in slug
         Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => 'test-page-with-dashes',
             'heading' => 'Test Page With Dashes',
             'markdown' => '# Test Content',
@@ -126,7 +126,7 @@ class RouteTest extends TestCase
     {
         // Create a page with empty markdown
         Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => 'empty-page',
             'heading' => 'Empty Page',
             'markdown' => '',
@@ -146,7 +146,7 @@ class RouteTest extends TestCase
         $slug = 'security-script-tag-page-'.Str::lower(Str::random(8));
 
         Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => $slug,
             'heading' => 'Security Script Tag Page',
             'markdown' => '<script>alert("page-xss")</script>'."\n\n".'Safe page content.',
@@ -168,7 +168,7 @@ class RouteTest extends TestCase
         $slug = 'security-javascript-link-page-'.Str::lower(Str::random(8));
 
         Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => $slug,
             'heading' => 'Security Javascript Link Page',
             'markdown' => '[Click me](javascript:alert("page-link"))',
@@ -189,7 +189,7 @@ class RouteTest extends TestCase
     {
         // Create a page with empty description (not null since it's required)
         $page = Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => 'no-description',
             'heading' => 'No Description',
             'markdown' => '# Content',
@@ -219,7 +219,7 @@ class RouteTest extends TestCase
 
         // Create a page
         $page = Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => 'binding-test',
             'heading' => 'Binding Test',
             'markdown' => '# Test',
@@ -241,7 +241,7 @@ class RouteTest extends TestCase
     {
         // Create multiple pages in the same area
         $page1 = Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => 'first-page',
             'heading' => 'First Page',
             'markdown' => '# First',
@@ -251,7 +251,7 @@ class RouteTest extends TestCase
         ]);
 
         $page2 = Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => 'second-page',
             'heading' => 'Second Page',
             'markdown' => '# Second',
@@ -280,7 +280,7 @@ class RouteTest extends TestCase
     {
         // Create pages with unique slugs in different areas
         $christPage = Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => 'christ-page',
             'heading' => 'Christ Page',
             'markdown' => '# Christ',
@@ -290,7 +290,7 @@ class RouteTest extends TestCase
         ]);
 
         $churchPage = Page::factory()->create([
-            'area' => PageArea::CHURCH->value,
+            'area' => PageArea::Church->value,
             'slug' => 'church-page',
             'heading' => 'Church Page',
             'markdown' => '# Church',
@@ -318,7 +318,7 @@ class RouteTest extends TestCase
     {
         // Create a test page to verify routing works correctly
         $page = Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => 'debug-test',
             'heading' => 'Debug Test',
             'markdown' => '# Debug',
@@ -338,21 +338,21 @@ class RouteTest extends TestCase
     {
         // Create navigation pages for each area
         $christPage = Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => 'nav-christ',
             'heading' => 'Nav Christ',
             'navigation' => true,
             'admin' => 'no',
         ]);
         $churchPage = Page::factory()->create([
-            'area' => PageArea::CHURCH->value,
+            'area' => PageArea::Church->value,
             'slug' => 'nav-church',
             'heading' => 'Nav Church',
             'navigation' => true,
             'admin' => 'no',
         ]);
         $communityPage = Page::factory()->create([
-            'area' => PageArea::COMMUNITY->value,
+            'area' => PageArea::Community->value,
             'slug' => 'nav-community',
             'heading' => 'Nav Community',
             'navigation' => true,

--- a/tests/Feature/StructuredDataTest.php
+++ b/tests/Feature/StructuredDataTest.php
@@ -130,7 +130,7 @@ class StructuredDataTest extends TestCase
     {
         $page = Page::factory()->create([
             'heading' => 'About Us',
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'about-us',
         ]);
 

--- a/tests/Feature/ViewComposerTest.php
+++ b/tests/Feature/ViewComposerTest.php
@@ -41,7 +41,7 @@ class ViewComposerTest extends TestCase
     {
         $page = Page::factory()->create([
             'slug' => 'about-us',
-            'area' => \App\Enums\PageArea::CHURCH,
+            'area' => \App\Enums\PageArea::Church,
             'heading' => 'About Our Church',
             'description' => 'Test Description',
         ]);
@@ -97,7 +97,7 @@ class ViewComposerTest extends TestCase
     {
         Page::factory()->create([
             'slug' => 'nav-page',
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'navigation' => true,
         ]);
 
@@ -111,7 +111,7 @@ class ViewComposerTest extends TestCase
     {
         Page::factory()->create([
             'slug' => 'expanded-nav-page',
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'navigation' => true,
         ]);
 
@@ -169,29 +169,29 @@ class ViewComposerTest extends TestCase
 
         Page::factory()->create([
             'slug' => $membersSlug,
-            'area' => PageArea::MEMBERS,
+            'area' => PageArea::Members,
             'admin' => 'no',
         ]);
 
         Page::unguarded(fn () => Page::query()->updateOrCreate(
             ['slug' => 'all-sermons'],
-            ['area' => PageArea::SERMONS, 'admin' => 'no', 'heading' => 'All Sermons', 'description' => 'All sermons', 'body' => 'All sermons', 'markdown' => '', 'navigation' => false],
+            ['area' => PageArea::Sermons, 'admin' => 'no', 'heading' => 'All Sermons', 'description' => 'All sermons', 'body' => 'All sermons', 'markdown' => '', 'navigation' => false],
         ));
 
         Page::unguarded(fn () => Page::query()->updateOrCreate(
             ['slug' => 'pages'],
-            ['area' => PageArea::MEMBERS, 'admin' => 'yes', 'heading' => 'Pages', 'description' => 'Admin pages', 'body' => 'Pages', 'markdown' => '', 'navigation' => false],
+            ['area' => PageArea::Members, 'admin' => 'yes', 'heading' => 'Pages', 'description' => 'Admin pages', 'body' => 'Pages', 'markdown' => '', 'navigation' => false],
         ));
 
         $links = app(RelatedPagePresenter::class)->ordered(
-            linkArea: PageArea::MEMBERS->value,
+            linkArea: PageArea::Members->value,
             slugToExclude: 'members',
             secondSlugToExclude: 'members',
             excludeAdminPages: true,
         );
 
-        $this->assertTrue($links->contains(fn (array $link): bool => $link['slug'] === $membersSlug && $link['area'] === PageArea::MEMBERS->value));
-        $this->assertFalse($links->contains(fn (array $link): bool => $link['area'] === PageArea::SERMONS->value));
+        $this->assertTrue($links->contains(fn (array $link): bool => $link['slug'] === $membersSlug && $link['area'] === PageArea::Members->value));
+        $this->assertFalse($links->contains(fn (array $link): bool => $link['area'] === PageArea::Sermons->value));
         $this->assertFalse($links->contains(fn (array $link): bool => $link['slug'] === 'pages'));
     }
 
@@ -202,7 +202,7 @@ class ViewComposerTest extends TestCase
             ['slug' => 'sunday-evenings'],
             Page::factory()->raw([
                 'slug' => 'sunday-evenings',
-                'area' => PageArea::COMMUNITY,
+                'area' => PageArea::Community,
                 'admin' => 'no',
             ]),
         );
@@ -211,14 +211,14 @@ class ViewComposerTest extends TestCase
             ['slug' => 'bible-study'],
             Page::factory()->raw([
                 'slug' => 'bible-study',
-                'area' => PageArea::COMMUNITY,
+                'area' => PageArea::Community,
                 'admin' => 'no',
             ]),
         );
 
         Page::factory()->create([
             'slug' => 'unrelated-page',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'admin' => 'no',
         ]);
 
@@ -240,7 +240,7 @@ class ViewComposerTest extends TestCase
             'slug' => 'view-composer-sunday-evenings-card',
             'heading' => 'Sunday Evenings',
             'description' => 'An evening service.',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
         ]);
 
         $view = View::make('components.page-card', [
@@ -276,7 +276,7 @@ class ViewComposerTest extends TestCase
     public function it_renders_related_pages_in_a_centered_grid_with_footer_spacing(): void
     {
         $links = Page::factory()->count(3)->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
         ]);
 
         $view = View::make('components.related-pages', [

--- a/tests/Unit/Models/PageTest.php
+++ b/tests/Unit/Models/PageTest.php
@@ -26,13 +26,13 @@ class PageTest extends TestCase
     {
         // Test getRouteAttribute
         $page1 = \App\Models\Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => 'about-us',
         ]);
         $this->assertEquals('/christ/about-us', $page1->route);
 
         $page2 = \App\Models\Page::factory()->create([
-            'area' => PageArea::COMMUNITY->value,
+            'area' => PageArea::Community->value,
             'slug' => 'events',
         ]);
         $this->assertEquals('/community/events', $page2->route);
@@ -84,17 +84,17 @@ class PageTest extends TestCase
         \App\Models\Page::query()->delete(); // Clear pages before this test
 
         // Test inArea() scope
-        $pageInChrist = \App\Models\Page::factory()->inArea(PageArea::CHRIST)->create(['navigation' => false]);
-        $pageInCommunity = \App\Models\Page::factory()->inArea(PageArea::COMMUNITY)->create(['navigation' => false]);
-        $pageInChurch = \App\Models\Page::factory()->inArea(PageArea::CHURCH)->create(['navigation' => false]);
+        $pageInChrist = \App\Models\Page::factory()->inArea(PageArea::Christ)->create(['navigation' => false]);
+        $pageInCommunity = \App\Models\Page::factory()->inArea(PageArea::Community)->create(['navigation' => false]);
+        $pageInChurch = \App\Models\Page::factory()->inArea(PageArea::Church)->create(['navigation' => false]);
 
-        $christPages = \App\Models\Page::inArea(PageArea::CHRIST)->get();
+        $christPages = \App\Models\Page::inArea(PageArea::Christ)->get();
         $this->assertCount(1, $christPages);
         $this->assertTrue($christPages->contains($pageInChrist));
         $this->assertFalse($christPages->contains($pageInCommunity));
         $this->assertFalse($christPages->contains($pageInChurch));
 
-        $communityPages = \App\Models\Page::inArea(PageArea::COMMUNITY)->get();
+        $communityPages = \App\Models\Page::inArea(PageArea::Community)->get();
         $this->assertCount(1, $communityPages);
         $this->assertTrue($communityPages->contains($pageInCommunity));
         $this->assertFalse($communityPages->contains($pageInChrist));
@@ -120,7 +120,7 @@ class PageTest extends TestCase
         // can handle string parameters without throwing type errors
 
         $page = \App\Models\Page::factory()->create([
-            'area' => PageArea::CHRIST->value,
+            'area' => PageArea::Christ->value,
             'slug' => 'test-slug',
             'heading' => 'Test Page',
             'markdown' => '# Test Content',
@@ -130,13 +130,13 @@ class PageTest extends TestCase
 
         // Test that the page can be found by area and slug
         $foundPage = Page::where('slug', 'test-slug')
-            ->where('area', PageArea::CHRIST->value)
+            ->where('area', PageArea::Christ->value)
             ->first();
 
         $this->assertNotNull($foundPage);
         $this->assertEquals($page->id, $foundPage->id);
         $this->assertEquals('Test Page', $foundPage->heading);
-        $this->assertEquals(PageArea::CHRIST, $foundPage->area);
+        $this->assertEquals(PageArea::Christ, $foundPage->area);
     }
 
     #[Test]
@@ -144,7 +144,7 @@ class PageTest extends TestCase
     {
         // Test that the show method returns the expected data structure
         $page = \App\Models\Page::factory()->create([
-            'area' => PageArea::CHURCH->value,
+            'area' => PageArea::Church->value,
             'slug' => 'about',
             'heading' => 'About Us',
             'markdown' => '# About Us\n\nThis is about us.',
@@ -164,7 +164,7 @@ This is about us.';
             'content' => $html,
             'heading' => 'About Us',
             'description' => 'About our church',
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'about',
         ];
 
@@ -179,7 +179,7 @@ This is about us.';
 
         $this->assertInstanceOf(Page::class, $expectedData['page']);
         $this->assertEquals('About Us', $expectedData['heading']);
-        $this->assertEquals(PageArea::CHURCH, $expectedData['area']);
+        $this->assertEquals(PageArea::Church, $expectedData['area']);
         $this->assertEquals('about', $expectedData['slug']);
     }
 
@@ -191,7 +191,7 @@ This is about us.';
 
         // This should throw a ModelNotFoundException
         Page::where('slug', 'nonexistent')
-            ->where('area', PageArea::CHRIST->value)
+            ->where('area', PageArea::Christ->value)
             ->firstOrFail();
     }
 }

--- a/tests/Unit/Services/PageCardServiceTest.php
+++ b/tests/Unit/Services/PageCardServiceTest.php
@@ -34,19 +34,19 @@ class PageCardServiceTest extends TestCase
 
         Page::factory()->create([
             'slug' => 'sunday-evenings',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'admin' => 'no',
         ]);
 
         Page::factory()->create([
             'slug' => 'bible-study',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'admin' => 'no',
         ]);
 
         Page::factory()->create([
             'slug' => 'unrelated-page',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'admin' => 'no',
         ]);
 
@@ -81,7 +81,7 @@ class PageCardServiceTest extends TestCase
         $pages = [];
         foreach ($slugs as $slug) {
             $pages[] = Page::factory()->create([
-                'area' => PageArea::COMMUNITY,
+                'area' => PageArea::Community,
                 'slug' => $slug,
                 'admin' => 'no',
             ]);
@@ -89,7 +89,7 @@ class PageCardServiceTest extends TestCase
 
         Page::factory()->create([
             'slug' => 'unrelated-community',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'admin' => 'no',
         ]);
 
@@ -115,25 +115,25 @@ class PageCardServiceTest extends TestCase
 
         Page::factory()->create([
             'slug' => 'sunday-mornings',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'admin' => 'no',
         ]);
 
         Page::factory()->create([
             'slug' => 'sunday-evenings',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'admin' => 'no',
         ]);
 
         Page::factory()->create([
             'slug' => 'bible-study',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'admin' => 'no',
         ]);
 
         Page::factory()->create([
             'slug' => 'unrelated-church',
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'admin' => 'no',
         ]);
 
@@ -159,33 +159,33 @@ class PageCardServiceTest extends TestCase
         ]);
 
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'about-us',
             'admin' => 'no',
         ]);
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'leadership',
             'admin' => 'no',
         ]);
 
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'privacy-policy',
             'admin' => 'no',
         ]);
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'safeguarding-policy',
             'admin' => 'no',
         ]);
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'admin-page',
             'admin' => 'yes',
         ]);
         Page::factory()->create([
-            'area' => PageArea::COMMUNITY,
+            'area' => PageArea::Community,
             'slug' => 'community-page',
             'admin' => 'no',
         ]);

--- a/tests/Unit/Services/PublicPageVisibilityGuardTest.php
+++ b/tests/Unit/Services/PublicPageVisibilityGuardTest.php
@@ -37,7 +37,7 @@ class PublicPageVisibilityGuardTest extends TestCase
     #[Test]
     public function it_returns_null_for_a_public_page_accessed_by_a_guest(): void
     {
-        $page = Page::factory()->create(['area' => PageArea::CHRIST->value, 'admin' => 'no']);
+        $page = Page::factory()->create(['area' => PageArea::Christ->value, 'admin' => 'no']);
 
         $result = $this->guard->enforce($page);
 
@@ -83,7 +83,7 @@ class PublicPageVisibilityGuardTest extends TestCase
     #[Test]
     public function it_redirects_a_guest_to_login_for_a_members_area_page(): void
     {
-        $page = Page::factory()->inArea(PageArea::MEMBERS)->create(['admin' => 'no']);
+        $page = Page::factory()->inArea(PageArea::Members)->create(['admin' => 'no']);
 
         $result = $this->guard->enforce($page);
 
@@ -97,7 +97,7 @@ class PublicPageVisibilityGuardTest extends TestCase
         $user = User::factory()->create();
         $this->actingAs($user);
 
-        $page = Page::factory()->inArea(PageArea::MEMBERS)->create(['admin' => 'no']);
+        $page = Page::factory()->inArea(PageArea::Members)->create(['admin' => 'no']);
 
         $result = $this->guard->enforce($page);
 

--- a/tests/Unit/View/Presenters/PageLinksRepositoryTest.php
+++ b/tests/Unit/View/Presenters/PageLinksRepositoryTest.php
@@ -26,9 +26,9 @@ class PageLinksRepositoryTest extends TestCase
     #[Test]
     public function it_returns_ordered_links_for_an_area(): void
     {
-        Page::factory()->create(['area' => PageArea::CHURCH, 'slug' => 'beta', 'admin' => 'no']);
-        Page::factory()->create(['area' => PageArea::CHURCH, 'slug' => 'alpha', 'admin' => 'no']);
-        Page::factory()->create(['area' => PageArea::COMMUNITY, 'slug' => 'gamma', 'admin' => 'no']);
+        Page::factory()->create(['area' => PageArea::Church, 'slug' => 'beta', 'admin' => 'no']);
+        Page::factory()->create(['area' => PageArea::Church, 'slug' => 'alpha', 'admin' => 'no']);
+        Page::factory()->create(['area' => PageArea::Community, 'slug' => 'gamma', 'admin' => 'no']);
 
         $results = $this->repository->orderedLinks('church', null, null);
 
@@ -45,9 +45,9 @@ class PageLinksRepositoryTest extends TestCase
     #[Test]
     public function it_excludes_slugs_from_ordered_links(): void
     {
-        Page::factory()->create(['area' => PageArea::CHURCH, 'slug' => 'alpha', 'admin' => 'no']);
-        Page::factory()->create(['area' => PageArea::CHURCH, 'slug' => 'beta', 'admin' => 'no']);
-        Page::factory()->create(['area' => PageArea::CHURCH, 'slug' => 'gamma', 'admin' => 'no']);
+        Page::factory()->create(['area' => PageArea::Church, 'slug' => 'alpha', 'admin' => 'no']);
+        Page::factory()->create(['area' => PageArea::Church, 'slug' => 'beta', 'admin' => 'no']);
+        Page::factory()->create(['area' => PageArea::Church, 'slug' => 'gamma', 'admin' => 'no']);
 
         $results = $this->repository->orderedLinks(
             linkArea: 'church',
@@ -62,8 +62,8 @@ class PageLinksRepositoryTest extends TestCase
     #[Test]
     public function it_excludes_admin_pages_when_requested(): void
     {
-        Page::factory()->create(['area' => PageArea::CHURCH, 'slug' => 'public', 'admin' => 'no']);
-        Page::factory()->create(['area' => PageArea::CHURCH, 'slug' => 'private', 'admin' => 'yes']);
+        Page::factory()->create(['area' => PageArea::Church, 'slug' => 'public', 'admin' => 'no']);
+        Page::factory()->create(['area' => PageArea::Church, 'slug' => 'private', 'admin' => 'yes']);
 
         $results = $this->repository->orderedLinks(
             linkArea: 'church',
@@ -91,7 +91,7 @@ class PageLinksRepositoryTest extends TestCase
     #[Test]
     public function it_returns_random_links_with_limit(): void
     {
-        Page::factory()->count(10)->create(['area' => PageArea::CHURCH, 'admin' => 'no']);
+        Page::factory()->count(10)->create(['area' => PageArea::Church, 'admin' => 'no']);
 
         $results = $this->repository->randomLinks('church', null, null, false, [], 3);
 
@@ -102,7 +102,7 @@ class PageLinksRepositoryTest extends TestCase
     public function it_selects_only_required_columns_and_loads_media(): void
     {
         Page::factory()->create([
-            'area' => PageArea::CHURCH,
+            'area' => PageArea::Church,
             'slug' => 'test-columns',
             'admin' => 'no',
             'body' => 'Long body content that should be excluded',


### PR DESCRIPTION
This PR refactors the `App\Enums\PageArea` enum to use `TitleCase` keys, aligning it with the project's coding standards as specified in `AGENTS.md` and `.jules/tidy.md`.

💡 **What:** Renamed enum keys in `PageArea.php` and updated approximately 150 call-sites across the codebase.
🎯 **Why:** To improve code consistency and reduce cognitive load by following the established project convention for enums.
🔄 **Behavior:** No functional changes. Backed string values remain identical, ensuring no impact on the database, URLs, or API.
✅ **Tests:** Verified with `composer phpstan` (0 errors) and `vendor/bin/pint`. Fixed call-sites in controllers, models, services, and an extensive suite of feature/unit tests.

---
*PR created automatically by Jules for task [12258469996400258710](https://jules.google.com/task/12258469996400258710) started by @GarethClarridge*