### PR TITLE
🏛️ Warden: Fortify Sermon data integrity with constraints and validation

### DIFF
--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -23,7 +23,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Str;
 use Spatie\Sitemap\Contracts\Sitemapable;
 use Spatie\Sitemap\Tags\Url;
 
@@ -212,10 +211,17 @@ class Sermon extends Model implements Sitemapable
         return [
             'title' => ['required', 'string', 'max:255'],
             'slug' => $slugRule,
+            'audio_file_path' => ['required', 'string', 'max:255'],
+            'video_file_path' => ['nullable', 'string', 'max:500'],
+            'date' => ['required', 'date'],
+            'service' => ['nullable', \Illuminate\Validation\Rule::enum(SermonService::class)],
+            'content_type' => ['required', \Illuminate\Validation\Rule::enum(SermonContentType::class)],
+            'source_type' => ['required', \Illuminate\Validation\Rule::enum(SermonSourceType::class)],
             'series' => ['nullable', 'string', 'max:255'],
             'reference' => ['nullable', 'string', 'max:255'],
             'preacher' => ['required', 'string', 'max:255'],
             'preacher_id' => ['nullable', 'integer', 'exists:preachers,id'],
+            'preacher_confidence' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'scripture_passage_id' => ['nullable', 'integer', 'exists:scripture_passages,id'],
             'download_count' => ['nullable', 'integer', 'min:0'],
             'duration' => ['nullable', 'numeric', 'min:0'],

--- a/database/migrations/2026_04_18_051728_add_audio_file_path_check_to_sermons_table.php
+++ b/database/migrations/2026_04_18_051728_add_audio_file_path_check_to_sermons_table.php
@@ -18,8 +18,8 @@ return new class extends Migration
 
         // Add the CHECK constraint
         // Ensures audio_file_path is not empty and has no leading/trailing whitespace.
-        // NOTE: We are NOT performing data cleanup here to comply with safety guidelines.
-        DB::statement("ALTER TABLE sermons ADD CONSTRAINT sermons_audio_file_path_format_check CHECK (audio_file_path = TRIM(audio_file_path) AND audio_file_path != '')");
+        // We use BINARY to ensure the check is exact and avoids collation-related matching.
+        DB::statement("ALTER TABLE sermons ADD CONSTRAINT sermons_audio_file_path_format_check CHECK (BINARY audio_file_path = TRIM(audio_file_path) AND audio_file_path != '')");
     }
 
     /**

--- a/database/migrations/2026_04_18_051728_add_audio_file_path_check_to_sermons_table.php
+++ b/database/migrations/2026_04_18_051728_add_audio_file_path_check_to_sermons_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        // Add the CHECK constraint
+        // Ensures audio_file_path is not empty and has no leading/trailing whitespace.
+        // NOTE: We are NOT performing data cleanup here to comply with safety guidelines.
+        DB::statement("ALTER TABLE sermons ADD CONSTRAINT sermons_audio_file_path_format_check CHECK (audio_file_path = TRIM(audio_file_path) AND audio_file_path != '')");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        DB::statement('ALTER TABLE sermons DROP CHECK sermons_audio_file_path_format_check');
+    }
+};

--- a/tests/Feature/Models/SermonIntegrityTest.php
+++ b/tests/Feature/Models/SermonIntegrityTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Models\Sermon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonIntegrityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function sermon_audio_file_path_cannot_be_empty(): void
+    {
+        $rules = Sermon::validationRules();
+
+        $validator = Validator::make([
+            'title' => 'Test Sermon',
+            'slug' => 'test-sermon',
+            'preacher' => 'Mark Drury',
+            'audio_file_path' => '',
+        ], $rules);
+
+        // Currently this passes because audio_file_path is not in the validationRules
+        $this->assertTrue($validator->fails(), 'Validation should fail for empty audio_file_path');
+        $this->assertArrayHasKey('audio_file_path', $validator->errors()->toArray());
+    }
+
+    #[Test]
+    public function sermon_video_file_path_cannot_exceed_500_chars(): void
+    {
+        $rules = Sermon::validationRules();
+        $longPath = str_repeat('a', 501);
+
+        $validator = Validator::make([
+            'title' => 'Test Sermon',
+            'slug' => 'test-sermon',
+            'preacher' => 'Mark Drury',
+            'audio_file_path' => 'audio.mp3',
+            'video_file_path' => $longPath,
+        ], $rules);
+
+        // Currently this passes because video_file_path is not in the validationRules
+        $this->assertTrue($validator->fails(), 'Validation should fail for too long video_file_path');
+        $this->assertArrayHasKey('video_file_path', $validator->errors()->toArray());
+    }
+
+    #[Test]
+    public function sermon_preacher_confidence_must_be_between_0_and_1(): void
+    {
+        $rules = Sermon::validationRules();
+
+        $validator = Validator::make([
+            'title' => 'Test Sermon',
+            'slug' => 'test-sermon',
+            'preacher' => 'Mark Drury',
+            'audio_file_path' => 'audio.mp3',
+            'preacher_confidence' => 1.1,
+        ], $rules);
+
+        // Currently this passes because preacher_confidence is in rules but without max:1
+        $this->assertTrue($validator->fails(), 'Validation should fail for preacher_confidence > 1');
+
+        $validator = Validator::make([
+            'title' => 'Test Sermon',
+            'slug' => 'test-sermon',
+            'preacher' => 'Mark Drury',
+            'audio_file_path' => 'audio.mp3',
+            'preacher_confidence' => -0.1,
+        ], $rules);
+
+        $this->assertTrue($validator->fails(), 'Validation should fail for preacher_confidence < 0');
+    }
+
+    #[Test]
+    public function sermon_enum_fields_are_validated(): void
+    {
+        $rules = Sermon::validationRules();
+
+        $validator = Validator::make([
+            'title' => 'Test Sermon',
+            'slug' => 'test-sermon',
+            'preacher' => 'Mark Drury',
+            'audio_file_path' => 'audio.mp3',
+            'service' => 'invalid-service',
+        ], $rules);
+
+        // Currently this passes because service is not in validationRules
+        $this->assertTrue($validator->fails(), 'Validation should fail for invalid service enum');
+    }
+
+    #[Test]
+    public function sermon_audio_file_path_database_constraint(): void
+    {
+        if (\Illuminate\Support\Facades\DB::getDriverName() !== 'mysql') {
+            $this->markTestSkipped('Database constraint is MySQL specific');
+        }
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        Sermon::factory()->create([
+            'audio_file_path' => '',
+        ]);
+    }
+}

--- a/tests/Feature/Models/SermonIntegrityTest.php
+++ b/tests/Feature/Models/SermonIntegrityTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Models;
 
+use App\Enums\SermonContentType;
+use App\Enums\SermonSourceType;
 use App\Models\Sermon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Validator;
@@ -14,19 +16,31 @@ class SermonIntegrityTest extends TestCase
 {
     use DatabaseTransactions;
 
+    /**
+     * @return array<string, mixed>
+     */
+    private function validSermonData(): array
+    {
+        return [
+            'title' => 'Test Sermon',
+            'slug' => 'test-sermon',
+            'audio_file_path' => 'audio.mp3',
+            'date' => '2025-01-01',
+            'content_type' => SermonContentType::Sermon->value,
+            'source_type' => SermonSourceType::Manual->value,
+            'preacher' => 'Mark Drury',
+        ];
+    }
+
     #[Test]
     public function sermon_audio_file_path_cannot_be_empty(): void
     {
         $rules = Sermon::validationRules();
+        $data = $this->validSermonData();
+        $data['audio_file_path'] = '';
 
-        $validator = Validator::make([
-            'title' => 'Test Sermon',
-            'slug' => 'test-sermon',
-            'preacher' => 'Mark Drury',
-            'audio_file_path' => '',
-        ], $rules);
+        $validator = Validator::make($data, $rules);
 
-        // Currently this passes because audio_file_path is not in the validationRules
         $this->assertTrue($validator->fails(), 'Validation should fail for empty audio_file_path');
         $this->assertArrayHasKey('audio_file_path', $validator->errors()->toArray());
     }
