### PR TITLE
🧹 Tidy: Add readonly modifier to promoted constructor properties

### DIFF
--- a/app/Services/CalendarCategorizationResult.php
+++ b/app/Services/CalendarCategorizationResult.php
@@ -9,7 +9,7 @@ use App\Models\CalendarEvent;
 readonly class CalendarCategorizationResult
 {
     public function __construct(
-        public CalendarEvent $event,
-        public bool $googleSynced,
+        public readonly CalendarEvent $event,
+        public readonly bool $googleSynced,
     ) {}
 }

--- a/app/Services/ProcessingReport.php
+++ b/app/Services/ProcessingReport.php
@@ -9,7 +9,7 @@ class ProcessingReport
     /**
      * @param  array<string, mixed>  $data
      */
-    public function __construct(public array $data) {}
+    public function __construct(public readonly array $data) {}
 
     /**
      * @return array<string, mixed>


### PR DESCRIPTION
Added the `readonly` modifier to constructor-promoted properties in `CalendarCategorizationResult` and `ProcessingReport`. This follows the project's coding standard for immutability in Services and Repositories.

Functional behavior is unchanged. Verified that static analysis passes and relevant unit tests for these classes also pass. A pre-existing failure in `SeoRegressionTest` was identified but is unrelated to these changes.

---
*PR created automatically by Jules for task [11377975257341637193](https://jules.google.com/task/11377975257341637193) started by @GarethClarridge*