### PR TITLE
🛡️ Sentinel: Add audit logging for destructive administrative actions

### DIFF
--- a/app/Http/Controllers/Admin/SermonAdminController.php
+++ b/app/Http/Controllers/Admin/SermonAdminController.php
@@ -26,7 +26,16 @@ class SermonAdminController extends Controller
     {
         $this->authorize('delete', $sermon);
 
+        $sermonId = $sermon->id;
+        $sermonTitle = $sermon->title;
+
         $sermon->delete();
+
+        \Illuminate\Support\Facades\Log::warning('Sermon deleted by admin', [
+            'admin_id' => auth()->id(),
+            'sermon_id' => $sermonId,
+            'sermon_title' => $sermonTitle,
+        ]);
 
         return redirect()->route('sermons.index')->with('message', 'Sermon successfully deleted!');
     }

--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -98,8 +98,15 @@ class MeetingController extends Controller
     {
         $this->authorize('delete', $meeting);
 
+        $meetingId = $meeting->id;
         $meetingSlug = $meeting->slug;
         $meeting->delete();
+
+        \Illuminate\Support\Facades\Log::warning('Meeting deleted by admin', [
+            'admin_id' => auth()->id(),
+            'meeting_id' => $meetingId,
+            'meeting_slug' => $meetingSlug,
+        ]);
 
         Session::flash('message', 'Meeting "'.$meetingSlug.'" successfully deleted!');
 

--- a/app/Livewire/Admin/ChurchServices/ReviewInboundEmails.php
+++ b/app/Livewire/Admin/ChurchServices/ReviewInboundEmails.php
@@ -148,7 +148,14 @@ class ReviewInboundEmails extends Component
             return;
         }
 
+        $subject = $inboundEmail->subject;
         $action->execute($inboundEmail, $userId);
+
+        \Illuminate\Support\Facades\Log::warning('Inbound email rejected by admin', [
+            'admin_id' => auth()->id(),
+            'inbound_email_id' => $inboundEmailId,
+            'subject' => $subject,
+        ]);
 
         $this->success('Inbound email rejected.');
     }

--- a/app/Livewire/Admin/Meetings/ListMeetings.php
+++ b/app/Livewire/Admin/Meetings/ListMeetings.php
@@ -82,7 +82,17 @@ class ListMeetings extends Component
 
         $this->authorizeAdmin();
 
+        $meetingId = $meeting->id;
+        $meetingSlug = $meeting->slug;
+
         $meeting->delete();
+
+        \Illuminate\Support\Facades\Log::warning('Meeting deleted by admin', [
+            'admin_id' => auth()->id(),
+            'meeting_id' => $meetingId,
+            'meeting_slug' => $meetingSlug,
+        ]);
+
         $this->success('Meeting deleted');
     }
 

--- a/app/Livewire/Admin/Pages/ListPages.php
+++ b/app/Livewire/Admin/Pages/ListPages.php
@@ -99,10 +99,14 @@ class ListPages extends Component
 
         $this->authorizeAdmin();
 
-        $count = count($this->selected);
-        $ids = $this->selected;
+        if ($this->selected === []) {
+            return;
+        }
 
-        Page::whereIn('id', $this->selected)->delete();
+        $ids = $this->selected;
+        $count = count($ids);
+
+        Page::whereIn('id', $ids)->delete();
 
         \Illuminate\Support\Facades\Log::warning('Multiple pages deleted by admin', [
             'admin_id' => auth()->id(),

--- a/app/Livewire/Admin/Pages/ListPages.php
+++ b/app/Livewire/Admin/Pages/ListPages.php
@@ -80,7 +80,17 @@ class ListPages extends Component
 
         $this->authorizeAdmin();
 
+        $pageId = $page->id;
+        $pageHeading = $page->heading;
+
         $page->delete();
+
+        \Illuminate\Support\Facades\Log::warning('Page deleted by admin', [
+            'admin_id' => auth()->id(),
+            'page_id' => $pageId,
+            'page_heading' => $pageHeading,
+        ]);
+
         $this->success('Page deleted');
     }
 
@@ -89,7 +99,17 @@ class ListPages extends Component
 
         $this->authorizeAdmin();
 
+        $count = count($this->selected);
+        $ids = $this->selected;
+
         Page::whereIn('id', $this->selected)->delete();
+
+        \Illuminate\Support\Facades\Log::warning('Multiple pages deleted by admin', [
+            'admin_id' => auth()->id(),
+            'count' => $count,
+            'page_ids' => $ids,
+        ]);
+
         $this->selected = [];
         $this->success('Pages deleted');
     }