@@ -35,17 +49,11 @@ class SermonIntegrityTest extends TestCase
     public function sermon_video_file_path_cannot_exceed_500_chars(): void
     {
         $rules = Sermon::validationRules();
-        $longPath = str_repeat('a', 501);
+        $data = $this->validSermonData();
+        $data['video_file_path'] = str_repeat('a', 501);
 
-        $validator = Validator::make([
-            'title' => 'Test Sermon',
-            'slug' => 'test-sermon',
-            'preacher' => 'Mark Drury',
-            'audio_file_path' => 'audio.mp3',
-            'video_file_path' => $longPath,
-        ], $rules);
+        $validator = Validator::make($data, $rules);
 
-        // Currently this passes because video_file_path is not in the validationRules
         $this->assertTrue($validator->fails(), 'Validation should fail for too long video_file_path');
         $this->assertArrayHasKey('video_file_path', $validator->errors()->toArray());
     }
@@ -54,44 +62,41 @@ class SermonIntegrityTest extends TestCase
     public function sermon_preacher_confidence_must_be_between_0_and_1(): void
     {
         $rules = Sermon::validationRules();
+        $data = $this->validSermonData();
 
-        $validator = Validator::make([
-            'title' => 'Test Sermon',
-            'slug' => 'test-sermon',
-            'preacher' => 'Mark Drury',
-            'audio_file_path' => 'audio.mp3',
-            'preacher_confidence' => 1.1,
-        ], $rules);
-
-        // Currently this passes because preacher_confidence is in rules but without max:1
+        $data['preacher_confidence'] = 1.1;
+        $validator = Validator::make($data, $rules);
         $this->assertTrue($validator->fails(), 'Validation should fail for preacher_confidence > 1');
+        $this->assertArrayHasKey('preacher_confidence', $validator->errors()->toArray());
 
-        $validator = Validator::make([
-            'title' => 'Test Sermon',
-            'slug' => 'test-sermon',
-            'preacher' => 'Mark Drury',
-            'audio_file_path' => 'audio.mp3',
-            'preacher_confidence' => -0.1,
-        ], $rules);
-
+        $data['preacher_confidence'] = -0.1;
+        $validator = Validator::make($data, $rules);
         $this->assertTrue($validator->fails(), 'Validation should fail for preacher_confidence < 0');
+        $this->assertArrayHasKey('preacher_confidence', $validator->errors()->toArray());
     }
 
     #[Test]
     public function sermon_enum_fields_are_validated(): void
     {
         $rules = Sermon::validationRules();
+        $data = $this->validSermonData();
 
-        $validator = Validator::make([
-            'title' => 'Test Sermon',
-            'slug' => 'test-sermon',
-            'preacher' => 'Mark Drury',
-            'audio_file_path' => 'audio.mp3',
-            'service' => 'invalid-service',
-        ], $rules);
-
-        // Currently this passes because service is not in validationRules
+        $data['service'] = 'invalid-service';
+        $validator = Validator::make($data, $rules);
         $this->assertTrue($validator->fails(), 'Validation should fail for invalid service enum');
+        $this->assertArrayHasKey('service', $validator->errors()->toArray());
+
+        $data['service'] = null;
+        $data['content_type'] = 'invalid-type';
+        $validator = Validator::make($data, $rules);
+        $this->assertTrue($validator->fails(), 'Validation should fail for invalid content_type enum');
+        $this->assertArrayHasKey('content_type', $validator->errors()->toArray());
+
+        $data['content_type'] = SermonContentType::Sermon->value;
+        $data['source_type'] = 'invalid-source';
+        $validator = Validator::make($data, $rules);
+        $this->assertTrue($validator->fails(), 'Validation should fail for invalid source_type enum');
+        $this->assertArrayHasKey('source_type', $validator->errors()->toArray());
     }
 
     #[Test]


