### PR TITLE
🛡️ Sentinel: Refactor bulk page deletion for integrity and logging

### DIFF
--- a/app/Livewire/Admin/Pages/ListPages.php
+++ b/app/Livewire/Admin/Pages/ListPages.php
@@ -93,15 +93,31 @@ class ListPages extends Component
 
     public function deleteSelected(): void
     {
-
         $this->authorizeAdmin();
+
+        if (empty($this->selected)) {
+            return;
+        }
+
+        $pages = Page::whereIn('id', $this->selected)->get();
+
+        if ($pages->isEmpty()) {
+            $this->selected = [];
+
+            return;
+        }
 
         Log::warning('Pages deleted by admin (batch)', [
             'admin_id' => auth()->id(),
-            'page_ids' => $this->selected,
+            'pages' => $pages->map(fn (Page $page) => [
+                'id' => $page->id,
+                'heading' => $page->heading,
+                'slug' => $page->slug,
+            ])->all(),
         ]);
 
-        Page::whereIn('id', $this->selected)->delete();
+        $pages->each->delete();
+
         $this->selected = [];
         $this->success('Pages deleted');
     }

--- a/tests/Feature/Security/AuditLoggingTest.php
+++ b/tests/Feature/Security/AuditLoggingTest.php
@@ -100,6 +100,11 @@ class AuditLoggingTest extends TestCase
         Log::spy();
         $pages = Page::factory()->count(3)->create();
         $ids = $pages->pluck('id')->all();
+        $descriptivePages = $pages->map(fn (Page $p) => [
+            'id' => $p->id,
+            'heading' => $p->heading,
+            'slug' => $p->slug,
+        ])->all();
 
         Livewire::actingAs($this->admin)
             ->test(ListPages::class)
@@ -112,7 +117,7 @@ class AuditLoggingTest extends TestCase
 
         Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Pages deleted by admin (batch)' &&
             $context['admin_id'] === $this->admin->id &&
-            $context['page_ids'] === $ids
+            $context['pages'] === $descriptivePages
         );
     }
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Administrative bulk deletion bypassed model lifecycle events and provided insufficient audit context.
🎯 **Impact:** Using the Query Builder for deletion bypassed events like media cleanup, potentially leaving orphaned files. Additionally, the audit log only recorded numeric IDs, making security reviews of destructive actions more difficult.
🔧 **Fix:** Refactored `deleteSelected` in `ListPages` to fetch model instances and delete them individually. This ensures all model-level logic and events are executed. The audit log was also updated to include the heading and slug of each deleted page.
✅ **Verification:** Verified via `tests/Feature/Security/AuditLoggingTest.php` and `tests/Feature/Livewire/AdminPageTest.php`. Log assertions now check for descriptive page metadata.

---
*PR created automatically by Jules for task [3841255190011894333](https://jules.google.com/task/3841255190011894333) started by @GarethClarridge*