### PR TITLE
🛡️ Sentinel: Add audit logging for calendar event categorization

### DIFF
--- a/app/Livewire/Admin/CalendarEvents/EditCalendarEvent.php
+++ b/app/Livewire/Admin/CalendarEvents/EditCalendarEvent.php
@@ -9,6 +9,7 @@ use App\Livewire\Traits\WithAdminAuthorization;
 use App\Livewire\Traits\WithNotifications;
 use App\Models\CalendarEvent;
 use App\Models\Meeting;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 use Livewire\Component;
@@ -75,6 +76,8 @@ class EditCalendarEvent extends Component
 
         $validated = $this->validate();
 
+        $oldMeetingSlug = $this->calendarEvent->meeting_slug;
+
         $this->calendarEvent->update([
             'title' => $validated['title'],
             'description' => $validated['description'],
@@ -86,6 +89,16 @@ class EditCalendarEvent extends Component
             'status' => $validated['status'],
             'is_categorized_automatically' => false,
         ]);
+
+        if ($oldMeetingSlug !== $validated['meetingSlug']) {
+            Log::warning('Calendar event categorization changed via edit form', [
+                'admin_id' => auth()->id(),
+                'event_id' => $this->calendarEvent->id,
+                'event_title' => $this->calendarEvent->title,
+                'old_meeting_slug' => $oldMeetingSlug,
+                'new_meeting_slug' => $validated['meetingSlug'],
+            ]);
+        }
 
         $this->success('Calendar event updated');
     }

--- a/app/Livewire/Admin/CalendarEvents/ListCalendarEvents.php
+++ b/app/Livewire/Admin/CalendarEvents/ListCalendarEvents.php
@@ -10,6 +10,7 @@ use App\Livewire\Traits\WithNotifications;
 use App\Models\CalendarEvent;
 use App\Models\Meeting;
 use App\Traits\EscapesLikeWildcards;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -55,10 +56,22 @@ class ListCalendarEvents extends Component
 
         $this->authorizeAdmin();
 
-        CalendarEvent::find($eventId)?->update([
-            'meeting_slug' => $meetingSlug,
-            'is_categorized_automatically' => false,
-        ]);
+        $event = CalendarEvent::find($eventId);
+
+        if ($event) {
+            $event->update([
+                'meeting_slug' => $meetingSlug,
+                'is_categorized_automatically' => false,
+            ]);
+
+            Log::warning('Calendar event categorized via list view', [
+                'admin_id' => auth()->id(),
+                'event_id' => $event->id,
+                'event_title' => $event->title,
+                'meeting_slug' => $meetingSlug,
+            ]);
+        }
+
         $this->success('Event categorized');
     }
 

