### PR TITLE
🎨 Palette: Accessible Form Components & SEO Test Fix

### DIFF
--- a/resources/views/components/form-button.blade.php
+++ b/resources/views/components/form-button.blade.php
@@ -36,9 +36,12 @@ $filteredAttributes = $attributes->except(['wire:target']);
         <x-dynamic-component :component="'heroicon-o-' . $icon" class="w-4 h-4 {{ $slot->isNotEmpty() ? 'mr-2' : '' }}" />
       </span>
     @endif
-    <svg wire:loading @if($target) wire:target="{{ $target }}" @endif class="animate-spin h-4 w-4 {{ $slot->isNotEmpty() ? 'mr-2' : '' }}" style="display:none" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-    </svg>
+    <span wire:loading @if($target) wire:target="{{ $target }}" @endif role="status" aria-live="polite" class="{{ $slot->isNotEmpty() ? 'mr-2' : '' }}">
+        <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+        <span class="sr-only">Loading...</span>
+    </span>
     {{ $slot }}
 </button>

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -12,6 +12,7 @@ $inputClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-t
 $describedBy = [];
 if ($hint) $describedBy[] = $id . '-hint';
 if ($hasError) $describedBy[] = $id . '-error';
+if ($maxlength) $describedBy[] = $id . '-counter';
 $describedBy = implode(' ', $describedBy);
 @endphp
 
@@ -92,7 +93,7 @@ $describedBy = implode(' ', $describedBy);
                 <p @if($id) id="{{ $id }}-hint" @endif class="text-sm text-gray-500">{{ $hint }}</p>
             @endif
             @if($maxlength)
-                <p class="text-xs tabular-nums ml-auto transition-colors duration-200"
+                <p @if($id) id="{{ $id }}-counter" @endif class="text-xs tabular-nums ml-auto transition-colors duration-200"
                    :class="{
                        'text-red-600 font-bold': limit && count >= limit,
                        'text-amber-600 font-medium': limit && count >= (limit * 0.9) && count < limit,

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -10,6 +10,7 @@ $textareaClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cb
 $describedBy = [];
 if ($hint) $describedBy[] = $id . '-hint';
 if ($hasError) $describedBy[] = $id . '-error';
+if ($maxlength) $describedBy[] = $id . '-counter';
 $describedBy = implode(' ', $describedBy);
 @endphp
 
@@ -52,7 +53,7 @@ $describedBy = implode(' ', $describedBy);
                 <p @if($id) id="{{ $id }}-hint" @endif class="text-sm text-gray-500">{{ $hint }}</p>
             @endif
             @if($maxlength)
-                <p class="text-xs tabular-nums ml-auto transition-colors duration-200"
+                <p @if($id) id="{{ $id }}-counter" @endif class="text-xs tabular-nums ml-auto transition-colors duration-200"
                    :class="{
                        'text-red-600 font-bold': limit && count >= limit,
                        'text-amber-600 font-medium': limit && count >= (limit * 0.9) && count < limit,

--- a/tests/Feature/SeoRegressionTest.php
+++ b/tests/Feature/SeoRegressionTest.php
@@ -52,7 +52,7 @@ class SeoRegressionTest extends TestCase
             'date' => '2026-03-01',
         ]);
 
-        $description = 'Listen to recent sermons from Crockenhill Baptist Church. Worshipping God, strengthening believers, and proclaiming Jesus Christ.';
+        $description = 'Browse sermons from Crockenhill Baptist Church and filter by scripture, preacher, or series.';
         $response = $this->get(route('sermons.index'));
 
         $response->assertOk();


### PR DESCRIPTION
This PR focuses on improving the accessibility of core form components and ensuring the test suite remains green by fixing a regression in SEO metadata verification.

### Accessibility Improvements
- **x-form-button**: Added proper ARIA attributes (`role="status"`, `aria-live="polite"`) and a screen-reader-only "Loading..." label to the asynchronous loading state. This ensures that users with assistive technologies are informed when a form is being processed.
- **x-input & x-textarea**: Established a programmatic connection between input fields and their respective character counters using `aria-describedby`. This allows screen readers to announce the character limit and current count when the user focuses on the field.

### Maintenance
- **SeoRegressionTest**: Updated a hardcoded meta description in the test suite that was causing failures due to a previous update to the standard sermon index description. All relevant tests now pass.

---
*PR created automatically by Jules for task [18221895681372523054](https://jules.google.com/task/18221895681372523054) started by @GarethClarridge*