### PR TITLE
🛡️ Sentinel: [HIGH] Prevent account enumeration in auth components

### DIFF
--- a/app/Livewire/Auth/ForgotPassword.php
+++ b/app/Livewire/Auth/ForgotPassword.php
@@ -58,11 +58,18 @@ class ForgotPassword extends Component
         return true;
     }
 
+    /**
+     * Get the rate limiting throttle key for the password reset request.
+     *
+     * Security: Str::limit is applied to the email identifier to provide Defense in Depth
+     * against potential Cache Key Injection or Denial of Service (DoS) attacks targeting
+     * the cache storage by providing extremely long keys.
+     */
     protected function throttleKey(): string
     {
-        $identifier = is_string($this->email) ? Str::lower($this->email) : 'invalid';
+        $email = is_string($this->email) ? $this->email : 'invalid';
 
-        return Str::transliterate('forgot|'.Str::limit($identifier, 300).'|'.request()->ip());
+        return Str::transliterate('forgot|'.Str::lower(Str::limit($email, 255)).'|'.request()->ip());
     }
 
     public function render(): View

--- a/app/Livewire/Auth/ForgotPassword.php
+++ b/app/Livewire/Auth/ForgotPassword.php
@@ -27,12 +27,13 @@ class ForgotPassword extends Component
 
     public function sendResetLink(): void
     {
+        $this->error = '';
+
         if ($this->isRateLimited()) {
             return;
         }
 
         $this->validate();
-        $this->error = '';
 
         RateLimiter::hit($this->throttleKey());
 
@@ -59,7 +60,9 @@ class ForgotPassword extends Component
 
     protected function throttleKey(): string
     {
-        return Str::transliterate('forgot|'.Str::lower($this->email).'|'.request()->ip());
+        $identifier = is_string($this->email) ? Str::lower($this->email) : 'invalid';
+
+        return Str::transliterate('forgot|'.Str::limit($identifier, 300).'|'.request()->ip());
     }
 
     public function render(): View

--- a/app/Livewire/Auth/ForgotPassword.php
+++ b/app/Livewire/Auth/ForgotPassword.php
@@ -27,12 +27,12 @@ class ForgotPassword extends Component
 
     public function sendResetLink(): void
     {
-        $this->validate();
-        $this->error = '';
-
         if ($this->isRateLimited()) {
             return;
         }
+
+        $this->validate();
+        $this->error = '';
 
         RateLimiter::hit($this->throttleKey());
 

--- a/app/Livewire/Auth/Login.php
+++ b/app/Livewire/Auth/Login.php
@@ -38,8 +38,9 @@ class Login extends Component
     public function login(): Redirector|RedirectResponse|null
     {
         $this->error = '';
+        $email = is_string($this->email) ? $this->email : 'invalid';
 
-        if ($this->isRateLimited($this->email)) {
+        if ($this->isRateLimited($email)) {
             return null;
         }
 
@@ -71,7 +72,7 @@ class Login extends Component
         return view('livewire.auth.login');
     }
 
-    private function isRateLimited(mixed $email): bool
+    private function isRateLimited(string $email): bool
     {
         if (! RateLimiter::tooManyAttempts($this->throttleKey($email), 5)) {
             return false;
@@ -88,10 +89,15 @@ class Login extends Component
         return true;
     }
 
-    private function throttleKey(mixed $email): string
+    /**
+     * Get the rate limiting throttle key for the login attempt.
+     *
+     * Security: Str::limit is applied to the email identifier to provide Defense in Depth
+     * against potential Cache Key Injection or Denial of Service (DoS) attacks targeting
+     * the cache storage by providing extremely long keys.
+     */
+    private function throttleKey(string $email): string
     {
-        $identifier = is_string($email) ? Str::lower($email) : 'invalid';
-
-        return Str::transliterate('login|'.Str::limit($identifier, 300).'|'.request()->ip());
+        return Str::transliterate('login|'.Str::lower(Str::limit($email, 255)).'|'.request()->ip());
     }
 }

--- a/app/Livewire/Auth/Login.php
+++ b/app/Livewire/Auth/Login.php
@@ -38,9 +38,8 @@ class Login extends Component
     public function login(): Redirector|RedirectResponse|null
     {
         $this->error = '';
-        $email = is_string($this->email) ? $this->email : '';
 
-        if ($this->isRateLimited($email)) {
+        if ($this->isRateLimited($this->email)) {
             return null;
         }
 
@@ -72,7 +71,7 @@ class Login extends Component
         return view('livewire.auth.login');
     }
 
-    private function isRateLimited(string $email): bool
+    private function isRateLimited(mixed $email): bool
     {
         if (! RateLimiter::tooManyAttempts($this->throttleKey($email), 5)) {
             return false;
@@ -89,8 +88,10 @@ class Login extends Component
         return true;
     }
 
-    private function throttleKey(string $email): string
+    private function throttleKey(mixed $email): string
     {
-        return Str::transliterate('login|'.Str::lower($email).'|'.request()->ip());
+        $identifier = is_string($email) ? Str::lower($email) : 'invalid';
+
+        return Str::transliterate('login|'.Str::limit($identifier, 300).'|'.request()->ip());
     }
 }

--- a/app/Livewire/Auth/Login.php
+++ b/app/Livewire/Auth/Login.php
@@ -37,15 +37,17 @@ class Login extends Component
 
     public function login(): Redirector|RedirectResponse|null
     {
-        $validated = $this->validate();
-        $email = (string) $validated['email'];
-        $password = (string) $validated['password'];
-        $remember = (bool) ($validated['remember'] ?? false);
         $this->error = '';
+        $email = is_string($this->email) ? $this->email : '';
 
         if ($this->isRateLimited($email)) {
             return null;
         }
+
+        $validated = $this->validate();
+        $email = (string) $validated['email'];
+        $password = (string) $validated['password'];
+        $remember = (bool) ($validated['remember'] ?? false);
 
         $credentials = [
             'email' => $email,

--- a/app/Livewire/Auth/Register.php
+++ b/app/Livewire/Auth/Register.php
@@ -52,6 +52,8 @@ class Register extends Component
 
     public function register(): Redirector|RedirectResponse|null
     {
+        $this->error = '';
+
         if ($this->isRateLimited()) {
             return null;
         }

--- a/app/Livewire/Auth/Register.php
+++ b/app/Livewire/Auth/Register.php
@@ -52,11 +52,11 @@ class Register extends Component
 
     public function register(): Redirector|RedirectResponse|null
     {
-        $this->validate();
-
         if ($this->isRateLimited()) {
             return null;
         }
+
+        $this->validate();
 
         RateLimiter::hit($this->throttleKey());
 

--- a/app/Livewire/Auth/ResetPassword.php
+++ b/app/Livewire/Auth/ResetPassword.php
@@ -59,11 +59,11 @@ class ResetPassword extends Component
 
     public function resetPassword(): Redirector|RedirectResponse|null
     {
-        $this->validate();
-
         if ($this->isRateLimited()) {
             return null;
         }
+
+        $this->validate();
 
         $data = [
             'token' => $this->token,

--- a/app/Livewire/Auth/ResetPassword.php
+++ b/app/Livewire/Auth/ResetPassword.php
@@ -59,6 +59,8 @@ class ResetPassword extends Component
 
     public function resetPassword(): Redirector|RedirectResponse|null
     {
+        $this->error = '';
+
         if ($this->isRateLimited()) {
             return null;
         }
@@ -111,7 +113,9 @@ class ResetPassword extends Component
 
     protected function throttleKey(): string
     {
-        return Str::transliterate('reset|'.Str::lower($this->email).'|'.request()->ip());
+        $identifier = is_string($this->email) ? Str::lower($this->email) : 'invalid';
+
+        return Str::transliterate('reset|'.Str::limit($identifier, 300).'|'.request()->ip());
     }
 
     public function render(): View

--- a/app/Livewire/Auth/ResetPassword.php
+++ b/app/Livewire/Auth/ResetPassword.php
@@ -111,11 +111,18 @@ class ResetPassword extends Component
         return true;
     }
 
+    /**
+     * Get the rate limiting throttle key for the password reset attempt.
+     *
+     * Security: Str::limit is applied to the email identifier to provide Defense in Depth
+     * against potential Cache Key Injection or Denial of Service (DoS) attacks targeting
+     * the cache storage by providing extremely long keys.
+     */
     protected function throttleKey(): string
     {
-        $identifier = is_string($this->email) ? Str::lower($this->email) : 'invalid';
+        $email = is_string($this->email) ? $this->email : 'invalid';
 
-        return Str::transliterate('reset|'.Str::limit($identifier, 300).'|'.request()->ip());
+        return Str::transliterate('reset|'.Str::lower(Str::limit($email, 255)).'|'.request()->ip());
     }
 
     public function render(): View


### PR DESCRIPTION
I have refactored the Livewire authentication components (`Login`, `Register`, `ForgotPassword`, and `ResetPassword`) to enhance the application's security posture. 

The primary change is moving the `isRateLimited()` check to the beginning of the action methods, before any input validation occurs. This implements a "Fail Fast" approach that protects the application from account enumeration attacks and reduces unnecessary database load from throttled clients.

**Changes:**
- **Register.php**: Rate limit check now precedes validation.
- **ForgotPassword.php**: Rate limit check now precedes validation.
- **ResetPassword.php**: Rate limit check now precedes validation.
- **Login.php**: Rate limit check now precedes validation. Included logic to safely extract the email for the throttle key while handling the property's dual type (`string|array`).

**Verification:**
- Ran `tests/Feature/Auth/AuthRateLimitingTest.php` (Pass)
- Ran `tests/Feature/Auth/LoginTest.php` (Pass)
- Ran `tests/Feature/Auth/RegisterTest.php` (Pass)
- Ran `tests/Feature/Auth/PasswordResetTest.php` (Pass)
- Verified code quality with `composer phpstan` and `./vendor/bin/pint`.

---
*PR created automatically by Jules for task [6354023650366415950](https://jules.google.com/task/6354023650366415950) started by @GarethClarridge*