### PR TITLE
🔦 Lighthouse: SEO and podcast discoverability improvements

### DIFF
--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -74,7 +74,19 @@ class SitemapService
             ->add(Url::create('/christ/sermons/series')
                 ->setPriority(0.7)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
-                ->addImage(asset('/images/headings/large/sermons.webp'), 'Sermon Series'));
+                ->addImage(asset('/images/headings/large/sermons.webp'), 'Sermon Series'))
+            ->add(Url::create('/christ/sermons/morning')
+                ->setPriority(0.7)
+                ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
+                ->addImage(asset('/images/headings/large/sermons.webp'), 'Sunday Morning Sermons'))
+            ->add(Url::create('/christ/sermons/evening')
+                ->setPriority(0.7)
+                ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
+                ->addImage(asset('/images/headings/large/sermons.webp'), 'Sunday Evening Sermons'))
+            ->add(Url::create('/christ/sermons/other')
+                ->setPriority(0.7)
+                ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
+                ->addImage(asset('/images/headings/large/sermons.webp'), 'Other Sermons and Talks'));
 
         if ($this->exposurePolicy->childrensTalksArePublic()) {
             $sitemap->add(

--- a/resources/views/components/podcast-discovery.blade.php
+++ b/resources/views/components/podcast-discovery.blade.php
@@ -1,0 +1,16 @@
+@php
+    $currentService = request()->routeIs('sermons.service') ? request()->route('service') : null;
+
+    $morningTitle = 'Sunday Morning Sermons';
+    if ($currentService === 'morning') {
+        $morningTitle .= ' (Current)';
+    }
+
+    $eveningTitle = 'Sunday Evening Sermons';
+    if ($currentService === 'evening') {
+        $eveningTitle .= ' (Current)';
+    }
+@endphp
+
+<link rel="alternate" type="application/rss+xml" title="{{ $morningTitle }}" href="{{ route('podcast.feed', 'morning') }}">
+<link rel="alternate" type="application/rss+xml" title="{{ $eveningTitle }}" href="{{ route('podcast.feed', 'evening') }}">

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -37,6 +37,8 @@
     <link rel="canonical" href="{{ url()->current() }}">
   @endif
 
+  <x-podcast-discovery />
+
   {{-- Preload hints for critical resources --}}
   <link rel="preload" as="image" href="/svg/pattern.svg">
   @yield('preload')

--- a/resources/views/sermons/index.blade.php
+++ b/resources/views/sermons/index.blade.php
@@ -17,8 +17,6 @@
     :description="$description"
     :image="asset('/images/headings/large/sermons.webp')"
 />
-<link rel="alternate" type="application/rss+xml" title="Sunday Morning Sermons" href="{{ route('podcast.feed', 'morning') }}">
-<link rel="alternate" type="application/rss+xml" title="Sunday Evening Sermons" href="{{ route('podcast.feed', 'evening') }}">
 
 {{-- JSON-LD Sermon List --}}
 <script type="application/ld+json">

--- a/resources/views/sermons/service.blade.php
+++ b/resources/views/sermons/service.blade.php
@@ -13,9 +13,6 @@
     :heading="$heading"
     :description="$description"
 />
-@if(in_array($service, ['morning', 'evening']))
-<link rel="alternate" type="application/rss+xml" title="{{ $heading }} Podcast" href="{{ route('podcast.feed', $service) }}">
-@endif
 
 {{-- JSON-LD Sermon List --}}
 <script type="application/ld+json">

--- a/tests/Feature/SitemapTest.php
+++ b/tests/Feature/SitemapTest.php
@@ -388,6 +388,19 @@ class SitemapTest extends TestCase
     }
 
     #[Test]
+    public function sitemap_includes_sermon_service_filter_pages(): void
+    {
+        Cache::forget('sitemap');
+
+        $response = $this->get('/sitemap.xml');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('<loc>http://localhost/christ/sermons/morning</loc>', $content);
+        $this->assertStringContainsString('<loc>http://localhost/christ/sermons/evening</loc>', $content);
+        $this->assertStringContainsString('<loc>http://localhost/christ/sermons/other</loc>', $content);
+    }
+
+    #[Test]
     public function old_sermons_have_yearly_change_frequency(): void
     {
         // Create an old sermon (> 365 days) - use 2 years to be safe


### PR DESCRIPTION
💡 What: Added sermon service filter pages to the sitemap and globalized podcast RSS discovery links.
🎯 Why: Ensures service-specific sermon archives are independently indexed and makes podcast feeds discoverable from every page on the site.
📊 Impact: Homepage, individual sermons, and specific service pages benefit from improved crawlability and social discovery.
🔍 Verification: New test case in SitemapTest, manual HTML inspection of layout output, and PHPStan/Pint confirmed.

---
*PR created automatically by Jules for task [9624215958158695545](https://jules.google.com/task/9624215958158695545) started by @GarethClarridge*