### PR TITLE
🔦 Lighthouse: Improve site discoverability and RSS discovery

### DIFF
--- a/app/Livewire/Admin/Meetings/EditMeeting.php
+++ b/app/Livewire/Admin/Meetings/EditMeeting.php
@@ -40,7 +40,7 @@ class EditMeeting extends Component
         Log::warning('Meeting updated by admin', [
             'admin_id' => auth()->id(),
             'meeting_id' => $this->meeting->id,
-            'slug' => $this->meeting->fresh()?->slug ?? $this->meeting->slug,
+            'slug' => ($fresh = $this->meeting->fresh()) instanceof Meeting ? $fresh->slug : $this->meeting->slug,
         ]);
 
         $this->success('Meeting updated');

--- a/app/Livewire/Admin/Pages/EditPage.php
+++ b/app/Livewire/Admin/Pages/EditPage.php
@@ -37,8 +37,8 @@ class EditPage extends Component
         Log::warning('Page updated by admin', [
             'admin_id' => auth()->id(),
             'page_id' => $this->page->id,
-            'heading' => $this->page->fresh()?->heading ?? $this->page->heading,
-            'slug' => $this->page->fresh()?->slug ?? $this->page->slug,
+            'heading' => ($fresh = $this->page->fresh()) instanceof Page ? $fresh->heading : $this->page->heading,
+            'slug' => ($fresh instanceof Page ? $fresh->slug : $this->page->slug),
         ]);
 
         $this->success('Page updated');

--- a/app/Livewire/Admin/Preachers/EditPreacher.php
+++ b/app/Livewire/Admin/Preachers/EditPreacher.php
@@ -80,8 +80,8 @@ class EditPreacher extends Component
         Log::warning('Preacher updated by admin', [
             'admin_id' => auth()->id(),
             'preacher_id' => $this->preacher->id,
-            'name' => $this->preacher->fresh()?->name ?? $this->preacher->name,
-            'slug' => $this->preacher->fresh()?->slug ?? $this->preacher->slug,
+            'name' => ($fresh = $this->preacher->fresh()) instanceof Preacher ? $fresh->name : $this->preacher->name,
+            'slug' => ($fresh instanceof Preacher ? $fresh->slug : $this->preacher->slug),
         ]);
 
         $this->success('Preacher updated');

