### PR TITLE
🧹 Tidy: Refactor model refresh in audit logs

### DIFF
--- a/app/Livewire/Admin/Meetings/EditMeeting.php
+++ b/app/Livewire/Admin/Meetings/EditMeeting.php
@@ -37,10 +37,11 @@ class EditMeeting extends Component
 
         $this->form->update();
 
+        $fresh = $this->meeting->fresh();
         Log::warning('Meeting updated by admin', [
             'admin_id' => auth()->id(),
             'meeting_id' => $this->meeting->id,
-            'slug' => $this->meeting->fresh()?->slug ?? $this->meeting->slug,
+            'slug' => ($fresh instanceof Meeting ? $fresh->slug : $this->meeting->slug),
         ]);
 
         $this->success('Meeting updated');

--- a/app/Livewire/Admin/Pages/EditPage.php
+++ b/app/Livewire/Admin/Pages/EditPage.php
@@ -34,11 +34,12 @@ class EditPage extends Component
 
         $this->form->update();
 
+        $fresh = $this->page->fresh();
         Log::warning('Page updated by admin', [
             'admin_id' => auth()->id(),
             'page_id' => $this->page->id,
-            'heading' => $this->page->fresh()?->heading ?? $this->page->heading,
-            'slug' => $this->page->fresh()?->slug ?? $this->page->slug,
+            'heading' => ($fresh instanceof Page ? $fresh->heading : $this->page->heading),
+            'slug' => ($fresh instanceof Page ? $fresh->slug : $this->page->slug),
         ]);
 
         $this->success('Page updated');

--- a/app/Livewire/Admin/Preachers/EditPreacher.php
+++ b/app/Livewire/Admin/Preachers/EditPreacher.php
@@ -77,11 +77,12 @@ class EditPreacher extends Component
             'is_active' => $validated['isActive'],
         ]);
 
+        $fresh = $this->preacher->fresh();
         Log::warning('Preacher updated by admin', [
             'admin_id' => auth()->id(),
             'preacher_id' => $this->preacher->id,
-            'name' => $this->preacher->fresh()?->name ?? $this->preacher->name,
-            'slug' => $this->preacher->fresh()?->slug ?? $this->preacher->slug,
+            'name' => ($fresh instanceof Preacher ? $fresh->name : $this->preacher->name),
+            'slug' => ($fresh instanceof Preacher ? $fresh->slug : $this->preacher->slug),
         ]);
 
         $this->success('Preacher updated');

--- a/app/Livewire/Admin/Sermons/EditSermon.php
+++ b/app/Livewire/Admin/Sermons/EditSermon.php
@@ -218,16 +218,17 @@ class EditSermon extends Component
 
         $this->sermon->update($updateData);
 
+        $fresh = $this->sermon->fresh();
         Log::warning('Sermon updated by admin', [
             'admin_id' => auth()->id(),
             'sermon_id' => $this->sermon->id,
-            'title' => $this->sermon->fresh()?->title ?? $this->sermon->title,
-            'slug' => $this->sermon->fresh()?->slug ?? $this->sermon->slug,
+            'title' => ($fresh instanceof Sermon ? $fresh->title : $this->sermon->title),
+            'slug' => ($fresh instanceof Sermon ? $fresh->slug : $this->sermon->slug),
         ]);
 
         // Dispatch enrichment after saving if reference was set or changed
         if ($referenceChanged && ! empty($newReference)) {
-            app(QueueScriptureEnrichment::class)->dispatch($this->sermon->fresh() ?? $this->sermon);
+            app(QueueScriptureEnrichment::class)->dispatch($fresh instanceof Sermon ? $fresh : $this->sermon);
         }
 
         $this->success('Sermon updated');


### PR DESCRIPTION
Refactored redundant and PHPStan-problematic model refresh patterns in administrative audit logs. Use explicit type checking to satisfy static analysis and improve consistency across Livewire components.

---
*PR created automatically by Jules for task [11972085408588453195](https://jules.google.com/task/11972085408588453195) started by @GarethClarridge*