### PR TITLE
🧹 Tidy: Add strict types and remove unused import in SermonResource

### DIFF
--- a/app/Http/Resources/SermonResource.php
+++ b/app/Http/Resources/SermonResource.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Resources;
 
-use App\Presenters\SermonViewPresenter;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Arr;
@@ -54,7 +55,6 @@ class SermonResource extends JsonResource
      * @return array{
      *     audio_url: ?string,
      *     canonical_url: string,
-     *     card_thumbnail_url: ?string,
      *     display_reference: ?string,
      *     formatted_duration: ?string,
      *     human_date: string,
@@ -78,9 +78,13 @@ class SermonResource extends JsonResource
         /** @var array{
          *     audio_url: ?string,
          *     canonical_url: string,
+         *     display_reference: ?string,
          *     formatted_duration: ?string,
+         *     human_date: string,
+         *     preacher_name: ?string,
          *     preacher_url: ?string,
          *     public_url: string,
+         *     series_url: ?string,
          *     thumbnail_url: ?string,
          *     transcript: ?string,
          *     video_url: ?string


### PR DESCRIPTION
Refactored `App\Http\Resources\SermonResource` to improve code quality and consistency. 

Key changes:
- Enabled strict typing for better type safety.
- Cleaned up an unused import that was adding unnecessary cognitive load.
- Synchronized internal PHPDoc type hints with actual implementation, ensuring `composer phpstan` passes with 0 errors for this file.

No functional changes were made; the API response remains identical. Correctness verified with `tests/Unit/Http/Resources/SermonResourceTest.php` and `tests/Feature/Api/SermonApiControllerTest.php`.

---
*PR created automatically by Jules for task [9003313359064723676](https://jules.google.com/task/9003313359064723676) started by @GarethClarridge*