--- a/app/Livewire/Admin/Sermons/EditSermon.php
+++ b/app/Livewire/Admin/Sermons/EditSermon.php
@@ -221,8 +221,8 @@ class EditSermon extends Component
         Log::warning('Sermon updated by admin', [
             'admin_id' => auth()->id(),
             'sermon_id' => $this->sermon->id,
-            'title' => $this->sermon->fresh()?->title ?? $this->sermon->title,
-            'slug' => $this->sermon->fresh()?->slug ?? $this->sermon->slug,
+            'title' => ($fresh = $this->sermon->fresh()) instanceof Sermon ? $fresh->title : $this->sermon->title,
+            'slug' => ($fresh instanceof Sermon ? $fresh->slug : $this->sermon->slug),
         ]);
 
         // Dispatch enrichment after saving if reference was set or changed

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -78,7 +78,19 @@ class SitemapService
             ->add(Url::create('/christ/sermons/series')
                 ->setPriority(0.7)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
-                ->addImage(asset('/images/headings/large/sermons.webp'), 'Sermon Series'));
+                ->addImage(asset('/images/headings/large/sermons.webp'), 'Sermon Series'))
+            ->add(Url::create('/christ/sermons/morning')
+                ->setPriority(0.7)
+                ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
+                ->addImage(asset('/images/headings/large/sermons.webp'), 'Sunday Morning Services'))
+            ->add(Url::create('/christ/sermons/evening')
+                ->setPriority(0.7)
+                ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
+                ->addImage(asset('/images/headings/large/sermons.webp'), 'Sunday Evening Services'))
+            ->add(Url::create('/christ/sermons/other')
+                ->setPriority(0.7)
+                ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
+                ->addImage(asset('/images/headings/large/sermons.webp'), 'Other Services'));
 
         if ($this->exposurePolicy->childrensTalksArePublic()) {
             $sitemap->add(

--- a/resources/views/childrens-corner/index.blade.php
+++ b/resources/views/childrens-corner/index.blade.php
@@ -6,6 +6,7 @@
 
 @section('meta_tags')
     <x-meta-tags :title="$heading" :description="$description" />
+    <x-podcast-discovery />
 
     {{-- JSON-LD ItemList --}}
     @if (isset($json_ld_data))

--- a/resources/views/components/podcast-discovery.blade.php
+++ b/resources/views/components/podcast-discovery.blade.php
@@ -1,2 +1,9 @@
+@props(['service' => null])
+
+@if ($service === 'morning' || $service === null)
 <link rel="alternate" type="application/rss+xml" title="Sunday Morning Services Podcast" href="{{ route('podcast.feed', 'morning') }}">
+@endif
+
+@if ($service === 'evening' || $service === null)
 <link rel="alternate" type="application/rss+xml" title="Sunday Evening Services Podcast" href="{{ route('podcast.feed', 'evening') }}">
+@endif

--- a/resources/views/components/podcast-discovery.blade.php
+++ b/resources/views/components/podcast-discovery.blade.php
@@ -1,2 +1,2 @@
-<link rel="alternate" type="application/rss+xml" title="Sunday Morning Sermons" href="{{ route('podcast.feed', 'morning') }}">
-<link rel="alternate" type="application/rss+xml" title="Sunday Evening Sermons" href="{{ route('podcast.feed', 'evening') }}">
+<link rel="alternate" type="application/rss+xml" title="Sunday Morning Services Podcast" href="{{ route('podcast.feed', 'morning') }}">
+<link rel="alternate" type="application/rss+xml" title="Sunday Evening Services Podcast" href="{{ route('podcast.feed', 'evening') }}">

--- a/resources/views/components/podcast-discovery.blade.php
+++ b/resources/views/components/podcast-discovery.blade.php
@@ -1,0 +1,2 @@
+<link rel="alternate" type="application/rss+xml" title="Sunday Morning Sermons" href="{{ route('podcast.feed', 'morning') }}">
+<link rel="alternate" type="application/rss+xml" title="Sunday Evening Sermons" href="{{ route('podcast.feed', 'evening') }}">

--- a/resources/views/full-width-pages/christ.blade.php
+++ b/resources/views/full-width-pages/christ.blade.php
@@ -15,6 +15,7 @@
   description="Learn about Jesus Christ - who he is, why you need him, and what he has done for you. Explore the good news of Christianity at Crockenhill Baptist Church."
   :image="asset('/images/homepage/may2024wide.webp')"
 />
+<x-podcast-discovery />
 
 <x-breadcrumbs area="christ" heading="Christ" jsonOnly />
 

--- a/resources/views/full-width-pages/christmas.blade.php
+++ b/resources/views/full-width-pages/christmas.blade.php
@@ -10,6 +10,7 @@
     description="Celebrate Christmas at Crockenhill Baptist Church. Join us for Carols by Candlelight, our Christmas morning service, and more festive events."
     :image="asset('/images/homepage/christmas2023.webp')"
 />
+<x-podcast-discovery />
 <x-schema.webpage
     heading="Christmas"
     description="Celebrate Christmas at Crockenhill Baptist Church. Join us for Carols by Candlelight, our Christmas morning service, and more festive events."

--- a/resources/views/full-width-pages/home.blade.php
+++ b/resources/views/full-width-pages/home.blade.php
@@ -10,6 +10,7 @@
   description="We are an independent evangelical church in Crockenhill, Kent. Worshipping God, strengthening believers, proclaiming Jesus Christ to all."
   :image="asset('/images/homepage/may2024wide.webp')"
   image-alt="Crockenhill Baptist Church members outside the church building" />
+<x-podcast-discovery />
 <x-schema.webpage
   heading="Crockenhill Baptist Church"
   description="We are an independent evangelical church in Crockenhill, Kent. Worshipping God, strengthening believers, proclaiming Jesus Christ to all."
@@ -41,7 +42,7 @@
         srcset="{{ asset('/images/homepage/may2024wide.webp') }}">
       <img
         src="{{ asset('/images/homepage/may2024wide.webp') }}"
-        alt=""
+        alt="Crockenhill Baptist Church members outside the church building"
         class="h-full w-full object-cover md:object-right"
         width="1200"
         height="450"

--- a/resources/views/sermons/all.blade.php
+++ b/resources/views/sermons/all.blade.php
@@ -16,6 +16,7 @@
     :description="$description"
     :image="asset('/images/headings/large/sermons.webp')"
 />
+<x-podcast-discovery />
 
 {{-- JSON-LD Sermon List --}}
 <script type="application/ld+json">

--- a/resources/views/sermons/index.blade.php
+++ b/resources/views/sermons/index.blade.php
@@ -16,8 +16,7 @@
     :description="$description"
     :image="asset('/images/headings/large/sermons.webp')"
 />
-<link rel="alternate" type="application/rss+xml" title="Sunday Morning Sermons" href="{{ route('podcast.feed', 'morning') }}">
-<link rel="alternate" type="application/rss+xml" title="Sunday Evening Sermons" href="{{ route('podcast.feed', 'evening') }}">
+<x-podcast-discovery />
 
 {{-- JSON-LD Sermon List --}}
 <script type="application/ld+json">

--- a/resources/views/sermons/preacher.blade.php
+++ b/resources/views/sermons/preacher.blade.php
@@ -10,6 +10,7 @@
     :description="$description"
     :image="$preacher->profile_image_url"
 />
+<x-podcast-discovery />
 <x-schema.webpage
     :heading="$heading"
     :description="$description"

--- a/resources/views/sermons/preachers.blade.php
+++ b/resources/views/sermons/preachers.blade.php
@@ -16,6 +16,7 @@
     :description="$description"
     :image="asset('/images/headings/large/sermons.webp')"
 />
+<x-podcast-discovery />
 
 {{-- JSON-LD Preachers List --}}
 @if(isset($json_ld_data))

--- a/resources/views/sermons/series.blade.php
+++ b/resources/views/sermons/series.blade.php
@@ -9,6 +9,7 @@
     :title="$heading"
     :description="$description"
 />
+<x-podcast-discovery />
 <x-schema.webpage
     :heading="$heading"
     :description="$description"

--- a/resources/views/sermons/serieses.blade.php
+++ b/resources/views/sermons/serieses.blade.php
@@ -16,6 +16,7 @@
     :description="$description"
     :image="asset('/images/headings/large/sermons.webp')"
 />
+<x-podcast-discovery />
 
 {{-- JSON-LD Series List --}}
 @if(isset($json_ld_data))

--- a/resources/views/sermons/service.blade.php
+++ b/resources/views/sermons/service.blade.php
@@ -13,7 +13,7 @@
     :heading="$heading"
     :description="$description"
 />
-<x-podcast-discovery />
+<x-podcast-discovery :$service />
 
 {{-- JSON-LD Sermon List --}}
 <script type="application/ld+json">

--- a/resources/views/sermons/service.blade.php
+++ b/resources/views/sermons/service.blade.php
@@ -13,9 +13,7 @@
     :heading="$heading"
     :description="$description"
 />
-@if(in_array($service, ['morning', 'evening']))
-<link rel="alternate" type="application/rss+xml" title="{{ $heading }} Podcast" href="{{ route('podcast.feed', $service) }}">
-@endif
+<x-podcast-discovery />
 
 {{-- JSON-LD Sermon List --}}
 <script type="application/ld+json">

--- a/tests/Feature/PodcastDiscoveryTest.php
+++ b/tests/Feature/PodcastDiscoveryTest.php
@@ -79,12 +79,30 @@ class PodcastDiscoveryTest extends TestCase
         $this->assertPodcastDiscoveryLinksPresent($response);
     }
 
-    public function test_service_page_has_podcast_discovery_links(): void
+    public function test_morning_service_page_has_only_morning_podcast_discovery_link(): void
     {
         $response = $this->get('/christ/sermons/morning');
 
         $response->assertStatus(200);
-        $this->assertPodcastDiscoveryLinksPresent($response);
+        $response->assertSee('<link rel="alternate" type="application/rss+xml" title="Sunday Morning Services Podcast" href="http://localhost/christ/sermons/morning/feed">', false);
+        $response->assertDontSee('<link rel="alternate" type="application/rss+xml" title="Sunday Evening Services Podcast" href="http://localhost/christ/sermons/evening/feed">', false);
+    }
+
+    public function test_evening_service_page_has_only_evening_podcast_discovery_link(): void
+    {
+        $response = $this->get('/christ/sermons/evening');
+
+        $response->assertStatus(200);
+        $response->assertSee('<link rel="alternate" type="application/rss+xml" title="Sunday Evening Services Podcast" href="http://localhost/christ/sermons/evening/feed">', false);
+        $response->assertDontSee('<link rel="alternate" type="application/rss+xml" title="Sunday Morning Services Podcast" href="http://localhost/christ/sermons/morning/feed">', false);
+    }
+
+    public function test_other_service_page_has_no_podcast_discovery_links(): void
+    {
+        $response = $this->get('/christ/sermons/other');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('rel="alternate" type="application/rss+xml"', false);
     }
 
     public function test_childrens_corner_index_has_podcast_discovery_links(): void

--- a/tests/Feature/PodcastDiscoveryTest.php
+++ b/tests/Feature/PodcastDiscoveryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Preacher;
+use App\Models\Sermon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PodcastDiscoveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_homepage_has_podcast_discovery_links(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $this->assertPodcastDiscoveryLinksPresent($response);
+    }
+
+    public function test_christ_page_has_podcast_discovery_links(): void
+    {
+        $response = $this->get('/christ');
+
+        $response->assertStatus(200);
+        $this->assertPodcastDiscoveryLinksPresent($response);
+    }
+
+    public function test_sermon_index_page_has_podcast_discovery_links(): void
+    {
+        $response = $this->get('/christ/sermons');
+
+        $response->assertStatus(200);
+        $this->assertPodcastDiscoveryLinksPresent($response);
+    }
+
+    public function test_all_sermons_page_has_podcast_discovery_links(): void
+    {
+        $response = $this->get('/christ/sermons/all');
+
+        $response->assertStatus(200);
+        $this->assertPodcastDiscoveryLinksPresent($response);
+    }
+
+    public function test_preachers_index_page_has_podcast_discovery_links(): void
+    {
+        $response = $this->get('/christ/sermons/preachers');
+
+        $response->assertStatus(200);
+        $this->assertPodcastDiscoveryLinksPresent($response);
+    }
+
+    public function test_individual_preacher_page_has_podcast_discovery_links(): void
+    {
+        $preacher = Preacher::factory()->create();
+
+        $response = $this->get("/christ/sermons/preachers/{$preacher->slug}");
+
+        $response->assertStatus(200);
+        $this->assertPodcastDiscoveryLinksPresent($response);
+    }
+
+    public function test_series_index_page_has_podcast_discovery_links(): void
+    {
+        $response = $this->get('/christ/sermons/series');
+
+        $response->assertStatus(200);
+        $this->assertPodcastDiscoveryLinksPresent($response);
+    }
+
+    public function test_individual_series_page_has_podcast_discovery_links(): void
+    {
+        Sermon::factory()->create(['series' => 'Living Hope']);
+
+        $response = $this->get('/christ/sermons/series/living-hope');
+
+        $response->assertStatus(200);
+        $this->assertPodcastDiscoveryLinksPresent($response);
+    }
+
+    public function test_service_page_has_podcast_discovery_links(): void
+    {
+        $response = $this->get('/christ/sermons/morning');
+
+        $response->assertStatus(200);
+        $this->assertPodcastDiscoveryLinksPresent($response);
+    }
+
+    public function test_childrens_corner_index_has_podcast_discovery_links(): void
+    {
+        config(['sermons.childrens_talks.public' => true]);
+        $response = $this->get('/christ/childrens-corner');
+
+        $response->assertStatus(200);
+        $this->assertPodcastDiscoveryLinksPresent($response);
+    }
+
+    private function assertPodcastDiscoveryLinksPresent($response): void
+    {
+        $response->assertSee('<link rel="alternate" type="application/rss+xml" title="Sunday Morning Sermons" href="http://localhost/christ/sermons/morning/feed">', false);
+        $response->assertSee('<link rel="alternate" type="application/rss+xml" title="Sunday Evening Sermons" href="http://localhost/christ/sermons/evening/feed">', false);
+    }
+}

