### PR TITLE
Add feature tests for Meeting admin Livewire components

### DIFF
--- a/tests/Feature/Livewire/Admin/Meetings/CreateMeetingTest.php
+++ b/tests/Feature/Livewire/Admin/Meetings/CreateMeetingTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire\Admin\Meetings;
+
+use App\Enums\MeetingFrequency;
+use App\Enums\MeetingType;
+use App\Livewire\Admin\Meetings\CreateMeeting;
+use App\Models\Meeting;
+use App\Models\Page;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Log;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CreateMeetingTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::factory()->crockenhillAdmin()->create(['is_admin' => true]);
+    }
+
+    #[Test]
+    public function it_authorizes_admin_access(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($user);
+
+        Livewire::test(CreateMeeting::class)
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_renders_successfully_for_admin(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(CreateMeeting::class)
+            ->assertStatus(200)
+            ->assertSee('Create Meeting');
+    }
+
+    #[Test]
+    public function it_can_create_a_meeting(): void
+    {
+        $this->actingAs($this->admin);
+        $page = Page::factory()->create();
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->with('New meeting created by admin', \Mockery::on(function ($args) {
+                return $args['admin_id'] === $this->admin->id &&
+                       $args['slug'] === 'new-meeting-test';
+            }));
+
+        Livewire::test(CreateMeeting::class)
+            ->set('form.slug', 'new-meeting-test')
+            ->set('form.type', MeetingType::Adults->value)
+            ->set('form.day', 'Monday')
+            ->set('form.startTime', '19:00')
+            ->set('form.who', 'Adults')
+            ->set('form.pageId', $page->id)
+            ->call('save')
+            ->assertHasNoErrors()
+            ->assertRedirect(route('admin.meetings.index'));
+
+        $this->assertDatabaseHas('meetings', [
+            'slug' => 'new-meeting-test',
+            'type' => MeetingType::Adults->value,
+            'day' => 'Monday',
+            'who' => 'Adults',
+            'page_id' => $page->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_validates_required_fields(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(CreateMeeting::class)
+            ->call('save')
+            ->assertHasErrors(['form.slug' => 'required', 'form.day' => 'required', 'form.who' => 'required']);
+    }
+
+    #[Test]
+    public function it_validates_slug_format(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(CreateMeeting::class)
+            ->set('form.slug', 'Invalid Slug!')
+            ->call('save')
+            ->assertHasErrors(['form.slug' => 'regex']);
+    }
+
+    #[Test]
+    public function it_validates_unique_slug(): void
+    {
+        Meeting::factory()->create(['slug' => 'existing-slug']);
+        $this->actingAs($this->admin);
+
+        Livewire::test(CreateMeeting::class)
+            ->set('form.slug', 'existing-slug')
+            ->call('save')
+            ->assertHasErrors(['form.slug' => 'unique']);
+    }
+
+    #[Test]
+    public function it_validates_recurring_frequency(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(CreateMeeting::class)
+            ->set('form.isRecurring', true)
+            ->set('form.frequency', null)
+            ->call('save')
+            ->assertHasErrors(['form.frequency' => 'required_if']);
+    }
+
+    #[Test]
+    public function it_can_create_a_recurring_meeting(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(CreateMeeting::class)
+            ->set('form.slug', 'recurring-meeting')
+            ->set('form.type', MeetingType::Adults->value)
+            ->set('form.day', 'Monday')
+            ->set('form.who', 'Adults')
+            ->set('form.isRecurring', true)
+            ->set('form.frequency', MeetingFrequency::Weekly->value)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('meetings', [
+            'slug' => 'recurring-meeting',
+            'is_recurring' => true,
+            'frequency' => MeetingFrequency::Weekly->value,
+        ]);
+    }
+}

--- a/tests/Feature/Livewire/Admin/Meetings/EditMeetingTest.php
+++ b/tests/Feature/Livewire/Admin/Meetings/EditMeetingTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire\Admin\Meetings;
+
+use App\Livewire\Admin\Meetings\EditMeeting;
+use App\Models\Meeting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Log;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class EditMeetingTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::factory()->crockenhillAdmin()->create(['is_admin' => true]);
+    }
+
+    #[Test]
+    public function it_authorizes_admin_access(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+        $meeting = Meeting::factory()->create();
+
+        $this->actingAs($user);
+
+        Livewire::test(EditMeeting::class, ['meeting' => $meeting])
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_renders_successfully_for_admin(): void
+    {
+        $meeting = Meeting::factory()->create();
+        $this->actingAs($this->admin);
+
+        Livewire::test(EditMeeting::class, ['meeting' => $meeting])
+            ->assertStatus(200)
+            ->assertSee('Edit Meeting')
+            ->assertSet('form.slug', $meeting->slug);
+    }
+
+    #[Test]
+    public function it_can_update_a_meeting(): void
+    {
+        $meeting = Meeting::factory()->create(['slug' => 'old-slug', 'who' => 'Old Who']);
+        $this->actingAs($this->admin);
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->with('Meeting updated by admin', \Mockery::on(function ($args) use ($meeting) {
+                return $args['admin_id'] === $this->admin->id &&
+                       $args['meeting_id'] === $meeting->id &&
+                       $args['slug'] === 'new-slug';
+            }));
+
+        Livewire::test(EditMeeting::class, ['meeting' => $meeting])
+            ->set('form.slug', 'new-slug')
+            ->set('form.who', 'New Who')
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('meetings', [
+            'id' => $meeting->id,
+            'slug' => 'new-slug',
+            'who' => 'New Who',
+        ]);
+    }
+
+    #[Test]
+    public function it_validates_unique_slug_ignoring_self(): void
+    {
+        $meeting = Meeting::factory()->create(['slug' => 'original-slug']);
+        $this->actingAs($this->admin);
+
+        Livewire::test(EditMeeting::class, ['meeting' => $meeting])
+            ->set('form.slug', 'original-slug')
+            ->call('save')
+            ->assertHasNoErrors();
+    }
+
+    #[Test]
+    public function it_validates_unique_slug_against_others(): void
+    {
+        $meeting1 = Meeting::factory()->create(['slug' => 'slug-one']);
+        $meeting2 = Meeting::factory()->create(['slug' => 'slug-two']);
+        $this->actingAs($this->admin);
+
+        Livewire::test(EditMeeting::class, ['meeting' => $meeting1])
+            ->set('form.slug', 'slug-two')
+            ->call('save')
+            ->assertHasErrors(['form.slug' => 'unique']);
+    }
+}

--- a/tests/Feature/Livewire/Admin/Meetings/ListMeetingsTest.php
+++ b/tests/Feature/Livewire/Admin/Meetings/ListMeetingsTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire\Admin\Meetings;
+
+use App\Enums\MeetingType;
+use App\Livewire\Admin\Meetings\ListMeetings;
+use App\Models\Meeting;
+use App\Models\Page;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Log;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ListMeetingsTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::factory()->crockenhillAdmin()->create(['is_admin' => true]);
+    }
+
+    #[Test]
+    public function it_authorizes_admin_access(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($user);
+
+        Livewire::test(ListMeetings::class)
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_renders_successfully_for_admin(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListMeetings::class)
+            ->assertStatus(200)
+            ->assertSee('Meetings');
+    }
+
+    #[Test]
+    public function it_lists_meetings(): void
+    {
+        $page = Page::factory()->create(['heading' => 'Prayer Meeting']);
+        $meeting = Meeting::factory()->create([
+            'page_id' => $page->id,
+            'who' => 'Everyone',
+        ]);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListMeetings::class)
+            ->assertSee('Prayer Meeting')
+            ->assertSee('Everyone');
+    }
+
+    #[Test]
+    public function it_filters_by_search_term_on_page_heading(): void
+    {
+        $page1 = Page::factory()->create(['heading' => 'Bible Study']);
+        $meeting1 = Meeting::factory()->create(['page_id' => $page1->id]);
+
+        $page2 = Page::factory()->create(['heading' => 'Youth Group']);
+        $meeting2 = Meeting::factory()->create(['page_id' => $page2->id]);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListMeetings::class)
+            ->set('search', 'Bible')
+            ->assertSee('Bible Study')
+            ->assertDontSee('Youth Group');
+    }
+
+    #[Test]
+    public function it_filters_by_search_term_on_day(): void
+    {
+        $meeting1 = Meeting::factory()->create(['day' => 'Monday']);
+        $meeting2 = Meeting::factory()->create(['day' => 'Tuesday']);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListMeetings::class)
+            ->set('search', 'Monday')
+            ->assertSee('Monday')
+            ->assertDontSee('Tuesday');
+    }
+
+    #[Test]
+    public function it_filters_by_search_term_on_who(): void
+    {
+        $meeting1 = Meeting::factory()->create(['who' => 'Children']);
+        $meeting2 = Meeting::factory()->create(['who' => 'Seniors']);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListMeetings::class)
+            ->set('search', 'Children')
+            ->assertSee('Children')
+            ->assertDontSee('Seniors');
+    }
+
+    #[Test]
+    public function it_filters_by_type(): void
+    {
+        Meeting::query()->delete();
+        $meeting1 = Meeting::factory()->create(['type' => MeetingType::Adults->value, 'who' => 'Adult Meeting']);
+        $meeting2 = Meeting::factory()->create(['type' => MeetingType::Occasional->value, 'who' => 'Occasional Meeting']);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListMeetings::class)
+            ->set('typeFilter', MeetingType::Adults->value)
+            ->assertSee('Adult Meeting')
+            ->assertDontSee('Occasional Meeting');
+    }
+
+    #[Test]
+    public function it_filters_by_recurring_status(): void
+    {
+        $meeting1 = Meeting::factory()->recurring()->create(['who' => 'Recurring User']);
+        $meeting2 = Meeting::factory()->notRecurring()->create(['who' => 'One-off User']);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListMeetings::class)
+            ->set('recurringFilter', true)
+            ->assertSee('Recurring User')
+            ->assertDontSee('One-off User')
+            ->set('recurringFilter', false)
+            ->assertSee('One-off User')
+            ->assertDontSee('Recurring User');
+    }
+
+    #[Test]
+    public function it_sorts_meetings(): void
+    {
+        Meeting::query()->delete();
+        Meeting::factory()->create(['slug' => 'b-meeting']);
+        Meeting::factory()->create(['slug' => 'a-meeting']);
+        Meeting::factory()->create(['slug' => 'c-meeting']);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListMeetings::class)
+            ->set('sortBy', 'slug')
+            ->set('sortDirection', 'asc')
+            ->assertSeeInOrder(['a-meeting', 'b-meeting', 'c-meeting'])
+            ->set('sortDirection', 'desc')
+            ->assertSeeInOrder(['c-meeting', 'b-meeting', 'a-meeting']);
+    }
+
+    #[Test]
+    public function it_sorts_by_schedule(): void
+    {
+        Meeting::query()->delete();
+        Meeting::factory()->create(['day' => 'Monday', 'start_time' => '10:00:00', 'end_time' => '11:00:00']);
+        Meeting::factory()->create(['day' => 'Monday', 'start_time' => '09:00:00', 'end_time' => '10:00:00']);
+        Meeting::factory()->create(['day' => 'Wednesday', 'start_time' => '10:00:00', 'end_time' => '11:00:00']);
+
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListMeetings::class)
+            ->set('sortBy', 'schedule')
+            ->set('sortDirection', 'asc')
+            ->assertSeeInOrder(['Monday', 'Monday', 'Wednesday']);
+    }
+
+    #[Test]
+    public function it_can_delete_a_meeting(): void
+    {
+        $meeting = Meeting::factory()->create();
+
+        $this->actingAs($this->admin);
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->with('Meeting deleted by admin', \Mockery::on(function ($args) use ($meeting) {
+                return $args['admin_id'] === $this->admin->id &&
+                       $args['meeting_id'] === $meeting->id &&
+                       $args['slug'] === $meeting->slug;
+            }));
+
+        Livewire::test(ListMeetings::class)
+            ->call('delete', $meeting)
+            ->assertDispatched('notify');
+
+        $this->assertDatabaseMissing('meetings', ['id' => $meeting->id]);
+    }
+}


### PR DESCRIPTION
I have implemented three new feature test files to cover the Meeting administration area, which was previously untested. 

### Tests Added:
- **ListMeetingsTest**: Verifies that only admins can access the list, searching by page title, day or audience works correctly, filters for meeting type and recurring status are functional, and sorting by slug or schedule behaves as expected. It also ensures the delete action works and is logged.
- **CreateMeetingTest**: Ensures admins can create new meetings with full validation coverage, including complex rules like requiring a frequency only when a meeting is recurring.
- **EditMeetingTest**: Validates the loading of existing meeting data into the form and ensures updates are saved correctly while respecting unique constraints (ignoring the current record).

All tests were verified to pass locally in the Jules environment. Static analysis (PHPStan) and formatting (Pint) were run to ensure code quality.

---
*PR created automatically by Jules for task [10986134671914209618](https://jules.google.com/task/10986134671914209618) started by @GarethClarridge*