### PR TITLE
🎨 Palette: Improve mobile menu toggle accessibility

### DIFF
--- a/resources/views/components/layout/header.blade.php
+++ b/resources/views/components/layout/header.blade.php
@@ -74,7 +74,7 @@
     class="ms-4 flex items-center justify-end rounded px-3 py-1 select-none whitespace-nowrap transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/90 focus-visible:ring-offset-2 focus-visible:ring-offset-cbc-teal-dark lg:col-start-12"
     type="button"
     role="button"
-    aria-label="Navigation"
+    :aria-label="expanded ? 'Close navigation' : 'Open navigation'"
     @click="expanded = ! expanded"
     @keydown.window.escape="expanded = false"
     :aria-expanded="expanded"

--- a/resources/views/components/layout/header.blade.php
+++ b/resources/views/components/layout/header.blade.php
@@ -73,7 +73,7 @@
   <button
     class="ms-4 flex items-center justify-end rounded px-3 py-1 select-none whitespace-nowrap transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/90 focus-visible:ring-offset-2 focus-visible:ring-offset-cbc-teal-dark lg:col-start-12"
     type="button"
-    role="button"
+    aria-label="Open navigation"
     :aria-label="expanded ? 'Close navigation' : 'Open navigation'"
     @click="expanded = ! expanded"
     @keydown.window.escape="expanded = false"

--- a/tests/Feature/RouteTest.php
+++ b/tests/Feature/RouteTest.php
@@ -399,7 +399,10 @@ class RouteTest extends TestCase
 
         $content = (string) $response->getContent();
 
-        $buttonStart = strpos($content, 'aria-label="Navigation"');
+        $buttonStart = strpos($content, ':aria-label="expanded ? \'Close navigation\' : \'Open navigation\'"');
+        if ($buttonStart === false) {
+            $buttonStart = strpos($content, 'aria-label="Navigation"');
+        }
         $this->assertNotFalse($buttonStart, 'Hamburger nav button is missing from the header');
 
         $buttonTagStart = strrpos(substr($content, 0, $buttonStart), '<button');


### PR DESCRIPTION
### 💡 What:
Implemented a dynamic `:aria-label` for the mobile navigation toggle in the header component. The label now switches between "Open navigation" and "Close navigation" based on the menu's state in Alpine.js.

### 🎯 Why:
The previous static "Navigation" label provided insufficient context for screen reader users when toggling the menu. By providing state-aware labels, users with assistive technologies receive immediate confirmation of the menu's current status and the action the button will perform.

### ♿ Accessibility:
- Improves screen reader feedback for the main navigation toggle.
- Follows the project's established pattern of using Alpine.js for interactive state.
- Ensures the button maintains an accessible name at all times.

### 📱 Responsive:
No visual changes for sighted users; the enhancement is specifically targeted at the mobile/small-screen navigation experience for assistive technology users.

### ✅ Verification:
- Verified via Playwright script that the attribute transitions correctly between states.
- Updated `tests/Feature/RouteTest.php` to ensure the "hamburger visibility" regression test remains valid with the new dynamic attribute.
- Built frontend assets to ensure compatibility with Vite.

---
*PR created automatically by Jules for task [3402412075804875208](https://jules.google.com/task/3402412075804875208) started by @GarethClarridge*