--- a/tests/Feature/PodcastDiscoveryTest.php
+++ b/tests/Feature/PodcastDiscoveryTest.php
@@ -98,7 +98,7 @@ class PodcastDiscoveryTest extends TestCase
 
     private function assertPodcastDiscoveryLinksPresent($response): void
     {
-        $response->assertSee('<link rel="alternate" type="application/rss+xml" title="Sunday Morning Sermons" href="http://localhost/christ/sermons/morning/feed">', false);
-        $response->assertSee('<link rel="alternate" type="application/rss+xml" title="Sunday Evening Sermons" href="http://localhost/christ/sermons/evening/feed">', false);
+        $response->assertSee('<link rel="alternate" type="application/rss+xml" title="Sunday Morning Services Podcast" href="http://localhost/christ/sermons/morning/feed">', false);
+        $response->assertSee('<link rel="alternate" type="application/rss+xml" title="Sunday Evening Services Podcast" href="http://localhost/christ/sermons/evening/feed">', false);
     }
 }

--- a/tests/Feature/SeoRegressionTest.php
+++ b/tests/Feature/SeoRegressionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use App\Enums\SermonService;
+use Illuminate\Support\Str;
 use App\Models\Sermon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
@@ -94,18 +95,18 @@ class SeoRegressionTest extends TestCase
             $response->assertSee("<title>{$label} Services | Crockenhill Baptist Church</title>", false);
             $response->assertSee('<meta name="description" content="'.$description.'">', false);
             $response->assertSee(
-                '<link rel="alternate" type="application/rss+xml" title="Sunday Morning Services Podcast" href="'.route('podcast.feed', 'morning').'">',
+                '<link rel="alternate" type="application/rss+xml" title="Sunday '.Str::title($service).' Services Podcast" href="'.route('podcast.feed', $service).'">',
                 false
             );
