### PR TITLE
🎨 Palette: Password visibility toggle

### DIFF
--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -4,10 +4,14 @@
 $modelName = $attributes->wire('model')->value();
 $id = $attributes->get('id', $modelName ? str_replace(['.', ' ', '[', ']'], '-', $modelName) : ($label ? \Illuminate\Support\Str::slug($label) : null));
 $hasError = $modelName && $errors->has($modelName);
+
+$type = $attributes->get('type', 'text');
+$isPassword = $type === 'password';
+
 $inputClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2'
     . ($icon ? ' pl-10' : '')
     . ($hasError ? ' border-red-300' : ' border-gray-300')
-    . ($clearable ? ' pr-10' : '');
+    . ($clearable || $isPassword ? ' pr-10' : '');
 
 $describedBy = [];
 if ($hint) $describedBy[] = $id . '-hint';
@@ -15,7 +19,7 @@ if ($hasError) $describedBy[] = $id . '-error';
 $describedBy = implode(' ', $describedBy);
 @endphp
 
-<div x-data="{ count: 0, limit: {{ $maxlength ?? 'null' }}, focused: false }"
+<div x-data="{ count: 0, limit: {{ $maxlength ?? 'null' }}, focused: false, showPassword: false }"
      x-init="count = $refs.input.value.length; @if($autofocus) $nextTick(() => $refs.input.focus()) @endif"
      @if($shortcut === 'slash') @keydown.window.slash="if (!['INPUT', 'TEXTAREA', 'SELECT'].includes(document.activeElement.tagName) && !document.activeElement.isContentEditable) { $event.preventDefault(); $refs.input.focus(); }" @endif>
     @if($label)
@@ -43,6 +47,9 @@ $describedBy = implode(' ', $describedBy);
                 'id' => $id,
                 'aria-label' => (!$label && $attributes->get('placeholder')) ? $attributes->get('placeholder') : null
             ]) }}
+            @if($isPassword)
+                :type="showPassword ? 'text' : 'password'"
+            @endif
             @if($maxlength) maxlength="{{ $maxlength }}" @endif
             @if($hasError) aria-invalid="true" @endif
             @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
@@ -71,6 +78,18 @@ $describedBy = implode(' ', $describedBy);
                 x-transition
                 wire:loading.remove wire:target="{{ $modelName }}">
                 <x-heroicon-o-x-mark class="h-4 w-4" />
+            </button>
+        @endif
+
+        @if($isPassword)
+            <button type="button"
+                @click="showPassword = !showPassword"
+                class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded"
+                :aria-label="showPassword ? 'Hide password' : 'Show password'"
+                :title="showPassword ? 'Hide password' : 'Show password'"
+                x-cloak>
+                <x-heroicon-o-eye x-show="!showPassword" class="h-5 w-5" />
+                <x-heroicon-o-eye-slash x-show="showPassword" class="h-5 w-5" />
             </button>
         @endif
 

--- a/tests/Feature/Auth/PasswordVisibilityToggleTest.php
+++ b/tests/Feature/Auth/PasswordVisibilityToggleTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Auth;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class PasswordVisibilityToggleTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function login_page_has_password_visibility_toggle(): void
     {
         $response = $this->get(route('login'));
@@ -21,7 +22,7 @@ class PasswordVisibilityToggleTest extends TestCase
         $response->assertSee('svg');
     }
 
-    /** @test */
+    #[Test]
     public function register_page_has_password_visibility_toggles(): void
     {
         $response = $this->get(route('register'));
@@ -31,7 +32,7 @@ class PasswordVisibilityToggleTest extends TestCase
         $this->assertEquals(2, substr_count($response->getContent(), 'showPassword = !showPassword'));
     }
 
-    /** @test */
+    #[Test]
     public function reset_password_page_has_password_visibility_toggles(): void
     {
         // We need a token for the reset password route

--- a/tests/Feature/Auth/PasswordVisibilityToggleTest.php
+++ b/tests/Feature/Auth/PasswordVisibilityToggleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use Tests\TestCase;
+
+class PasswordVisibilityToggleTest extends TestCase
+{
+    /** @test */
+    public function login_page_has_password_visibility_toggle(): void
+    {
+        $response = $this->get(route('login'));
+
+        $response->assertStatus(200);
+        $response->assertSee('showPassword');
+        $response->assertSee(':type="showPassword ? \'text\' : \'password\'"', false);
+        $response->assertSee('Show password');
+        $response->assertSee('Hide password');
+        $response->assertSee('svg');
+    }
+
+    /** @test */
+    public function register_page_has_password_visibility_toggles(): void
+    {
+        $response = $this->get(route('register'));
+
+        $response->assertStatus(200);
+        // Should have two toggles (password and password_confirmation)
+        $this->assertEquals(2, substr_count($response->getContent(), 'showPassword = !showPassword'));
+    }
+
+    /** @test */
+    public function reset_password_page_has_password_visibility_toggles(): void
+    {
+        // We need a token for the reset password route
+        $response = $this->get(route('password.reset', ['token' => 'fake-token']));
+
+        $response->assertStatus(200);
+        // Should have two toggles
+        $this->assertEquals(2, substr_count($response->getContent(), 'showPassword = !showPassword'));
+    }
+}


### PR DESCRIPTION
### 💡 What:
Implemented an accessible password visibility toggle in the shared `x-input` Blade component. This adds an "eye" icon button inside password fields that allows users to reveal and hide their entered password.

### 🎯 Why:
Improve the user experience during authentication by allowing users to verify their password entry, reducing frustration from typos—especially on mobile devices or for users with motor impairments.

### ♿ Accessibility:
- Uses `aria-label` to clearly communicate the button's action ("Show password" / "Hide password").
- Icon button is keyboard navigable and uses the project's standard focus rings.
- Uses semantic `button` type to avoid accidental form submissions.

### 📱 Responsive:
- The toggle button is positioned absolutely within the input container, ensuring it remains accessible and correctly aligned on all screen sizes.
- Input padding is automatically adjusted to `pr-10` for password fields to prevent text from overlapping the icon.

---
*PR created automatically by Jules for task [12882128606634500645](https://jules.google.com/task/12882128606634500645) started by @GarethClarridge*