### PR TITLE
🛡️ Sentinel: Enhance anti-enumeration security in auth components

### DIFF
--- a/app/Livewire/Auth/ForgotPassword.php
+++ b/app/Livewire/Auth/ForgotPassword.php
@@ -27,12 +27,13 @@ class ForgotPassword extends Component
 
     public function sendResetLink(): void
     {
-        $this->validate();
         $this->error = '';
 
         if ($this->isRateLimited()) {
             return;
         }
+
+        $this->validate();
 
         RateLimiter::hit($this->throttleKey());
 

--- a/app/Livewire/Auth/Login.php
+++ b/app/Livewire/Auth/Login.php
@@ -37,15 +37,24 @@ class Login extends Component
 
     public function login(): Redirector|RedirectResponse|null
     {
-        $validated = $this->validate();
-        $email = (string) $validated['email'];
-        $password = (string) $validated['password'];
-        $remember = (bool) ($validated['remember'] ?? false);
         $this->error = '';
+
+        $email = is_string($this->email) ? $this->email : '';
+        if (is_array($this->email)) {
+            $email = '';
+        }
+
+        // Security: Limit email length before rate limiting to prevent DoS via large strings.
+        $email = Str::limit($email, 300, '');
 
         if ($this->isRateLimited($email)) {
             return null;
         }
+
+        $validated = $this->validate();
+        $email = (string) $validated['email'];
+        $password = (string) $validated['password'];
+        $remember = (bool) ($validated['remember'] ?? false);
 
         $credentials = [
             'email' => $email,

--- a/app/Livewire/Auth/Register.php
+++ b/app/Livewire/Auth/Register.php
@@ -52,11 +52,13 @@ class Register extends Component
 
     public function register(): Redirector|RedirectResponse|null
     {
-        $this->validate();
+        $this->error = '';
 
         if ($this->isRateLimited()) {
             return null;
         }
+
+        $this->validate();
 
         RateLimiter::hit($this->throttleKey());
 

--- a/app/Livewire/Auth/ResetPassword.php
+++ b/app/Livewire/Auth/ResetPassword.php
@@ -59,11 +59,13 @@ class ResetPassword extends Component
 
     public function resetPassword(): Redirector|RedirectResponse|null
     {
-        $this->validate();
+        $this->error = '';
 
         if ($this->isRateLimited()) {
             return null;
         }
+
+        $this->validate();
 
         $data = [
             'token' => $this->token,

--- a/tests/Feature/Auth/Security/AntiEnumerationThrottlingTest.php
+++ b/tests/Feature/Auth/Security/AntiEnumerationThrottlingTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth\Security;
+
+use App\Livewire\Auth\Register;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AntiEnumerationThrottlingTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function registration_is_throttled_before_unique_email_validation(): void
+    {
+        $existingUser = User::factory()->create(['email' => 'duplicate@example.com']);
+
+        $component = Livewire::test(Register::class)
+            ->set('name', 'Test User')
+            ->set('email', 'newuser@example.com')
+            ->set('password', 'StrongPass123!@#Unique')
+            ->set('password_confirmation', 'StrongPass123!@#Unique');
+
+        // Make 3 successful registrations (deleting user after each)
+        for ($i = 0; $i < 3; $i++) {
+            $email = "newuser{$i}@example.com";
+            $component->set('email', $email)
+                ->call('register')
+                ->assertHasNoErrors();
+            User::where('email', $email)->delete();
+        }
+
+        // 2. The next attempt should be throttled immediately,
+        // even if we use the duplicate email.
+        $component->set('email', 'duplicate@example.com')
+            ->call('register');
+
+        $error = $component->get('error');
+        $this->assertStringContainsString('Too many login attempts', $error);
+
+        // IMPORTANT: It should NOT have the 'unique' validation error
+        // because validation should not have run yet.
+        $component->assertHasNoErrors(['email' => 'unique']);
+    }
+}


### PR DESCRIPTION
Enhanced the security of authentication Livewire components (Login, Register, ForgotPassword, ResetPassword) by reordering logic to execute rate limiting before input validation. This prevents account enumeration and reduces the impact of DoS attacks. Also added string length limiting to the email property in the Login component before it reaches the rate limiter for additional protection. Verified the fix with a new feature test `tests/Feature/Auth/Security/AntiEnumerationThrottlingTest.php`.

---
*PR created automatically by Jules for task [12368962832196713953](https://jules.google.com/task/12368962832196713953) started by @GarethClarridge*