### PR TITLE
🏛️ Warden: Fortify PreacherAlias data integrity with migration and validation

### DIFF
--- a/app/Livewire/Admin/Preachers/EditPreacher.php
+++ b/app/Livewire/Admin/Preachers/EditPreacher.php
@@ -77,11 +77,12 @@ class EditPreacher extends Component
             'is_active' => $validated['isActive'],
         ]);
 
+        $fresh = $this->preacher->fresh();
         Log::warning('Preacher updated by admin', [
             'admin_id' => auth()->id(),
             'preacher_id' => $this->preacher->id,
-            'name' => $this->preacher->fresh()?->name ?? $this->preacher->name,
-            'slug' => $this->preacher->fresh()?->slug ?? $this->preacher->slug,
+            'name' => ($fresh instanceof Preacher ? $fresh->name : $this->preacher->name),
+            'slug' => ($fresh instanceof Preacher ? $fresh->slug : $this->preacher->slug),
         ]);
 
         $this->success('Preacher updated');
@@ -92,18 +93,18 @@ class EditPreacher extends Component
 
         $this->authorizeAdmin();
 
-        $this->validateOnly('newAlias');
+        $this->newAlias = strtolower(trim($this->newAlias));
 
-        $alias = strtolower(trim($this->newAlias));
+        $this->validate([
+            'newAlias' => PreacherAlias::validationRules()['alias'],
+        ], [
+            'newAlias.unique' => 'This alias already exists.',
+        ]);
 
-        if ($alias === '') {
-            return;
-        }
-
-        PreacherAlias::firstOrCreate(
-            ['alias' => $alias],
-            ['preacher_id' => $this->preacher->id]
-        );
+        PreacherAlias::create([
+            'alias' => $this->newAlias,
+            'preacher_id' => $this->preacher->id,
+        ]);
 
         $this->newAlias = '';
         $this->preacher->refresh();

--- a/app/Models/PreacherAlias.php
+++ b/app/Models/PreacherAlias.php
@@ -29,6 +29,34 @@ class PreacherAlias extends Model
     ];
 
     /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'id' => 'integer',
+            'preacher_id' => 'integer',
+        ];
+    }
+
+    /**
+     * @return array<string, list<string|mixed>>
+     */
+    public static function validationRules(?self $alias = null): array
+    {
+        $uniqueAlias = \Illuminate\Validation\Rule::unique('preacher_aliases', 'alias');
+
+        if ($alias) {
+            $uniqueAlias->ignore($alias->id);
+        }
+
+        return [
+            'preacher_id' => ['required', 'integer', 'exists:preachers,id'],
+            'alias' => ['required', 'string', 'max:255', $uniqueAlias],
+        ];
+    }
+
+    /**
      * @return BelongsTo<Preacher, $this>
      */
     public function preacher(): BelongsTo

--- a/database/migrations/2026_04_16_052656_add_integrity_check_to_preacher_aliases_table.php
+++ b/database/migrations/2026_04_16_052656_add_integrity_check_to_preacher_aliases_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        // 1. Ensure existing data is normalized before adding the constraint
+        DB::table('preacher_aliases')->update([
+            'alias' => DB::raw('LOWER(TRIM(alias))'),
+        ]);
+
+        // 2. Add the CHECK constraint
+        // Ensures alias is lowercase, has no leading/trailing whitespace, and is not empty.
+        DB::statement("ALTER TABLE preacher_aliases ADD CONSTRAINT preacher_aliases_alias_format_check CHECK (alias = LOWER(TRIM(alias)) AND alias != '')");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        DB::statement('ALTER TABLE preacher_aliases DROP CHECK preacher_aliases_alias_format_check');
+    }
+};

--- a/database/migrations/2026_04_16_052656_add_integrity_check_to_preacher_aliases_table.php
+++ b/database/migrations/2026_04_16_052656_add_integrity_check_to_preacher_aliases_table.php
@@ -25,7 +25,8 @@ return new class extends Migration
 
         // 2. Add the CHECK constraint
         // Ensures alias is lowercase, has no leading/trailing whitespace, and is not empty.
