### PR TITLE
🧹 Tidy: refactor CalendarEventStatus enum keys to TitleCase

### DIFF
--- a/app/Enums/CalendarEventStatus.php
+++ b/app/Enums/CalendarEventStatus.php
@@ -10,18 +10,18 @@ enum CalendarEventStatus: string
 {
     use HasValues;
 
-    case CONFIRMED = 'confirmed';
-    case PENDING = 'pending';
-    case TENTATIVE = 'tentative';
-    case CANCELLED = 'cancelled';
+    case Confirmed = 'confirmed';
+    case Pending = 'pending';
+    case Tentative = 'tentative';
+    case Cancelled = 'cancelled';
 
     public function label(): string
     {
         return match ($this) {
-            self::CONFIRMED => 'Confirmed',
-            self::PENDING => 'Pending',
-            self::TENTATIVE => 'Tentative',
-            self::CANCELLED => 'Cancelled',
+            self::Confirmed => 'Confirmed',
+            self::Pending => 'Pending',
+            self::Tentative => 'Tentative',
+            self::Cancelled => 'Cancelled',
         };
     }
 }

--- a/app/Models/CalendarEvent.php
+++ b/app/Models/CalendarEvent.php
@@ -103,6 +103,6 @@ class CalendarEvent extends Model
      */
     public function scopeConfirmed(Builder $query): Builder
     {
-        return $query->where('status', 'confirmed');
+        return $query->where('status', \App\Enums\CalendarEventStatus::Confirmed);
     }
 }

--- a/database/factories/CalendarEventFactory.php
+++ b/database/factories/CalendarEventFactory.php
@@ -28,7 +28,7 @@ class CalendarEventFactory extends Factory
             'location' => $this->faker->city(),
             'start_datetime' => $start,
             'end_datetime' => $end,
-            'status' => 'confirmed',
+            'status' => \App\Enums\CalendarEventStatus::Confirmed,
             'is_categorized_automatically' => false,
         ];
     }
@@ -39,7 +39,7 @@ class CalendarEventFactory extends Factory
     public function pending(): static
     {
         return $this->state(fn (array $attributes) => [
-            'status' => 'pending',
+            'status' => \App\Enums\CalendarEventStatus::Pending,
         ]);
     }
 

--- a/database/migrations/2026_03_25_073747_formalize_calendar_event_constraints.php
+++ b/database/migrations/2026_03_25_073747_formalize_calendar_event_constraints.php
@@ -22,7 +22,7 @@ return new class extends Migration
                 $table->string('status', 255)->default('confirmed')->change();
             } else {
                 $table->enum('status', CalendarEventStatus::values())
-                    ->default(CalendarEventStatus::CONFIRMED->value)
+                    ->default(CalendarEventStatus::Confirmed->value)
                     ->change();
 
                 // MySQL 8.0.16+ supports CHECK constraints.

--- a/tests/Feature/DataIntegrity/CalendarEventIntegrityTest.php
+++ b/tests/Feature/DataIntegrity/CalendarEventIntegrityTest.php
@@ -18,11 +18,11 @@ class CalendarEventIntegrityTest extends TestCase
     #[Test]
     public function it_allows_valid_status_values(): void
     {
-        $event = CalendarEvent::factory()->create(['status' => CalendarEventStatus::CONFIRMED]);
-        $this->assertEquals(CalendarEventStatus::CONFIRMED, $event->fresh()->status);
+        $event = CalendarEvent::factory()->create(['status' => CalendarEventStatus::Confirmed]);
+        $this->assertEquals(CalendarEventStatus::Confirmed, $event->fresh()->status);
 
-        $event->update(['status' => CalendarEventStatus::PENDING]);
-        $this->assertEquals(CalendarEventStatus::PENDING, $event->fresh()->status);
+        $event->update(['status' => CalendarEventStatus::Pending]);
+        $this->assertEquals(CalendarEventStatus::Pending, $event->fresh()->status);
     }
 
     #[Test]

--- a/tests/Feature/Security/AuditLoggingTest.php
+++ b/tests/Feature/Security/AuditLoggingTest.php
@@ -259,7 +259,7 @@ class AuditLoggingTest extends TestCase
         $event = \App\Models\CalendarEvent::factory()->create([
             'title' => 'Event Title',
             'meeting_slug' => 'old-slug',
-            'status' => CalendarEventStatus::CONFIRMED,
+            'status' => CalendarEventStatus::Confirmed,
         ]);
 
         Livewire::actingAs($this->admin)


### PR DESCRIPTION
This PR refactors the `CalendarEventStatus` enum to use TitleCase keys, following the project's code quality standards. 

Key changes:
- Updated `app/Enums/CalendarEventStatus.php` keys to `Confirmed`, `Pending`, `Tentative`, and `Cancelled`.
- Updated all occurrences of these enum keys across the codebase, including:
    - `app/Models/CalendarEvent.php`
    - `database/factories/CalendarEventFactory.php`
    - `database/migrations/2026_03_25_073747_formalize_calendar_event_constraints.php`
    - `tests/Feature/DataIntegrity/CalendarEventIntegrityTest.php`
    - `tests/Feature/Security/AuditLoggingTest.php`
- Verified that no `UPPER_SNAKE_CASE` references to `CalendarEventStatus` remain.
- Ensured backed values remain unchanged to avoid database regressions.
- All tests passed, and PHPStan reports no errors.

---
*PR created automatically by Jules for task [2277848199417602798](https://jules.google.com/task/2277848199417602798) started by @GarethClarridge*