### PR TITLE
fix: add descriptive alt text to homepage hero image

### DIFF
--- a/resources/views/full-width-pages/home.blade.php
+++ b/resources/views/full-width-pages/home.blade.php
@@ -41,7 +41,7 @@
         srcset="{{ asset('/images/homepage/may2024wide.webp') }}">
       <img
         src="{{ asset('/images/homepage/may2024wide.webp') }}"
-        alt=""
+        alt="Crockenhill Baptist Church members outside the church building"
         class="h-full w-full object-cover md:object-right"
         width="1200"
         height="450"


### PR DESCRIPTION
## Summary
- Replaces `alt=""` on the homepage LCP hero `<img>` with a meaningful description
- Improves accessibility score and provides context for screen reader users
- This was the only unique item from the closed PRs #390 and #367

## Test plan
- [ ] Verify the homepage renders with the correct alt text
- [ ] No other changes — single-line edit to `home.blade.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)