-        DB::statement("ALTER TABLE preacher_aliases ADD CONSTRAINT preacher_aliases_alias_format_check CHECK (alias = LOWER(TRIM(alias)) AND alias != '')");
+        // We use BINARY to ensure the check is case-sensitive even on case-insensitive collations.
+        DB::statement("ALTER TABLE preacher_aliases ADD CONSTRAINT preacher_aliases_alias_format_check CHECK (BINARY alias = LOWER(TRIM(alias)) AND alias != '')");
     }
 
     /**

--- a/tests/Feature/Livewire/Admin/Preachers/AdminPreacherTest.php
+++ b/tests/Feature/Livewire/Admin/Preachers/AdminPreacherTest.php
@@ -32,6 +32,25 @@ class AdminPreacherTest extends TestCase
     }
 
     #[Test]
+    public function it_validates_alias_uniqueness_after_normalization_in_edit_component(): void
+    {
+        $preacher1 = Preacher::factory()->create();
+        $preacher2 = Preacher::factory()->create();
+
+        PreacherAlias::create([
+            'preacher_id' => $preacher1->id,
+            'alias' => 'normalized-alias',
+        ]);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(EditPreacher::class, ['preacher' => $preacher2])
+            ->set('newAlias', '  NORMALIZED-ALIAS  ')
+            ->call('addAlias')
+            ->assertHasErrors(['newAlias' => 'unique']);
+    }
+
+    #[Test]
     public function list_preachers_component_renders_successfully_for_admin(): void
     {
         $this->actingAs($this->admin);
@@ -207,6 +226,38 @@ class AdminPreacherTest extends TestCase
             ->call('removeAlias', $alias->id);
 
         $this->assertModelMissing($alias);
+    }
+
+    #[Test]
+    public function it_validates_alias_uniqueness_in_edit_component(): void
+    {
+        $preacher1 = Preacher::factory()->create();
+        $preacher2 = Preacher::factory()->create();
+
+        PreacherAlias::create([
+            'preacher_id' => $preacher1->id,
+            'alias' => 'duplicate-alias',
+        ]);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(EditPreacher::class, ['preacher' => $preacher2])
+            ->set('newAlias', 'duplicate-alias')
+            ->call('addAlias')
+            ->assertHasErrors(['newAlias' => 'unique']);
+    }
+
+    #[Test]
+    public function it_validates_alias_max_length_in_edit_component(): void
+    {
+        $preacher = Preacher::factory()->create();
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(EditPreacher::class, ['preacher' => $preacher])
+            ->set('newAlias', str_repeat('a', 256))
+            ->call('addAlias')
+            ->assertHasErrors(['newAlias' => 'max']);
     }
 
     #[Test]

--- a/tests/Unit/Models/PreacherAliasTest.php
+++ b/tests/Unit/Models/PreacherAliasTest.php
@@ -73,4 +73,50 @@ class PreacherAliasTest extends TestCase
         $this->assertEquals($preacher->id, $retrieved->preacher_id);
         $this->assertEquals('Alternative Name', $retrieved->alias);
     }
+
+    #[Test]
+    public function it_casts_id_and_preacher_id_to_integers(): void
+    {
+        $preacher = Preacher::factory()->create();
+        $alias = PreacherAlias::create([
+            'preacher_id' => (string) $preacher->id,
+            'alias' => 'String ID Test',
+        ]);
+
+        $this->assertIsInt($alias->id);
+        $this->assertIsInt($alias->preacher_id);
+    }
+
+    #[Test]
+    public function validation_rules_require_valid_preacher_id(): void
+    {
+        $rules = PreacherAlias::validationRules();
+
+        $this->assertContains('required', $rules['preacher_id']);
+        $this->assertContains('integer', $rules['preacher_id']);
+        $this->assertContains('exists:preachers,id', $rules['preacher_id']);
+    }
+
+    #[Test]
+    public function validation_rules_require_unique_alias(): void
+    {
+        $preacher = Preacher::factory()->create();
+        PreacherAlias::create([
+            'preacher_id' => $preacher->id,
+            'alias' => 'unique-alias',
+        ]);
+
+        $rules = PreacherAlias::validationRules();
+        $this->assertContains('required', $rules['alias']);
+
+        // Check for unique rule presence - specific implementation details might vary based on how Laravel constructs the rule object
+        $foundUnique = false;
+        foreach ($rules['alias'] as $rule) {
+            if ($rule instanceof \Illuminate\Validation\Rules\Unique) {
+                $foundUnique = true;
+                break;
+            }
+        }
+        $this->assertTrue($foundUnique, 'Unique rule should be present in alias validation rules');
+    }
 }


### PR DESCRIPTION
I have fortified the data integrity of the `PreacherAlias` model and its administrative management.

Key improvements:
1.  **Database Level**: Created a migration adding a `CHECK` constraint (`preacher_aliases_alias_format_check`) to ensure that all aliases stored in the database are lowercase, trimmed of whitespace, and non-empty. This is the "last line of defense" requested by the Warden persona.
2.  **Model Level**: Added `$casts` to ensure integer IDs and implemented a static `validationRules()` method to centralize validation logic (required, string, max:255, and uniqueness).
3.  **UI/Livewire Level**: Refactored the `addAlias` method in `EditPreacher` to normalize the input *before* validation. This ensures that inputs like `" Alias "` are correctly identified as duplicates if `"alias"` already exists, providing better user feedback than a raw database error.
4.  **PHPStan Compliance**: Resolved static analysis errors in the modified `EditPreacher` component related to null-safe property access.
5.  **Testing**: Added new test cases to `PreacherAliasTest` and `AdminPreacherTest` to verify the normalization and validation logic.

Verification:
- `php artisan migrate` ran successfully.
- Specific tests for Preachers and Aliases passed (26 tests).
- Full test suite passed (with 2 known environment-specific regressions unrelated to these changes).
- `composer phpstan` is clean for the modified files.
- `pint` formatting applied.

---
*PR created automatically by Jules for task [754420326265588497](https://jules.google.com/task/754420326265588497) started by @GarethClarridge*