### PR TITLE
🧹 Tidy: Standardize SermonService enum keys to TitleCase

### DIFF
--- a/app/Data/SermonMetadata.php
+++ b/app/Data/SermonMetadata.php
@@ -100,16 +100,16 @@ class SermonMetadata extends Data
             if ($filePath && file_exists($filePath)) {
                 $createdTimestamp = filectime($filePath);
                 if ($createdTimestamp === false) {
-                    return SermonService::MORNING;
+                    return SermonService::Morning;
                 }
 
                 $creationTime = Carbon::createFromTimestamp($createdTimestamp);
 
                 // If created before 2 PM, assume morning service
                 if ($creationTime->hour < 14) {
-                    return SermonService::MORNING;
+                    return SermonService::Morning;
                 } else {
-                    return SermonService::EVENING;
+                    return SermonService::Evening;
                 }
             }
         } catch (\Exception $e) {
@@ -117,7 +117,7 @@ class SermonMetadata extends Data
         }
 
         // Default to morning service
-        return SermonService::MORNING;
+        return SermonService::Morning;
     }
 
     /**

--- a/app/Enums/SermonService.php
+++ b/app/Enums/SermonService.php
@@ -10,16 +10,16 @@ enum SermonService: string
 {
     use HasValues;
 
-    case MORNING = 'morning';
-    case EVENING = 'evening';
-    case OTHER = 'other';
+    case Morning = 'morning';
+    case Evening = 'evening';
+    case Other = 'other';
 
     public function label(): string
     {
         return match ($this) {
-            self::MORNING => 'Morning',
-            self::EVENING => 'Evening',
-            self::OTHER => 'Other',
+            self::Morning => 'Morning',
+            self::Evening => 'Evening',
+            self::Other => 'Other',
         };
     }
 }

--- a/app/Http/Controllers/PodcastFeedController.php
+++ b/app/Http/Controllers/PodcastFeedController.php
@@ -20,7 +20,7 @@ class PodcastFeedController extends Controller
     public function show(string $service): Response
     {
         $serviceEnum = SermonService::tryFrom($service);
-        if ($serviceEnum === null || ! in_array($serviceEnum, [SermonService::MORNING, SermonService::EVENING], true)) {
+        if ($serviceEnum === null || ! in_array($serviceEnum, [SermonService::Morning, SermonService::Evening], true)) {
             abort(404, 'Feed not found');
         }
 
@@ -28,8 +28,8 @@ class PodcastFeedController extends Controller
         $metadata = $this->feedService->getFeedMetadata($service);
 
         $viewName = match ($serviceEnum) {
-            SermonService::MORNING => 'rss.morningFeed',
-            SermonService::EVENING => 'rss.eveningFeed',
+            SermonService::Morning => 'rss.morningFeed',
+            SermonService::Evening => 'rss.eveningFeed',
         };
 
         $content = view($viewName, [

--- a/app/Http/Controllers/SermonController.php
+++ b/app/Http/Controllers/SermonController.php
@@ -224,9 +224,9 @@ class SermonController extends Controller
         $sermons = $this->sermonRepository->getSermonsByService($serviceEnum);
 
         $serviceLabel = match ($serviceEnum) {
-            SermonService::MORNING => 'Sunday Morning',
-            SermonService::EVENING => 'Sunday Evening',
-            SermonService::OTHER => Str::title($service),
+            SermonService::Morning => 'Sunday Morning',
+            SermonService::Evening => 'Sunday Evening',
+            SermonService::Other => Str::title($service),
         };
 
         return view('sermons.service', [

--- a/app/Queries/ServiceReviewDashboardQuery.php
+++ b/app/Queries/ServiceReviewDashboardQuery.php
@@ -495,9 +495,9 @@ class ServiceReviewDashboardQuery
     private function serviceSort(?SermonService $service): int
     {
         return match ($service) {
-            SermonService::MORNING => 1,
-            SermonService::EVENING => 2,
-            SermonService::OTHER => 3,
+            SermonService::Morning => 1,
+            SermonService::Evening => 2,
+            SermonService::Other => 3,
             default => 9,
         };
     }

--- a/app/Services/LegacyPlayDateSongUsageImporter.php
+++ b/app/Services/LegacyPlayDateSongUsageImporter.php
@@ -149,8 +149,8 @@ class LegacyPlayDateSongUsageImporter
     private function serviceFromLegacySlot(string $slot): SermonService
     {
         return match ($slot) {
-            'a' => SermonService::MORNING,
-            'p' => SermonService::EVENING,
+            'a' => SermonService::Morning,
+            'p' => SermonService::Evening,
             default => throw new RuntimeException('Unsupported legacy play_date slot: '.$slot),
         };
     }

--- a/app/Services/LegacySermonImporter.php
+++ b/app/Services/LegacySermonImporter.php
@@ -289,9 +289,9 @@ final class LegacySermonImporter
         }
 
         return match (strtolower($raw)) {
-            'am', 'morning' => SermonService::MORNING,
-            'pm', 'evening' => SermonService::EVENING,
-            default => SermonService::OTHER,
+            'am', 'morning' => SermonService::Morning,
+            'pm', 'evening' => SermonService::Evening,
+            default => SermonService::Other,
         };
     }
 

--- a/app/Services/MetadataExtractionService.php
+++ b/app/Services/MetadataExtractionService.php
@@ -241,10 +241,10 @@ class MetadataExtractionService
         $hour = $time->hour;
 
         if ($hour >= 6 && $hour < 14) {
-            return SermonService::MORNING;
+            return SermonService::Morning;
         }
 
-        return SermonService::EVENING;
+        return SermonService::Evening;
     }
 
     public function determineServiceFromFilename(string $filename): SermonService
@@ -261,9 +261,9 @@ class MetadataExtractionService
             if ($hour >= 0 && $hour <= 23 && $minute >= 0 && $minute <= 59) {
                 // Use the same 2 PM (14:00) cutoff
                 if ($hour < 14) {
-                    return SermonService::MORNING;
+                    return SermonService::Morning;
                 } else {
-                    return SermonService::EVENING;
+                    return SermonService::Evening;
                 }
             }
         }
@@ -277,7 +277,7 @@ class MetadataExtractionService
             preg_match('/10[:\-\s]?30/', $lowerFilename) ||
             preg_match('/11[:\-\s]?00/', $lowerFilename)
         ) {
-            return SermonService::MORNING;
+            return SermonService::Morning;
         }
 
         // Evening patterns
@@ -291,10 +291,10 @@ class MetadataExtractionService
             preg_match('/18[:\-\s]?30/', $lowerFilename) ||
             preg_match('/19[:\-\s]?00/', $lowerFilename)
         ) {
-            return SermonService::EVENING;
+            return SermonService::Evening;
         }
 
-        return SermonService::MORNING;
+        return SermonService::Morning;
     }
 
     public function isValidDate(int $year, int $month, int $day): bool

--- a/app/Services/OosEmailParserService.php
+++ b/app/Services/OosEmailParserService.php
@@ -146,7 +146,7 @@ class OosEmailParserService
         foreach (['subject' => $subject, 'body' => $body] as $source => $text) {
             if (preg_match('/\bmorning\b/i', $text) === 1 || preg_match('/(?:^|[\s(\[])(AM)(?:$|[\s)\]])/u', $text) === 1) {
                 return [
-                    'service' => SermonService::MORNING,
+                    'service' => SermonService::Morning,
                     'confidence' => $source === 'subject' ? 1.0 : 0.95,
                     'method' => "{$source}_keyword",
                 ];
@@ -154,7 +154,7 @@ class OosEmailParserService
 
             if (preg_match('/\bevening\b/i', $text) === 1 || preg_match('/(?:^|[\s(\[])(PM)(?:$|[\s)\]])/u', $text) === 1) {
                 return [
-                    'service' => SermonService::EVENING,
+                    'service' => SermonService::Evening,
                     'confidence' => $source === 'subject' ? 1.0 : 0.95,
                     'method' => "{$source}_keyword",
                 ];
@@ -164,7 +164,7 @@ class OosEmailParserService
                 $meridiem = strtolower($matches[3]);
 
                 return [
-                    'service' => $meridiem === 'am' ? SermonService::MORNING : SermonService::EVENING,
+                    'service' => $meridiem === 'am' ? SermonService::Morning : SermonService::Evening,
                     'confidence' => $source === 'subject' ? 0.82 : 0.78,
                     'method' => "{$source}_time_hint",
                 ];

--- a/app/Services/OpenLpServiceParser.php
+++ b/app/Services/OpenLpServiceParser.php
@@ -303,14 +303,14 @@ class OpenLpServiceParser
         $normalised = strtoupper((string) preg_replace('/[^a-zA-Z]+/', ' ', $value));
 
         if (preg_match('/\b(AM|MORNING)\b/', $normalised) === 1) {
-            return [SermonService::MORNING, true];
+            return [SermonService::Morning, true];
         }
 
         if (preg_match('/\b(PM|EVENING)\b/', $normalised) === 1) {
-            return [SermonService::EVENING, true];
+            return [SermonService::Evening, true];
         }
 
-        return [SermonService::OTHER, false];
+        return [SermonService::Other, false];
     }
 
     private function normaliseDate(string $date): ?string

--- a/app/Services/SermonCreationService.php
+++ b/app/Services/SermonCreationService.php
@@ -238,7 +238,7 @@ class SermonCreationService
                 'extraction_method' => $processingMetadata['service_extraction_method'] ?? 'unknown',
             ]);
 
-            return SermonService::tryFrom((string) $extractedService) ?? SermonService::MORNING;
+            return SermonService::tryFrom((string) $extractedService) ?? SermonService::Morning;
         }
 
         // Strategy 2: Fall back to filename parsing
@@ -251,7 +251,7 @@ class SermonCreationService
                 'filename' => $filename,
             ]);
 
-            return SermonService::EVENING;
+            return SermonService::Evening;
         }
 
         // Check for morning service indicators (am or morning)
@@ -261,13 +261,13 @@ class SermonCreationService
                 'filename' => $filename,
             ]);
 
-            return SermonService::MORNING;
+            return SermonService::Morning;
         }
 
         // Strategy 3: Try to detect service type from time in filename
         $hour = $this->extractTimeFromFilename($filename);
         if ($hour !== null) {
-            $service = $hour < 12 ? SermonService::MORNING : SermonService::EVENING;
+            $service = $hour < 12 ? SermonService::Morning : SermonService::Evening;
             Log::info('SermonCreationService: Detected service from time in filename', [
                 'processing_id' => $processingLog->processing_id,
                 'filename' => $filename,
@@ -284,7 +284,7 @@ class SermonCreationService
             'filename' => $filename,
         ]);
 
-        return SermonService::MORNING;
+        return SermonService::Morning;
     }
 
     /**
@@ -363,7 +363,7 @@ class SermonCreationService
             } else {
                 // Fallback: simple filename parsing when no processing log
                 $serviceValue = $context['service'] ?? (str_contains(strtolower($filename), 'evening') ? 'evening' : 'morning');
-                $service = $serviceValue instanceof SermonService ? $serviceValue : (SermonService::tryFrom((string) $serviceValue) ?? SermonService::MORNING);
+                $service = $serviceValue instanceof SermonService ? $serviceValue : (SermonService::tryFrom((string) $serviceValue) ?? SermonService::Morning);
             }
 
             $serviceLabel = $service->label();

--- a/database/factories/ChurchServiceFactory.php
+++ b/database/factories/ChurchServiceFactory.php
@@ -23,9 +23,9 @@ class ChurchServiceFactory extends Factory
         return [
             'date' => $this->faker->date(),
             'service' => $this->faker->randomElement([
-                SermonService::MORNING->value,
-                SermonService::EVENING->value,
-                SermonService::OTHER->value,
+                SermonService::Morning->value,
+                SermonService::Evening->value,
+                SermonService::Other->value,
             ]),
             'source' => 'openlp',
             'original_filename' => $this->faker->date('Y-m-d').' AM.osz',

--- a/database/factories/SermonFactory.php
+++ b/database/factories/SermonFactory.php
@@ -16,7 +16,7 @@ class SermonFactory extends Factory
 
         return [
             'date' => $this->faker->date(),
-            'service' => $this->faker->randomElement([SermonService::MORNING->value, SermonService::EVENING->value, SermonService::OTHER->value]),
+            'service' => $this->faker->randomElement([SermonService::Morning->value, SermonService::Evening->value, SermonService::Other->value]),
             'content_type' => SermonContentType::Sermon,
             'audio_file_path' => Str::slug($title).'.mp3',
             'filetype' => 'mp3',

--- a/database/seeders/SermonSeeder.php
+++ b/database/seeders/SermonSeeder.php
@@ -26,7 +26,7 @@ class SermonSeeder extends Seeder
         $sermons = [
             [
                 'date' => '2024-12-15',
-                'service' => SermonService::MORNING->value,
+                'service' => SermonService::Morning->value,
                 'title' => 'The Birth of Our Saviour',
                 'slug' => 'the-birth-of-our-saviour',
                 'reference' => 'Luke 2:1-20',
@@ -39,7 +39,7 @@ class SermonSeeder extends Seeder
             ],
             [
                 'date' => '2024-12-08',
-                'service' => SermonService::MORNING->value,
+                'service' => SermonService::Morning->value,
                 'title' => 'Walking in the Light',
                 'slug' => 'walking-in-the-light',
                 'reference' => '1 John 1:5-10',
@@ -52,7 +52,7 @@ class SermonSeeder extends Seeder
             ],
             [
                 'date' => '2024-12-01',
-                'service' => SermonService::OTHER->value,
+                'service' => SermonService::Other->value,
                 'title' => 'Special Service Example',
                 'slug' => 'special-service-example',
                 'reference' => 'Psalm 100',
@@ -91,7 +91,7 @@ class SermonSeeder extends Seeder
         $talks = [
             [
                 'date' => '2024-12-15',
-                'service' => SermonService::MORNING->value,
+                'service' => SermonService::Morning->value,
                 'title' => "Who is Jesus? (Children's Talk)",
                 'slug' => 'childrens-talk-who-is-jesus',
                 'reference' => 'Mark 1:1-11',
@@ -103,7 +103,7 @@ class SermonSeeder extends Seeder
             ],
             [
                 'date' => '2024-12-08',
-                'service' => SermonService::MORNING->value,
+                'service' => SermonService::Morning->value,
                 'title' => "God Made the World (Children's Talk)",
                 'slug' => 'childrens-talk-god-made-the-world',
                 'reference' => 'Genesis 1:1',
@@ -115,7 +115,7 @@ class SermonSeeder extends Seeder
             ],
             [
                 'date' => '2024-12-01',
-                'service' => SermonService::MORNING->value,
+                'service' => SermonService::Morning->value,
                 'title' => "The Good Shepherd (Children's Talk)",
                 'slug' => 'childrens-talk-the-good-shepherd',
                 'reference' => 'John 10:11-18',
@@ -153,7 +153,7 @@ class SermonSeeder extends Seeder
             ['slug' => 'the-prodigal-son'],
             [
                 'date' => '2024-11-24',
-                'service' => SermonService::MORNING->value,
+                'service' => SermonService::Morning->value,
                 'title' => 'The Prodigal Son',
                 'reference' => 'Luke 15:11-32',
                 'preacher' => $preacher?->name ?? 'Mark Drury',
@@ -168,12 +168,12 @@ class SermonSeeder extends Seeder
 
         $processingLog->update(['sermon_id' => $sermon->id]);
 
-        $churchService = ChurchService::where('date', '2024-11-24')->where('service', SermonService::MORNING->value)->first();
+        $churchService = ChurchService::where('date', '2024-11-24')->where('service', SermonService::Morning->value)->first();
 
         if (! $churchService) {
             $churchService = ChurchService::create([
                 'date' => '2024-11-24',
-                'service' => SermonService::MORNING->value,
+                'service' => SermonService::Morning->value,
                 'source' => 'openlp',
                 'original_filename' => '2024-11-24 AM.osz',
                 'needs_review' => false,

--- a/resources/views/livewire/admin/church-services/list-church-services.blade.php
+++ b/resources/views/livewire/admin/church-services/list-church-services.blade.php
@@ -83,8 +83,8 @@
                     <td class="px-4 py-3">
                         <p class="font-medium">{{ $churchService->date->format('j M Y') }}</p>
                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ match($churchService->service) {
-                            \App\Enums\SermonService::MORNING => 'bg-green-100 text-green-800',
-                            \App\Enums\SermonService::EVENING => 'bg-amber-100 text-amber-800',
+                            \App\Enums\SermonService::Morning => 'bg-green-100 text-green-800',
+                            \App\Enums\SermonService::Evening => 'bg-amber-100 text-amber-800',
                             default => 'bg-gray-100 text-gray-800',
                         } }}">
                             {{ $churchService->service->label() }}

--- a/resources/views/livewire/admin/church-services/processing-review-list.blade.php
+++ b/resources/views/livewire/admin/church-services/processing-review-list.blade.php
@@ -48,8 +48,8 @@
                                 @endif
                                 @if($log->extracted_service)
                                     <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium {{ match($log->extracted_service) {
-                                        \App\Enums\SermonService::MORNING => 'bg-green-100 text-green-800',
-                                        \App\Enums\SermonService::EVENING => 'bg-amber-100 text-amber-800',
+                                        \App\Enums\SermonService::Morning => 'bg-green-100 text-green-800',
+                                        \App\Enums\SermonService::Evening => 'bg-amber-100 text-amber-800',
                                         default => 'bg-gray-100 text-gray-800',
                                     } }}">
                                         {{ $log->extracted_service->label() }}

--- a/resources/views/livewire/admin/church-services/processing-review.blade.php
+++ b/resources/views/livewire/admin/church-services/processing-review.blade.php
@@ -29,8 +29,8 @@
                         @if($log->extracted_service)
                             &mdash;
                             <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium {{ match($log->extracted_service) {
-                                \App\Enums\SermonService::MORNING => 'bg-green-100 text-green-800',
-                                \App\Enums\SermonService::EVENING => 'bg-amber-100 text-amber-800',
+                                \App\Enums\SermonService::Morning => 'bg-green-100 text-green-800',
+                                \App\Enums\SermonService::Evening => 'bg-amber-100 text-amber-800',
                                 default => 'bg-gray-100 text-gray-800',
                             } }}">
                                 {{ $log->extracted_service->label() }}

--- a/resources/views/livewire/admin/church-services/service-review-dashboard.blade.php
+++ b/resources/views/livewire/admin/church-services/service-review-dashboard.blade.php
@@ -46,9 +46,9 @@
                         <div class="flex flex-wrap items-center gap-2">
                             <h2 class="font-display text-2xl text-gray-900">{{ $group['date_label'] }}</h2>
                             <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ match($group['service_enum']) {
-                                \App\Enums\SermonService::MORNING => 'bg-green-100 text-green-800',
-                                \App\Enums\SermonService::EVENING => 'bg-amber-100 text-amber-800',
-                                \App\Enums\SermonService::OTHER => 'bg-slate-100 text-slate-800',
+                                \App\Enums\SermonService::Morning => 'bg-green-100 text-green-800',
+                                \App\Enums\SermonService::Evening => 'bg-amber-100 text-amber-800',
+                                \App\Enums\SermonService::Other => 'bg-slate-100 text-slate-800',
                                 default => 'bg-gray-100 text-gray-700',
                             } }}">
                                 {{ $group['service_label'] }}

--- a/resources/views/livewire/admin/sermons/list-sermons.blade.php
+++ b/resources/views/livewire/admin/sermons/list-sermons.blade.php
@@ -78,8 +78,8 @@
                     {{-- Service --}}
                     <td class="px-4 py-3">
                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ match($sermon->service) {
-                            \App\Enums\SermonService::MORNING => 'bg-green-100 text-green-800',
-                            \App\Enums\SermonService::EVENING => 'bg-amber-100 text-amber-800',
+                            \App\Enums\SermonService::Morning => 'bg-green-100 text-green-800',
+                            \App\Enums\SermonService::Evening => 'bg-amber-100 text-amber-800',
                             default => 'bg-gray-100 text-gray-800',
                         } }}">
                             {{ $sermon->service->label() }}

--- a/tests/Feature/Actions/DeleteLivestreamUploadTest.php
+++ b/tests/Feature/Actions/DeleteLivestreamUploadTest.php
@@ -44,7 +44,7 @@ class DeleteLivestreamUploadTest extends TestCase
         $processingId = '11111111-1111-1111-1111-111111111111';
         $service = ChurchService::factory()->create([
             'date' => '2026-04-06',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => MediaType::Livestream->value,
             'needs_review' => true,
             'import_metadata' => [
@@ -66,7 +66,7 @@ class DeleteLivestreamUploadTest extends TestCase
         $sermon = Sermon::factory()->fromLivestream()->create([
             'livestream_processing_id' => $processingId,
             'date' => '2026-04-06',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'content_type' => SermonContentType::Sermon,
             'audio_file_path' => 'sermons/audio/'.$processingId.'_sermon.mp3',
             'video_file_path' => 'sermons/771/video.mp4',
@@ -159,7 +159,7 @@ class DeleteLivestreamUploadTest extends TestCase
         $processingId = '22222222-2222-2222-2222-222222222222';
         $service = ChurchService::factory()->create([
             'date' => '2026-04-13',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'manual',
             'needs_review' => true,
             'import_metadata' => [

--- a/tests/Feature/Actions/InboundEmail/ApproveInboundEmailImportTest.php
+++ b/tests/Feature/Actions/InboundEmail/ApproveInboundEmailImportTest.php
@@ -71,7 +71,7 @@ class ApproveInboundEmailImportTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [
                     ['position' => 1, 'type' => 'custom', 'title' => 'Welcome', 'metadata' => ['email_type' => 'welcome']],
                     ['position' => 2, 'type' => 'custom', 'title' => 'Sermon', 'metadata' => ['email_type' => 'sermon']],

--- a/tests/Feature/Actions/InboundEmail/InboundEmailPreviewFactoryTest.php
+++ b/tests/Feature/Actions/InboundEmail/InboundEmailPreviewFactoryTest.php
@@ -36,7 +36,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-08',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [
                     ['type' => 'custom', 'title' => 'Welcome', 'metadata' => ['email_type' => 'welcome']],
                 ],
@@ -93,7 +93,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [
                     ['type' => 'sermon', 'title' => 'A Sermon'],
                 ],
@@ -112,7 +112,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [],
             ),
         ]);
@@ -129,7 +129,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [['type' => 'sermon', 'title' => 'A Sermon']],
             ),
         ]);
@@ -178,7 +178,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-06-29',
-                    resolvedService: SermonService::MORNING->value,
+                    resolvedService: SermonService::Morning->value,
                     items: [],
                 ),
                 ['failure' => ['message' => 'Parser crashed']],
@@ -198,7 +198,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-06-29',
-                    resolvedService: SermonService::MORNING->value,
+                    resolvedService: SermonService::Morning->value,
                     items: [],
                 ),
                 ['reparsed_at' => '2026-03-12T11:30:00+00:00'],

--- a/tests/Feature/Actions/InboundEmail/ReparseInboundEmailTest.php
+++ b/tests/Feature/Actions/InboundEmail/ReparseInboundEmailTest.php
@@ -41,7 +41,7 @@ class ReparseInboundEmailTest extends TestCase
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-06-22',
-                    resolvedService: SermonService::MORNING->value,
+                    resolvedService: SermonService::Morning->value,
                     items: [
                         ['position' => 1, 'type' => 'custom', 'title' => 'Old Welcome', 'metadata' => ['email_type' => 'welcome']],
                     ],
@@ -86,7 +86,7 @@ class ReparseInboundEmailTest extends TestCase
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-07-06',
-                    resolvedService: SermonService::MORNING->value,
+                    resolvedService: SermonService::Morning->value,
                     items: [],
                     needsReview: true,
                     shouldImport: false,
@@ -121,7 +121,7 @@ class ReparseInboundEmailTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [
                     ['position' => 1, 'type' => 'custom', 'title' => 'Welcome', 'metadata' => ['email_type' => 'welcome']],
                 ],

--- a/tests/Feature/Actions/PrefillChurchServiceFromInboundEmailTest.php
+++ b/tests/Feature/Actions/PrefillChurchServiceFromInboundEmailTest.php
@@ -42,7 +42,7 @@ class PrefillChurchServiceFromInboundEmailTest extends TestCase
                 'recipient' => 'oos@crockenhill.org',
                 'parsing' => [
                     'resolved_date' => '2026-06-01',
-                    'resolved_service' => SermonService::MORNING->value,
+                    'resolved_service' => SermonService::Morning->value,
                     'items' => [
                         [
                             'position' => 1,
@@ -70,7 +70,7 @@ class PrefillChurchServiceFromInboundEmailTest extends TestCase
         $result = $this->action->execute($inboundEmail->id);
 
         $this->assertSame('2026-06-01', $result['date']);
-        $this->assertSame(SermonService::MORNING->value, $result['service']);
+        $this->assertSame(SermonService::Morning->value, $result['service']);
         $this->assertCount(2, $result['items']);
         $this->assertSame(ServiceSectionType::WELCOME->value, $result['items'][0]['section_type']);
         $this->assertSame('Welcome', $result['items'][0]['title']);
@@ -94,7 +94,7 @@ class PrefillChurchServiceFromInboundEmailTest extends TestCase
                 ->with(\Mockery::on(fn ($arg) => $arg instanceof InboundEmail && $arg->id === $inboundEmail->id))
                 ->andReturn(new \App\Data\OosEmailParseResult(
                     date: '2026-06-01',
-                    service: SermonService::MORNING,
+                    service: SermonService::Morning,
                     items: [
                         [
                             'position' => 1,
@@ -117,7 +117,7 @@ class PrefillChurchServiceFromInboundEmailTest extends TestCase
         $result = $action->execute($inboundEmail->id);
 
         $this->assertSame('2026-06-01', $result['date'] ?? null);
-        $this->assertSame(SermonService::MORNING->value, $result['service'] ?? null);
+        $this->assertSame(SermonService::Morning->value, $result['service'] ?? null);
 
         // Parser result should be stored
         $inboundEmail->refresh();
@@ -132,7 +132,7 @@ class PrefillChurchServiceFromInboundEmailTest extends TestCase
                 'recipient' => 'oos@crockenhill.org',
                 'parsing' => [
                     'resolved_date' => '2026-06-08',
-                    'resolved_service' => SermonService::MORNING->value,
+                    'resolved_service' => SermonService::Morning->value,
                     'items' => [
                         ['position' => 1, 'type' => 'custom', 'title' => "Children's Talk", 'source_title' => null, 'openlp_search_title' => null, 'metadata' => null],
                         ['position' => 2, 'type' => 'custom', 'title' => 'Opening Prayer', 'source_title' => null, 'openlp_search_title' => null, 'metadata' => null],
@@ -167,7 +167,7 @@ class PrefillChurchServiceFromInboundEmailTest extends TestCase
                 'recipient' => 'oos@crockenhill.org',
                 'parsing' => [
                     'resolved_date' => '2026-06-15',
-                    'resolved_service' => SermonService::MORNING->value,
+                    'resolved_service' => SermonService::Morning->value,
                     'items' => [
                         [
                             'position' => 1,
@@ -198,7 +198,7 @@ class PrefillChurchServiceFromInboundEmailTest extends TestCase
                 'recipient' => 'oos@crockenhill.org',
                 'parsing' => [
                     'resolved_date' => '2026-06-22',
-                    'resolved_service' => SermonService::EVENING->value,
+                    'resolved_service' => SermonService::Evening->value,
                     'items' => [
                         ['position' => 1, 'type' => 'custom', 'title' => 'Valid Item', 'source_title' => null, 'openlp_search_title' => null, 'metadata' => null],
                         ['position' => 2, 'type' => 'custom', 'title' => '', 'source_title' => null, 'openlp_search_title' => null, 'metadata' => null],
@@ -249,7 +249,7 @@ class PrefillChurchServiceFromInboundEmailTest extends TestCase
                 'recipient' => 'oos@crockenhill.org',
                 'parsing' => [
                     'resolved_date' => '2026-06-29',
-                    'resolved_service' => SermonService::MORNING->value,
+                    'resolved_service' => SermonService::Morning->value,
                     'items' => [
                         ['position' => 1, 'type' => 'custom', 'title' => 'Item One', 'source_title' => null, 'openlp_search_title' => null, 'metadata' => null],
                         ['position' => 2, 'type' => 'custom', 'title' => 'Item Two', 'source_title' => null, 'openlp_search_title' => null, 'metadata' => null],

--- a/tests/Feature/Actions/SaveChurchServiceFromAdminTest.php
+++ b/tests/Feature/Actions/SaveChurchServiceFromAdminTest.php
@@ -65,7 +65,7 @@ class SaveChurchServiceFromAdminTest extends TestCase
         ];
 
         $result = $this->action->execute(
-            validated: ['date' => '2026-05-03', 'service' => SermonService::MORNING->value],
+            validated: ['date' => '2026-05-03', 'service' => SermonService::Morning->value],
             syncPayload: $payload,
             churchService: null,
             userId: $this->admin->id,
@@ -74,7 +74,7 @@ class SaveChurchServiceFromAdminTest extends TestCase
         $this->assertInstanceOf(ChurchService::class, $result);
         $this->assertDatabaseHas('church_services', [
             'date' => '2026-05-03',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'manual',
             'needs_review' => false,
         ]);
@@ -90,7 +90,7 @@ class SaveChurchServiceFromAdminTest extends TestCase
     {
         $service = ChurchService::factory()->create([
             'date' => '2026-05-10',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'source' => 'openlp',
             'original_filename' => '2026-05-10 AM.osz',
             'needs_review' => true,
@@ -120,7 +120,7 @@ class SaveChurchServiceFromAdminTest extends TestCase
         ];
 
         $result = $this->action->execute(
-            validated: ['date' => '2026-05-10', 'service' => SermonService::MORNING->value],
+            validated: ['date' => '2026-05-10', 'service' => SermonService::Morning->value],
             syncPayload: $payload,
             churchService: $service,
             userId: $this->admin->id,
@@ -154,7 +154,7 @@ class SaveChurchServiceFromAdminTest extends TestCase
         ]];
 
         $result = $this->action->execute(
-            validated: ['date' => '2026-06-01', 'service' => SermonService::MORNING->value],
+            validated: ['date' => '2026-06-01', 'service' => SermonService::Morning->value],
             syncPayload: $payload,
             churchService: null,
             userId: $this->admin->id,
@@ -175,7 +175,7 @@ class SaveChurchServiceFromAdminTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-06-08',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'source' => 'manual',
         ]);
 
@@ -202,7 +202,7 @@ class SaveChurchServiceFromAdminTest extends TestCase
         ]];
 
         $this->action->execute(
-            validated: ['date' => '2026-06-08', 'service' => SermonService::MORNING->value],
+            validated: ['date' => '2026-06-08', 'service' => SermonService::Morning->value],
             syncPayload: $payload,
             churchService: $service,
             userId: $this->admin->id,
@@ -229,7 +229,7 @@ class SaveChurchServiceFromAdminTest extends TestCase
         ]];
 
         $this->action->execute(
-            validated: ['date' => '2026-06-15', 'service' => SermonService::MORNING->value],
+            validated: ['date' => '2026-06-15', 'service' => SermonService::Morning->value],
             syncPayload: $payload,
             churchService: null,
             userId: $this->admin->id,
@@ -254,7 +254,7 @@ class SaveChurchServiceFromAdminTest extends TestCase
         ]];
 
         $result = $this->action->execute(
-            validated: ['date' => '2026-07-01', 'service' => SermonService::MORNING->value],
+            validated: ['date' => '2026-07-01', 'service' => SermonService::Morning->value],
             syncPayload: $payload,
             churchService: null,
             userId: $this->admin->id,

--- a/tests/Feature/Actions/ServiceReview/BatchApproveServicePublicationsTest.php
+++ b/tests/Feature/Actions/ServiceReview/BatchApproveServicePublicationsTest.php
@@ -44,13 +44,13 @@ class BatchApproveServicePublicationsTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-06-01',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $service->id,
             'extracted_date' => '2026-06-01',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([
@@ -82,13 +82,13 @@ class BatchApproveServicePublicationsTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-06-02',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $service->id,
             'extracted_date' => '2026-06-02',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -119,13 +119,13 @@ class BatchApproveServicePublicationsTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-06-03',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $service->id,
             'extracted_date' => '2026-06-03',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -152,24 +152,24 @@ class BatchApproveServicePublicationsTest extends TestCase
 
         $selectedService = ChurchService::factory()->create([
             'date' => '2026-06-04',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $otherService = ChurchService::factory()->create([
             'date' => '2026-06-04',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
         ]);
 
         $selectedRun = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $selectedService->id,
             'extracted_date' => '2026-06-04',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $otherRun = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $otherService->id,
             'extracted_date' => '2026-06-04',
-            'extracted_service' => SermonService::EVENING->value,
+            'extracted_service' => SermonService::Evening->value,
         ]);
 
         $selectedSection = ServiceSection::factory()->create([
@@ -209,13 +209,13 @@ class BatchApproveServicePublicationsTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-06-05',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $service->id,
             'extracted_date' => '2026-06-05',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $first = ServiceSection::factory()->create([
@@ -259,7 +259,7 @@ class BatchApproveServicePublicationsTest extends TestCase
     {
         $service = ChurchService::factory()->create([
             'date' => '2026-06-06',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $result = $this->action->execute($service, $this->admin->id);
@@ -282,13 +282,13 @@ class BatchApproveServicePublicationsTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-06-07',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $service->id,
             'extracted_date' => '2026-06-07',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([

--- a/tests/Feature/Actions/ServiceReview/ResolvePendingStructureMergeTest.php
+++ b/tests/Feature/Actions/ServiceReview/ResolvePendingStructureMergeTest.php
@@ -211,7 +211,7 @@ class ResolvePendingStructureMergeTest extends TestCase
     {
         $service = ChurchService::factory()->create([
             'date' => '2026-03-23',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => ChurchServiceItemSource::LIVESTREAM->value,
             'needs_review' => true,
             'import_metadata' => array_merge($extraMetadata, [

--- a/tests/Feature/Actions/ServiceReview/SaveServiceSectionTest.php
+++ b/tests/Feature/Actions/ServiceReview/SaveServiceSectionTest.php
@@ -42,7 +42,7 @@ class SaveServiceSectionTest extends TestCase
     {
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-06-01',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([

--- a/tests/Feature/Api/ChurchServiceControllerTest.php
+++ b/tests/Feature/Api/ChurchServiceControllerTest.php
@@ -51,7 +51,7 @@ class ChurchServiceControllerTest extends TestCase
 
         $this->assertDatabaseHas('church_services', [
             'date' => '2024-11-17',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'openlp',
         ]);
         $this->assertDatabaseCount('church_service_items', 2);
@@ -176,7 +176,7 @@ class ChurchServiceControllerTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2024-11-17',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'source' => 'email',
             'needs_review' => false,
             'import_metadata' => [
@@ -229,7 +229,7 @@ class ChurchServiceControllerTest extends TestCase
     {
         $service = ChurchService::factory()->create([
             'date' => '2024-11-17',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'source' => 'email',
             'needs_review' => true,
             'import_metadata' => [
@@ -299,7 +299,7 @@ class ChurchServiceControllerTest extends TestCase
 
         MediaProcessingLog::factory()->livestream()->completed()->create([
             'extracted_date' => '2024-11-17',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $upload = $this->validOpenLpUpload();
@@ -373,7 +373,7 @@ class ChurchServiceControllerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2024-11-17',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         ChurchServiceItem::factory()->count(2)->create([
@@ -465,7 +465,7 @@ class ChurchServiceControllerTest extends TestCase
         // at the outer transaction level) and returns a successful response, not a 500.
         ChurchService::factory()->create([
             'date' => '2024-11-17',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $raced = false;

--- a/tests/Feature/Api/SermonApiControllerTest.php
+++ b/tests/Feature/Api/SermonApiControllerTest.php
@@ -64,12 +64,12 @@ class SermonApiControllerTest extends TestCase
     {
         Sermon::factory()->create([
             'title' => 'Morning Sermon',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'content_type' => SermonContentType::Sermon,
         ]);
         Sermon::factory()->create([
             'title' => 'Evening Sermon',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
             'content_type' => SermonContentType::Sermon,
         ]);
 

--- a/tests/Feature/ChurchServicePipelineAlignmentTest.php
+++ b/tests/Feature/ChurchServicePipelineAlignmentTest.php
@@ -32,7 +32,7 @@ class ChurchServicePipelineAlignmentTest extends TestCase
     {
         $processingLog = MediaProcessingLog::factory()->livestream()->processing()->create([
             'extracted_date' => '2026-08-02',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         LivestreamSegment::factory()->song()->create([
@@ -74,7 +74,7 @@ class ChurchServicePipelineAlignmentTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-08-09',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $song = ChurchServiceItem::factory()->create([
@@ -86,7 +86,7 @@ class ChurchServicePipelineAlignmentTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->processing()->create([
             'extracted_date' => '2026-08-09',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         LivestreamSegment::factory()->song()->create([
@@ -123,7 +123,7 @@ class ChurchServicePipelineAlignmentTest extends TestCase
         $processingLog = MediaProcessingLog::factory()->livestream()->completed()->create([
             'church_service_id' => null,
             'extracted_date' => '2026-08-16',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
             'current_step' => 'completed',
         ]);
 
@@ -142,7 +142,7 @@ class ChurchServicePipelineAlignmentTest extends TestCase
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-08-16',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $song = ChurchServiceItem::factory()->create([

--- a/tests/Feature/ChurchServiceReconciliationDispatchTest.php
+++ b/tests/Feature/ChurchServiceReconciliationDispatchTest.php
@@ -24,12 +24,12 @@ class ChurchServiceReconciliationDispatchTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->completed()->create([
             'extracted_date' => '2026-04-19',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-04-19',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         Queue::assertPushed(
@@ -44,18 +44,18 @@ class ChurchServiceReconciliationDispatchTest extends TestCase
     {
         $processingLog = MediaProcessingLog::factory()->livestream()->completed()->create([
             'extracted_date' => '2026-04-26',
-            'extracted_service' => SermonService::EVENING->value,
+            'extracted_service' => SermonService::Evening->value,
         ]);
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-04-26',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         Queue::fake();
 
         $churchService->update([
-            'service' => SermonService::EVENING->value,
+            'service' => SermonService::Evening->value,
         ]);
 
         Queue::assertPushed(
@@ -70,12 +70,12 @@ class ChurchServiceReconciliationDispatchTest extends TestCase
     {
         MediaProcessingLog::factory()->livestream()->completed()->create([
             'extracted_date' => '2026-04-26',
-            'extracted_service' => SermonService::EVENING->value,
+            'extracted_service' => SermonService::Evening->value,
         ]);
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-04-26',
-            'service' => SermonService::EVENING->value,
+            'service' => SermonService::Evening->value,
         ]);
 
         Queue::fake();
@@ -95,12 +95,12 @@ class ChurchServiceReconciliationDispatchTest extends TestCase
         MediaProcessingLog::factory()->livestream()->create([
             'status' => 'processing',
             'extracted_date' => '2026-05-03',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ChurchService::factory()->create([
             'date' => '2026-05-03',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         Queue::assertNothingPushed();
@@ -111,12 +111,12 @@ class ChurchServiceReconciliationDispatchTest extends TestCase
     {
         $processingLog = MediaProcessingLog::factory()->livestream()->completed()->create([
             'extracted_date' => '2026-05-10',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-05-04',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         Queue::fake();

--- a/tests/Feature/Console/BackfillMediaProcessingIdentityCommandTest.php
+++ b/tests/Feature/Console/BackfillMediaProcessingIdentityCommandTest.php
@@ -22,7 +22,7 @@ class BackfillMediaProcessingIdentityCommandTest extends TestCase
             'extracted_service' => null,
             'processing_metadata' => [
                 'extracted_date' => '2026-01-12',
-                'extracted_service' => SermonService::MORNING->value,
+                'extracted_service' => SermonService::Morning->value,
             ],
         ]);
 
@@ -46,7 +46,7 @@ class BackfillMediaProcessingIdentityCommandTest extends TestCase
             'extracted_service' => null,
             'processing_metadata' => [
                 'extracted_date' => '2026-01-19',
-                'extracted_service' => SermonService::MORNING->value,
+                'extracted_service' => SermonService::Morning->value,
             ],
         ]);
 
@@ -55,7 +55,7 @@ class BackfillMediaProcessingIdentityCommandTest extends TestCase
             'extracted_service' => null,
             'processing_metadata' => [
                 'extracted_date' => '2026-02-02',
-                'extracted_service' => SermonService::EVENING->value,
+                'extracted_service' => SermonService::Evening->value,
             ],
         ]);
 
@@ -75,10 +75,10 @@ class BackfillMediaProcessingIdentityCommandTest extends TestCase
         $invalidMetadata->refresh();
 
         $this->assertSame('2026-01-19', $fullyMissing->extracted_date?->toDateString());
-        $this->assertSame(SermonService::MORNING, $fullyMissing->extracted_service);
+        $this->assertSame(SermonService::Morning, $fullyMissing->extracted_service);
 
         $this->assertSame('2026-01-26', $partiallyMissing->extracted_date?->toDateString());
-        $this->assertSame(SermonService::EVENING, $partiallyMissing->extracted_service);
+        $this->assertSame(SermonService::Evening, $partiallyMissing->extracted_service);
 
         $this->assertNull($invalidMetadata->extracted_date);
         $this->assertNull($invalidMetadata->extracted_service);
@@ -92,7 +92,7 @@ class BackfillMediaProcessingIdentityCommandTest extends TestCase
             'extracted_service' => null,
             'processing_metadata' => [
                 'extracted_date' => '2026-02-09',
-                'extracted_service' => SermonService::MORNING->value,
+                'extracted_service' => SermonService::Morning->value,
             ],
         ]);
 
@@ -104,6 +104,6 @@ class BackfillMediaProcessingIdentityCommandTest extends TestCase
         $processingLog->refresh();
 
         $this->assertSame('2026-02-09', $processingLog->extracted_date?->toDateString());
-        $this->assertSame(SermonService::MORNING, $processingLog->extracted_service);
+        $this->assertSame(SermonService::Morning, $processingLog->extracted_service);
     }
 }

--- a/tests/Feature/Console/ImportLegacySermonBatchCommandTest.php
+++ b/tests/Feature/Console/ImportLegacySermonBatchCommandTest.php
@@ -89,7 +89,7 @@ class ImportLegacySermonBatchCommandTest extends TestCase
         $this->assertSame(MediaType::Audio, $log->processing_type);
         $this->assertSame(ProcessingStatus::Pending, $log->status);
         $this->assertSame('2024-03-10', $log->extracted_date?->toDateString());
-        $this->assertSame(SermonService::MORNING, $log->extracted_service);
+        $this->assertSame(SermonService::Morning, $log->extracted_service);
         $this->assertSame(2700.0, $log->duration);
         $this->assertNotNull($log->file_hash);
         $this->assertNotNull($log->file_size);
@@ -275,7 +275,7 @@ class ImportLegacySermonBatchCommandTest extends TestCase
         $log = MediaProcessingLog::query()->first();
         $this->assertNotNull($log);
         $this->assertSame('Evening Talk', $log->processing_metadata?->id3Metadata?->title);
-        $this->assertSame(SermonService::EVENING, $log->extracted_service);
+        $this->assertSame(SermonService::Evening, $log->extracted_service);
     }
 
     /**

--- a/tests/Feature/Console/ImportLegacySongUsageCommandTest.php
+++ b/tests/Feature/Console/ImportLegacySongUsageCommandTest.php
@@ -63,7 +63,7 @@ class ImportLegacySongUsageCommandTest extends TestCase
 
         $morningService = ChurchService::query()
             ->where('date', '2013-04-28')
-            ->where('service', SermonService::MORNING->value)
+            ->where('service', SermonService::Morning->value)
             ->firstOrFail();
 
         $this->assertSame('legacy_play_date', $morningService->source);
@@ -86,7 +86,7 @@ class ImportLegacySongUsageCommandTest extends TestCase
 
         $eveningService = ChurchService::query()
             ->where('date', '2013-04-28')
-            ->where('service', SermonService::EVENING->value)
+            ->where('service', SermonService::Evening->value)
             ->firstOrFail();
 
         $this->assertDatabaseHas('church_service_items', [
@@ -126,7 +126,7 @@ class ImportLegacySongUsageCommandTest extends TestCase
 
         $churchService = ChurchService::factory()->create([
             'date' => '2013-04-28',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'email',
         ]);
 

--- a/tests/Feature/Console/ImportOpenLpDirectoryCommandTest.php
+++ b/tests/Feature/Console/ImportOpenLpDirectoryCommandTest.php
@@ -73,12 +73,12 @@ class ImportOpenLpDirectoryCommandTest extends TestCase
         $this->assertDatabaseCount('church_services', 2);
         $this->assertDatabaseHas('church_services', [
             'date' => '2024-11-17',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'original_filename' => '2024-11-17 AM.osz',
         ]);
         $this->assertDatabaseHas('church_services', [
             'date' => '2024-11-17',
-            'service' => SermonService::EVENING->value,
+            'service' => SermonService::Evening->value,
             'original_filename' => '2024-11-17 PM.osz',
         ]);
     }
@@ -101,7 +101,7 @@ class ImportOpenLpDirectoryCommandTest extends TestCase
 
         $this->assertDatabaseHas('church_services', [
             'date' => '2023-01-01',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'original_filename' => '01-Jan-23 AM.osz',
         ]);
     }

--- a/tests/Feature/InboundEmailImportRaceConditionTest.php
+++ b/tests/Feature/InboundEmailImportRaceConditionTest.php
@@ -27,7 +27,7 @@ class InboundEmailImportRaceConditionTest extends TestCase
 
         $parseResult = new OosEmailParseResult(
             date: '2025-05-11',
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             items: [],
             confidenceScore: 0.95,
             needsReview: false,

--- a/tests/Feature/Jobs/ProcessInboundOosEmailTest.php
+++ b/tests/Feature/Jobs/ProcessInboundOosEmailTest.php
@@ -56,7 +56,7 @@ class ProcessInboundOosEmailTest extends TestCase
         $service = ChurchService::query()->firstOrFail();
 
         $this->assertSame('2026-03-16', $service->date->toDateString());
-        $this->assertSame(SermonService::MORNING, $service->service);
+        $this->assertSame(SermonService::Morning, $service->service);
         $this->assertSame('email', $service->source);
         $this->assertFalse($service->needs_review);
         $this->assertCount(4, $service->items()->get());
@@ -147,7 +147,7 @@ class ProcessInboundOosEmailTest extends TestCase
         $service = ChurchService::query()->with(['items.song', 'mediaProcessingLogs'])->sole();
         $songUsage = app(PublicSongUsageService::class);
 
-        $this->assertSame(SermonService::EVENING, $service->service);
+        $this->assertSame(SermonService::Evening, $service->service);
         $this->assertSame('email', $service->source);
         $this->assertCount(0, $service->mediaProcessingLogs);
         $this->assertCount(3, $service->items);

--- a/tests/Feature/Livewire/Admin/AdminUrlStateTest.php
+++ b/tests/Feature/Livewire/Admin/AdminUrlStateTest.php
@@ -66,7 +66,7 @@ class AdminUrlStateTest extends TestCase
 
         Sermon::factory()->withDate(now()->subMonths(18))->create([
             'title' => 'Grace for Today',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'preacher' => $preacher->name,
             'preacher_id' => $preacher->id,
             'series' => 'Grace Series',
@@ -76,7 +76,7 @@ class AdminUrlStateTest extends TestCase
 
         Sermon::factory()->withDate(now()->subWeeks(2))->create([
             'title' => 'Hope for Tomorrow',
-            'service' => SermonService::EVENING->value,
+            'service' => SermonService::Evening->value,
             'series' => 'Hope Series',
             'needs_preacher_review' => false,
             'video_file_path' => null,
@@ -84,7 +84,7 @@ class AdminUrlStateTest extends TestCase
 
         Livewire::withQueryParams([
             'search' => 'Grace',
-            'serviceFilter' => SermonService::MORNING->value,
+            'serviceFilter' => SermonService::Morning->value,
             'preacherFilter' => (string) $preacher->id,
             'seriesFilter' => 'Grace Series',
             'hasVideoFilter' => '1',
@@ -92,7 +92,7 @@ class AdminUrlStateTest extends TestCase
             'last12Months' => '0',
         ])->test(ListSermons::class)
             ->assertSet('search', 'Grace')
-            ->assertSet('serviceFilter', SermonService::MORNING->value)
+            ->assertSet('serviceFilter', SermonService::Morning->value)
             ->assertSet('preacherFilter', $preacher->id)
             ->assertSet('seriesFilter', 'Grace Series')
             ->assertSet('hasVideoFilter', true)
@@ -291,25 +291,25 @@ class AdminUrlStateTest extends TestCase
 
         ChurchService::factory()->create([
             'date' => '2026-01-19',
-            'service' => SermonService::EVENING->value,
+            'service' => SermonService::Evening->value,
             'original_filename' => '2026-01-19 PM.osz',
             'needs_review' => true,
         ]);
 
         ChurchService::factory()->create([
             'date' => '2026-01-12',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'original_filename' => '2026-01-12 AM.osz',
             'needs_review' => false,
         ]);
 
         Livewire::withQueryParams([
             'search' => '2026-01-19',
-            'serviceFilter' => SermonService::EVENING->value,
+            'serviceFilter' => SermonService::Evening->value,
             'needsReviewFilter' => '1',
         ])->test(ListChurchServices::class)
             ->assertSet('search', '2026-01-19')
-            ->assertSet('serviceFilter', SermonService::EVENING->value)
+            ->assertSet('serviceFilter', SermonService::Evening->value)
             ->assertSet('needsReviewFilter', true)
             ->assertSee('2026-01-19 PM.osz')
             ->assertDontSee('2026-01-12 AM.osz');
@@ -322,12 +322,12 @@ class AdminUrlStateTest extends TestCase
 
         $eveningService = ChurchService::factory()->create([
             'date' => '2026-02-08',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
         ]);
 
         $morningService = ChurchService::factory()->create([
             'date' => '2026-03-08',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $songA = Song::factory()->create([
@@ -360,12 +360,12 @@ class AdminUrlStateTest extends TestCase
 
         Livewire::withQueryParams([
             'search' => 'Writer Two',
-            'serviceFilter' => SermonService::EVENING->value,
+            'serviceFilter' => SermonService::Evening->value,
             'dateFrom' => '2026-02-01',
             'dateTo' => '2026-02-28',
         ])->test(ListSongs::class)
             ->assertSet('search', 'Writer Two')
-            ->assertSet('serviceFilter', SermonService::EVENING->value)
+            ->assertSet('serviceFilter', SermonService::Evening->value)
             ->assertSet('dateFrom', '2026-02-01')
             ->assertSet('dateTo', '2026-02-28')
             ->assertSee('Song B')
@@ -443,7 +443,7 @@ class AdminUrlStateTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-07-06',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [
                     ['type' => 'custom', 'title' => 'Welcome', 'metadata' => ['email_type' => 'welcome']],
                     ['type' => 'songs', 'title' => 'Opening Hymn', 'metadata' => null],
@@ -456,7 +456,7 @@ class AdminUrlStateTest extends TestCase
         ])->test(ManageChurchService::class)
             ->assertSet('inboundEmailId', $email->id)
             ->assertSet('date', '2026-07-06')
-            ->assertSet('service', SermonService::MORNING->value)
+            ->assertSet('service', SermonService::Morning->value)
             ->assertSet('items.0.title', 'Welcome')
             ->assertSet('items.1.title', 'Opening Hymn');
     }

--- a/tests/Feature/Livewire/Admin/ChurchServices/ShowChurchServiceTest.php
+++ b/tests/Feature/Livewire/Admin/ChurchServices/ShowChurchServiceTest.php
@@ -55,7 +55,7 @@ class ShowChurchServiceTest extends TestCase
         config(['queue.default' => 'sync']);
 
         $serviceDate = '2026-01-15';
-        $serviceType = SermonService::MORNING;
+        $serviceType = SermonService::Morning;
 
         $churchService = ChurchService::factory()->create([
             'date' => $serviceDate,
@@ -95,7 +95,7 @@ class ShowChurchServiceTest extends TestCase
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-04-20',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'livestream',
             'needs_review' => true,
             'import_metadata' => [
@@ -110,7 +110,7 @@ class ShowChurchServiceTest extends TestCase
             'status' => ProcessingStatus::Completed,
             'church_service_id' => null,
             'extracted_date' => '2026-04-20',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $sermon = Sermon::factory()->fromLivestream()->create([
@@ -154,7 +154,7 @@ class ShowChurchServiceTest extends TestCase
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-04-27',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'livestream',
             'import_metadata' => [
                 'livestream_projection' => [
@@ -183,7 +183,7 @@ class ShowChurchServiceTest extends TestCase
             'processing_metadata' => [
                 'repair' => [
                     'original_extracted_date' => '2026-04-27',
-                    'original_extracted_service' => SermonService::MORNING->value,
+                    'original_extracted_service' => SermonService::Morning->value,
                 ],
             ],
         ]);

--- a/tests/Feature/Livewire/Admin/EditSermonTest.php
+++ b/tests/Feature/Livewire/Admin/EditSermonTest.php
@@ -37,7 +37,7 @@ class EditSermonTest extends TestCase
             'title' => 'Original Title',
             'slug' => 'original-title',
             'date' => '2025-06-15',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'preacher' => 'John Smith',
             'reference' => 'John 3:16',
             'series' => null,
@@ -140,7 +140,7 @@ class EditSermonTest extends TestCase
             ->set('title', 'Updated Title')
             ->set('slug', 'updated-title')
             ->set('date', '2025-07-01')
-            ->set('service', SermonService::EVENING->value)
+            ->set('service', SermonService::Evening->value)
             ->set('preacherId', null)
             ->set('preacher', 'David Johnson')
             ->set('reference', 'Romans 8:28')

--- a/tests/Feature/Livewire/Admin/SearchSecurityAndGroupingTest.php
+++ b/tests/Feature/Livewire/Admin/SearchSecurityAndGroupingTest.php
@@ -116,18 +116,18 @@ class SearchSecurityAndGroupingTest extends TestCase
 
         Sermon::factory()->create([
             'title' => 'The Grace of God',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'date' => now()->subDays(1),
         ]);
 
         Sermon::factory()->create([
             'title' => 'Evening Grace',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
             'date' => now()->subDays(2),
         ]);
 
         Livewire::test(ListSermons::class)
-            ->set('serviceFilter', SermonService::MORNING->value)
+            ->set('serviceFilter', SermonService::Morning->value)
             ->set('search', 'Grace')
             ->assertSee('The Grace of God')
             ->assertDontSee('Evening Grace');
@@ -211,14 +211,14 @@ class SearchSecurityAndGroupingTest extends TestCase
             'original_filename' => 'Match Ready',
             'needs_review' => false,
             'date' => '2026-01-01',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         ChurchService::factory()->create([
             'original_filename' => 'Match Review',
             'needs_review' => true,
             'date' => '2026-01-02',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
         ]);
 
         Livewire::test(ListChurchServices::class)

--- a/tests/Feature/Livewire/Admin/Sermons/EditSermonTest.php
+++ b/tests/Feature/Livewire/Admin/Sermons/EditSermonTest.php
@@ -169,7 +169,7 @@ class EditSermonTest extends TestCase
     {
         $sermon = Sermon::factory()->create([
             'title' => 'Original Title',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'date' => '2025-01-01',
         ]);
 
@@ -178,14 +178,14 @@ class EditSermonTest extends TestCase
         Livewire::test(EditSermon::class, ['sermon' => $sermon])
             ->set('title', 'Brand New Title')
             ->set('date', '2025-02-01')
-            ->set('service', SermonService::EVENING->value)
+            ->set('service', SermonService::Evening->value)
             ->call('save')
             ->assertDispatched('notify');
 
         $sermon->refresh();
         $this->assertEquals('Brand New Title', $sermon->title);
         $this->assertEquals('2025-02-01', $sermon->date->format('Y-m-d'));
-        $this->assertEquals(SermonService::EVENING, $sermon->service);
+        $this->assertEquals(SermonService::Evening, $sermon->service);
     }
 
     #[Test]

--- a/tests/Feature/Livewire/AdminChurchServiceTest.php
+++ b/tests/Feature/Livewire/AdminChurchServiceTest.php
@@ -73,7 +73,7 @@ class AdminChurchServiceTest extends TestCase
             ->openLp()
             ->state([
                 'date' => '2026-01-12',
-                'service' => SermonService::MORNING,
+                'service' => SermonService::Morning,
                 'original_filename' => '2026-01-12 AM.osz',
             ])
             ->create();
@@ -83,14 +83,14 @@ class AdminChurchServiceTest extends TestCase
             ->needsReview()
             ->state([
                 'date' => '2026-01-19',
-                'service' => SermonService::EVENING,
+                'service' => SermonService::Evening,
                 'original_filename' => '2026-01-19 PM.osz',
             ])
             ->create();
 
         Livewire::test(ListChurchServices::class)
             ->assertSee('Services')
-            ->set('serviceFilter', SermonService::EVENING->value)
+            ->set('serviceFilter', SermonService::Evening->value)
             ->assertSee('2026-01-19 PM.osz')
             ->assertDontSee('2026-01-12 AM.osz')
             ->set('serviceFilter', null)
@@ -150,7 +150,7 @@ class AdminChurchServiceTest extends TestCase
         $this->assertDatabaseHas('church_services', [
             'id' => $service->id,
             'date' => '2024-11-17',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'openlp',
             'original_filename' => '2024-11-17 AM.osz',
         ]);
@@ -211,7 +211,7 @@ class AdminChurchServiceTest extends TestCase
 
         $component = Livewire::test(ManageChurchService::class)
             ->set('date', '2026-05-03')
-            ->set('service', SermonService::MORNING->value)
+            ->set('service', SermonService::Morning->value)
             ->set('items.0.section_type', ServiceSectionType::WELCOME->value)
             ->set('items.0.title', 'Welcome and Call to Worship')
             ->call('addItem')
@@ -255,7 +255,7 @@ class AdminChurchServiceTest extends TestCase
 
         Livewire::test(ManageChurchService::class)
             ->set('date', '2026-05-03')
-            ->set('service', SermonService::MORNING->value)
+            ->set('service', SermonService::Morning->value)
             ->set('items.0.section_type', ServiceSectionType::WELCOME->value)
             ->set('items.0.title', 'Welcome and Call to Worship')
             ->call('save');
@@ -278,7 +278,7 @@ class AdminChurchServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-05-10',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
             'source' => 'openlp',
             'original_filename' => '2026-05-10 PM.osz',
             'needs_review' => true,
@@ -365,7 +365,7 @@ class AdminChurchServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-05-17',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'source' => 'manual',
         ]);
 
@@ -382,7 +382,7 @@ class AdminChurchServiceTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->completed()->create([
             'extracted_date' => '2026-05-17',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         Livewire::test(ManageChurchService::class, ['churchService' => $service])
@@ -415,7 +415,7 @@ class AdminChurchServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-05-24',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
             'source' => 'manual',
         ]);
 
@@ -479,12 +479,12 @@ class AdminChurchServiceTest extends TestCase
 
         ChurchService::factory()->create([
             'date' => '2026-05-17',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         Livewire::test(ManageChurchService::class)
             ->set('date', '2026-05-17')
-            ->set('service', SermonService::MORNING->value)
+            ->set('service', SermonService::Morning->value)
             ->set('items.0.section_type', ServiceSectionType::WELCOME->value)
             ->set('items.0.title', 'Welcome')
             ->call('save')
@@ -498,7 +498,7 @@ class AdminChurchServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-02-22',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => true,
             'import_metadata' => [
                 'confidence_score' => 0.4,
@@ -543,7 +543,7 @@ class AdminChurchServiceTest extends TestCase
         $service = $this->churchServiceScenario()
             ->state([
                 'date' => '2026-02-22',
-                'service' => SermonService::MORNING,
+                'service' => SermonService::Morning,
             ])
             ->create();
 
@@ -558,7 +558,7 @@ class AdminChurchServiceTest extends TestCase
             ->as(\App\Enums\MediaType::Livestream)
             ->state([
                 'extracted_date' => '2026-02-22',
-                'extracted_service' => SermonService::MORNING,
+                'extracted_service' => SermonService::Morning,
             ])
             ->create();
 
@@ -566,7 +566,7 @@ class AdminChurchServiceTest extends TestCase
             ->as(\App\Enums\MediaType::Livestream)
             ->state([
                 'extracted_date' => '2026-02-23',
-                'extracted_service' => SermonService::MORNING,
+                'extracted_service' => SermonService::Morning,
             ])
             ->create();
 
@@ -636,12 +636,12 @@ class AdminChurchServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-03-01',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $run = MediaProcessingLog::factory()->livestream()->completed()->create([
             'extracted_date' => '2026-03-01',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         SermonProcessingStep::factory()->create([
@@ -699,12 +699,12 @@ class AdminChurchServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-04-05',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $processingRun = MediaProcessingLog::factory()->livestream()->pending()->create([
             'extracted_date' => '2026-04-05',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
         ]);
 
         Livewire::test(ShowChurchService::class, ['churchService' => $service])
@@ -743,17 +743,17 @@ class AdminChurchServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-04-12',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $videoRun = MediaProcessingLog::factory()->video()->create([
             'extracted_date' => '2026-04-12',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
         ]);
 
         $mismatchedRun = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-04-19',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
         ]);
 
         Livewire::test(ShowChurchService::class, ['churchService' => $service])
@@ -775,12 +775,12 @@ class AdminChurchServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-04-26',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $processingRun = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-04-26',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
             'source_file_path' => null,
             'status' => ProcessingStatus::Completed,
         ]);
@@ -816,7 +816,7 @@ class AdminChurchServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-05-01',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -841,7 +841,7 @@ class AdminChurchServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-05-08',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $item = ChurchServiceItem::factory()->create([
@@ -854,7 +854,7 @@ class AdminChurchServiceTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-08',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
         ]);
 
         ServiceSection::factory()->create([
@@ -884,7 +884,7 @@ class AdminChurchServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-05-15',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $item = ChurchServiceItem::factory()->create([
@@ -896,7 +896,7 @@ class AdminChurchServiceTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-15',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
         ]);
 
         ServiceSection::factory()->create([
@@ -931,12 +931,12 @@ class AdminChurchServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-05-22',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-22',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
         ]);
 
         ServiceSection::factory()->create([
@@ -963,7 +963,7 @@ class AdminChurchServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-05-29',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $item = ChurchServiceItem::factory()->create([
@@ -975,7 +975,7 @@ class AdminChurchServiceTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-29',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
         ]);
 
         ServiceSection::factory()->create([
@@ -1002,7 +1002,7 @@ class AdminChurchServiceTest extends TestCase
             ->livestream()
             ->state([
                 'date' => '2026-03-23',
-                'service' => SermonService::MORNING,
+                'service' => SermonService::Morning,
                 'needs_review' => true,
                 'import_metadata' => [
                     'pending_structure_merge' => [
@@ -1042,7 +1042,7 @@ class AdminChurchServiceTest extends TestCase
         $service = $this->churchServiceScenario()
             ->state([
                 'date' => '2026-03-23',
-                'service' => SermonService::MORNING,
+                'service' => SermonService::Morning,
                 'needs_review' => false,
             ])
             ->create();
@@ -1061,7 +1061,7 @@ class AdminChurchServiceTest extends TestCase
             ->livestream()
             ->state([
                 'date' => '2026-03-23',
-                'service' => SermonService::MORNING,
+                'service' => SermonService::Morning,
                 'needs_review' => true,
                 'import_metadata' => [
                     'pending_structure_merge' => [
@@ -1121,7 +1121,7 @@ class AdminChurchServiceTest extends TestCase
             ->livestream()
             ->state([
                 'date' => '2026-03-23',
-                'service' => SermonService::MORNING,
+                'service' => SermonService::Morning,
                 'needs_review' => true,
                 'import_metadata' => [
                     'pending_structure_merge' => [
@@ -1188,7 +1188,7 @@ class AdminChurchServiceTest extends TestCase
             ->livestream()
             ->state([
                 'date' => '2026-03-23',
-                'service' => SermonService::MORNING,
+                'service' => SermonService::Morning,
                 'needs_review' => true,
                 'import_metadata' => [
                     'pending_structure_merge' => [

--- a/tests/Feature/Livewire/AdminInboundEmailReviewTest.php
+++ b/tests/Feature/Livewire/AdminInboundEmailReviewTest.php
@@ -45,7 +45,7 @@ class AdminInboundEmailReviewTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-08',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [
                     ['type' => 'custom', 'title' => 'Welcome', 'metadata' => ['email_type' => 'welcome']],
                     ['type' => 'songs', 'title' => 'Living Hope', 'metadata' => null],
@@ -59,7 +59,7 @@ class AdminInboundEmailReviewTest extends TestCase
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-06-15',
-                    resolvedService: SermonService::EVENING->value,
+                    resolvedService: SermonService::Evening->value,
                     items: [],
                 ),
                 [
@@ -96,7 +96,7 @@ class AdminInboundEmailReviewTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-08',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [
                     ['type' => 'custom', 'title' => 'Welcome', 'metadata' => ['email_type' => 'welcome']],
                 ],
@@ -133,7 +133,7 @@ class AdminInboundEmailReviewTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-08',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [
                     ['type' => 'custom', 'title' => 'Welcome', 'metadata' => ['email_type' => 'welcome']],
                 ],
@@ -195,7 +195,7 @@ class AdminInboundEmailReviewTest extends TestCase
 
         $service = ChurchService::query()
             ->where('date', '2026-06-22')
-            ->where('service', SermonService::MORNING->value)
+            ->where('service', SermonService::Morning->value)
             ->sole();
 
         $component->assertRedirect(route('admin.services.show', $service));
@@ -221,7 +221,7 @@ class AdminInboundEmailReviewTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [
                     ['position' => 1, 'type' => 'custom', 'title' => 'Welcome', 'metadata' => ['email_type' => 'welcome']],
                     ['position' => 2, 'type' => 'custom', 'title' => 'Sermon', 'metadata' => ['email_type' => 'sermon']],
@@ -234,7 +234,7 @@ class AdminInboundEmailReviewTest extends TestCase
 
         $service = ChurchService::query()
             ->where('date', '2026-06-29')
-            ->where('service', SermonService::MORNING->value)
+            ->where('service', SermonService::Morning->value)
             ->sole();
 
         $component->assertRedirect(route('admin.services.show', $service));
@@ -266,7 +266,7 @@ class AdminInboundEmailReviewTest extends TestCase
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-06-22',
-                    resolvedService: SermonService::MORNING->value,
+                    resolvedService: SermonService::Morning->value,
                     items: [
                         ['position' => 1, 'type' => 'custom', 'title' => 'Old Welcome', 'metadata' => ['email_type' => 'welcome']],
                     ],
@@ -322,7 +322,7 @@ class AdminInboundEmailReviewTest extends TestCase
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-07-06',
-                    resolvedService: SermonService::MORNING->value,
+                    resolvedService: SermonService::Morning->value,
                     items: [],
                 ),
                 [
@@ -364,7 +364,7 @@ class AdminInboundEmailReviewTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [
                     ['position' => 1, 'type' => 'custom', 'title' => 'Welcome', 'metadata' => ['email_type' => 'welcome']],
                 ],
@@ -413,7 +413,7 @@ class AdminInboundEmailReviewTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [
                     ['type' => 'custom', 'title' => 'Welcome', 'metadata' => ['email_type' => 'welcome']],
                 ],
@@ -434,7 +434,7 @@ class AdminInboundEmailReviewTest extends TestCase
             'status' => InboundEmailStatus::PENDING->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-07-06',
-                resolvedService: SermonService::MORNING->value,
+                resolvedService: SermonService::Morning->value,
                 items: [
                     ['type' => 'custom', 'title' => 'Welcome', 'metadata' => ['email_type' => 'welcome']],
                     ['type' => 'custom', 'title' => 'Opening Prayer', 'metadata' => ['email_type' => 'prayer']],
@@ -444,14 +444,14 @@ class AdminInboundEmailReviewTest extends TestCase
 
         $component = Livewire::test(ManageChurchService::class, ['inboundEmailId' => $email->id])
             ->assertSet('date', '2026-07-06')
-            ->assertSet('service', SermonService::MORNING->value)
+            ->assertSet('service', SermonService::Morning->value)
             ->assertSet('items.0.title', 'Welcome')
             ->assertSet('items.1.title', 'Opening Prayer')
             ->call('save');
 
         $service = ChurchService::query()
             ->where('date', '2026-07-06')
-            ->where('service', SermonService::MORNING->value)
+            ->where('service', SermonService::Morning->value)
             ->sole();
 
         $component->assertRedirect(route('admin.services.show', $service));

--- a/tests/Feature/Livewire/AdminSectionPublicationQueueTest.php
+++ b/tests/Feature/Livewire/AdminSectionPublicationQueueTest.php
@@ -42,7 +42,7 @@ class AdminSectionPublicationQueueTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-10',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -80,7 +80,7 @@ class AdminSectionPublicationQueueTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-17',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([
@@ -114,7 +114,7 @@ class AdminSectionPublicationQueueTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-18',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([
@@ -149,7 +149,7 @@ class AdminSectionPublicationQueueTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-19',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([

--- a/tests/Feature/Livewire/AdminServiceReviewDashboardTest.php
+++ b/tests/Feature/Livewire/AdminServiceReviewDashboardTest.php
@@ -46,7 +46,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-05-24',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => true,
         ]);
 
@@ -61,7 +61,7 @@ class AdminServiceReviewDashboardTest extends TestCase
         $run = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $service->id,
             'extracted_date' => '2026-05-24',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -102,7 +102,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-05-25',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => true,
         ]);
 
@@ -124,7 +124,7 @@ class AdminServiceReviewDashboardTest extends TestCase
         $run = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $service->id,
             'extracted_date' => '2026-05-25',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -174,7 +174,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-31',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $approveSection = ServiceSection::factory()->create([
@@ -217,7 +217,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-06-01',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([
@@ -239,7 +239,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-06-07',
-            'extracted_service' => SermonService::EVENING->value,
+            'extracted_service' => SermonService::Evening->value,
         ]);
 
         $section = ServiceSection::factory()->create([
@@ -275,7 +275,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-06-08',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $overridePreacher = Preacher::factory()->create(['name' => 'Mary Helper']);
@@ -330,24 +330,24 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $selectedService = ChurchService::factory()->create([
             'date' => '2026-06-09',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $otherService = ChurchService::factory()->create([
             'date' => '2026-06-09',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
         ]);
 
         $selectedRun = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $selectedService->id,
             'extracted_date' => '2026-06-09',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $otherRun = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $otherService->id,
             'extracted_date' => '2026-06-09',
-            'extracted_service' => SermonService::EVENING->value,
+            'extracted_service' => SermonService::Evening->value,
         ]);
 
         $selectedFirst = ServiceSection::factory()->create([
@@ -425,13 +425,13 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-06-10',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $service->id,
             'extracted_date' => '2026-06-10',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $eligibleSection = ServiceSection::factory()->create([
@@ -494,7 +494,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-06-14',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([
@@ -519,7 +519,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-06-21',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([
@@ -587,7 +587,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         ChurchService::factory()->create([
             'date' => '2026-06-28',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
             'needs_review' => true,
         ]);
 
@@ -606,7 +606,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-06',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -642,7 +642,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-07',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -678,7 +678,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-08',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $first = ServiceSection::factory()->create([
@@ -716,7 +716,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-09',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $first = ServiceSection::factory()->create([
@@ -756,7 +756,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-10',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $first = ServiceSection::factory()->create([
@@ -801,7 +801,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-11',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $first = ServiceSection::factory()->create([
@@ -845,7 +845,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-12',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
             'source_file_path' => 'temp/media-processing/source.mp4',
         ]);
 
@@ -900,7 +900,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-13',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
             'source_file_path' => 'temp/media-processing/missing-source.mp4',
         ]);
 
@@ -954,7 +954,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-14',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $first = ServiceSection::factory()->create([
@@ -1002,12 +1002,12 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $runA = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-15',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $runB = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-15',
-            'extracted_service' => SermonService::EVENING->value,
+            'extracted_service' => SermonService::Evening->value,
         ]);
 
         $first = ServiceSection::factory()->create([
@@ -1045,7 +1045,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-16',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $first = ServiceSection::factory()->create([
@@ -1080,7 +1080,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-17',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $first = ServiceSection::factory()->create([
@@ -1117,7 +1117,7 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-07-18',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $first = ServiceSection::factory()->create([

--- a/tests/Feature/Livewire/AdminSongCatalogTest.php
+++ b/tests/Feature/Livewire/AdminSongCatalogTest.php
@@ -43,11 +43,11 @@ class AdminSongCatalogTest extends TestCase
 
         $morningService = ChurchService::factory()->create([
             'date' => '2026-02-01',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
         $eveningService = ChurchService::factory()->create([
             'date' => '2026-02-08',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
         ]);
 
         $songA = Song::factory()->create([
@@ -93,7 +93,7 @@ class AdminSongCatalogTest extends TestCase
             ->assertSee('Song B')
             ->assertDontSee('Song A')
             ->set('search', '')
-            ->set('serviceFilter', SermonService::MORNING->value)
+            ->set('serviceFilter', SermonService::Morning->value)
             ->assertViewHas('songs', function ($songs) use ($songA, $songB): bool {
                 $collection = $songs->getCollection()->keyBy('id');
 
@@ -138,7 +138,7 @@ class AdminSongCatalogTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-03-10',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $song = Song::factory()->create([

--- a/tests/Feature/Livewire/BrowseSongsTest.php
+++ b/tests/Feature/Livewire/BrowseSongsTest.php
@@ -92,7 +92,7 @@ class BrowseSongsTest extends TestCase
         $song = Song::factory()->create(['title' => 'Sung This Year']);
         $churchService = ChurchService::factory()->create([
             'date' => now()->format('Y-01-15'),
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
         ChurchServiceItem::factory()->create([
             'church_service_id' => $churchService->id,

--- a/tests/Feature/MediaProcessingIdentityResolverTest.php
+++ b/tests/Feature/MediaProcessingIdentityResolverTest.php
@@ -28,10 +28,10 @@ class MediaProcessingIdentityResolverTest extends TestCase
     {
         $log = MediaProcessingLog::factory()->create([
             'extracted_date' => '2024-05-12',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
             'processing_metadata' => [
                 'extracted_date' => '2024-05-13', // Should be ignored
-                'extracted_service' => SermonService::EVENING->value, // Should be ignored
+                'extracted_service' => SermonService::Evening->value, // Should be ignored
             ],
         ]);
 
@@ -39,7 +39,7 @@ class MediaProcessingIdentityResolverTest extends TestCase
 
         $this->assertNotNull($identity);
         $this->assertEquals('2024-05-12', $identity['date']);
-        $this->assertEquals(SermonService::MORNING, $identity['service']);
+        $this->assertEquals(SermonService::Morning, $identity['service']);
     }
 
     #[Test]
@@ -50,7 +50,7 @@ class MediaProcessingIdentityResolverTest extends TestCase
             'extracted_service' => null,
             'processing_metadata' => [
                 'extracted_date' => '2024-05-13',
-                'extracted_service' => SermonService::EVENING->value,
+                'extracted_service' => SermonService::Evening->value,
             ],
         ]);
 
@@ -58,7 +58,7 @@ class MediaProcessingIdentityResolverTest extends TestCase
 
         $this->assertNotNull($identity);
         $this->assertEquals('2024-05-13', $identity['date']);
-        $this->assertEquals(SermonService::EVENING, $identity['service']);
+        $this->assertEquals(SermonService::Evening, $identity['service']);
     }
 
     #[Test]
@@ -92,8 +92,8 @@ class MediaProcessingIdentityResolverTest extends TestCase
     #[Test]
     public function it_parses_valid_service(): void
     {
-        $this->assertEquals(SermonService::MORNING, $this->resolver->parseService('morning'));
-        $this->assertEquals(SermonService::EVENING, $this->resolver->parseService('evening'));
+        $this->assertEquals(SermonService::Morning, $this->resolver->parseService('morning'));
+        $this->assertEquals(SermonService::Evening, $this->resolver->parseService('evening'));
     }
 
     #[Test]
@@ -109,12 +109,12 @@ class MediaProcessingIdentityResolverTest extends TestCase
     {
         $log = MediaProcessingLog::factory()->create([
             'extracted_date' => '2024-05-12',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
         ]);
 
-        $this->assertTrue($this->resolver->matchesService($log, '2024-05-12', SermonService::MORNING));
-        $this->assertFalse($this->resolver->matchesService($log, '2024-05-13', SermonService::MORNING));
-        $this->assertFalse($this->resolver->matchesService($log, '2024-05-12', SermonService::EVENING));
+        $this->assertTrue($this->resolver->matchesService($log, '2024-05-12', SermonService::Morning));
+        $this->assertFalse($this->resolver->matchesService($log, '2024-05-13', SermonService::Morning));
+        $this->assertFalse($this->resolver->matchesService($log, '2024-05-12', SermonService::Evening));
     }
 
     #[Test]
@@ -122,16 +122,16 @@ class MediaProcessingIdentityResolverTest extends TestCase
     {
         MediaProcessingLog::factory()->create([
             'extracted_date' => '2024-05-12',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
         ]);
 
         MediaProcessingLog::factory()->create([
             'extracted_date' => '2024-05-13',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
         ]);
 
         $query = MediaProcessingLog::query();
-        $this->resolver->scopeMatchesIdentity($query, '2024-05-12', SermonService::MORNING);
+        $this->resolver->scopeMatchesIdentity($query, '2024-05-12', SermonService::Morning);
 
         $results = $query->get();
         $this->assertCount(1, $results);
@@ -146,7 +146,7 @@ class MediaProcessingIdentityResolverTest extends TestCase
             'extracted_service' => null,
             'processing_metadata' => [
                 'extracted_date' => '2024-05-12',
-                'extracted_service' => SermonService::MORNING->value,
+                'extracted_service' => SermonService::Morning->value,
             ],
         ]);
 
@@ -155,12 +155,12 @@ class MediaProcessingIdentityResolverTest extends TestCase
             'extracted_service' => null,
             'processing_metadata' => [
                 'extracted_date' => '2024-05-13',
-                'extracted_service' => SermonService::MORNING->value,
+                'extracted_service' => SermonService::Morning->value,
             ],
         ]);
 
         $query = MediaProcessingLog::query();
-        $this->resolver->scopeMatchesIdentity($query, '2024-05-12', SermonService::MORNING);
+        $this->resolver->scopeMatchesIdentity($query, '2024-05-12', SermonService::Morning);
 
         $results = $query->get();
         $this->assertCount(1, $results);

--- a/tests/Feature/PodcastFeedControllerTest.php
+++ b/tests/Feature/PodcastFeedControllerTest.php
@@ -40,7 +40,7 @@ class PodcastFeedControllerTest extends TestCase
     {
         $sermon = Sermon::factory()->create([
             'title' => 'Morning Message',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'content_type' => SermonContentType::Sermon,
         ]);
 

--- a/tests/Feature/PodcastFeedTest.php
+++ b/tests/Feature/PodcastFeedTest.php
@@ -75,7 +75,7 @@ class PodcastFeedTest extends TestCase
     public function morning_feed_returns_valid_rss(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
             'duration' => 2700, // 45 minutes
         ]);
@@ -94,7 +94,7 @@ class PodcastFeedTest extends TestCase
     public function evening_feed_returns_valid_rss(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::EVENING->value,
+            'service' => SermonService::Evening->value,
             'audio_file_path' => 'test.mp3',
         ]);
 
@@ -125,7 +125,7 @@ class PodcastFeedTest extends TestCase
     {
         // Create sermon without audio by inserting directly with null
         $noAudioSermon = Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'placeholder.mp3', // Will be set to empty string below
             'title' => 'No Audio Sermon',
         ]);
@@ -133,7 +133,7 @@ class PodcastFeedTest extends TestCase
         \DB::table('sermons')->where('id', $noAudioSermon->id)->update(['audio_file_path' => '']);
 
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'has-audio.mp3',
             'title' => 'Has Audio Sermon',
         ]);
@@ -149,7 +149,7 @@ class PodcastFeedTest extends TestCase
     public function feed_excludes_sermons_with_empty_audio_path(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => '',
             'title' => 'Empty Audio Path Sermon',
         ]);
@@ -164,13 +164,13 @@ class PodcastFeedTest extends TestCase
     public function feed_only_includes_correct_service_type(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'morning.mp3',
             'title' => 'Morning Service Sermon',
         ]);
 
         Sermon::factory()->create([
-            'service' => SermonService::EVENING->value,
+            'service' => SermonService::Evening->value,
             'audio_file_path' => 'evening.mp3',
             'title' => 'Evening Service Sermon',
         ]);
@@ -195,7 +195,7 @@ class PodcastFeedTest extends TestCase
     public function feed_formats_duration_correctly(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
             'duration' => 2700, // 45 minutes = 00:45:00
         ]);
@@ -210,7 +210,7 @@ class PodcastFeedTest extends TestCase
     public function feed_formats_long_duration_correctly(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
             'duration' => 5432, // 1:30:32
         ]);
@@ -225,7 +225,7 @@ class PodcastFeedTest extends TestCase
     public function feed_handles_null_duration(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
             'duration' => null,
         ]);
@@ -240,7 +240,7 @@ class PodcastFeedTest extends TestCase
     public function feed_includes_canonical_url(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
             'slug' => 'test-sermon',
             'date' => '2024-06-15',
@@ -256,7 +256,7 @@ class PodcastFeedTest extends TestCase
     public function feed_includes_podcast_summary(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
             'reference' => 'John 3:16',
             'preacher' => 'Mark Drury',
@@ -273,7 +273,7 @@ class PodcastFeedTest extends TestCase
     public function feed_includes_rfc2822_pub_date(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
             'date' => '2024-06-15',
         ]);
@@ -289,7 +289,7 @@ class PodcastFeedTest extends TestCase
     public function feed_includes_guid_with_prefix(): void
     {
         $sermon = Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
         ]);
 
@@ -303,7 +303,7 @@ class PodcastFeedTest extends TestCase
     public function feed_includes_itunes_metadata(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
         ]);
 
@@ -324,7 +324,7 @@ class PodcastFeedTest extends TestCase
     public function feed_includes_atom_self_link(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
         ]);
 
@@ -339,14 +339,14 @@ class PodcastFeedTest extends TestCase
     public function feed_orders_sermons_by_date_descending(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'old.mp3',
             'title' => 'Old Sermon',
             'date' => '2024-01-01',
         ]);
 
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'new.mp3',
             'title' => 'New Sermon',
             'date' => '2024-06-01',
@@ -370,7 +370,7 @@ class PodcastFeedTest extends TestCase
 
         for ($i = 1; $i <= 10; $i++) {
             Sermon::factory()->create([
-                'service' => SermonService::MORNING->value,
+                'service' => SermonService::Morning->value,
                 'audio_file_path' => "sermon-{$i}.mp3",
                 'title' => "Sermon Number {$i}",
                 'date' => now()->subDays($i),
@@ -392,7 +392,7 @@ class PodcastFeedTest extends TestCase
     public function feed_is_valid_xml(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
         ]);
 
@@ -436,7 +436,7 @@ class PodcastFeedTest extends TestCase
         $this->mockStorageServiceWithCallCounts(publicUrlCalls: 1, fileSizeCalls: 1);
 
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
             'title' => 'Cached Sermon',
         ]);
@@ -452,7 +452,7 @@ class PodcastFeedTest extends TestCase
     public function feed_cache_is_invalidated_when_sermon_is_created(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
             'title' => 'Cached Sermon',
         ]);
@@ -464,7 +464,7 @@ class PodcastFeedTest extends TestCase
 
         // Create another sermon
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'new.mp3',
             'title' => 'New Sermon After Cache',
         ]);
@@ -480,7 +480,7 @@ class PodcastFeedTest extends TestCase
     public function feed_cache_is_invalidated_when_sermon_is_updated(): void
     {
         $sermon = Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
             'title' => 'Original Sermon Title',
         ]);
@@ -502,7 +502,7 @@ class PodcastFeedTest extends TestCase
     public function feed_cache_is_invalidated_when_sermon_is_deleted(): void
     {
         $sermon = Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
             'title' => 'Sermon To Delete',
         ]);
@@ -527,7 +527,7 @@ class PodcastFeedTest extends TestCase
         ]);
 
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
             'preacher' => 'Original preacher',
             'preacher_id' => $preacher->id,
@@ -592,7 +592,7 @@ class PodcastFeedTest extends TestCase
         $this->withoutMiddleware();
 
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
         ]);
 
@@ -626,7 +626,7 @@ class PodcastFeedTest extends TestCase
     public function feed_includes_enclosure_with_file_size(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
         ]);
 
@@ -643,7 +643,7 @@ class PodcastFeedTest extends TestCase
     public function feed_includes_episode_image(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'audio_file_path' => 'test.mp3',
         ]);
 

--- a/tests/Feature/PublicSongCatalogServiceTest.php
+++ b/tests/Feature/PublicSongCatalogServiceTest.php
@@ -50,7 +50,7 @@ class PublicSongCatalogServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2026-01-15',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -72,7 +72,7 @@ class PublicSongCatalogServiceTest extends TestCase
         foreach (['2026-01-05', '2026-02-10'] as $date) {
             $churchService = ChurchService::factory()->create([
                 'date' => $date,
-                'service' => SermonService::MORNING,
+                'service' => SermonService::Morning,
             ]);
 
             ChurchServiceItem::factory()->create([
@@ -111,7 +111,7 @@ class PublicSongCatalogServiceTest extends TestCase
         foreach (['2026-01-01', '2026-01-08'] as $date) {
             $churchService = ChurchService::factory()->create([
                 'date' => $date,
-                'service' => SermonService::MORNING,
+                'service' => SermonService::Morning,
             ]);
 
             ChurchServiceItem::factory()->create([
@@ -123,7 +123,7 @@ class PublicSongCatalogServiceTest extends TestCase
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-01-15',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -151,7 +151,7 @@ class PublicSongCatalogServiceTest extends TestCase
 
         $service = ChurchService::factory()->create([
             'date' => '2024-06-01',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -182,7 +182,7 @@ class PublicSongCatalogServiceTest extends TestCase
 
         $churchService = ChurchService::factory()->create([
             'date' => now()->format('Y-01-20'),
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -204,7 +204,7 @@ class PublicSongCatalogServiceTest extends TestCase
         foreach ([now()->format('Y-03-01'), '2025-03-01'] as $date) {
             $churchService = ChurchService::factory()->create([
                 'date' => $date,
-                'service' => SermonService::MORNING,
+                'service' => SermonService::Morning,
             ]);
 
             ChurchServiceItem::factory()->create([
@@ -231,7 +231,7 @@ class PublicSongCatalogServiceTest extends TestCase
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-02-08',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $countedItem = ChurchServiceItem::factory()->create([

--- a/tests/Feature/PublicSongDetailTest.php
+++ b/tests/Feature/PublicSongDetailTest.php
@@ -90,7 +90,7 @@ class PublicSongDetailTest extends TestCase
 
         $nonLivestreamedService = ChurchService::factory()->create([
             'date' => '2026-02-16',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -103,7 +103,7 @@ class PublicSongDetailTest extends TestCase
 
         $livestreamedService = ChurchService::factory()->create([
             'date' => '2026-02-09',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $detectedItem = ChurchServiceItem::factory()->create([

--- a/tests/Feature/Queries/ServiceReviewDashboardQueryTest.php
+++ b/tests/Feature/Queries/ServiceReviewDashboardQueryTest.php
@@ -45,7 +45,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
     {
         ChurchService::factory()->create([
             'date' => '2026-05-24',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => true,
         ]);
 
@@ -62,7 +62,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
     {
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-25',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -84,7 +84,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
     {
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-26',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -106,13 +106,13 @@ class ServiceReviewDashboardQueryTest extends TestCase
     {
         $olderService = ChurchService::factory()->create([
             'date' => '2026-05-10',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => true,
         ]);
 
         $newerService = ChurchService::factory()->create([
             'date' => '2026-05-24',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => true,
         ]);
 
@@ -128,21 +128,21 @@ class ServiceReviewDashboardQueryTest extends TestCase
     {
         ChurchService::factory()->create([
             'date' => '2026-05-24',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
             'needs_review' => true,
         ]);
 
         ChurchService::factory()->create([
             'date' => '2026-05-24',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => true,
         ]);
 
         $groups = $this->query->reviewGroups();
 
         $this->assertCount(2, $groups);
-        $this->assertSame(SermonService::MORNING, $groups[0]['service_enum']);
-        $this->assertSame(SermonService::EVENING, $groups[1]['service_enum']);
+        $this->assertSame(SermonService::Morning, $groups[0]['service_enum']);
+        $this->assertSame(SermonService::Evening, $groups[1]['service_enum']);
     }
 
     #[Test]
@@ -150,14 +150,14 @@ class ServiceReviewDashboardQueryTest extends TestCase
     {
         $service = ChurchService::factory()->create([
             'date' => '2026-05-24',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => false,
         ]);
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $service->id,
             'extracted_date' => '2026-05-24',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -191,7 +191,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-24',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([
@@ -218,7 +218,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
     {
         $run = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-24',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
         $sermon = Sermon::factory()->create();
 
@@ -242,14 +242,14 @@ class ServiceReviewDashboardQueryTest extends TestCase
     {
         $service = ChurchService::factory()->create([
             'date' => '2026-05-24',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => true,
         ]);
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $service->id,
             'extracted_date' => '2026-05-24',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -460,24 +460,24 @@ class ServiceReviewDashboardQueryTest extends TestCase
     {
         $service = ChurchService::factory()->create([
             'date' => '2026-06-01',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $otherService = ChurchService::factory()->create([
             'date' => '2026-06-01',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
         ]);
 
         $run = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $service->id,
             'extracted_date' => '2026-06-01',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $otherRun = MediaProcessingLog::factory()->livestream()->create([
             'church_service_id' => $otherService->id,
             'extracted_date' => '2026-06-01',
-            'extracted_service' => SermonService::EVENING->value,
+            'extracted_service' => SermonService::Evening->value,
         ]);
 
         $matchedSection = ServiceSection::factory()->create([

--- a/tests/Feature/Repositories/SermonRepositoryTest.php
+++ b/tests/Feature/Repositories/SermonRepositoryTest.php
@@ -248,13 +248,13 @@ class SermonRepositoryTest extends TestCase
     public function it_returns_sermons_by_service(): void
     {
         Sermon::query()->delete();
-        Sermon::factory()->create(['service' => SermonService::MORNING, 'content_type' => \App\Enums\SermonContentType::Sermon]);
-        Sermon::factory()->create(['service' => SermonService::EVENING, 'content_type' => \App\Enums\SermonContentType::Sermon]);
+        Sermon::factory()->create(['service' => SermonService::Morning, 'content_type' => \App\Enums\SermonContentType::Sermon]);
+        Sermon::factory()->create(['service' => SermonService::Evening, 'content_type' => \App\Enums\SermonContentType::Sermon]);
 
-        $result = $this->repository->getSermonsByService(SermonService::MORNING);
+        $result = $this->repository->getSermonsByService(SermonService::Morning);
 
         $this->assertCount(1, $result);
-        $this->assertEquals(SermonService::MORNING, $result->first()->service);
+        $this->assertEquals(SermonService::Morning, $result->first()->service);
     }
 
     #[Test]
@@ -265,19 +265,19 @@ class SermonRepositoryTest extends TestCase
 
         Sermon::factory()->create([
             'title' => 'Original Service Title',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'content_type' => \App\Enums\SermonContentType::Sermon,
         ]);
 
         // First call caches
-        $this->repository->getSermonsByService(SermonService::MORNING);
+        $this->repository->getSermonsByService(SermonService::Morning);
         $this->assertTrue(Cache::has('sermons_service_morning'));
 
         // Modify DB
         Sermon::query()->update(['title' => 'Updated Service Title']);
 
         // Second call should return cached data
-        $result = $this->repository->getSermonsByService(SermonService::MORNING);
+        $result = $this->repository->getSermonsByService(SermonService::Morning);
         $this->assertEquals('Original Service Title', $result->first()->title);
     }
 

--- a/tests/Feature/SeoRegressionTest.php
+++ b/tests/Feature/SeoRegressionTest.php
@@ -43,12 +43,12 @@ class SeoRegressionTest extends TestCase
     {
         Sermon::factory()->create([
             'title' => 'Morning Sermon',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'date' => '2026-03-01',
         ]);
         Sermon::factory()->create([
             'title' => 'Evening Sermon',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
             'date' => '2026-03-01',
         ]);
 
@@ -74,12 +74,12 @@ class SeoRegressionTest extends TestCase
     {
         Sermon::factory()->create([
             'title' => 'Morning Sermon',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'date' => '2026-03-02',
         ]);
         Sermon::factory()->create([
             'title' => 'Evening Sermon',
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
             'date' => '2026-03-02',
         ]);
 
@@ -105,7 +105,7 @@ class SeoRegressionTest extends TestCase
     {
         Sermon::factory()->create([
             'title' => 'Other Sermon',
-            'service' => SermonService::OTHER,
+            'service' => SermonService::Other,
             'date' => '2026-03-03',
         ]);
 

--- a/tests/Feature/SermonPagesTest.php
+++ b/tests/Feature/SermonPagesTest.php
@@ -34,17 +34,17 @@ class SermonPagesTest extends TestCase
         // Create test sermons for each service type
         Sermon::factory()->create([
             'title' => 'Morning Test Sermon',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'slug' => 'morning-test-sermon',
         ]);
         Sermon::factory()->create([
             'title' => 'Evening Test Sermon',
-            'service' => SermonService::EVENING->value,
+            'service' => SermonService::Evening->value,
             'slug' => 'evening-test-sermon',
         ]);
         Sermon::factory()->create([
             'title' => 'Other Test Sermon',
-            'service' => SermonService::OTHER->value,
+            'service' => SermonService::Other->value,
             'slug' => 'other-test-sermon',
         ]);
     }
@@ -335,7 +335,7 @@ class SermonPagesTest extends TestCase
         Sermon::factory()->create([
             'title' => 'Public Browse Sermon',
             'series' => 'Browse Series',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'preacher' => $preacher->name,
             'preacher_id' => $preacher->id,
             'content_type' => SermonContentType::Sermon,
@@ -344,7 +344,7 @@ class SermonPagesTest extends TestCase
         Sermon::factory()->create([
             'title' => "Hidden Children's Talk",
             'series' => 'Browse Series',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'preacher' => $preacher->name,
             'preacher_id' => $preacher->id,
             'content_type' => SermonContentType::ChildrensTalk,

--- a/tests/Feature/SermonProcessingJobChainTest.php
+++ b/tests/Feature/SermonProcessingJobChainTest.php
@@ -58,7 +58,7 @@ class SermonProcessingJobChainTest extends TestCase
         $processingId = 'test-processing-id';
         $metadata = SermonMetadata::create(
             date: Carbon::parse('2024-01-15'),
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             filename: 'stored-file.mp3',
             originalName: '2024-01-15_morning_sermon.mp3',
             duration: 3600.0,
@@ -94,7 +94,7 @@ class SermonProcessingJobChainTest extends TestCase
         $this->assertDatabaseHas('sermons', [
             'audio_file_path' => $storedFilePath,
             'date' => '2024-01-15',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'preacher' => 'Visiting Speaker',
         ]);
 
@@ -119,7 +119,7 @@ class SermonProcessingJobChainTest extends TestCase
         $processingId = 'test-processing-id';
         $metadata = SermonMetadata::create(
             date: Carbon::parse('2024-01-15'),
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             filename: 'stored-file.mp3',
             originalName: '2024-01-15_morning_sermon.mp3',
             duration: 3600.0,
@@ -525,7 +525,7 @@ class SermonProcessingJobChainTest extends TestCase
         $processingId = 'integration-test-id';
         $metadata = SermonMetadata::create(
             date: Carbon::parse('2024-01-15'),
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             filename: 'stored-file.mp3',
             originalName: '2024-01-15_morning_sermon.mp3',
             duration: 3600.0,
@@ -656,7 +656,7 @@ class SermonProcessingJobChainTest extends TestCase
         $processingId = 'db-test-id';
         $metadata = SermonMetadata::create(
             date: Carbon::parse('2024-01-15'),
-            service: SermonService::EVENING,
+            service: SermonService::Evening,
             filename: 'stored-file.mp3',
             originalName: '2024-01-15_evening_sermon.mp3',
             duration: 3600.0,
@@ -689,7 +689,7 @@ class SermonProcessingJobChainTest extends TestCase
         $this->assertDatabaseHas('sermons', [
             'audio_file_path' => $storedFilePath,
             'date' => '2024-01-15',
-            'service' => SermonService::EVENING->value,
+            'service' => SermonService::Evening->value,
             'preacher' => 'Visiting Speaker',
         ]);
 

--- a/tests/Feature/SermonSeoTest.php
+++ b/tests/Feature/SermonSeoTest.php
@@ -128,7 +128,7 @@ class SermonSeoTest extends TestCase
     public function service_sermons_page_has_item_list_structured_data_and_breadcrumbs()
     {
         Sermon::factory()->count(2)->create([
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'content_type' => SermonContentType::Sermon,
         ]);
 

--- a/tests/Feature/Services/LegacyPlayDateSongUsageImporterTest.php
+++ b/tests/Feature/Services/LegacyPlayDateSongUsageImporterTest.php
@@ -58,7 +58,7 @@ INSERT INTO `play_date` VALUES (2,'102','2024-03-24','p','');
 
         $this->assertDatabaseHas('church_services', [
             'date' => '2024-03-24',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'review_state' => ChurchServiceReviewState::REVIEWED->value,
         ]);
 
@@ -89,7 +89,7 @@ INSERT INTO `play_date` VALUES (2,'102','2024-03-24','p','');
         // Check that the service and item were not persisted after roll back
         $this->assertDatabaseMissing('church_services', [
             'date' => '2024-03-24',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
     }
 
@@ -131,7 +131,7 @@ INSERT INTO `play_date` VALUES (2,'102','2024-03-24','p','');
         Song::factory()->create(['id' => 101]);
         ChurchService::factory()->create([
             'date' => '2024-03-24',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $sqlContent = "INSERT INTO `play_date` VALUES (1,'101','2024-03-24','a','');";
@@ -149,7 +149,7 @@ INSERT INTO `play_date` VALUES (2,'102','2024-03-24','p','');
         $song = Song::factory()->create(['id' => 101]);
         $service = ChurchService::factory()->create([
             'date' => '2024-03-24',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
         ChurchServiceItem::factory()->create([
             'church_service_id' => $service->id,
@@ -172,7 +172,7 @@ INSERT INTO `play_date` VALUES (2,'102','2024-03-24','p','');
         $song = Song::factory()->create(['id' => 101]);
         $service = ChurchService::factory()->create([
             'date' => '2024-03-24',
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
         ChurchServiceItem::factory()->create([
             'church_service_id' => $service->id,

--- a/tests/Feature/SongSectionAlignerTest.php
+++ b/tests/Feature/SongSectionAlignerTest.php
@@ -32,7 +32,7 @@ class SongSectionAlignerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-10-05',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         // Two OoS items with identical titles — the first item wins the first available section.
@@ -92,7 +92,7 @@ class SongSectionAlignerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-10-12',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $song = Song::factory()->create(['title' => 'Be Thou My Vision']);
@@ -137,7 +137,7 @@ class SongSectionAlignerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-10-19',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $song = Song::factory()->create(['title' => 'How Great Thou Art']);
@@ -188,7 +188,7 @@ class SongSectionAlignerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-10-26',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         // Item with no title evidence at all — will score 0.0 against any section.
@@ -231,7 +231,7 @@ class SongSectionAlignerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-11-02',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $song = Song::factory()->create(['title' => 'O Praise the Name']);
@@ -284,7 +284,7 @@ class SongSectionAlignerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-10-26',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $song = Song::factory()->create(['title' => 'Though the Nations Rage']);

--- a/tests/Feature/StructuralSectionAlignerTest.php
+++ b/tests/Feature/StructuralSectionAlignerTest.php
@@ -29,7 +29,7 @@ class StructuralSectionAlignerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-11-09',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $prayerItem = ChurchServiceItem::factory()->create([
@@ -93,7 +93,7 @@ class StructuralSectionAlignerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-11-16',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         // OoS has: SERMON item first, then PRAYER item
@@ -145,7 +145,7 @@ class StructuralSectionAlignerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-11-23',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $bibleItem = ChurchServiceItem::factory()->create([
@@ -190,7 +190,7 @@ class StructuralSectionAlignerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-11-30',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $readingItem = ChurchServiceItem::factory()->create([
@@ -233,7 +233,7 @@ class StructuralSectionAlignerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-12-07',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $readingItem = ChurchServiceItem::factory()->create([
@@ -274,7 +274,7 @@ class StructuralSectionAlignerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-12-14',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $prayerItem = ChurchServiceItem::factory()->create([
@@ -317,7 +317,7 @@ class StructuralSectionAlignerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-12-21',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $item = ChurchServiceItem::factory()->create([

--- a/tests/Feature/ViewComposerTest.php
+++ b/tests/Feature/ViewComposerTest.php
@@ -20,12 +20,12 @@ class ViewComposerTest extends TestCase
     public function it_populates_footer_with_latest_sermons(): void
     {
         Sermon::factory()->create([
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'date' => now()->subDay(),
             'title' => 'Latest Morning',
         ]);
         Sermon::factory()->create([
-            'service' => SermonService::EVENING,
+            'service' => SermonService::Evening,
             'date' => now()->subDay(),
             'title' => 'Latest Evening',
         ]);
@@ -259,7 +259,7 @@ class ViewComposerTest extends TestCase
             'title' => 'Rendered Sermon',
             'slug' => 'rendered-sermon',
             'date' => now(),
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $view = View::make('components.sermon-list', [

--- a/tests/Unit/Data/OosOpenLpDataTest.php
+++ b/tests/Unit/Data/OosOpenLpDataTest.php
@@ -52,7 +52,7 @@ class OosOpenLpDataTest extends TestCase
     {
         $result = new OosEmailParseResult(
             date: '2024-03-10',
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             items: [['position' => 1, 'type' => 'song', 'title' => 'How Great Thou Art', 'source_title' => null, 'openlp_search_title' => null, 'metadata' => null]],
             confidenceScore: 0.88,
             needsReview: false,
@@ -61,7 +61,7 @@ class OosOpenLpDataTest extends TestCase
         );
 
         $this->assertSame('2024-03-10', $result->date);
-        $this->assertSame(SermonService::MORNING, $result->service);
+        $this->assertSame(SermonService::Morning, $result->service);
         $this->assertCount(1, $result->items);
         $this->assertSame(0.88, $result->confidenceScore);
         $this->assertFalse($result->needsReview);
@@ -93,14 +93,14 @@ class OosOpenLpDataTest extends TestCase
     {
         $result = new OpenLpParseResult(
             date: '2024-06-02',
-            service: SermonService::EVENING,
+            service: SermonService::Evening,
             items: [['position' => 1, 'type' => 'sermon', 'title' => 'The Gospel', 'source_title' => null, 'openlp_search_title' => null, 'metadata' => null]],
             needsReview: false,
             importMetadata: ['file' => 'service.osz'],
         );
 
         $this->assertSame('2024-06-02', $result->date);
-        $this->assertSame(SermonService::EVENING, $result->service);
+        $this->assertSame(SermonService::Evening, $result->service);
         $this->assertCount(1, $result->items);
         $this->assertFalse($result->needsReview);
         $this->assertSame(['file' => 'service.osz'], $result->importMetadata);
@@ -114,7 +114,7 @@ class OosOpenLpDataTest extends TestCase
         $churchService = ChurchService::factory()->create();
         $parseResult = new OpenLpParseResult(
             date: '2024-06-02',
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             items: [],
             needsReview: false,
             importMetadata: [],

--- a/tests/Unit/Data/SermonCreationOptionsTest.php
+++ b/tests/Unit/Data/SermonCreationOptionsTest.php
@@ -54,14 +54,14 @@ class SermonCreationOptionsTest extends TestCase
             $section,
             $processingLog,
             date: '2026-05-10',
-            service: \App\Enums\SermonService::MORNING
+            service: \App\Enums\SermonService::Morning
         );
 
         $this->assertSame('sermons/audio/section-55.mp3', $options->audioFilePath);
         $this->assertSame('sermons/sections/55/video.mp4', $options->videoFilePath);
         $this->assertSame(SermonSourceType::Livestream, $options->sourceType);
         $this->assertSame('2026-05-10', $options->date);
-        $this->assertSame(\App\Enums\SermonService::MORNING, $options->service);
+        $this->assertSame(\App\Enums\SermonService::Morning, $options->service);
         $this->assertSame("Children's Talk", $options->customTitle);
         $this->assertSame(SermonContentType::ChildrensTalk, $options->contentType);
         $this->assertSame($preacher->id, $options->preacherId);

--- a/tests/Unit/Data/SermonMetadataDataTest.php
+++ b/tests/Unit/Data/SermonMetadataDataTest.php
@@ -22,7 +22,7 @@ class SermonMetadataDataTest extends TestCase
 
         $metadata = SermonMetadata::create(
             date: $date,
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             filename: 'hashed-file.mp3',
             originalName: '2024-03-10_sermon.mp3',
             duration: 3600.0,
@@ -32,7 +32,7 @@ class SermonMetadataDataTest extends TestCase
         );
 
         $this->assertTrue($date->isSameDay($metadata->date));
-        $this->assertSame(SermonService::MORNING, $metadata->service);
+        $this->assertSame(SermonService::Morning, $metadata->service);
         $this->assertSame('hashed-file.mp3', $metadata->filename);
         $this->assertSame('2024-03-10_sermon.mp3', $metadata->originalName);
         $this->assertSame(3600.0, $metadata->duration);
@@ -46,7 +46,7 @@ class SermonMetadataDataTest extends TestCase
     {
         $metadata = SermonMetadata::create(
             date: Carbon::today(),
-            service: SermonService::EVENING,
+            service: SermonService::Evening,
             filename: 'hashed.mp3',
             originalName: 'sermon.mp3',
         );
@@ -65,7 +65,7 @@ class SermonMetadataDataTest extends TestCase
     {
         $metadata = SermonMetadata::create(
             date: Carbon::today(),
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             filename: 'hashed.mp3',
             originalName: $filename,
         );
@@ -97,7 +97,7 @@ class SermonMetadataDataTest extends TestCase
     {
         $original = SermonMetadata::create(
             date: Carbon::parse('2024-01-01'),
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             filename: 'hash.mp3',
             originalName: 'old-name.mp3',
             duration: 1800.0,
@@ -111,6 +111,6 @@ class SermonMetadataDataTest extends TestCase
         // Other fields preserved
         $this->assertSame('hash.mp3', $updated->filename);
         $this->assertSame(1800.0, $updated->duration);
-        $this->assertSame(SermonService::MORNING, $updated->service);
+        $this->assertSame(SermonService::Morning, $updated->service);
     }
 }

--- a/tests/Unit/Jobs/AlignWithOosTest.php
+++ b/tests/Unit/Jobs/AlignWithOosTest.php
@@ -26,7 +26,7 @@ class AlignWithOosTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-07-05',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $song = ChurchServiceItem::factory()->create([
@@ -38,7 +38,7 @@ class AlignWithOosTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->processing()->create([
             'extracted_date' => '2026-07-05',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([
@@ -75,7 +75,7 @@ class AlignWithOosTest extends TestCase
     {
         $processingLog = MediaProcessingLog::factory()->livestream()->processing()->create([
             'extracted_date' => '2026-07-12',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([

--- a/tests/Unit/Jobs/ClassifyServiceSectionsTest.php
+++ b/tests/Unit/Jobs/ClassifyServiceSectionsTest.php
@@ -30,7 +30,7 @@ class ClassifyServiceSectionsTest extends TestCase
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-22',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -50,7 +50,7 @@ class ClassifyServiceSectionsTest extends TestCase
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'status' => 'pending',
             'extracted_date' => '2026-03-22',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         LivestreamSegment::factory()->song()->create([
@@ -92,7 +92,7 @@ class ClassifyServiceSectionsTest extends TestCase
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'status' => 'pending',
             'extracted_date' => '2026-03-29',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         LivestreamSegment::factory()->song()->create([
@@ -155,7 +155,7 @@ class ClassifyServiceSectionsTest extends TestCase
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-30',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -169,7 +169,7 @@ class ClassifyServiceSectionsTest extends TestCase
             'status' => 'completed',
             'current_step' => 'completed',
             'extracted_date' => '2026-03-30',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         LivestreamSegment::factory()->song()->create([

--- a/tests/Unit/Jobs/ProjectLivestreamServiceStructureTest.php
+++ b/tests/Unit/Jobs/ProjectLivestreamServiceStructureTest.php
@@ -38,7 +38,7 @@ class ProjectLivestreamServiceStructureTest extends TestCase
             'processing_id' => 'test-job-001',
             'status' => ProcessingStatus::Processing,
             'extracted_date' => '2026-03-23',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([

--- a/tests/Unit/Jobs/PublishApprovedServiceSectionTest.php
+++ b/tests/Unit/Jobs/PublishApprovedServiceSectionTest.php
@@ -41,7 +41,7 @@ class PublishApprovedServiceSectionTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-10',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([
@@ -108,7 +108,7 @@ class PublishApprovedServiceSectionTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-17',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([
@@ -151,7 +151,7 @@ class PublishApprovedServiceSectionTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-24',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $section = ServiceSection::factory()->create([
@@ -235,7 +235,7 @@ class PublishApprovedServiceSectionTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-05-31',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
             'original_filename' => '2026-05-31-morning-service.mp4',
         ]);
         $preacher = Preacher::factory()->create(['name' => 'Mary Helper']);
@@ -301,7 +301,7 @@ class PublishApprovedServiceSectionTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-06-07',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
             'original_filename' => '2026-06-07-morning-service.mp4',
         ]);
 

--- a/tests/Unit/Jobs/ReconcileServiceSectionsTest.php
+++ b/tests/Unit/Jobs/ReconcileServiceSectionsTest.php
@@ -26,7 +26,7 @@ class ReconcileServiceSectionsTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-05-10',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $song = ChurchServiceItem::factory()->create([
@@ -47,7 +47,7 @@ class ReconcileServiceSectionsTest extends TestCase
             'current_step' => 'completed',
             'church_service_id' => null,
             'extracted_date' => '2026-05-10',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $songSegment = LivestreamSegment::factory()->song()->create([
@@ -143,14 +143,14 @@ class ReconcileServiceSectionsTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-05-17',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $processingLog = MediaProcessingLog::factory()->livestream()->completed()->create([
             'current_step' => 'completed',
             'church_service_id' => null,
             'extracted_date' => '2026-05-17',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([

--- a/tests/Unit/Jobs/TranscribeSpeechSegmentsTest.php
+++ b/tests/Unit/Jobs/TranscribeSpeechSegmentsTest.php
@@ -366,7 +366,7 @@ class TranscribeSpeechSegmentsTest extends TestCase
             'source_file_path' => 'temp/source-video.mp4',
             'processing_id' => 'speech-classification-handoff',
             'extracted_date' => '2026-03-29',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         Storage::disk('local')->put('temp/source-video.mp4', 'video');

--- a/tests/Unit/Models/ChurchServiceTest.php
+++ b/tests/Unit/Models/ChurchServiceTest.php
@@ -21,11 +21,11 @@ class ChurchServiceTest extends TestCase
     public function test_church_service_casts_service_to_sermon_service_enum(): void
     {
         $churchService = ChurchService::factory()->create([
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $this->assertInstanceOf(SermonService::class, $churchService->service);
-        $this->assertSame(SermonService::MORNING, $churchService->service);
+        $this->assertSame(SermonService::Morning, $churchService->service);
     }
 
     #[Test]
@@ -55,14 +55,14 @@ class ChurchServiceTest extends TestCase
     {
         ChurchService::factory()->create([
             'date' => '2024-11-17',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $this->expectException(QueryException::class);
 
         ChurchService::factory()->create([
             'date' => '2024-11-17',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
     }
 

--- a/tests/Unit/Models/SermonTest.php
+++ b/tests/Unit/Models/SermonTest.php
@@ -30,8 +30,8 @@ class SermonTest extends TestCase
 
         $this->assertInstanceOf(\App\Enums\SermonService::class, $sermon->service);
         $this->assertContains($sermon->service, [
-            \App\Enums\SermonService::MORNING,
-            \App\Enums\SermonService::EVENING,
+            \App\Enums\SermonService::Morning,
+            \App\Enums\SermonService::Evening,
         ]);
         // $this->assertEquals($serviceModel->id, $sermon->service->id); // This was incorrect
 
@@ -117,9 +117,9 @@ class SermonTest extends TestCase
 
         // Test forService scope
         $service1Date = Carbon::parse('2023-03-10');
-        $service1Type = \App\Enums\SermonService::MORNING;
+        $service1Type = \App\Enums\SermonService::Morning;
         $service2Date = Carbon::parse('2023-03-12');
-        $service2Type = \App\Enums\SermonService::EVENING;
+        $service2Type = \App\Enums\SermonService::Evening;
 
         $sermonForService1 = \App\Models\Sermon::factory()->create([
             'date' => $service1Date,
@@ -130,7 +130,7 @@ class SermonTest extends TestCase
             'service' => $service2Type,
         ]);
         // Another sermon on same date as service1 but different type
-        \App\Models\Sermon::factory()->create(['date' => $service1Date, 'service' => \App\Enums\SermonService::EVENING]);
+        \App\Models\Sermon::factory()->create(['date' => $service1Date, 'service' => \App\Enums\SermonService::Evening]);
 
         // The scopeForService filters by service type
         $sermonsForService1ByType = \App\Models\Sermon::forService($service1Type)
@@ -140,7 +140,7 @@ class SermonTest extends TestCase
         $this->assertFalse($sermonsForService1ByType->contains($sermonForService2));
 
         // If we want to assert that sermons for morning services on a specific date are found:
-        $sermonsForMorningServiceOnDate = \App\Models\Sermon::forService(\App\Enums\SermonService::MORNING)
+        $sermonsForMorningServiceOnDate = \App\Models\Sermon::forService(\App\Enums\SermonService::Morning)
             ->whereDate('date', $service1Date)
             ->get();
         $this->assertTrue($sermonsForMorningServiceOnDate->contains($sermonForService1));

--- a/tests/Unit/Services/ChurchServiceCanonicalStateServiceTest.php
+++ b/tests/Unit/Services/ChurchServiceCanonicalStateServiceTest.php
@@ -39,7 +39,7 @@ class ChurchServiceCanonicalStateServiceTest extends TestCase
     #[Test]
     public function it_returns_an_empty_array_for_a_service_with_no_items(): void
     {
-        $churchService = ChurchService::factory()->create(['service' => SermonService::MORNING]);
+        $churchService = ChurchService::factory()->create(['service' => SermonService::Morning]);
 
         $result = $this->service->snapshot($churchService);
 
@@ -49,7 +49,7 @@ class ChurchServiceCanonicalStateServiceTest extends TestCase
     #[Test]
     public function it_snapshots_a_service_item_with_all_expected_keys(): void
     {
-        $churchService = ChurchService::factory()->create(['service' => SermonService::MORNING]);
+        $churchService = ChurchService::factory()->create(['service' => SermonService::Morning]);
 
         ChurchServiceItem::factory()->create([
             'church_service_id' => $churchService->id,
@@ -75,7 +75,7 @@ class ChurchServiceCanonicalStateServiceTest extends TestCase
     #[Test]
     public function it_excludes_section_type_from_item_metadata_in_snapshot(): void
     {
-        $churchService = ChurchService::factory()->create(['service' => SermonService::MORNING]);
+        $churchService = ChurchService::factory()->create(['service' => SermonService::Morning]);
 
         ChurchServiceItem::factory()->create([
             'church_service_id' => $churchService->id,
@@ -93,7 +93,7 @@ class ChurchServiceCanonicalStateServiceTest extends TestCase
     #[Test]
     public function it_returns_null_for_metadata_when_only_section_type_was_set(): void
     {
-        $churchService = ChurchService::factory()->create(['service' => SermonService::MORNING]);
+        $churchService = ChurchService::factory()->create(['service' => SermonService::Morning]);
 
         ChurchServiceItem::factory()->create([
             'church_service_id' => $churchService->id,
@@ -110,7 +110,7 @@ class ChurchServiceCanonicalStateServiceTest extends TestCase
     #[Test]
     public function it_normalises_associative_metadata_keys_by_sorting(): void
     {
-        $churchService = ChurchService::factory()->create(['service' => SermonService::MORNING]);
+        $churchService = ChurchService::factory()->create(['service' => SermonService::Morning]);
 
         ChurchServiceItem::factory()->create([
             'church_service_id' => $churchService->id,
@@ -130,7 +130,7 @@ class ChurchServiceCanonicalStateServiceTest extends TestCase
     #[Test]
     public function it_returns_empty_diff_when_nothing_has_changed(): void
     {
-        $churchService = ChurchService::factory()->create(['service' => SermonService::MORNING]);
+        $churchService = ChurchService::factory()->create(['service' => SermonService::Morning]);
 
         ChurchServiceItem::factory()->create([
             'church_service_id' => $churchService->id,
@@ -150,7 +150,7 @@ class ChurchServiceCanonicalStateServiceTest extends TestCase
     #[Test]
     public function it_detects_an_added_item(): void
     {
-        $churchService = ChurchService::factory()->create(['service' => SermonService::MORNING]);
+        $churchService = ChurchService::factory()->create(['service' => SermonService::Morning]);
 
         $before = $this->service->snapshot($churchService->load('items'));
 
@@ -173,7 +173,7 @@ class ChurchServiceCanonicalStateServiceTest extends TestCase
     #[Test]
     public function it_detects_a_removed_item(): void
     {
-        $churchService = ChurchService::factory()->create(['service' => SermonService::MORNING]);
+        $churchService = ChurchService::factory()->create(['service' => SermonService::Morning]);
 
         $item = ChurchServiceItem::factory()->create([
             'church_service_id' => $churchService->id,
@@ -198,7 +198,7 @@ class ChurchServiceCanonicalStateServiceTest extends TestCase
     #[Test]
     public function it_detects_an_updated_item_field(): void
     {
-        $churchService = ChurchService::factory()->create(['service' => SermonService::MORNING]);
+        $churchService = ChurchService::factory()->create(['service' => SermonService::Morning]);
 
         $item = ChurchServiceItem::factory()->create([
             'church_service_id' => $churchService->id,
@@ -227,7 +227,7 @@ class ChurchServiceCanonicalStateServiceTest extends TestCase
     #[Test]
     public function it_reports_all_changed_fields_in_an_updated_item(): void
     {
-        $churchService = ChurchService::factory()->create(['service' => SermonService::MORNING]);
+        $churchService = ChurchService::factory()->create(['service' => SermonService::Morning]);
 
         $item = ChurchServiceItem::factory()->create([
             'church_service_id' => $churchService->id,

--- a/tests/Unit/Services/ChurchServiceCanonicalUpdateServiceTest.php
+++ b/tests/Unit/Services/ChurchServiceCanonicalUpdateServiceTest.php
@@ -38,7 +38,7 @@ class ChurchServiceCanonicalUpdateServiceTest extends TestCase
         Event::fake();
 
         $churchService = ChurchService::factory()->create([
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => false,
             'import_metadata' => ['confidence_score' => 1.0],
         ]);
@@ -73,7 +73,7 @@ class ChurchServiceCanonicalUpdateServiceTest extends TestCase
         Event::fake();
 
         $churchService = ChurchService::factory()->create([
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => false,
             'import_metadata' => ['confidence_score' => 1.0],
         ]);
@@ -121,7 +121,7 @@ class ChurchServiceCanonicalUpdateServiceTest extends TestCase
         Event::fake();
 
         $churchService = ChurchService::factory()->create([
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => false,
             'import_metadata' => [
                 'confidence_score' => 1.0,
@@ -163,7 +163,7 @@ class ChurchServiceCanonicalUpdateServiceTest extends TestCase
         Event::fake();
 
         $churchService = ChurchService::factory()->create([
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => false,
             'import_metadata' => ['confidence_score' => 1.0],
         ]);
@@ -203,7 +203,7 @@ class ChurchServiceCanonicalUpdateServiceTest extends TestCase
         Event::fake();
 
         $churchService = ChurchService::factory()->create([
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => false,
             'import_metadata' => ['confidence_score' => 1.0],
         ]);

--- a/tests/Unit/Services/ChurchServiceItemSyncServiceTest.php
+++ b/tests/Unit/Services/ChurchServiceItemSyncServiceTest.php
@@ -170,7 +170,7 @@ class ChurchServiceItemSyncServiceTest extends TestCase
     public function test_updates_position_on_reorder(): void
     {
         $churchService = ChurchService::factory()->create([
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
         ]);
 
         $first = ChurchServiceItem::factory()->create([
@@ -721,7 +721,7 @@ class ChurchServiceItemSyncServiceTest extends TestCase
         Event::fake();
 
         $churchService = ChurchService::factory()->create([
-            'service' => SermonService::MORNING,
+            'service' => SermonService::Morning,
             'needs_review' => false,
             'import_metadata' => ['confidence_score' => 1.0],
         ]);

--- a/tests/Unit/Services/ChurchServiceReconciliationDispatcherTest.php
+++ b/tests/Unit/Services/ChurchServiceReconciliationDispatcherTest.php
@@ -26,7 +26,7 @@ class ChurchServiceReconciliationDispatcherTest extends TestCase
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-15',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $processingLog = MediaProcessingLog::factory()->livestream()->completed()->create([
@@ -69,7 +69,7 @@ class ChurchServiceReconciliationDispatcherTest extends TestCase
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-16',
-            'service' => SermonService::EVENING->value,
+            'service' => SermonService::Evening->value,
         ]);
 
         $processingLog = MediaProcessingLog::factory()->livestream()->completed()->create([
@@ -97,7 +97,7 @@ class ChurchServiceReconciliationDispatcherTest extends TestCase
 
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-17',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $matchedByColumns = MediaProcessingLog::factory()->livestream()->completed()->create([

--- a/tests/Unit/Services/ChurchServiceReviewSynchronizerTest.php
+++ b/tests/Unit/Services/ChurchServiceReviewSynchronizerTest.php
@@ -34,7 +34,7 @@ class ChurchServiceReviewSynchronizerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-10-05',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'needs_review' => false,
         ]);
 
@@ -51,7 +51,7 @@ class ChurchServiceReviewSynchronizerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-10-06',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'needs_review' => true,
             'import_metadata' => [],
         ]);
@@ -76,7 +76,7 @@ class ChurchServiceReviewSynchronizerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-10-07',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'needs_review' => false,
             'import_metadata' => [],
         ]);
@@ -103,7 +103,7 @@ class ChurchServiceReviewSynchronizerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-10-08',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'import_metadata' => [],
         ]);
 
@@ -121,7 +121,7 @@ class ChurchServiceReviewSynchronizerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-10-09',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'import_metadata' => ['review_triggers' => ['stale_trigger']],
         ]);
 
@@ -138,7 +138,7 @@ class ChurchServiceReviewSynchronizerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-10-10',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'email',
             'needs_review' => false,
             'import_metadata' => ['confidence_score' => 0.80],
@@ -155,7 +155,7 @@ class ChurchServiceReviewSynchronizerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-10-11',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'manual',
             'needs_review' => false,
             'import_metadata' => ['confidence_score' => 0.80],
@@ -174,7 +174,7 @@ class ChurchServiceReviewSynchronizerTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-10-12',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'manual',
             'needs_review' => false,
             'import_metadata' => [

--- a/tests/Unit/Services/ChurchServiceStructureMergeServiceTest.php
+++ b/tests/Unit/Services/ChurchServiceStructureMergeServiceTest.php
@@ -83,7 +83,7 @@ class ChurchServiceStructureMergeServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-23',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => ChurchServiceItemSource::OPENLP->value,
         ]);
 
@@ -209,7 +209,7 @@ class ChurchServiceStructureMergeServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-23',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => ChurchServiceItemSource::OPENLP->value,
         ]);
 
@@ -266,7 +266,7 @@ class ChurchServiceStructureMergeServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-23',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => ChurchServiceItemSource::LIVESTREAM->value,
         ]);
 

--- a/tests/Unit/Services/ImportChurchServiceFromOpenLpTest.php
+++ b/tests/Unit/Services/ImportChurchServiceFromOpenLpTest.php
@@ -54,7 +54,7 @@ class ImportChurchServiceFromOpenLpTest extends TestCase
 
         $this->assertTrue($result->wasCreated);
         $this->assertSame('2024-11-17', $result->churchService->date->toDateString());
-        $this->assertSame(SermonService::MORNING, $result->churchService->service);
+        $this->assertSame(SermonService::Morning, $result->churchService->service);
         $this->assertCount(2, $result->churchService->items);
         $this->assertSame('upload_filename', $result->parseResult->importMetadata['parse_method'] ?? null);
         $this->assertSame(1, $result->linkResult['matched']);

--- a/tests/Unit/Services/InboundEmailImportServiceTest.php
+++ b/tests/Unit/Services/InboundEmailImportServiceTest.php
@@ -35,7 +35,7 @@ class InboundEmailImportServiceTest extends TestCase
 
         $parseResult = new OosEmailParseResult(
             date: '2025-03-09',
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             items: [
                 ['position' => 1, 'type' => 'songs', 'title' => 'In Christ Alone', 'source_title' => null, 'openlp_search_title' => 'in christ alone@', 'metadata' => null],
             ],
@@ -52,7 +52,7 @@ class InboundEmailImportServiceTest extends TestCase
 
         $this->assertNotNull($restored);
         $this->assertSame('2025-03-09', $restored->date);
-        $this->assertSame(SermonService::MORNING, $restored->service);
+        $this->assertSame(SermonService::Morning, $restored->service);
         $this->assertCount(1, $restored->items);
         $this->assertSame('In Christ Alone', $restored->items[0]['title']);
         $this->assertSame(0.92, $restored->confidenceScore);
@@ -112,7 +112,7 @@ class InboundEmailImportServiceTest extends TestCase
 
         $parseResult = new OosEmailParseResult(
             date: '2025-03-09',
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             items: [
                 ['position' => 1, 'type' => 'songs', 'title' => 'Amazing Grace', 'source_title' => null, 'openlp_search_title' => null, 'metadata' => null],
             ],
@@ -129,7 +129,7 @@ class InboundEmailImportServiceTest extends TestCase
             'service' => 'morning',
         ]);
         $this->assertSame('2025-03-09', (string) $churchService->date->toDateString());
-        $this->assertSame(SermonService::MORNING, $churchService->service);
+        $this->assertSame(SermonService::Morning, $churchService->service);
         $this->assertCount(1, $churchService->items);
     }
 
@@ -140,7 +140,7 @@ class InboundEmailImportServiceTest extends TestCase
 
         $parseResult = new OosEmailParseResult(
             date: '2025-03-09',
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             items: [],
             confidenceScore: 0.5,
             needsReview: true,
@@ -161,7 +161,7 @@ class InboundEmailImportServiceTest extends TestCase
 
         $parseResult = new OosEmailParseResult(
             date: '2025-03-09',
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             items: [],
             confidenceScore: 0.5,
             needsReview: true,
@@ -183,7 +183,7 @@ class InboundEmailImportServiceTest extends TestCase
 
         $parseResult = new OosEmailParseResult(
             date: '2025-03-09',
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             items: [],
             confidenceScore: 0.9,
             needsReview: false,
@@ -204,7 +204,7 @@ class InboundEmailImportServiceTest extends TestCase
 
         $parseResult = new OosEmailParseResult(
             date: null,
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             items: [],
             confidenceScore: 0.0,
             needsReview: true,

--- a/tests/Unit/Services/LivestreamChurchServiceProjectionServiceTest.php
+++ b/tests/Unit/Services/LivestreamChurchServiceProjectionServiceTest.php
@@ -34,7 +34,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     #[Test]
     public function test_creates_new_service_and_items_when_no_matching_service_exists(): void
     {
-        $log = $this->createProcessingLog('2026-03-23', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-23', SermonService::Morning);
 
         $this->createSections($log, [
             ['type' => ServiceSectionType::SONG, 'title' => 'Amazing Grace', 'confidence' => 0.95],
@@ -52,7 +52,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
 
         $this->assertNotNull($churchService);
         $this->assertSame('2026-03-23', $churchService->date->toDateString());
-        $this->assertSame(SermonService::MORNING, $churchService->service);
+        $this->assertSame(SermonService::Morning, $churchService->service);
         $this->assertSame(ChurchServiceItemSource::LIVESTREAM->value, $churchService->source);
 
         $items = $churchService->items()->orderBy('position')->get();
@@ -71,7 +71,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     #[Test]
     public function test_links_sections_back_to_projected_items(): void
     {
-        $log = $this->createProcessingLog('2026-03-23', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-23', SermonService::Morning);
 
         $sections = $this->createSections($log, [
             ['type' => ServiceSectionType::SONG, 'title' => 'Song A', 'confidence' => 0.9],
@@ -99,7 +99,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-23',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => ChurchServiceItemSource::LIVESTREAM->value,
         ]);
 
@@ -110,7 +110,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
             'title' => 'Old Song',
         ]);
 
-        $log = $this->createProcessingLog('2026-03-23', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-23', SermonService::Morning);
 
         $this->createSections($log, [
             ['type' => ServiceSectionType::SONG, 'title' => 'New Song', 'confidence' => 0.9],
@@ -135,7 +135,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-23',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'openlp',
         ]);
 
@@ -147,7 +147,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
             'source' => ChurchServiceItemSource::OPENLP->value,
         ]);
 
-        $log = $this->createProcessingLog('2026-03-23', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-23', SermonService::Morning);
 
         $this->createSections($log, [
             ['type' => ServiceSectionType::SONG, 'title' => 'Livestream Song', 'confidence' => 0.9],
@@ -190,7 +190,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     #[Test]
     public function test_skips_when_no_sections_exist(): void
     {
-        $log = $this->createProcessingLog('2026-03-23', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-23', SermonService::Morning);
 
         $result = $this->service->project($log);
 
@@ -201,7 +201,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     #[Test]
     public function test_skips_when_all_sections_are_filtered_out(): void
     {
-        $log = $this->createProcessingLog('2026-03-23', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-23', SermonService::Morning);
 
         ServiceSection::factory()->create([
             'media_processing_log_id' => $log->id,
@@ -220,7 +220,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     #[Test]
     public function test_sets_needs_review_when_sections_have_low_confidence(): void
     {
-        $log = $this->createProcessingLog('2026-03-23', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-23', SermonService::Morning);
 
         $this->createSections($log, [
             ['type' => ServiceSectionType::SONG, 'title' => 'Song', 'confidence' => 0.9],
@@ -238,7 +238,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     #[Test]
     public function test_sets_needs_review_when_sections_flagged_for_manual_review(): void
     {
-        $log = $this->createProcessingLog('2026-03-23', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-23', SermonService::Morning);
 
         ServiceSection::factory()->create([
             'media_processing_log_id' => $log->id,
@@ -261,7 +261,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     #[Test]
     public function test_stores_projection_metadata_on_service(): void
     {
-        $log = $this->createProcessingLog('2026-03-23', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-23', SermonService::Morning);
 
         $this->createSections($log, [
             ['type' => ServiceSectionType::SONG, 'title' => 'Song', 'confidence' => 0.9],
@@ -279,7 +279,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     #[Test]
     public function test_stores_projection_metadata_on_items(): void
     {
-        $log = $this->createProcessingLog('2026-03-23', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-23', SermonService::Morning);
 
         $this->createSections($log, [
             ['type' => ServiceSectionType::SONG, 'title' => 'Song', 'confidence' => 0.9],
@@ -298,7 +298,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     #[Test]
     public function test_does_not_create_duplicate_service_on_rerun(): void
     {
-        $log = $this->createProcessingLog('2026-03-23', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-23', SermonService::Morning);
 
         $this->createSections($log, [
             ['type' => ServiceSectionType::SONG, 'title' => 'Song A', 'confidence' => 0.9],
@@ -320,7 +320,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
 
         $serviceCount = ChurchService::query()
             ->whereDate('date', '2026-03-23')
-            ->where('service', SermonService::MORNING->value)
+            ->where('service', SermonService::Morning->value)
             ->count();
 
         $this->assertSame(1, $serviceCount);
@@ -331,7 +331,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-23',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'openlp',
         ]);
 
@@ -340,7 +340,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
             'source' => ChurchServiceItemSource::OPENLP->value,
         ]);
 
-        $log = $this->createProcessingLog('2026-03-23', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-23', SermonService::Morning);
 
         $this->createSections($log, [
             ['type' => ServiceSectionType::SONG, 'title' => 'Song', 'confidence' => 0.9],
@@ -359,7 +359,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     {
         // Regression for fix #3: an OTHER-type section with low confidence that was
         // excluded by the mapper must not trigger needs_review on the projected service.
-        $log = $this->createProcessingLog('2026-03-27', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-27', SermonService::Morning);
 
         ServiceSection::factory()->create([
             'media_processing_log_id' => $log->id,
@@ -394,7 +394,7 @@ class LivestreamChurchServiceProjectionServiceTest extends TestCase
     #[Test]
     public function test_stores_confidence_summary_on_service_projection_metadata(): void
     {
-        $log = $this->createProcessingLog('2026-03-27', SermonService::MORNING);
+        $log = $this->createProcessingLog('2026-03-27', SermonService::Morning);
 
         $this->createSections($log, [
             ['type' => ServiceSectionType::SONG, 'title' => 'Song A', 'confidence' => 0.95],

--- a/tests/Unit/Services/MediaProcessingIdentityResolverTest.php
+++ b/tests/Unit/Services/MediaProcessingIdentityResolverTest.php
@@ -26,7 +26,7 @@ class MediaProcessingIdentityResolverTest extends TestCase
     {
         $log = MediaProcessingLog::factory()->make([
             'extracted_date' => '2024-03-20',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
             'processing_metadata' => [
                 'extracted_date' => '2024-01-01',
                 'extracted_service' => 'evening',
@@ -37,7 +37,7 @@ class MediaProcessingIdentityResolverTest extends TestCase
 
         $this->assertNotNull($identity);
         $this->assertEquals('2024-03-20', $identity['date']);
-        $this->assertEquals(SermonService::MORNING, $identity['service']);
+        $this->assertEquals(SermonService::Morning, $identity['service']);
     }
 
     #[Test]
@@ -56,7 +56,7 @@ class MediaProcessingIdentityResolverTest extends TestCase
 
         $this->assertNotNull($identity);
         $this->assertEquals('2024-03-20', $identity['date']);
-        $this->assertEquals(SermonService::MORNING, $identity['service']);
+        $this->assertEquals(SermonService::Morning, $identity['service']);
     }
 
     #[Test]
@@ -90,8 +90,8 @@ class MediaProcessingIdentityResolverTest extends TestCase
     #[Test]
     public function it_parses_valid_services(): void
     {
-        $this->assertEquals(SermonService::MORNING, $this->resolver->parseService('morning'));
-        $this->assertEquals(SermonService::EVENING, $this->resolver->parseService('evening'));
+        $this->assertEquals(SermonService::Morning, $this->resolver->parseService('morning'));
+        $this->assertEquals(SermonService::Evening, $this->resolver->parseService('evening'));
     }
 
     #[Test]
@@ -107,12 +107,12 @@ class MediaProcessingIdentityResolverTest extends TestCase
     {
         $log = MediaProcessingLog::factory()->make([
             'extracted_date' => '2024-03-20',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
         ]);
 
-        $this->assertTrue($this->resolver->matchesService($log, '2024-03-20', SermonService::MORNING));
-        $this->assertFalse($this->resolver->matchesService($log, '2024-03-21', SermonService::MORNING));
-        $this->assertFalse($this->resolver->matchesService($log, '2024-03-20', SermonService::EVENING));
+        $this->assertTrue($this->resolver->matchesService($log, '2024-03-20', SermonService::Morning));
+        $this->assertFalse($this->resolver->matchesService($log, '2024-03-21', SermonService::Morning));
+        $this->assertFalse($this->resolver->matchesService($log, '2024-03-20', SermonService::Evening));
     }
 
     #[Test]
@@ -120,16 +120,16 @@ class MediaProcessingIdentityResolverTest extends TestCase
     {
         $matchingLog = MediaProcessingLog::factory()->create([
             'extracted_date' => '2024-03-20',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
         ]);
 
         MediaProcessingLog::factory()->create([
             'extracted_date' => '2024-03-21',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
         ]);
 
         $results = MediaProcessingLog::query()
-            ->tap(fn ($q) => $this->resolver->scopeMatchesIdentity($q, '2024-03-20', SermonService::MORNING))
+            ->tap(fn ($q) => $this->resolver->scopeMatchesIdentity($q, '2024-03-20', SermonService::Morning))
             ->get();
 
         $this->assertCount(1, $results);
@@ -158,7 +158,7 @@ class MediaProcessingIdentityResolverTest extends TestCase
         ]);
 
         $results = MediaProcessingLog::query()
-            ->tap(fn ($q) => $this->resolver->scopeMatchesIdentity($q, '2024-03-20', SermonService::MORNING))
+            ->tap(fn ($q) => $this->resolver->scopeMatchesIdentity($q, '2024-03-20', SermonService::Morning))
             ->get();
 
         $this->assertCount(1, $results);
@@ -171,7 +171,7 @@ class MediaProcessingIdentityResolverTest extends TestCase
         // Log where column matches but metadata doesn't - should match because columns are checked first
         $log1 = MediaProcessingLog::factory()->create([
             'extracted_date' => '2024-03-20',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
             'processing_metadata' => [
                 'extracted_date' => '2024-01-01',
                 'extracted_service' => 'evening',
@@ -186,7 +186,7 @@ class MediaProcessingIdentityResolverTest extends TestCase
 
         $log2 = MediaProcessingLog::factory()->create([
             'extracted_date' => '2024-03-21',
-            'extracted_service' => SermonService::MORNING,
+            'extracted_service' => SermonService::Morning,
             'processing_metadata' => [
                 'extracted_date' => '2024-03-20',
                 'extracted_service' => 'morning',
@@ -194,7 +194,7 @@ class MediaProcessingIdentityResolverTest extends TestCase
         ]);
 
         $results = MediaProcessingLog::query()
-            ->tap(fn ($q) => $this->resolver->scopeMatchesIdentity($q, '2024-03-20', SermonService::MORNING))
+            ->tap(fn ($q) => $this->resolver->scopeMatchesIdentity($q, '2024-03-20', SermonService::Morning))
             ->get();
 
         $this->assertCount(1, $results);

--- a/tests/Unit/Services/MetadataExtractionServiceTest.php
+++ b/tests/Unit/Services/MetadataExtractionServiceTest.php
@@ -207,7 +207,7 @@ class MetadataExtractionServiceTest extends TestCase
 
         foreach ($morningTimes as $time) {
             $result = $this->service->determineServiceFromTime($time);
-            $this->assertEquals(SermonService::MORNING, $result, "Failed for time: {$time->format('H:i')}");
+            $this->assertEquals(SermonService::Morning, $result, "Failed for time: {$time->format('H:i')}");
         }
 
         // Evening times (2 PM onwards and before 6 AM)
@@ -222,7 +222,7 @@ class MetadataExtractionServiceTest extends TestCase
 
         foreach ($eveningTimes as $time) {
             $result = $this->service->determineServiceFromTime($time);
-            $this->assertEquals(SermonService::EVENING, $result, "Failed for time: {$time->format('H:i')}");
+            $this->assertEquals(SermonService::Evening, $result, "Failed for time: {$time->format('H:i')}");
         }
     }
 
@@ -242,7 +242,7 @@ class MetadataExtractionServiceTest extends TestCase
 
         foreach ($morningFilenames as $filename) {
             $result = $this->service->determineServiceFromFilename($filename);
-            $this->assertEquals(SermonService::MORNING, $result, "Failed for filename: {$filename}");
+            $this->assertEquals(SermonService::Morning, $result, "Failed for filename: {$filename}");
         }
 
         // Evening patterns
@@ -257,7 +257,7 @@ class MetadataExtractionServiceTest extends TestCase
 
         foreach ($eveningFilenames as $filename) {
             $result = $this->service->determineServiceFromFilename($filename);
-            $this->assertEquals(SermonService::EVENING, $result, "Failed for filename: {$filename}");
+            $this->assertEquals(SermonService::Evening, $result, "Failed for filename: {$filename}");
         }
     }
 
@@ -274,7 +274,7 @@ class MetadataExtractionServiceTest extends TestCase
 
         foreach ($morningFilenames as $filename => $description) {
             $result = $this->service->determineServiceFromFilename($filename);
-            $this->assertEquals(SermonService::MORNING, $result, "Failed for {$description}: {$filename}");
+            $this->assertEquals(SermonService::Morning, $result, "Failed for {$description}: {$filename}");
         }
 
         // Evening times (14:00 and after)
@@ -288,7 +288,7 @@ class MetadataExtractionServiceTest extends TestCase
 
         foreach ($eveningFilenames as $filename => $description) {
             $result = $this->service->determineServiceFromFilename($filename);
-            $this->assertEquals(SermonService::EVENING, $result, "Failed for {$description}: {$filename}");
+            $this->assertEquals(SermonService::Evening, $result, "Failed for {$description}: {$filename}");
         }
     }
 
@@ -305,7 +305,7 @@ class MetadataExtractionServiceTest extends TestCase
         foreach ($invalidTimes as $filename) {
             // Should default to morning since no other patterns match
             $result = $this->service->determineServiceFromFilename($filename);
-            $this->assertEquals(SermonService::MORNING, $result, "Failed for invalid time: {$filename}");
+            $this->assertEquals(SermonService::Morning, $result, "Failed for invalid time: {$filename}");
         }
     }
 
@@ -321,7 +321,7 @@ class MetadataExtractionServiceTest extends TestCase
 
         foreach ($neutralFilenames as $filename) {
             $result = $this->service->determineServiceFromFilename($filename);
-            $this->assertEquals(SermonService::MORNING, $result, "Failed for filename: {$filename}");
+            $this->assertEquals(SermonService::Morning, $result, "Failed for filename: {$filename}");
         }
     }
 
@@ -330,9 +330,9 @@ class MetadataExtractionServiceTest extends TestCase
     {
         // These should not match AM/PM patterns
         $testCases = [
-            'example.mp3' => SermonService::MORNING, // 'am' in 'example' shouldn't match
-            'spam_filter.mp3' => SermonService::MORNING, // 'am' in 'spam' shouldn't match
-            'team_meeting.mp3' => SermonService::MORNING, // 'am' in 'team' shouldn't match
+            'example.mp3' => SermonService::Morning, // 'am' in 'example' shouldn't match
+            'spam_filter.mp3' => SermonService::Morning, // 'am' in 'spam' shouldn't match
+            'team_meeting.mp3' => SermonService::Morning, // 'am' in 'team' shouldn't match
         ];
 
         foreach ($testCases as $filename => $expected) {
@@ -350,7 +350,7 @@ class MetadataExtractionServiceTest extends TestCase
 
         $this->assertInstanceOf(SermonMetadata::class, $result);
         $this->assertEquals('2024-01-15', $result->date->format('Y-m-d'));
-        $this->assertEquals(SermonService::MORNING, $result->service);
+        $this->assertEquals(SermonService::Morning, $result->service);
         $this->assertEquals('2024-01-15_morning_sermon.mp3', $result->filename);
         $this->assertEquals('2024-01-15_morning_sermon.mp3', $result->originalName);
     }
@@ -385,15 +385,15 @@ class MetadataExtractionServiceTest extends TestCase
         $complexFilenames = [
             'CBC_2024-01-15_10.30am_John_3.16-21.mp3' => [
                 'date' => '2024-01-15',
-                'service' => SermonService::MORNING,
+                'service' => SermonService::Morning,
             ],
             '15.01.2024_evening_service_Romans_8.mp3' => [
                 'date' => '2024-01-15',
-                'service' => SermonService::EVENING,
+                'service' => SermonService::Evening,
             ],
             'Sermon_20240630_PM_1_John_2.1-6.mp3' => [
                 'date' => '2024-06-30',
-                'service' => SermonService::EVENING,
+                'service' => SermonService::Evening,
             ],
         ];
 

--- a/tests/Unit/Services/OosAlignmentServiceCharacterizationTest.php
+++ b/tests/Unit/Services/OosAlignmentServiceCharacterizationTest.php
@@ -26,7 +26,7 @@ class OosAlignmentServiceCharacterizationTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-08-03',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
@@ -61,7 +61,7 @@ class OosAlignmentServiceCharacterizationTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-08-10',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -90,7 +90,7 @@ class OosAlignmentServiceCharacterizationTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-08-17',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -151,7 +151,7 @@ class OosAlignmentServiceCharacterizationTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-08-24',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $songItem = ChurchServiceItem::factory()->create([
@@ -196,7 +196,7 @@ class OosAlignmentServiceCharacterizationTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-08-31',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $item = ChurchServiceItem::factory()->create([
@@ -247,7 +247,7 @@ class OosAlignmentServiceCharacterizationTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-09-07',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $prayerItem = ChurchServiceItem::factory()->create([
@@ -324,7 +324,7 @@ class OosAlignmentServiceCharacterizationTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-09-14',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -395,7 +395,7 @@ class OosAlignmentServiceCharacterizationTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-09-21',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([

--- a/tests/Unit/Services/OosAlignmentServiceTest.php
+++ b/tests/Unit/Services/OosAlignmentServiceTest.php
@@ -25,7 +25,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-06-07',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $firstSong = ChurchServiceItem::factory()->create([
@@ -96,7 +96,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-06-14',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $prayer = ChurchServiceItem::factory()->create([
@@ -162,7 +162,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-06-18',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $prayer = ChurchServiceItem::factory()->create([
@@ -203,7 +203,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-06-21',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $song = ChurchServiceItem::factory()->create([
@@ -253,7 +253,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-06-25',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -296,7 +296,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-06-28',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -344,7 +344,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-07-20',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $item = ChurchServiceItem::factory()->create([
@@ -389,7 +389,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-07-21',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $item = ChurchServiceItem::factory()->create([
@@ -430,7 +430,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-07-03',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $item = ChurchServiceItem::factory()->create([
@@ -471,7 +471,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-07-06',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
@@ -498,7 +498,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-07-09',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         // Item exists in OoS but has no Song record linked
@@ -540,7 +540,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-07-05',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'needs_review' => true,
             'import_metadata' => [
                 'review_triggers' => ['unmatched_song_sections'],
@@ -585,7 +585,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-07-12',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'email',
             'needs_review' => true,
             'import_metadata' => [
@@ -632,7 +632,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-07-19',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => 'manual',
             'needs_review' => true,
             'import_metadata' => [
@@ -691,7 +691,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-11-23',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -744,7 +744,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-11-24',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -794,7 +794,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-11-26',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -845,7 +845,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-11-27',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -894,7 +894,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-11-28',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -945,7 +945,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-11-29',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -998,7 +998,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-11-30',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $song = ChurchServiceItem::factory()->create([
@@ -1081,7 +1081,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-12-01',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -1144,7 +1144,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-12-02',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -1199,7 +1199,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-11-25',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -1275,7 +1275,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-12-07',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -1340,7 +1340,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-12-08',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -1402,7 +1402,7 @@ class OosAlignmentServiceTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-12-09',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([

--- a/tests/Unit/Services/OosEmailParserServiceTest.php
+++ b/tests/Unit/Services/OosEmailParserServiceTest.php
@@ -53,7 +53,7 @@ class OosEmailParserServiceTest extends TestCase
 
         $this->assertSame("Welcome\nBefore the throne of God above\nOpening prayer\nLuke 15:1-32", $extractor->capturedBody);
         $this->assertSame('2026-03-16', $result->date);
-        $this->assertSame(SermonService::MORNING, $result->service);
+        $this->assertSame(SermonService::Morning, $result->service);
         $this->assertTrue($result->shouldImport);
         $this->assertFalse($result->needsReview);
         $this->assertGreaterThanOrEqual(0.90, $result->confidenceScore);
@@ -88,7 +88,7 @@ class OosEmailParserServiceTest extends TestCase
         $result = $parser->parse($email);
 
         $this->assertSame('2026-03-16', $result->date);
-        $this->assertSame(SermonService::MORNING, $result->service);
+        $this->assertSame(SermonService::Morning, $result->service);
         $this->assertTrue($result->shouldImport);
         $this->assertTrue($result->needsReview);
         $this->assertGreaterThanOrEqual(0.75, $result->confidenceScore);
@@ -235,6 +235,6 @@ class OosEmailParserServiceTest extends TestCase
 
         $result = $parser->parse($email);
 
-        $this->assertSame(SermonService::EVENING, $result->service);
+        $this->assertSame(SermonService::Evening, $result->service);
     }
 }

--- a/tests/Unit/Services/OpenLpServiceParserTest.php
+++ b/tests/Unit/Services/OpenLpServiceParserTest.php
@@ -43,7 +43,7 @@ class OpenLpServiceParserTest extends TestCase
         $result = $this->parser->parse($upload);
 
         $this->assertSame('2024-11-17', $result->date);
-        $this->assertSame(SermonService::MORNING, $result->service);
+        $this->assertSame(SermonService::Morning, $result->service);
         $this->assertCount(2, $result->items);
         $this->assertFalse($result->needsReview);
     }
@@ -60,7 +60,7 @@ class OpenLpServiceParserTest extends TestCase
         $result = $this->parser->parse($upload);
 
         $this->assertSame('2024-11-17', $result->date);
-        $this->assertSame(SermonService::MORNING, $result->service);
+        $this->assertSame(SermonService::Morning, $result->service);
     }
 
     #[Test]
@@ -75,7 +75,7 @@ class OpenLpServiceParserTest extends TestCase
         $result = $this->parser->parse($upload);
 
         $this->assertSame('2024-11-17', $result->date);
-        $this->assertSame(SermonService::EVENING, $result->service);
+        $this->assertSame(SermonService::Evening, $result->service);
     }
 
     #[Test]
@@ -90,7 +90,7 @@ class OpenLpServiceParserTest extends TestCase
         $result = $this->parser->parse($upload);
 
         $this->assertSame('2023-01-01', $result->date);
-        $this->assertSame(SermonService::MORNING, $result->service);
+        $this->assertSame(SermonService::Morning, $result->service);
     }
 
     #[Test]
@@ -105,7 +105,7 @@ class OpenLpServiceParserTest extends TestCase
         $result = $this->parser->parse($upload);
 
         $this->assertSame('2024-05-26', $result->date);
-        $this->assertSame(SermonService::OTHER, $result->service);
+        $this->assertSame(SermonService::Other, $result->service);
     }
 
     #[Test]
@@ -120,7 +120,7 @@ class OpenLpServiceParserTest extends TestCase
         $result = $this->parser->parse($upload);
 
         $this->assertSame('2024-01-07', $result->date);
-        $this->assertSame(SermonService::OTHER, $result->service);
+        $this->assertSame(SermonService::Other, $result->service);
     }
 
     #[Test]
@@ -255,7 +255,7 @@ class OpenLpServiceParserTest extends TestCase
         $result = $this->parser->parse($upload);
 
         $this->assertSame('2024-11-17', $result->date);
-        $this->assertSame(SermonService::EVENING, $result->service);
+        $this->assertSame(SermonService::Evening, $result->service);
         $this->assertSame('embedded_filename', $result->importMetadata['parse_method']);
     }
 
@@ -270,7 +270,7 @@ class OpenLpServiceParserTest extends TestCase
 
         $result = $this->parser->parse($upload);
 
-        $this->assertSame(SermonService::MORNING, $result->service);
+        $this->assertSame(SermonService::Morning, $result->service);
         $this->assertTrue($result->importMetadata['filename_mismatch']);
         $this->assertLessThan(1.0, $result->importMetadata['confidence_score']);
         $this->assertTrue($result->needsReview);

--- a/tests/Unit/Services/PodcastFeedServiceTest.php
+++ b/tests/Unit/Services/PodcastFeedServiceTest.php
@@ -56,7 +56,7 @@ class PodcastFeedServiceTest extends TestCase
 
         config(['podcast.cache.enabled' => false]);
 
-        $sermons = $this->service->getSermonsForFeed(SermonService::MORNING);
+        $sermons = $this->service->getSermonsForFeed(SermonService::Morning);
 
         $this->assertCount(3, $sermons);
         $sermons->each(fn ($feedItem) => $this->assertInstanceOf(\App\Data\PodcastFeedItemReadModel::class, $feedItem));
@@ -79,7 +79,7 @@ class PodcastFeedServiceTest extends TestCase
 
         config(['podcast.cache.enabled' => false]);
 
-        $sermons = $this->service->getSermonsForFeed(SermonService::MORNING);
+        $sermons = $this->service->getSermonsForFeed(SermonService::Morning);
 
         $this->assertCount(2, $sermons);
     }
@@ -105,7 +105,7 @@ class PodcastFeedServiceTest extends TestCase
 
         config(['podcast.cache.enabled' => false]);
 
-        $sermons = $this->service->getSermonsForFeed(SermonService::MORNING);
+        $sermons = $this->service->getSermonsForFeed(SermonService::Morning);
 
         $this->assertCount(1, $sermons);
         $this->assertSame('Main Sermon', $sermons->sole()->title);
@@ -124,7 +124,7 @@ class PodcastFeedServiceTest extends TestCase
 
         config(['podcast.cache.enabled' => false]);
 
-        $sermons = $this->service->getSermonsForFeed(SermonService::MORNING);
+        $sermons = $this->service->getSermonsForFeed(SermonService::Morning);
 
         $sermon = $sermons->first();
         $this->assertEquals('https://cdn.example.com/sermon.mp3', $sermon->enclosureUrl);
@@ -144,7 +144,7 @@ class PodcastFeedServiceTest extends TestCase
 
         config(['podcast.cache.enabled' => false]);
 
-        $sermons = $this->service->getSermonsForFeed(SermonService::MORNING);
+        $sermons = $this->service->getSermonsForFeed(SermonService::Morning);
 
         $this->assertEquals(0, $sermons->first()->enclosureLength);
     }
@@ -211,7 +211,7 @@ class PodcastFeedServiceTest extends TestCase
 
         $this->assertFalse(Cache::has('podcast_feed_morning'));
 
-        $this->service->getSermonsForFeed(SermonService::MORNING);
+        $this->service->getSermonsForFeed(SermonService::Morning);
 
         $this->assertTrue(Cache::has('podcast_feed_morning'));
     }
@@ -248,7 +248,7 @@ class PodcastFeedServiceTest extends TestCase
 
         config(['podcast.cache.enabled' => false]);
 
-        $sermons = $this->service->getSermonsForFeed(SermonService::MORNING);
+        $sermons = $this->service->getSermonsForFeed(SermonService::Morning);
 
         $this->assertCount(0, $sermons);
     }
@@ -266,7 +266,7 @@ class PodcastFeedServiceTest extends TestCase
         $this->storageService->method('getPublicUrl')->willReturn('https://example.com/sermon.mp3');
         $this->storageService->method('getFileSize')->willReturn(1024);
 
-        $sermons = $this->service->getSermonsForFeed(SermonService::MORNING);
+        $sermons = $this->service->getSermonsForFeed(SermonService::Morning);
 
         $this->assertCount(2, $sermons);
     }

--- a/tests/Unit/Services/ProcessingInitiatorTest.php
+++ b/tests/Unit/Services/ProcessingInitiatorTest.php
@@ -38,7 +38,7 @@ class ProcessingInitiatorTest extends TestCase
         $extractedDateTime = Carbon::create(2026, 2, 10, 10, 30, 0);
 
         $this->metadataService->method('extractDateFromVideo')->willReturn($extractedDateTime);
-        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::MORNING);
+        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::Morning);
 
         $log = $this->initiator->initiateProcessing($file, MediaType::Video);
 
@@ -56,7 +56,7 @@ class ProcessingInitiatorTest extends TestCase
         $extractedDateTime = Carbon::create(2026, 2, 10, 18, 30, 0);
 
         $this->metadataService->method('extractDateFromVideo')->willReturn($extractedDateTime);
-        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::EVENING);
+        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::Evening);
 
         $log = $this->initiator->initiateProcessing($file, MediaType::Video);
 
@@ -76,7 +76,7 @@ class ProcessingInitiatorTest extends TestCase
             ->expects($this->once())
             ->method('determineServiceFromTime')
             ->with($extractedDateTime)
-            ->willReturn(SermonService::MORNING);
+            ->willReturn(SermonService::Morning);
 
         $this->initiator->initiateProcessing($file, MediaType::Video);
     }
@@ -92,7 +92,7 @@ class ProcessingInitiatorTest extends TestCase
             ->expects($this->once())
             ->method('determineServiceFromFilename')
             ->with('evening-sermon.mp4')
-            ->willReturn(SermonService::EVENING);
+            ->willReturn(SermonService::Evening);
 
         $log = $this->initiator->initiateProcessing($file, MediaType::Video);
 
@@ -111,7 +111,7 @@ class ProcessingInitiatorTest extends TestCase
             ->method('extractDateFromVideo')
             ->with($file, $clientFileDate)
             ->willReturn($extractedDateTime);
-        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::MORNING);
+        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::Morning);
 
         $this->initiator->initiateProcessing($file, MediaType::Video, $clientFileDate);
     }
@@ -123,7 +123,7 @@ class ProcessingInitiatorTest extends TestCase
         $extractedDateTime = Carbon::create(2026, 2, 10, 10, 30, 0);
 
         $this->metadataService->method('extractDateFromVideo')->willReturn($extractedDateTime);
-        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::MORNING);
+        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::Morning);
 
         $log = $this->initiator->initiateProcessing($file, MediaType::Livestream);
 
@@ -138,7 +138,7 @@ class ProcessingInitiatorTest extends TestCase
         $extractedDateTime = Carbon::create(2026, 2, 10, 10, 30, 0);
 
         $this->metadataService->method('extractDateFromVideo')->willReturn($extractedDateTime);
-        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::MORNING);
+        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::Morning);
 
         $log = $this->initiator->initiateProcessing($file, MediaType::Livestream, null, [
             'source_file_path' => 'livestream/temp/test.mp4',
@@ -158,7 +158,7 @@ class ProcessingInitiatorTest extends TestCase
         $extractedDateTime = Carbon::create(2026, 2, 10, 10, 30, 0);
 
         $this->metadataService->method('extractDateFromVideo')->willReturn($extractedDateTime);
-        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::MORNING);
+        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::Morning);
 
         $log = $this->initiator->initiateProcessing($file, MediaType::Livestream, null, [
             'processing_metadata' => [
@@ -184,7 +184,7 @@ class ProcessingInitiatorTest extends TestCase
         $extractedDateTime = Carbon::create(2026, 2, 10, 10, 30, 0);
 
         $this->metadataService->method('extractDateFromVideo')->willReturn($extractedDateTime);
-        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::MORNING);
+        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::Morning);
 
         $log1 = $this->initiator->initiateProcessing($file, MediaType::Video);
         $log2 = $this->initiator->initiateProcessing($file, MediaType::Video);
@@ -199,7 +199,7 @@ class ProcessingInitiatorTest extends TestCase
         $extractedDateTime = Carbon::create(2026, 2, 10, 10, 30, 0);
 
         $this->metadataService->method('extractDateFromVideo')->willReturn($extractedDateTime);
-        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::MORNING);
+        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::Morning);
 
         $log = $this->initiator->initiateProcessing($file, MediaType::Video);
 
@@ -220,7 +220,7 @@ class ProcessingInitiatorTest extends TestCase
         $extractedDateTime = Carbon::create(2026, 2, 10, 10, 30, 0);
 
         $this->metadataService->method('extractDateFromVideo')->willReturn($extractedDateTime);
-        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::MORNING);
+        $this->metadataService->method('determineServiceFromTime')->willReturn(SermonService::Morning);
 
         $log = $this->initiator->initiateProcessing($file, MediaType::Video);
 

--- a/tests/Unit/Services/SermonCreationServiceTest.php
+++ b/tests/Unit/Services/SermonCreationServiceTest.php
@@ -112,10 +112,10 @@ class SermonCreationServiceTest extends TestCase
         ]);
 
         $service = $this->service->extractServiceType($log, '2024-03-15-evening-sermon.mp3');
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $service);
 
         $service = $this->service->extractServiceType($log, '2024-03-15-EVENING-sermon.mp3');
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $service);
     }
 
     #[Test]
@@ -126,10 +126,10 @@ class SermonCreationServiceTest extends TestCase
         ]);
 
         $service = $this->service->extractServiceType($log, '2024-03-15-morning-sermon.mp3');
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $service);
 
         $service = $this->service->extractServiceType($log, '2024-03-15-MORNING-sermon.mp3');
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $service);
     }
 
     #[Test]
@@ -140,10 +140,10 @@ class SermonCreationServiceTest extends TestCase
         ]);
 
         $service = $this->service->extractServiceType($log, '2024-10-19-pm.mp3');
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $service);
 
         $service = $this->service->extractServiceType($log, '2024-10-19_pm.mp3');
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $service);
     }
 
     #[Test]
@@ -154,10 +154,10 @@ class SermonCreationServiceTest extends TestCase
         ]);
 
         $service = $this->service->extractServiceType($log, '2024-10-19-am.mp3');
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $service);
 
         $service = $this->service->extractServiceType($log, '2024-10-19_am.mp3');
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $service);
     }
 
     #[Test]
@@ -169,19 +169,19 @@ class SermonCreationServiceTest extends TestCase
 
         // Test various time formats that indicate evening (>= 12:00)
         $service = $this->service->extractServiceType($log, '2024-10-19-18:00.mp3');
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $service);
 
         $service = $this->service->extractServiceType($log, '2024-10-19-1830.mp3');
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $service);
 
         $service = $this->service->extractServiceType($log, '2024-10-19-14:30.mp3');
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $service);
 
         $service = $this->service->extractServiceType($log, '2024-10-19_18-30.mp3');
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $service);
 
         $service = $this->service->extractServiceType($log, 'sermon-12:00.mp3');
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $service);
     }
 
     #[Test]
@@ -193,19 +193,19 @@ class SermonCreationServiceTest extends TestCase
 
         // Test various time formats that indicate morning (< 12:00)
         $service = $this->service->extractServiceType($log, '2024-10-19-10:00.mp3');
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $service);
 
         $service = $this->service->extractServiceType($log, '2024-10-19-1030.mp3');
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $service);
 
         $service = $this->service->extractServiceType($log, '2024-10-19-09:30.mp3');
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $service);
 
         $service = $this->service->extractServiceType($log, '2024-10-19_08-30.mp3');
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $service);
 
         $service = $this->service->extractServiceType($log, 'sermon-06:00.mp3');
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $service);
     }
 
     #[Test]
@@ -217,10 +217,10 @@ class SermonCreationServiceTest extends TestCase
 
         // These should default to morning because the date is not a valid time
         $service = $this->service->extractServiceType($log, '2024-10-19.mp3');
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $service);
 
         $service = $this->service->extractServiceType($log, '19-10-2024.mp3');
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $service);
     }
 
     #[Test]
@@ -232,15 +232,15 @@ class SermonCreationServiceTest extends TestCase
 
         // Even with evening time, "am" marker should take priority
         $service = $this->service->extractServiceType($log, '2024-10-19-18:00-am.mp3');
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $service);
 
         // Even with morning time, "pm" marker should take priority
         $service = $this->service->extractServiceType($log, '2024-10-19-10:00-pm.mp3');
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $service);
 
         // "evening" keyword should take priority
         $service = $this->service->extractServiceType($log, '2024-10-19-10:00-evening.mp3');
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $service);
     }
 
     #[Test]
@@ -251,7 +251,7 @@ class SermonCreationServiceTest extends TestCase
         ]);
 
         $service = $this->service->extractServiceType($log, '2024-03-15-sermon.mp3');
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $service);
     }
 
     #[Test]
@@ -267,7 +267,7 @@ class SermonCreationServiceTest extends TestCase
 
         // Even though filename says "morning", metadata should win
         $service = $this->service->extractServiceType($log, '2024-03-15-morning-sermon.mp3');
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $service);
     }
 
     #[Test]
@@ -347,7 +347,7 @@ class SermonCreationServiceTest extends TestCase
             [
                 'filename' => '2024-03-15.mp3',
                 'processing_log' => $log,
-                'service' => \App\Enums\SermonService::MORNING,
+                'service' => \App\Enums\SermonService::Morning,
             ]
         );
 
@@ -393,7 +393,7 @@ class SermonCreationServiceTest extends TestCase
         $this->assertEquals('The Power of Prayer', $sermon->title);
         $this->assertEquals('audio/test.mp3', $sermon->audio_file_path);
         $this->assertEquals('2024-03-15', $sermon->date->format('Y-m-d'));
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $sermon->service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $sermon->service);
         $this->assertEquals('Prayer Series', $sermon->series);
         $this->assertEquals('Matthew 6:5-15', $sermon->reference);
         $this->assertEquals(SermonSourceType::AudioUpload, $sermon->source_type);
@@ -422,7 +422,7 @@ class SermonCreationServiceTest extends TestCase
         $this->assertEquals('Faith and Works', $sermon->title);
         $this->assertEquals('audio/test.mp3', $sermon->audio_file_path);
         $this->assertEquals('video/test.mp4', $sermon->video_file_path);
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $sermon->service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $sermon->service);
         $this->assertEquals(SermonSourceType::VideoUpload, $sermon->source_type);
     }
 
@@ -452,7 +452,7 @@ class SermonCreationServiceTest extends TestCase
         $this->assertEquals('audio/livestream-segment.mp3', $sermon->audio_file_path);
         $this->assertEquals(SermonSourceType::Livestream, $sermon->source_type);
         $this->assertEquals('test-processing-id', $sermon->livestream_processing_id);
-        $this->assertEquals(\App\Enums\SermonService::MORNING, $sermon->service);
+        $this->assertEquals(\App\Enums\SermonService::Morning, $sermon->service);
     }
 
     #[Test]
@@ -583,12 +583,12 @@ class SermonCreationServiceTest extends TestCase
             audioFilePath: 'audio/test.mp3',
             originalFilename: '2024-03-15-morning-sermon.mp3',
             sourceType: SermonSourceType::AudioUpload,
-            service: \App\Enums\SermonService::EVENING,
+            service: \App\Enums\SermonService::Evening,
         );
 
         $sermon = $this->service->createSermon($log, $options);
 
-        $this->assertEquals(\App\Enums\SermonService::EVENING, $sermon->service);
+        $this->assertEquals(\App\Enums\SermonService::Evening, $sermon->service);
     }
 
     #[Test]

--- a/tests/Unit/Services/ServiceSectionClassifierTest.php
+++ b/tests/Unit/Services/ServiceSectionClassifierTest.php
@@ -34,7 +34,7 @@ class ServiceSectionClassifierTest extends TestCase
     {
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-03-01',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $introSpeech = LivestreamSegment::factory()->speech()->create([
@@ -99,7 +99,7 @@ class ServiceSectionClassifierTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-08',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $songOne = ChurchServiceItem::factory()->create([
@@ -125,7 +125,7 @@ class ServiceSectionClassifierTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-03-08',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $segmentOne = LivestreamSegment::factory()->song()->create([
@@ -185,7 +185,7 @@ class ServiceSectionClassifierTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-10',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         $item = ChurchServiceItem::factory()->create([
@@ -198,7 +198,7 @@ class ServiceSectionClassifierTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-03-10',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $segment = LivestreamSegment::factory()->speech()->create([
@@ -223,7 +223,7 @@ class ServiceSectionClassifierTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-15',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -242,7 +242,7 @@ class ServiceSectionClassifierTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-03-15',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         $speechOnlySegment = LivestreamSegment::factory()->speech()->create([
@@ -270,7 +270,7 @@ class ServiceSectionClassifierTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-22',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -289,7 +289,7 @@ class ServiceSectionClassifierTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-03-22',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         LivestreamSegment::factory()->song()->create([
@@ -323,7 +323,7 @@ class ServiceSectionClassifierTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-29',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
 
         ChurchServiceItem::factory()->create([
@@ -342,7 +342,7 @@ class ServiceSectionClassifierTest extends TestCase
 
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-03-29',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         LivestreamSegment::factory()->song()->create([
@@ -376,7 +376,7 @@ class ServiceSectionClassifierTest extends TestCase
     {
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-04-05',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         LivestreamSegment::factory()->speech()->create([
@@ -413,7 +413,7 @@ class ServiceSectionClassifierTest extends TestCase
     {
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-04-12',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         LivestreamSegment::factory()->speech()->create([
@@ -450,7 +450,7 @@ class ServiceSectionClassifierTest extends TestCase
     {
         $processingLog = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-04-19',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         // 22 minutes - only one exceeds 20 min threshold

--- a/tests/Unit/Services/StructuralSectionAlignerTest.php
+++ b/tests/Unit/Services/StructuralSectionAlignerTest.php
@@ -32,7 +32,7 @@ class StructuralSectionAlignerTest extends TestCase
     {
         return ChurchService::factory()->create([
             'date' => '2026-06-07',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
         ]);
     }
 

--- a/tests/Unit/Services/StructureMergeIntegrationTest.php
+++ b/tests/Unit/Services/StructureMergeIntegrationTest.php
@@ -39,7 +39,7 @@ class StructureMergeIntegrationTest extends TestCase
     #[Test]
     public function test_openlp_import_stages_review_when_high_confidence_livestream_disagrees(): void
     {
-        $churchService = $this->createLivestreamService('2024-11-17', SermonService::MORNING, [
+        $churchService = $this->createLivestreamService('2024-11-17', SermonService::Morning, [
             ['type' => 'songs', 'title' => 'Amazing Grace', 'confidence' => 'high'],
             ['type' => 'custom', 'title' => 'Sermon', 'section_type' => ServiceSectionType::SERMON, 'confidence' => 'high'],
         ]);
@@ -77,7 +77,7 @@ class StructureMergeIntegrationTest extends TestCase
     #[Test]
     public function test_openlp_import_auto_merges_when_low_confidence_livestream(): void
     {
-        $this->createLivestreamService('2024-11-17', SermonService::MORNING, [
+        $this->createLivestreamService('2024-11-17', SermonService::Morning, [
             ['type' => 'songs', 'title' => 'Unknown Song', 'confidence' => 'low'],
         ]);
 
@@ -130,7 +130,7 @@ class StructureMergeIntegrationTest extends TestCase
     #[Test]
     public function test_email_import_stages_review_when_high_confidence_livestream_disagrees(): void
     {
-        $churchService = $this->createLivestreamService('2026-03-22', SermonService::MORNING, [
+        $churchService = $this->createLivestreamService('2026-03-22', SermonService::Morning, [
             ['type' => 'songs', 'title' => 'Amazing Grace', 'confidence' => 'high'],
             ['type' => 'custom', 'title' => 'Sermon', 'section_type' => ServiceSectionType::SERMON, 'confidence' => 'high'],
         ]);
@@ -141,7 +141,7 @@ class StructureMergeIntegrationTest extends TestCase
 
         $parseResult = new \App\Data\OosEmailParseResult(
             date: '2026-03-22',
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             items: [
                 ['position' => 1, 'type' => 'songs', 'title' => 'Different Song', 'source_title' => null, 'openlp_search_title' => null, 'metadata' => null],
                 ['position' => 2, 'type' => 'custom', 'title' => 'Opening Prayer', 'source_title' => null, 'openlp_search_title' => null, 'metadata' => ['section_type' => ServiceSectionType::PRAYER->value]],
@@ -174,7 +174,7 @@ class StructureMergeIntegrationTest extends TestCase
     {
         $churchService = ChurchService::factory()->create([
             'date' => '2026-03-22',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => ChurchServiceItemSource::OPENLP->value,
         ]);
 
@@ -192,7 +192,7 @@ class StructureMergeIntegrationTest extends TestCase
 
         $parseResult = new \App\Data\OosEmailParseResult(
             date: '2026-03-22',
-            service: SermonService::MORNING,
+            service: SermonService::Morning,
             items: [
                 ['position' => 1, 'type' => 'songs', 'title' => 'New Song', 'source_title' => null, 'openlp_search_title' => null, 'metadata' => null],
             ],
@@ -221,7 +221,7 @@ class StructureMergeIntegrationTest extends TestCase
         // 1. Project a livestream service
         $log = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-03-27',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -284,7 +284,7 @@ class StructureMergeIntegrationTest extends TestCase
     {
         $log = MediaProcessingLog::factory()->livestream()->create([
             'extracted_date' => '2026-03-27',
-            'extracted_service' => SermonService::MORNING->value,
+            'extracted_service' => SermonService::Morning->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -331,7 +331,7 @@ class StructureMergeIntegrationTest extends TestCase
     public function test_openlp_import_keeps_livestream_source_while_merge_is_staged(): void
     {
         // Regression for fix #7: source must not jump to 'openlp' before merge is accepted
-        $churchService = $this->createLivestreamService('2024-11-17', SermonService::MORNING, [
+        $churchService = $this->createLivestreamService('2024-11-17', SermonService::Morning, [
             ['type' => 'songs', 'title' => 'Amazing Grace', 'confidence' => 'high'],
         ]);
 
@@ -362,7 +362,7 @@ class StructureMergeIntegrationTest extends TestCase
         // review exists), clearPendingMerge must not overwrite it back to false.
         $service = ChurchService::factory()->create([
             'date' => '2026-03-27',
-            'service' => SermonService::MORNING->value,
+            'service' => SermonService::Morning->value,
             'source' => ChurchServiceItemSource::LIVESTREAM->value,
             'needs_review' => true,
             'import_metadata' => [


### PR DESCRIPTION
Refactored the `SermonService` enum to use TitleCase keys, improving consistency with project standards. This change was applied project-wide to over 60 files, including models, services, controllers, and tests. Functional behavior remains unchanged as string backing values were preserved.

---
*PR created automatically by Jules for task [1133162925171265633](https://jules.google.com/task/1133162925171265633) started by @GarethClarridge*