--- a/app/Services/CalendarService.php
+++ b/app/Services/CalendarService.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use App\Models\CalendarEvent;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Log;
 
 class CalendarService
 {
@@ -86,6 +87,13 @@ class CalendarService
         $event->update([
             'meeting_slug' => $meetingSlug,
             'is_categorized_automatically' => false,
+        ]);
+
+        Log::warning('Calendar event manually categorized', [
+            'admin_id' => auth()->id(),
+            'event_id' => $event->id,
+            'event_title' => $event->title,
+            'meeting_slug' => $meetingSlug,
         ]);
 
         $googleSynced = $event->google_event_id !== null

--- a/tests/Feature/Security/AuditLoggingTest.php
+++ b/tests/Feature/Security/AuditLoggingTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Security;
 
+use App\Enums\CalendarEventStatus;
 use App\Enums\InboundEmailStatus;
+use App\Livewire\Admin\CalendarEvents\EditCalendarEvent;
+use App\Livewire\Admin\CalendarEvents\ListCalendarEvents;
 use App\Livewire\Admin\ChurchServices\ReviewInboundEmails;
 use App\Livewire\Admin\Meetings\ListMeetings;
 use App\Livewire\Admin\Pages\ListPages;
@@ -19,6 +22,7 @@ use App\Models\PreacherAlias;
 use App\Models\Sermon;
 use App\Models\SpeakerProfile;
 use App\Models\User;
+use App\Services\GoogleCalendarSyncService;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Log;
 use Livewire\Livewire;
@@ -222,6 +226,81 @@ class AuditLoggingTest extends TestCase
             $context['admin_id'] === $this->admin->id &&
             $context['preacher_id'] === $preacher->id &&
             $context['profile_id'] === $profile->id
+        );
+    }
+
+    #[Test]
+    public function it_logs_calendar_event_categorization_via_livewire_list(): void
+    {
+        Log::spy();
+        Meeting::factory()->create(['slug' => 'new-meeting-slug']);
+        $event = \App\Models\CalendarEvent::factory()->create(['title' => 'Event Title']);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListCalendarEvents::class)
+            ->call('categorize', $event->id, 'new-meeting-slug');
+
+        $this->assertEquals('new-meeting-slug', $event->fresh()->meeting_slug);
+
+        Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Calendar event categorized via list view' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['event_id'] === $event->id &&
+            $context['event_title'] === 'Event Title' &&
+            $context['meeting_slug'] === 'new-meeting-slug'
+        );
+    }
+
+    #[Test]
+    public function it_logs_calendar_event_categorization_via_livewire_edit(): void
+    {
+        Log::spy();
+        Meeting::factory()->create(['slug' => 'old-slug']);
+        Meeting::factory()->create(['slug' => 'new-slug']);
+        $event = \App\Models\CalendarEvent::factory()->create([
+            'title' => 'Event Title',
+            'meeting_slug' => 'old-slug',
+            'status' => CalendarEventStatus::CONFIRMED,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(EditCalendarEvent::class, ['calendarEvent' => $event])
+            ->set('meetingSlug', 'new-slug')
+            ->call('save');
+
+        $this->assertEquals('new-slug', $event->fresh()->meeting_slug);
+
+        Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Calendar event categorization changed via edit form' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['event_id'] === $event->id &&
+            $context['event_title'] === 'Event Title' &&
+            $context['old_meeting_slug'] === 'old-slug' &&
+            $context['new_meeting_slug'] === 'new-slug'
+        );
+    }
+
+    #[Test]
+    public function it_logs_calendar_event_categorization_via_service(): void
+    {
+        Log::spy();
+
+        // Mock GoogleCalendarSyncService to avoid calling Google Calendar API
+        $this->mock(GoogleCalendarSyncService::class, function ($mock) {
+            $mock->shouldReceive('syncCategorizationToGoogle')->andReturn(true);
+        });
+
+        Meeting::factory()->create(['slug' => 'service-slug']);
+        $event = \App\Models\CalendarEvent::factory()->create(['title' => 'Service Event']);
+
+        $this->actingAs($this->admin);
+        app(\App\Services\CalendarService::class)->manuallyCategorizeEvent($event->id, 'service-slug');
+
+        $this->assertEquals('service-slug', $event->fresh()->meeting_slug);
+
+        Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Calendar event manually categorized' &&
+            $context['admin_id'] === $this->admin->id &&
+            $context['event_id'] === $event->id &&
+            $context['event_title'] === 'Service Event' &&
+            $context['meeting_slug'] === 'service-slug'
         );
     }
 


### PR DESCRIPTION
🛡️ **Sentinel: Add audit logging for calendar event categorization**

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Lack of audit trail for administrative organization of calendar data.
🎯 **Impact:** Unauthorized or erroneous categorization of events could occur without a trace, making it difficult to investigate data integrity issues or administrative misuse.
🔧 **Fix:** Implemented `Log::warning` calls (following the project's existing audit logging pattern) across all entry points for calendar event categorization: the core service, the list view quick action, and the full edit form.
✅ **Verification:** Added three new test cases to `tests/Feature/Security/AuditLoggingTest.php` that verify categorization via each entry point correctly records the actor and target metadata. All 59 relevant tests passed.

---
*PR created automatically by Jules for task [8541722424705717193](https://jules.google.com/task/8541722424705717193) started by @GarethClarridge*