-            $response->assertSee(
-                '<link rel="alternate" type="application/rss+xml" title="Sunday Evening Services Podcast" href="'.route('podcast.feed', 'evening').'">',
+            $response->assertDontSee(
+                '<link rel="alternate" type="application/rss+xml" title="Sunday '.Str::title($service === 'morning' ? 'evening' : 'morning').' Services Podcast"',
                 false
             );
         }
     }
 
     #[Test]
-    public function other_service_page_includes_podcast_discovery_links(): void
+    public function other_service_page_does_not_render_podcast_discovery_links(): void
     {
         Sermon::factory()->create([
             'title' => 'Other Sermon',
@@ -121,13 +122,6 @@ class SeoRegressionTest extends TestCase
             '<meta name="description" content="Listen to recent Other sermons from Crockenhill Baptist Church.">',
             false
         );
-        $response->assertSee(
-            '<link rel="alternate" type="application/rss+xml" title="Sunday Morning Services Podcast" href="'.route('podcast.feed', 'morning').'">',
-            false
-        );
-        $response->assertSee(
-            '<link rel="alternate" type="application/rss+xml" title="Sunday Evening Services Podcast" href="'.route('podcast.feed', 'evening').'">',
-            false
-        );
+        $response->assertDontSee('rel="alternate" type="application/rss+xml"', false);
     }
 }

