### PR TITLE
🛡️ Sentinel: Harden and standardize Media API authorization

### DIFF
--- a/app/Http/Controllers/Api/MediaController.php
+++ b/app/Http/Controllers/Api/MediaController.php
@@ -5,33 +5,29 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api;
 
 use App\Actions\ConfirmLivestreamSermonSegment;
-use App\Enums\ApiTokenAbility;
 use App\Enums\MediaType;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\CancelMediaProcessingRequest;
+use App\Http\Requests\ConfirmMediaSegmentRequest;
 use App\Http\Requests\MediaStatusRequest;
-use App\Services\MediaValidationService;
+use App\Http\Requests\ProcessMediaRequest;
+use App\Http\Requests\RetryMediaProcessingRequest;
 use App\Services\UnifiedMediaProcessor;
 use App\Services\VideoProcessingOptions;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 
 class MediaController extends Controller
 {
     public function __construct(
         private readonly UnifiedMediaProcessor $mediaProcessor,
-        private readonly MediaValidationService $validation,
     ) {}
 
     /**
      * Upload and process media file - handles all types (audio, video, livestream)
      */
-    public function upload(Request $request, string $type): JsonResponse
+    public function upload(ProcessMediaRequest $request, string $type): JsonResponse
     {
-        if (($abilityResponse = $this->ensureMediaProcessAbility($request)) !== null) {
-            return $abilityResponse;
-        }
-
         $mediaType = MediaType::tryFrom($type);
         if ($mediaType === null) {
             return response()->json([
@@ -41,7 +37,7 @@ class MediaController extends Controller
             ], 400);
         }
 
-        $validated = $request->validate($this->uploadRules($mediaType));
+        $validated = $request->validated();
 
         try {
             $file = $request->file('file');
@@ -84,10 +80,6 @@ class MediaController extends Controller
      */
     public function status(MediaStatusRequest $request, string $processingId): JsonResponse
     {
-        if (($abilityResponse = $this->ensureMediaProcessAbility($request)) !== null) {
-            return $abilityResponse;
-        }
-
         // Validate processing ID format
         if (! $this->isValidProcessingId($processingId)) {
             return response()->json([
@@ -138,12 +130,8 @@ class MediaController extends Controller
     /**
      * Cancel processing
      */
-    public function cancel(Request $request, string $processingId): JsonResponse
+    public function cancel(CancelMediaProcessingRequest $request, string $processingId): JsonResponse
     {
-        if (($abilityResponse = $this->ensureMediaProcessAbility($request)) !== null) {
-            return $abilityResponse;
-        }
-
         // Validate processing ID format
         if (! $this->isValidProcessingId($processingId)) {
             return response()->json([
@@ -164,20 +152,14 @@ class MediaController extends Controller
     /**
      * Confirm a sermon segment for a livestream run awaiting manual review
      */
-    public function confirmSegment(Request $request, string $processingId, ConfirmLivestreamSermonSegment $action): JsonResponse
+    public function confirmSegment(ConfirmMediaSegmentRequest $request, string $processingId, ConfirmLivestreamSermonSegment $action): JsonResponse
     {
-        if (($abilityResponse = $this->ensureMediaProcessAbility($request)) !== null) {
-            return $abilityResponse;
-        }
-
         if (! $this->isValidProcessingId($processingId)) {
             return response()->json([
                 'success' => false,
                 'message' => 'Invalid processing ID format',
             ], 400);
         }
-
-        $request->validate(['segment_id' => ['required', 'integer', 'min:1']]);
 
         /** @var \App\Models\User $user */
         $user = $request->user();
@@ -206,12 +188,8 @@ class MediaController extends Controller
     /**
      * Retry processing
      */
-    public function retry(Request $request, string $processingId): JsonResponse
+    public function retry(RetryMediaProcessingRequest $request, string $processingId): JsonResponse
     {
-        if (($abilityResponse = $this->ensureMediaProcessAbility($request)) !== null) {
-            return $abilityResponse;
-        }
-
         // Validate processing ID format
         if (! $this->isValidProcessingId($processingId)) {
             return response()->json([
@@ -248,32 +226,6 @@ class MediaController extends Controller
         $withoutControlChars = str_replace(["\r", "\n", "\t"], ' ', $value);
 
         return trim((string) preg_replace('/\s+/', ' ', $withoutControlChars));
-    }
-
-    private function ensureMediaProcessAbility(Request $request): ?JsonResponse
-    {
-        if ($request->bearerToken() === null) {
-            return null;
-        }
-
-        if ($request->user()?->tokenCan(ApiTokenAbility::MEDIA_PROCESS->value)) {
-            return null;
-        }
-
-        return response()->json([
-            'message' => 'Missing required token ability: '.ApiTokenAbility::MEDIA_PROCESS->value,
-        ], 403);
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function uploadRules(MediaType $mediaType): array
-    {
-        return array_merge(
-            $this->validation->rulesForType($mediaType),
-            VideoProcessingOptions::validationRules($mediaType)
-        );
     }
 
     /**

--- a/app/Http/Requests/CancelMediaProcessingRequest.php
+++ b/app/Http/Requests/CancelMediaProcessingRequest.php
@@ -4,19 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Enums\ApiTokenAbility;
 use Illuminate\Foundation\Http\FormRequest;
 
-class MediaStatusRequest extends FormRequest
+class CancelMediaProcessingRequest extends FormRequest
 {
-    protected function prepareForValidation(): void
-    {
-        if ($this->has('include_logs')) {
-            $this->merge([
-                'include_logs' => $this->normalizeBoolean($this->input('include_logs')),
-            ]);
-        }
-    }
-
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -32,7 +24,7 @@ class MediaStatusRequest extends FormRequest
 
         // When using a bearer token (e.g., from a separate uploader tool),
         // we must also verify the granular token ability.
-        if ($this->bearerToken() !== null && ! $user->tokenCan(\App\Enums\ApiTokenAbility::MEDIA_PROCESS->value)) {
+        if ($this->bearerToken() !== null && ! $user->tokenCan(ApiTokenAbility::MEDIA_PROCESS->value)) {
             return false;
         }
 
@@ -46,22 +38,6 @@ class MediaStatusRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'include_logs' => ['nullable', 'boolean'],
-            'log_limit' => ['nullable', 'integer', 'min:1', 'max:100'],
-        ];
-    }
-
-    private function normalizeBoolean(mixed $value): mixed
-    {
-        if (! is_string($value)) {
-            return $value;
-        }
-
-        return match (strtolower($value)) {
-            'true' => true,
-            'false' => false,
-            default => $value,
-        };
+        return [];
     }
 }

--- a/app/Http/Requests/ConfirmMediaSegmentRequest.php
+++ b/app/Http/Requests/ConfirmMediaSegmentRequest.php
@@ -4,19 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Enums\ApiTokenAbility;
 use Illuminate\Foundation\Http\FormRequest;
 
-class MediaStatusRequest extends FormRequest
+class ConfirmMediaSegmentRequest extends FormRequest
 {
-    protected function prepareForValidation(): void
-    {
-        if ($this->has('include_logs')) {
-            $this->merge([
-                'include_logs' => $this->normalizeBoolean($this->input('include_logs')),
-            ]);
-        }
-    }
-
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -32,7 +24,7 @@ class MediaStatusRequest extends FormRequest
 
         // When using a bearer token (e.g., from a separate uploader tool),
         // we must also verify the granular token ability.
-        if ($this->bearerToken() !== null && ! $user->tokenCan(\App\Enums\ApiTokenAbility::MEDIA_PROCESS->value)) {
+        if ($this->bearerToken() !== null && ! $user->tokenCan(ApiTokenAbility::MEDIA_PROCESS->value)) {
             return false;
         }
 
@@ -47,21 +39,7 @@ class MediaStatusRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'include_logs' => ['nullable', 'boolean'],
-            'log_limit' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'segment_id' => ['required', 'integer', 'min:1'],
         ];
-    }
-
-    private function normalizeBoolean(mixed $value): mixed
-    {
-        if (! is_string($value)) {
-            return $value;
-        }
-
-        return match (strtolower($value)) {
-            'true' => true,
-            'false' => false,
-            default => $value,
-        };
     }
 }

--- a/app/Http/Requests/ProcessMediaRequest.php
+++ b/app/Http/Requests/ProcessMediaRequest.php
@@ -19,12 +19,24 @@ class ProcessMediaRequest extends FormRequest
 
     /**
      * Determine if the user is authorized to make this request.
+     *
+     * Provides Defense in Depth alongside the media.process middleware.
      */
     public function authorize(): bool
     {
         $user = $this->user();
 
-        return $user?->can('create', \App\Models\Sermon::class) ?? false;
+        if ($user?->canAccessAdmin() !== true) {
+            return false;
+        }
+
+        // When using a bearer token (e.g., from a separate uploader tool),
+        // we must also verify the granular token ability.
+        if ($this->bearerToken() !== null && ! $user->tokenCan(\App\Enums\ApiTokenAbility::MEDIA_PROCESS->value)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -34,7 +46,7 @@ class ProcessMediaRequest extends FormRequest
      */
     public function rules(): array
     {
-        $type = $this->input('type');
+        $type = $this->route('type') ?? $this->input('type');
         $mediaType = is_string($type) ? MediaType::tryFrom($type) : null;
         $validation = $this->validationService();
 
@@ -44,7 +56,7 @@ class ProcessMediaRequest extends FormRequest
 
         return [
             ...$fileRules,
-            'type' => ['required', Rule::enum(MediaType::class)],
+            'type' => [$this->route('type') ? 'nullable' : 'required', Rule::enum(MediaType::class)],
             ...VideoProcessingOptions::validationRules($mediaType),
         ];
     }

--- a/app/Http/Requests/RetryMediaProcessingRequest.php
+++ b/app/Http/Requests/RetryMediaProcessingRequest.php
@@ -4,19 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Enums\ApiTokenAbility;
 use Illuminate\Foundation\Http\FormRequest;
 
-class MediaStatusRequest extends FormRequest
+class RetryMediaProcessingRequest extends FormRequest
 {
-    protected function prepareForValidation(): void
-    {
-        if ($this->has('include_logs')) {
-            $this->merge([
-                'include_logs' => $this->normalizeBoolean($this->input('include_logs')),
-            ]);
-        }
-    }
-
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -32,7 +24,7 @@ class MediaStatusRequest extends FormRequest
 
         // When using a bearer token (e.g., from a separate uploader tool),
         // we must also verify the granular token ability.
-        if ($this->bearerToken() !== null && ! $user->tokenCan(\App\Enums\ApiTokenAbility::MEDIA_PROCESS->value)) {
+        if ($this->bearerToken() !== null && ! $user->tokenCan(ApiTokenAbility::MEDIA_PROCESS->value)) {
             return false;
         }
 
@@ -46,22 +38,6 @@ class MediaStatusRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'include_logs' => ['nullable', 'boolean'],
-            'log_limit' => ['nullable', 'integer', 'min:1', 'max:100'],
-        ];
-    }
-
-    private function normalizeBoolean(mixed $value): mixed
-    {
-        if (! is_string($value)) {
-            return $value;
-        }
-
-        return match (strtolower($value)) {
-            'true' => true,
-            'false' => false,
-            default => $value,
-        };
+        return [];
     }
 }

--- a/tests/Feature/Security/InformationLeakageTest.php
+++ b/tests/Feature/Security/InformationLeakageTest.php
@@ -37,6 +37,12 @@ class InformationLeakageTest extends TestCase
             $mock->shouldReceive('rulesForType')
                 ->andReturn(['file' => 'required|file']);
 
+            $mock->shouldReceive('maxFileSizeForDisplay')
+                ->andReturn('100MB');
+
+            $mock->shouldReceive('allowedExtensionsForDisplay')
+                ->andReturn('MP3, WAV, M4A');
+
             $mock->shouldReceive('validateUploadedFile')
                 ->andThrow(new \RuntimeException('Sensitive DB Error: table "users" not found at /var/www/html/database/schema.sql'));
         });
@@ -65,6 +71,12 @@ class InformationLeakageTest extends TestCase
         $this->mock(\App\Services\MediaValidationService::class, function ($mock) {
             $mock->shouldReceive('rulesForType')
                 ->andReturn(['file' => 'required|file']);
+
+            $mock->shouldReceive('maxFileSizeForDisplay')
+                ->andReturn('100MB');
+
+            $mock->shouldReceive('allowedExtensionsForDisplay')
+                ->andReturn('MP3, WAV, M4A');
 
             $mock->shouldReceive('validateUploadedFile')
                 ->andThrow(new InvalidFileException(['File is too large']));


### PR DESCRIPTION
🛡️ Sentinel: Security Enhancement

This PR hardens the Media Processing API by standardizing all endpoints to use dedicated Form Requests and implementing defense-in-depth authorization.

🚨 **Severity:** MEDIUM (Security Enhancement)
💡 **Vulnerability:** Inconsistent authorization patterns and reliance on a single layer of middleware for some endpoints.
🎯 **Impact:** Reduced defense-in-depth and potential for over-privileged tokens to access administrative media actions if middleware was misconfigured.
🔧 **Fix:**
- Consolidated authorization logic into Form Requests (`ProcessMediaRequest`, `MediaStatusRequest`, `CancelMediaProcessingRequest`, `RetryMediaProcessingRequest`, `ConfirmMediaSegmentRequest`).
- Authorization now explicitly verifies both admin status (`canAccessAdmin()`) and granular Sanctum token abilities (`MEDIA_PROCESS`) for bearer tokens.
- Standardized the `MediaController` to use these Form Requests consistently.
- Cleaned up unused dependencies and redundant manual checks in the controller.
✅ **Verification:** Verified by running `MediaControllerTest` and `InformationLeakageTest`. All tests passed. Static analysis (`phpstan`) and formatting (`pint`) were also completed successfully.

---
*PR created automatically by Jules for task [3502141627039435064](https://jules.google.com/task/3502141627039435064) started by @GarethClarridge*