### PR TITLE
🎨 Palette: Improve sermon admin UX and scannability

### DIFF
--- a/app/Livewire/Admin/Sermons/EditSermon.php
+++ b/app/Livewire/Admin/Sermons/EditSermon.php
@@ -218,11 +218,12 @@ class EditSermon extends Component
 
         $this->sermon->update($updateData);
 
+        $fresh = $this->sermon->fresh();
         Log::warning('Sermon updated by admin', [
             'admin_id' => auth()->id(),
             'sermon_id' => $this->sermon->id,
-            'title' => $this->sermon->fresh()?->title ?? $this->sermon->title,
-            'slug' => $this->sermon->fresh()?->slug ?? $this->sermon->slug,
+            'title' => ($fresh instanceof Sermon ? $fresh->title : $this->sermon->title),
+            'slug' => ($fresh instanceof Sermon ? $fresh->slug : $this->sermon->slug),
         ]);
 
         // Dispatch enrichment after saving if reference was set or changed

--- a/resources/views/livewire/admin/sermons/edit-sermon.blade.php
+++ b/resources/views/livewire/admin/sermons/edit-sermon.blade.php
@@ -41,6 +41,7 @@
         <x-button :link="$publicUrl" variant="ghost" icon="eye" inline>
             View Public
         </x-button>
+        <x-clipboard-button :content="$publicUrl" label="Copy Link" title="Copy public link to clipboard" class="text-gray-500 hover:text-gray-700" />
         <x-button link="{{ route('admin.sermons.index') }}" variant="outline" inline>
             Cancel
         </x-button>

--- a/resources/views/livewire/admin/sermons/list-sermons.blade.php
+++ b/resources/views/livewire/admin/sermons/list-sermons.blade.php
@@ -58,7 +58,7 @@
                         ? route('childrens-corner.show', ['sermon' => $sermon->slug])
                         : route('sermons.show', ['sermon' => $sermon->slug]);
                 @endphp
-                <tr class="hover:bg-gray-50">
+                <tr class="hover:bg-gray-50 {{ $sermon->needs_preacher_review ? 'border-l-4 border-amber-400 bg-amber-50/30' : '' }}">
                     {{-- Title --}}
                     <td class="px-4 py-3">
                         <p class="font-medium">{{ Str::limit($sermon->title, 50) }}</p>
@@ -87,7 +87,11 @@
                     </td>
                     {{-- Preacher --}}
                     <td class="px-4 py-3">
-                        <span class="text-sm">{{ $sermonViewPresenter->displayPreacherName($sermon) }}</span>
+                        @if($preacherName = $sermonViewPresenter->displayPreacherName($sermon))
+                            <span class="text-sm">{{ $preacherName }}</span>
+                        @else
+                            <span class="text-sm text-gray-300">-</span>
+                        @endif
                         @if($sermon->needs_preacher_review)
                             <span class="ml-1 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800">Review</span>
                         @endif


### PR DESCRIPTION
🎨 Palette: Improve sermon admin UX and scannability

I've implemented three focused micro-UX and accessibility improvements in the **Sermons & Talks** admin area to make the interface more intuitive and efficient for church admins.

### 💡 What:
1.  **"Needs Review" Highlighting**: Rows in the sermon list that have the `needs_preacher_review` flag set are now highlighted with `bg-amber-50` and a `border-l-4 border-amber-400` on the first cell.
2.  **Preacher Fallback**: The Preacher column in the admin list now displays a muted gray `-` when the name is empty, providing better visual consistency across the table.
3.  **Edit Page "Copy Link"**: A new "Copy Link" button (using the `x-clipboard-button` component) has been added to the Sermon Edit action bar.

### 🎯 Why:
- **Scannability**: Admins can now immediately see which recordings require their attention (e.g., AI confidence issues) without searching for the small "Review" badge.
- **Consistency**: Prevents "holes" in the data table which can be confusing to scan.
- **Efficiency**: Saves admins multiple clicks when they need to share a direct link to a sermon they are currently editing.

### ♿ Accessibility:
- The "Needs Review" highlighting provides a strong visual cue for attention.
- The "Copy Link" button includes proper ARIA labels and provides immediate "Copied!" feedback via an ARIA-live region (built into the existing component).
- Keyboard focus states and transitions are preserved and follow the project's design standards.

### ✅ Verification:
- Run `php artisan test` on relevant Livewire admin tests (all passed).
- Fixed PHPStan null-safety errors in `EditSermon.php`.
- Verified the existence and props of the `x-clipboard-button` component.
- Successfully ran `npm run build` to ensure frontend assets are ready.

---
*PR created automatically by Jules for task [15378710838269050787](https://jules.google.com/task/15378710838269050787) started by @GarethClarridge*