--- a/tests/Feature/SeoRegressionTest.php
+++ b/tests/Feature/SeoRegressionTest.php
@@ -94,14 +94,18 @@ class SeoRegressionTest extends TestCase
             $response->assertSee("<title>{$label} Services | Crockenhill Baptist Church</title>", false);
             $response->assertSee('<meta name="description" content="'.$description.'">', false);
             $response->assertSee(
-                '<link rel="alternate" type="application/rss+xml" title="'.$label.' Services Podcast" href="'.route('podcast.feed', $service).'">',
+                '<link rel="alternate" type="application/rss+xml" title="Sunday Morning Sermons" href="'.route('podcast.feed', 'morning').'">',
+                false
+            );
+            $response->assertSee(
+                '<link rel="alternate" type="application/rss+xml" title="Sunday Evening Sermons" href="'.route('podcast.feed', 'evening').'">',
                 false
             );
         }
     }
 
     #[Test]
-    public function other_service_page_does_not_render_a_podcast_discovery_link(): void
+    public function other_service_page_includes_podcast_discovery_links(): void
     {
         Sermon::factory()->create([
             'title' => 'Other Sermon',
@@ -117,6 +121,13 @@ class SeoRegressionTest extends TestCase
             '<meta name="description" content="Listen to recent Other sermons from Crockenhill Baptist Church.">',
             false
         );
-        $response->assertDontSee('rel="alternate" type="application/rss+xml"', false);
+        $response->assertSee(
+            '<link rel="alternate" type="application/rss+xml" title="Sunday Morning Sermons" href="'.route('podcast.feed', 'morning').'">',
+            false
+        );
+        $response->assertSee(
+            '<link rel="alternate" type="application/rss+xml" title="Sunday Evening Sermons" href="'.route('podcast.feed', 'evening').'">',
+            false
+        );
     }
 }

--- a/tests/Feature/SeoRegressionTest.php
+++ b/tests/Feature/SeoRegressionTest.php
@@ -60,11 +60,11 @@ class SeoRegressionTest extends TestCase
         $response->assertSee('<meta name="description" content="'.$description.'">', false);
         $response->assertSee('<meta property="og:description" content="'.$description.'">', false);
         $response->assertSee(
-            '<link rel="alternate" type="application/rss+xml" title="Sunday Morning Sermons" href="'.route('podcast.feed', 'morning').'">',
+            '<link rel="alternate" type="application/rss+xml" title="Sunday Morning Services Podcast" href="'.route('podcast.feed', 'morning').'">',
             false
         );
         $response->assertSee(
-            '<link rel="alternate" type="application/rss+xml" title="Sunday Evening Sermons" href="'.route('podcast.feed', 'evening').'">',
+            '<link rel="alternate" type="application/rss+xml" title="Sunday Evening Services Podcast" href="'.route('podcast.feed', 'evening').'">',
             false
         );
     }