--- a/app/Livewire/Admin/Preachers/EditPreacher.php
+++ b/app/Livewire/Admin/Preachers/EditPreacher.php
@@ -106,9 +106,22 @@ class EditPreacher extends Component
 
         $this->authorizeAdmin();
 
-        PreacherAlias::where('id', $aliasId)
+        $alias = PreacherAlias::where('id', $aliasId)
             ->where('preacher_id', $this->preacher->id)
-            ->delete();
+            ->first();
+
+        if ($alias instanceof PreacherAlias) {
+            $aliasValue = $alias->alias;
+            $alias->delete();
+
+            \Illuminate\Support\Facades\Log::warning('Preacher alias removed by admin', [
+                'admin_id' => auth()->id(),
+                'preacher_id' => $this->preacher->id,
+                'preacher_name' => $this->preacher->name,
+                'alias_id' => $aliasId,
+                'alias' => $aliasValue,
+            ]);
+        }
 
         $this->preacher->refresh();
     }
@@ -157,9 +170,20 @@ class EditPreacher extends Component
 
         $this->authorizeAdmin();
 
-        SpeakerProfile::where('id', $profileId)
+        $profile = SpeakerProfile::where('id', $profileId)
             ->where('preacher_id', $this->preacher->id)
-            ->update(['is_active' => false]);
+            ->first();
+
+        if ($profile instanceof SpeakerProfile) {
+            $profile->update(['is_active' => false]);
+
+            \Illuminate\Support\Facades\Log::warning('Speaker profile deactivated by admin', [
+                'admin_id' => auth()->id(),
+                'preacher_id' => $this->preacher->id,
+                'preacher_name' => $this->preacher->name,
+                'speaker_profile_id' => $profileId,
+            ]);
+        }
 
         $this->success('Speaker profile deactivated. This preacher will no longer be matched automatically.');
         $this->preacher->refresh();

--- a/app/Livewire/Admin/Preachers/ListPreachers.php
+++ b/app/Livewire/Admin/Preachers/ListPreachers.php
@@ -68,7 +68,16 @@ class ListPreachers extends Component
 
         $this->authorizeAdmin();
 
+        $preacherId = $preacher->id;
+        $preacherName = $preacher->name;
+
         $preacher->delete();
+
+        \Illuminate\Support\Facades\Log::warning('Preacher deleted by admin', [
+            'admin_id' => auth()->id(),
+            'preacher_id' => $preacherId,
+            'preacher_name' => $preacherName,
+        ]);
 
         $this->success('Preacher deleted');
     }

--- a/app/Livewire/Admin/Sermons/ListSermons.php
+++ b/app/Livewire/Admin/Sermons/ListSermons.php
@@ -118,7 +118,16 @@ class ListSermons extends Component
 
         $this->authorizeAdmin();
 
+        $sermonId = $sermon->id;
+        $sermonTitle = $sermon->title;
+
         $sermon->delete();
+
+        \Illuminate\Support\Facades\Log::warning('Sermon deleted by admin', [
+            'admin_id' => auth()->id(),
+            'sermon_id' => $sermonId,
+            'sermon_title' => $sermonTitle,
+        ]);
 
         $this->success('Sermon deleted');
     }

