### PR TITLE
🏛️ Warden: fortify core model integrity and page schema

### DIFF
--- a/app/Models/CalendarEvent.php
+++ b/app/Models/CalendarEvent.php
@@ -44,14 +44,30 @@ class CalendarEvent extends Model
 
     /**
      * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
      */
     protected function casts(): array
     {
         return [
+            'id' => 'integer',
             'start_datetime' => 'datetime',
             'end_datetime' => 'datetime',
             'status' => \App\Enums\CalendarEventStatus::class,
             'is_categorized_automatically' => 'boolean',
+        ];
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public static function validationRules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'speaker' => ['nullable', 'string', 'max:255'],
+            'location' => ['nullable', 'string', 'max:255'],
+            'status' => ['required', 'string', 'in:'.implode(',', \App\Enums\CalendarEventStatus::values())],
         ];
     }
 

--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -88,10 +88,14 @@ class Meeting extends Model implements HasMedia, Sitemapable
 
     /**
      * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
      */
     protected function casts(): array
     {
         return [
+            'id' => 'integer',
+            'page_id' => 'integer',
             'pictures' => 'boolean',
             'meeting_date' => 'datetime',
             'is_recurring' => 'boolean',
@@ -99,6 +103,36 @@ class Meeting extends Model implements HasMedia, Sitemapable
             'end_time' => 'datetime:H:i:s',
             'type' => MeetingType::class,
             'frequency' => MeetingFrequency::class,
+        ];
+    }
+
+    /**
+     * @return array<string, list<string|mixed>>
+     */
+    public static function validationRules(?self $meeting = null): array
+    {
+        $slugRule = ['required', 'string', 'max:255'];
+        $uniqueSlug = \Illuminate\Validation\Rule::unique('meetings', 'slug');
+        if ($meeting) {
+            $uniqueSlug->ignore($meeting->id);
+        }
+        $slugRule[] = $uniqueSlug;
+
+        $pageIdRule = ['nullable', 'integer', 'exists:pages,id'];
+        $uniquePageId = \Illuminate\Validation\Rule::unique('meetings', 'page_id');
+        if ($meeting) {
+            $uniquePageId->ignore($meeting->id);
+        }
+        $pageIdRule[] = $uniquePageId;
+
+        return [
+            'slug' => $slugRule,
+            'day' => ['required', 'string', 'max:255'],
+            'location' => ['nullable', 'string', 'max:255'],
+            'who' => ['required', 'string', 'max:255'],
+            'leaders_phone' => ['nullable', 'string', 'max:255'],
+            'leaders_email' => ['nullable', 'email', 'max:255'],
+            'page_id' => $pageIdRule,
         ];
     }
 

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -74,12 +74,42 @@ class Page extends Model implements HasMedia, Sitemapable
 
     /**
      * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
      */
     protected function casts(): array
     {
         return [
+            'id' => 'integer',
             'navigation' => 'boolean',
             'area' => PageArea::class,
+            'sort_order' => 'integer',
+        ];
+    }
+
+    /**
+     * @return array<string, list<string|mixed>>
+     */
+    public static function validationRules(?self $page = null, ?string $area = null): array
+    {
+        $slugRule = ['required', 'string', 'max:255', 'alpha_dash'];
+
+        $uniqueRule = \Illuminate\Validation\Rule::unique('pages', 'slug');
+        if ($page) {
+            $uniqueRule->ignore($page->id);
+        }
+        if ($area) {
+            $uniqueRule->where('area', $area);
+        }
+
+        $slugRule[] = $uniqueRule;
+
+        return [
+            'heading' => ['required', 'string', 'max:255'],
+            'slug' => $slugRule,
+            'area' => ['required', 'string', 'in:'.implode(',', PageArea::values())],
+            'description' => ['required', 'string', 'max:155'],
+            'sort_order' => ['nullable', 'integer', 'min:0'],
         ];
     }
 