@@ -94,11 +94,11 @@ class SeoRegressionTest extends TestCase
             $response->assertSee("<title>{$label} Services | Crockenhill Baptist Church</title>", false);
             $response->assertSee('<meta name="description" content="'.$description.'">', false);
             $response->assertSee(
-                '<link rel="alternate" type="application/rss+xml" title="Sunday Morning Sermons" href="'.route('podcast.feed', 'morning').'">',
+                '<link rel="alternate" type="application/rss+xml" title="Sunday Morning Services Podcast" href="'.route('podcast.feed', 'morning').'">',
                 false
             );
             $response->assertSee(
-                '<link rel="alternate" type="application/rss+xml" title="Sunday Evening Sermons" href="'.route('podcast.feed', 'evening').'">',
+                '<link rel="alternate" type="application/rss+xml" title="Sunday Evening Services Podcast" href="'.route('podcast.feed', 'evening').'">',
                 false
             );
         }
@@ -122,11 +122,11 @@ class SeoRegressionTest extends TestCase
             false
         );
         $response->assertSee(
-            '<link rel="alternate" type="application/rss+xml" title="Sunday Morning Sermons" href="'.route('podcast.feed', 'morning').'">',
+            '<link rel="alternate" type="application/rss+xml" title="Sunday Morning Services Podcast" href="'.route('podcast.feed', 'morning').'">',
             false
         );
         $response->assertSee(
-            '<link rel="alternate" type="application/rss+xml" title="Sunday Evening Sermons" href="'.route('podcast.feed', 'evening').'">',
+            '<link rel="alternate" type="application/rss+xml" title="Sunday Evening Services Podcast" href="'.route('podcast.feed', 'evening').'">',
             false
         );
     }

--- a/tests/Feature/SitemapTest.php
+++ b/tests/Feature/SitemapTest.php
@@ -384,7 +384,19 @@ class SitemapTest extends TestCase
         // Should still contain static URLs
         $this->assertStringContainsString('<loc>http://localhost</loc>', $content);
         $this->assertStringContainsString('<loc>http://localhost/christ</loc>', $content);
+    }
 
+    #[Test]
+    public function sitemap_contains_service_filter_urls(): void
+    {
+        Cache::forget('sitemap');
+
+        $response = $this->get('/sitemap.xml');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('<loc>http://localhost/christ/sermons/morning</loc>', $content);
+        $this->assertStringContainsString('<loc>http://localhost/christ/sermons/evening</loc>', $content);
+        $this->assertStringContainsString('<loc>http://localhost/christ/sermons/other</loc>', $content);
     }
 
     #[Test]


### PR DESCRIPTION
This PR implements a series of SEO and metadata improvements to make the site's content more discoverable and shareable.

Key changes:
- Created a new reusable `<x-podcast-discovery />` Blade component containing RSS discovery links for Sunday Morning and Sunday Evening sermon feeds.
- Integrated RSS discovery across all key sermon entry points, including the homepage, sermon index, preacher profiles, series listings, and the children's corner.
- Updated the `SitemapService` to explicitly include URLs for sermon service filter pages (`/christ/sermons/morning`, `/christ/sermons/evening`, `/christ/sermons/other`), ensuring these important categorization indices are independently crawled by search engines.
- Added descriptive `alt` text to the primary homepage hero image to improve both SEO and accessibility.
- Created a new feature test `tests/Feature/PodcastDiscoveryTest.php` to verify RSS discovery across the site.
- Updated `tests/Feature/SitemapTest.php` and `tests/Feature/SeoRegressionTest.php` to reflect the new discoverability improvements.
- Fixed a series of pre-existing PHPStan static analysis errors in administrative Livewire components related to null-safe access on model `fresh()` calls.

These improvements ensure that podcast applications can easily find sermon feeds from any relevant page and that search engines have a complete map of the site's organized sermon content.

---
*PR created automatically by Jules for task [7137491229368442707](https://jules.google.com/task/7137491229368442707) started by @GarethClarridge*