--- a/tests/Feature/Security/AuditLoggingTest.php
+++ b/tests/Feature/Security/AuditLoggingTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use App\Enums\InboundEmailStatus;
+use App\Livewire\Admin\ChurchServices\ReviewInboundEmails;
+use App\Livewire\Admin\Pages\ListPages;
+use App\Livewire\Admin\Preachers\EditPreacher;
+use App\Livewire\Admin\Preachers\ListPreachers;
+use App\Livewire\Admin\Sermons\ListSermons;
+use App\Models\InboundEmail;
+use App\Models\Meeting;
+use App\Models\Page;
+use App\Models\Preacher;
+use App\Models\PreacherAlias;
+use App\Models\Sermon;
+use App\Models\SpeakerProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Log;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AuditLoggingTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
+    }
+
+    #[Test]
+    public function it_logs_sermon_deletion_via_livewire(): void
+    {
+        Log::spy();
+        $sermon = Sermon::factory()->create(['title' => 'Sermon to delete']);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListSermons::class)
+            ->call('delete', $sermon);
+
+        $this->assertDatabaseMissing('sermons', ['id' => $sermon->id]);
+
+        Log::assertLogged(\Psr\Log\LogLevel::WARNING, fn ($message, $context) =>
+            $message === 'Sermon deleted by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['sermon_id'] === $sermon->id &&
+            $context['sermon_title'] === 'Sermon to delete'
+        );
+    }
+
+    #[Test]
+    public function it_logs_page_deletion_via_livewire(): void
+    {
+        Log::spy();
+        $page = Page::factory()->create(['heading' => 'Page to delete']);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPages::class)
+            ->call('delete', $page);
+
+        $this->assertDatabaseMissing('pages', ['id' => $page->id]);
+
+        Log::assertLogged(\Psr\Log\LogLevel::WARNING, fn ($message, $context) =>
+            $message === 'Page deleted by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['page_id'] === $page->id &&
+            $context['page_heading'] === 'Page to delete'
+        );
+    }
+
+    #[Test]
+    public function it_logs_bulk_page_deletion_via_livewire(): void
+    {
+        Log::spy();
+        $pages = Page::factory()->count(3)->create();
+        $ids = $pages->pluck('id')->all();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPages::class)
+            ->set('selected', $ids)
+            ->call('deleteSelected');
+
+        foreach ($ids as $id) {
+            $this->assertDatabaseMissing('pages', ['id' => $id]);
+        }
+
+        Log::assertLogged(\Psr\Log\LogLevel::WARNING, fn ($message, $context) =>
+            $message === 'Multiple pages deleted by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['count'] === 3 &&
+            $context['page_ids'] === $ids
+        );
+    }
+
+    #[Test]
+    public function it_logs_preacher_deletion_via_livewire(): void
+    {
+        Log::spy();
+        $preacher = Preacher::factory()->create(['name' => 'Preacher Name']);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPreachers::class)
+            ->call('delete', $preacher);
+
+        $this->assertDatabaseMissing('preachers', ['id' => $preacher->id]);
+
+        Log::assertLogged(\Psr\Log\LogLevel::WARNING, fn ($message, $context) =>
+            $message === 'Preacher deleted by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['preacher_id'] === $preacher->id &&
+            $context['preacher_name'] === 'Preacher Name'
+        );
+    }
+
+    #[Test]
+    public function it_logs_preacher_alias_removal(): void
+    {
+        Log::spy();
+        $preacher = Preacher::factory()->create(['name' => 'Preacher Name']);
+        $alias = PreacherAlias::create(['preacher_id' => $preacher->id, 'alias' => 'old alias']);
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPreacher::class, ['preacher' => $preacher])
+            ->call('removeAlias', $alias->id);
+
+        $this->assertDatabaseMissing('preacher_aliases', ['id' => $alias->id]);
+
+        Log::assertLogged(\Psr\Log\LogLevel::WARNING, fn ($message, $context) =>
+            $message === 'Preacher alias removed by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['preacher_id'] === $preacher->id &&
+            $context['preacher_name'] === 'Preacher Name' &&
+            $context['alias_id'] === $alias->id &&
+            $context['alias'] === 'old alias'
+        );
+    }
+
+    #[Test]
+    public function it_logs_speaker_profile_deactivation(): void
+    {
+        Log::spy();
+        $preacher = Preacher::factory()->create(['name' => 'Preacher Name']);
+        $profile = SpeakerProfile::factory()->create([
+            'preacher_id' => $preacher->id,
+            'is_active' => true,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPreacher::class, ['preacher' => $preacher])
+            ->call('removeProfile', $profile->id);
+
+        $this->assertDatabaseHas('speaker_profiles', [
+            'id' => $profile->id,
+            'is_active' => false,
+        ]);
+
+        Log::assertLogged(\Psr\Log\LogLevel::WARNING, fn ($message, $context) =>
+            $message === 'Speaker profile deactivated by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['preacher_id'] === $preacher->id &&
+            $context['preacher_name'] === 'Preacher Name' &&
+            $context['speaker_profile_id'] === $profile->id
+        );
+    }
+
+    #[Test]
+    public function it_logs_meeting_deletion_via_controller(): void
+    {
+        Log::spy();
+        $meeting = Meeting::factory()->create(['slug' => 'meeting-slug']);
+
+        $this->actingAs($this->admin)
+            ->delete(route('meetings.destroy', $meeting))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('meetings', ['id' => $meeting->id]);
+
+        Log::assertLogged(\Psr\Log\LogLevel::WARNING, fn ($message, $context) =>
+            $message === 'Meeting deleted by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['meeting_id'] === $meeting->id &&
+            $context['meeting_slug'] === 'meeting-slug'
+        );
+    }
+
+    #[Test]
+    public function it_logs_sermon_deletion_via_controller(): void
+    {
+        Log::spy();
+        $sermon = Sermon::factory()->create(['title' => 'Sermon Title']);
+
+        // Note: This project uses POST for sermon deletion routes
+        $this->actingAs($this->admin)
+            ->post(route('sermons.destroy', $sermon->slug))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('sermons', ['id' => $sermon->id]);
+
+        Log::assertLogged(\Psr\Log\LogLevel::WARNING, fn ($message, $context) =>
+            $message === 'Sermon deleted by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['sermon_id'] === $sermon->id &&
+            $context['sermon_title'] === 'Sermon Title'
+        );
+    }
+
+    #[Test]
+    public function it_logs_inbound_email_rejection_via_livewire(): void
+    {
+        Log::spy();
+        $email = InboundEmail::factory()->create([
+            'status' => InboundEmailStatus::PENDING->value,
+            'subject' => 'Suspicious Email',
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(ReviewInboundEmails::class)
+            ->call('reject', $email->id);
+
+        $email->refresh();
+        $this->assertSame(InboundEmailStatus::REJECTED, $email->status);
+
+        Log::assertLogged(\Psr\Log\LogLevel::WARNING, fn ($message, $context) =>
+            $message === 'Inbound email rejected by admin' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['inbound_email_id'] === $email->id &&
+            $context['subject'] === 'Suspicious Email'
+        );
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add audit logging for destructive administrative actions

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Lack of accountability for destructive administrative actions. If an admin account was compromised or if an internal user acted maliciously, there was no audit trail for deletions of core content like sermons, pages, or meetings.
🎯 **Impact:** Unauthorized data loss without a clear trail of who performed the action, making incident response and recovery more difficult.
🔧 **Fix:** Implemented centralized audit logging using `Log::warning` in core administrative components (Livewire) and Controllers. Captured actor IDs and identifying metadata for all deletions and sensitive state changes.
✅ **Verification:** Added a new feature test `tests/Feature/Security/AuditLoggingTest.php` that uses `Log::spy()` to assert that the correct log entries with expected context are generated for each identified destructive action. Verified existing tests pass with consolidated logging.

---
*PR created automatically by Jules for task [2488241901770462347](https://jules.google.com/task/2488241901770462347) started by @GarethClarridge*