### PR DESCRIPTION
🏛️ Warden: Fortify Sermon data integrity with constraints and validation

💡 **What:** This change strengthens the data integrity of the `Sermon` model by adding a database-level `CHECK` constraint for the `audio_file_path` column and expanding the centralized `validationRules()` method to cover missing fields and Enums.

🎯 **Why:** 
- Prevents invalid/empty `audio_file_path` values which are critical for sermon playback.
- Ensures model validation aligns with MySQL column lengths (`audio_file_path`: 255, `video_file_path`: 500) to prevent `Data too long` exceptions.
- Centralizes Enum validation (`SermonService`, `SermonContentType`, `SermonSourceType`) to ensure consistent data across different creation flows.
- Enforces the 0-1 range for `preacher_confidence` at the validation layer.

🗄️ **Migration:** 
- `2026_04_18_051728_add_audio_file_path_check_to_sermons_table.php`: Adds `sermons_audio_file_path_format_check`.

✅ **Verification:** 
- Created `tests/Feature/Models/SermonIntegrityTest.php` verifying both validation rules and the database constraint.
- `Sermon` unit tests pass.
- `php artisan migrate:fresh` runs successfully.
- PHPStan is at 0 errors.

⚠️ **Rollback:** `php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [5849674729668402602](https://jules.google.com/task/5849674729668402602) started by @GarethClarridge*