### PR TITLE
🎨 Palette: Add smooth transitions to key UI interactions

### DIFF
--- a/resources/views/components/clipboard-button.blade.php
+++ b/resources/views/components/clipboard-button.blade.php
@@ -40,8 +40,33 @@ $copiedIconComponent = 'heroicon-o-' . $copiedIcon;
     :title="copied ? {{ \Illuminate\Support\Js::from($copiedLabel) }} : {{ \Illuminate\Support\Js::from($title) }}"
     x-cloak
 >
-    <x-dynamic-component :component="$iconComponent" x-show="!copied" class="w-4 h-4" aria-hidden="true" />
-    <x-dynamic-component :component="$copiedIconComponent" x-show="copied" class="w-4 h-4 text-cbc-teal" aria-hidden="true" x-cloak />
+    <div class="relative h-4 w-4 shrink-0">
+        <x-dynamic-component
+            :component="$iconComponent"
+            x-show="!copied"
+            x-transition:enter="transition ease-out duration-300"
+            x-transition:enter-start="opacity-0 scale-90"
+            x-transition:enter-end="opacity-100 scale-100"
+            x-transition:leave="transition ease-in duration-200"
+            x-transition:leave-start="opacity-100 scale-100"
+            x-transition:leave-end="opacity-0 scale-90"
+            class="absolute inset-0 h-4 w-4"
+            aria-hidden="true"
+        />
+        <x-dynamic-component
+            :component="$copiedIconComponent"
+            x-show="copied"
+            x-transition:enter="transition ease-out duration-300"
+            x-transition:enter-start="opacity-0 scale-90"
+            x-transition:enter-end="opacity-100 scale-100"
+            x-transition:leave="transition ease-in duration-200"
+            x-transition:leave-start="opacity-100 scale-100"
+            x-transition:leave-end="opacity-0 scale-90"
+            class="absolute inset-0 h-4 w-4 text-cbc-teal"
+            aria-hidden="true"
+            x-cloak
+        />
+    </div>
 
     <span @if($hideLabel) x-bind:class="{ 'sr-only': !copied }" @endif
           x-text="copied ? {{ \Illuminate\Support\Js::from($copiedLabel) }} : {{ \Illuminate\Support\Js::from($label) }}"

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -188,6 +188,9 @@ $hasPublicVideo = filled($sermonView['video_url']);
           x-transition:enter="transition ease-out duration-200"
           x-transition:enter-start="opacity-0 -translate-y-1"
           x-transition:enter-end="opacity-100 translate-y-0"
+          x-transition:leave="transition ease-in duration-150"
+          x-transition:leave-start="opacity-100 translate-y-0"
+          x-transition:leave-end="opacity-0 -translate-y-1"
           class="p-6 max-h-96 overflow-y-auto">
           <div class="prose prose-gray max-w-none text-gray-700">
             {!! Str::markdown($sermonView['transcript'], [
@@ -312,7 +315,10 @@ $hasPublicVideo = filled($sermonView['video_url']);
           x-cloak
           x-transition:enter="transition ease-out duration-200"
           x-transition:enter-start="opacity-0 -translate-y-1"
-          x-transition:enter-end="opacity-100 translate-y-0">
+          x-transition:enter-end="opacity-100 translate-y-0"
+          x-transition:leave="transition ease-in duration-150"
+          x-transition:leave-start="opacity-100 translate-y-0"
+          x-transition:leave-end="opacity-0 -translate-y-1">
           @if ($sermon->scripturePassage)
           <div class="p-6">
             <div


### PR DESCRIPTION
This PR introduces two micro-UX improvements to enhance the polish and perceived performance of the site:

1. **Clipboard Button Polish**: The `clipboard-button` component now features smooth cross-fade transitions between the default and "copied" icons. We've also updated the positioning logic to use a relative container with absolute icons, ensuring zero layout shift during the state change.

2. **Smooth Sermon Collapsibles**: The transcript and Bible passage sections on the sermon view now include symmetrical `x-transition:leave` directives. This ensures that when a user collapses these sections, they animate smoothly upwards instead of snapping shut, providing a more refined and pleasant interaction.

These changes follow the project's TALL stack patterns and accessibility standards.

---
*PR created automatically by Jules for task [6757168552944790524](https://jules.google.com/task/6757168552944790524) started by @GarethClarridge*