--- a/app/Models/Preacher.php
+++ b/app/Models/Preacher.php
@@ -49,10 +49,40 @@ class Preacher extends Model implements Sitemapable
         'is_active',
     ];
 
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     {
         return [
+            'id' => 'integer',
             'is_active' => 'boolean',
+        ];
+    }
+
+    /**
+     * @return array<string, list<string|mixed>>
+     */
+    public static function validationRules(?self $preacher = null): array
+    {
+        $nameRule = ['required', 'string', 'max:255'];
+        $slugRule = ['required', 'string', 'max:255'];
+
+        $uniqueName = \Illuminate\Validation\Rule::unique('preachers', 'name');
+        $uniqueSlug = \Illuminate\Validation\Rule::unique('preachers', 'slug');
+
+        if ($preacher) {
+            $uniqueName->ignore($preacher->id);
+            $uniqueSlug->ignore($preacher->id);
+        }
+
+        $nameRule[] = $uniqueName;
+        $slugRule[] = $uniqueSlug;
+
+        return [
+            'name' => $nameRule,
+            'slug' => $slugRule,
+            'image_path' => ['nullable', 'string', 'max:255'],
         ];
     }
 

--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -165,10 +165,13 @@ class Sermon extends Model implements Sitemapable
 
     /**
      * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
      */
     protected function casts(): array
     {
         return [
+            'id' => 'integer',
             'date' => 'date',
             'points' => 'array',
             'service' => SermonService::class,
@@ -187,6 +190,34 @@ class Sermon extends Model implements Sitemapable
             'preacher_confidence' => 'float',
             'needs_preacher_review' => 'boolean',
             'download_count' => 'integer',
+            'preacher_id' => 'integer',
+            'scripture_passage_id' => 'integer',
+            'duration' => 'float',
+        ];
+    }
+
+    /**
+     * @return array<string, list<string|mixed>>
+     */
+    public static function validationRules(?self $sermon = null): array
+    {
+        $slugRule = ['required', 'string', 'max:255'];
+        $uniqueSlug = \Illuminate\Validation\Rule::unique('sermons', 'slug');
+        if ($sermon) {
+            $uniqueSlug->ignore($sermon->id);
+        }
+        $slugRule[] = $uniqueSlug;
+
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => $slugRule,
+            'series' => ['nullable', 'string', 'max:255'],
+            'reference' => ['nullable', 'string', 'max:255'],
+            'preacher' => ['required', 'string', 'max:255'],
+            'preacher_id' => ['nullable', 'integer', 'exists:preachers,id'],
+            'scripture_passage_id' => ['nullable', 'integer', 'exists:scripture_passages,id'],
+            'download_count' => ['nullable', 'integer', 'min:0'],
+            'duration' => ['nullable', 'numeric', 'min:0'],
         ];
     }
 

--- a/database/migrations/2026_04_13_082111_formalize_pages_area_column.php
+++ b/database/migrations/2026_04_13_082111_formalize_pages_area_column.php
@@ -65,15 +65,24 @@ return new class extends Migration
     public function down(): void
     {
         if (DB::getDriverName() === 'mysql') {
-            DB::statement(sprintf('ALTER TABLE pages DROP CHECK %s', self::SORT_ORDER_CHECK));
+            try {
+                DB::statement(sprintf('ALTER TABLE pages DROP CHECK %s', self::SORT_ORDER_CHECK));
+            } catch (\Exception) {
+                // Ignore if constraint doesn't exist
+            }
         }
 
         Schema::table('pages', function (Blueprint $table) {
             $table->string('area', 50)->nullable(false)->change();
 
-            if (Schema::hasColumn('pages', 'sort_order')) {
-                $table->dropColumn('sort_order');
-            }
+            /**
+             * Safety: Avoid dropping sort_order on rollback.
+             *
+             * Since this migration is defensive about adding the column in up(),
+             * we remain defensive in down(). We do not drop the column because
+             * it might have existed before this migration was run, and dropping
+             * it would be destructive to data this migration didn't own.
+             */
         });
     }
 };

--- a/database/migrations/2026_04_13_082111_formalize_pages_area_column.php
+++ b/database/migrations/2026_04_13_082111_formalize_pages_area_column.php
@@ -31,14 +31,13 @@ return new class extends Migration
         // 2. Data Cleanup: Normalize area values to lowercase and ensure they are valid
         $validAreas = PageArea::values();
 
