### PR TITLE
🧹 Tidy: Refactor SchemaGuardrailAudit to use Eloquent models

### DIFF
--- a/app/Support/SchemaGuardrailAudit.php
+++ b/app/Support/SchemaGuardrailAudit.php
@@ -99,7 +99,7 @@ class SchemaGuardrailAudit
      */
     public function speakerSampleDuplicates(): array
     {
-        return SpeakerSample::query()
+        return DB::table('speaker_samples')
             ->whereNotNull('sermon_id')
             ->selectRaw('speaker_profile_id, sermon_id, source, COUNT(*) as duplicate_count')
             ->groupBy('speaker_profile_id', 'sermon_id', 'source')
@@ -108,11 +108,11 @@ class SchemaGuardrailAudit
             ->orderBy('sermon_id')
             ->orderBy('source')
             ->get()
-            ->map(fn (SpeakerSample $row): array => [
+            ->map(fn (object $row): array => [
                 'speaker_profile_id' => (int) $row->speaker_profile_id,
                 'sermon_id' => (int) $row->sermon_id,
-                'source' => (string) $row->source->value,
-                'duplicate_count' => (int) $row->getAttribute('duplicate_count'),
+                'source' => (string) $row->source,
+                'duplicate_count' => (int) $row->duplicate_count,
             ])
             ->all();
     }

--- a/app/Support/SchemaGuardrailAudit.php
+++ b/app/Support/SchemaGuardrailAudit.php
@@ -6,6 +6,11 @@ namespace App\Support;
 
 use App\Enums\ServiceSectionPublicationStatus;
 use App\Enums\ServiceSectionStatus;
+use App\Models\ChurchServiceItem;
+use App\Models\MediaProcessingLog;
+use App\Models\ServiceSection;
+use App\Models\SpeakerProfile;
+use App\Models\SpeakerSample;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
@@ -72,7 +77,7 @@ class SchemaGuardrailAudit
      */
     public function speakerProfileDuplicates(): array
     {
-        return DB::table('speaker_profiles')
+        return SpeakerProfile::query()
             ->selectRaw('preacher_id, provider, model_version, COUNT(*) as duplicate_count')
             ->groupBy('preacher_id', 'provider', 'model_version')
             ->havingRaw('COUNT(*) > 1')
@@ -80,11 +85,11 @@ class SchemaGuardrailAudit
             ->orderBy('provider')
             ->orderBy('model_version')
             ->get()
-            ->map(fn (object $row): array => [
+            ->map(fn (SpeakerProfile $row): array => [
                 'preacher_id' => (int) $row->preacher_id,
                 'provider' => (string) $row->provider,
                 'model_version' => (string) $row->model_version,
-                'duplicate_count' => (int) $row->duplicate_count,
+                'duplicate_count' => (int) $row->getAttribute('duplicate_count'),
             ])
             ->all();
     }
@@ -94,7 +99,7 @@ class SchemaGuardrailAudit
      */
     public function speakerSampleDuplicates(): array
     {
-        return DB::table('speaker_samples')
+        return SpeakerSample::query()
             ->whereNotNull('sermon_id')
             ->selectRaw('speaker_profile_id, sermon_id, source, COUNT(*) as duplicate_count')
             ->groupBy('speaker_profile_id', 'sermon_id', 'source')
@@ -103,18 +108,18 @@ class SchemaGuardrailAudit
             ->orderBy('sermon_id')
             ->orderBy('source')
             ->get()
-            ->map(fn (object $row): array => [
+            ->map(fn (SpeakerSample $row): array => [
                 'speaker_profile_id' => (int) $row->speaker_profile_id,
                 'sermon_id' => (int) $row->sermon_id,
-                'source' => (string) $row->source,
-                'duplicate_count' => (int) $row->duplicate_count,
+                'source' => (string) $row->source->value,
+                'duplicate_count' => (int) $row->getAttribute('duplicate_count'),
             ])
             ->all();
     }
 
     public function orphanedMediaProcessingLogs(): int
     {
-        return DB::table('media_processing_logs')
+        return MediaProcessingLog::query()
             ->leftJoin('sermons', 'sermons.id', '=', 'media_processing_logs.sermon_id')
             ->whereNotNull('media_processing_logs.sermon_id')
             ->whereNull('sermons.id')
@@ -126,7 +131,7 @@ class SchemaGuardrailAudit
      */
     public function duplicateActiveChurchServiceItemPositions(): array
     {
-        return DB::table('church_service_items')
+        return ChurchServiceItem::query()
             ->selectRaw('church_service_id, position, COUNT(*) as row_count')
             ->whereNull('deleted_at')
             ->groupBy('church_service_id', 'position')
@@ -134,10 +139,10 @@ class SchemaGuardrailAudit
             ->orderBy('church_service_id')
             ->orderBy('position')
             ->get()
-            ->map(fn (object $row): array => [
+            ->map(fn (ChurchServiceItem $row): array => [
                 'church_service_id' => (int) $row->church_service_id,
                 'position' => (int) $row->position,
-                'row_count' => (int) $row->row_count,
+                'row_count' => (int) $row->getAttribute('row_count'),
             ])
             ->all();
     }
@@ -196,7 +201,7 @@ class SchemaGuardrailAudit
 
     public function invalidServiceSectionPublicationLifecycleRows(): int
     {
-        return DB::table('service_sections')
+        return ServiceSection::query()
             ->where(function ($query): void {
                 $query->where(function ($query): void {
                     $query->where('publication_status', ServiceSectionPublicationStatus::PUBLISHED->value)
@@ -229,7 +234,7 @@ class SchemaGuardrailAudit
 
     public function invalidServiceSectionTimingRows(): int
     {
-        return DB::table('service_sections')
+        return ServiceSection::query()
             ->where(function ($query): void {
                 $query->where('start_time', '<', 0)
                     ->orWhere('duration', '<', 0)


### PR DESCRIPTION
💡 **What:** Refactored `SchemaGuardrailAudit` to use Eloquent models instead of raw `DB::table()` calls where appropriate.
🎯 **Why:** Aligns with project standards to prefer Eloquent queries. Improves type safety and readability.
🔄 **Behavior:** No functional changes. Robustness against invalid data is preserved by keeping `DB::table()` for enum validation methods.
✅ **Tests:** `SchemaGuardrailAuditTest` and `AuditSchemaGuardrailsCommandTest` pass. Full suite verified for regressions.

---
*PR created automatically by Jules for task [9067544436256586692](https://jules.google.com/task/9067544436256586692) started by @GarethClarridge*