-        foreach (DB::table('pages')->select('area')->distinct()->pluck('area') as $area) {
-            $normalized = strtolower(trim((string) $area));
-            if (! in_array($normalized, $validAreas, true)) {
-                $normalized = PageArea::Church->value;
-            }
+        DB::table('pages')->update([
+            'area' => DB::raw('LOWER(TRIM(area))'),
+        ]);
 
-            DB::table('pages')->where('area', $area)->update(['area' => $normalized]);
-        }
+        DB::table('pages')
+            ->whereNotIn('area', $validAreas)
+            ->update(['area' => PageArea::Church->value]);
 
         // 3. Formalize area as ENUM and add CHECK constraint for sort_order
         $isMysql = DB::getDriverName() === 'mysql';

--- a/database/migrations/2026_04_13_082111_formalize_pages_area_column.php
+++ b/database/migrations/2026_04_13_082111_formalize_pages_area_column.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PageArea;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const SORT_ORDER_CHECK = 'pages_sort_order_check';
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasTable('pages')) {
+            return;
+        }
+
+        // 1. Add missing sort_order column if it doesn't exist
+        Schema::table('pages', function (Blueprint $table) {
+            if (! Schema::hasColumn('pages', 'sort_order')) {
+                $table->unsignedInteger('sort_order')->nullable()->after('navigation');
+            }
+        });
+
+        // 2. Data Cleanup: Normalize area values to lowercase and ensure they are valid
+        $validAreas = PageArea::values();
+
+        foreach (DB::table('pages')->select('area')->distinct()->pluck('area') as $area) {
+            $normalized = strtolower(trim((string) $area));
+            if (! in_array($normalized, $validAreas, true)) {
+                $normalized = PageArea::Church->value;
+            }
+
+            DB::table('pages')->where('area', $area)->update(['area' => $normalized]);
+        }
+
+        // 3. Formalize area as ENUM and add CHECK constraint for sort_order
+        $isMysql = DB::getDriverName() === 'mysql';
+
+        Schema::table('pages', function (Blueprint $table) use ($validAreas, $isMysql) {
+            if ($isMysql) {
+                $table->enum('area', $validAreas)->nullable(false)->change();
+            } else {
+                $table->string('area', 50)->nullable(false)->change();
+            }
+        });
+
+        if ($isMysql) {
+            DB::statement(sprintf(
+                'ALTER TABLE pages ADD CONSTRAINT %s CHECK (sort_order >= 0 OR sort_order IS NULL)',
+                self::SORT_ORDER_CHECK
+            ));
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement(sprintf('ALTER TABLE pages DROP CHECK %s', self::SORT_ORDER_CHECK));
+        }
+
+        Schema::table('pages', function (Blueprint $table) {
+            $table->string('area', 50)->nullable(false)->change();
+
+            if (Schema::hasColumn('pages', 'sort_order')) {
+                $table->dropColumn('sort_order');
+            }
+        });
+    }
+};


### PR DESCRIPTION
### 💡 What:
This PR fortifies the data integrity of the core application models and the `pages` table schema.

### 🎯 Why:
1.  **Type Safety**: Core models were missing explicit integer casts for primary and foreign keys. This ensures consistent behavior across the application and prevents subtle bugs during serialization or comparison.
2.  **Schema Enforcement**: The `pages.area` column was a plain `VARCHAR`, allowing invalid values. Formalizing it as an `ENUM` ensures database-level validation.
3.  **Validation Centralization**: Moving validation logic into the models (`validationRules()`) allows for reuse in background jobs, seeders, and various UI components, ensuring integrity rules are enforced consistently.
4.  **Database Safeguards**: Added a `CHECK` constraint to the new `pages.sort_order` column to prevent negative values at the storage layer.

### 🗄️ Migration:
- `2026_04_13_082111_formalize_pages_area_column.php`:
    - Converts `pages.area` to `ENUM('christ', 'church', 'community', 'members', 'sermons')`.
    - Adds `pages.sort_order` (`unsignedInteger`, nullable).
    - Adds `CONSTRAINT pages_sort_order_check CHECK (sort_order >= 0 OR sort_order IS NULL)`.

### ✅ Verification:
- Ran targeted integrity tests: `PageIntegrityTest`, `MeetingIntegrityTest`, `SermonIntegrityTest`, `PreacherIntegrityTest`, `CalendarEventIntegrityTest`.
- All `phpstan` checks passed (0 errors).
- Code formatted using `pint`.
- Verified schema changes using `php artisan tinker`.

### ⚠️ Rollback:
`php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [16567120961496863553](https://jules.google.com/task/16567120961496863553) started by @GarethClarridge*