### PR TITLE
🛡️ Sentinel: Hardened security headers and added auth audit logging

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -39,7 +39,7 @@ class SecurityHeaders
 
         // Security Header: Permissions Policy
         // Restricts sensitive browser features that this application does not use
-        $response->headers->set('Permissions-Policy', 'camera=(), microphone=(), geolocation=(), payment=()');
+        $response->headers->set('Permissions-Policy', 'accelerometer=(), ambient-light-sensor=(), camera=(), display-capture=(), gamepad=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()');
 
         // Security Header: Content Security Policy (CSP)
         // Provides an additional layer of security by restricting where resources can be loaded from.

--- a/app/Livewire/Auth/Login.php
+++ b/app/Livewire/Auth/Login.php
@@ -62,6 +62,16 @@ class Login extends Component
         $remember = (bool) ($validated['remember'] ?? false);
 
         if (Auth::attempt($credentials, $remember)) {
+            $user = Auth::user();
+
+            if ($user instanceof \App\Models\User && $user->is_admin) {
+                \Illuminate\Support\Facades\Log::warning('Admin logged in', [
+                    'admin_id' => $user->id,
+                    'email' => $user->email,
+                    'ip' => request()->ip(),
+                ]);
+            }
+
             RateLimiter::clear($this->throttleKey($credentials['email']));
             Session::regenerate();
 

--- a/app/Livewire/Auth/Register.php
+++ b/app/Livewire/Auth/Register.php
@@ -78,6 +78,12 @@ class Register extends Component
 
         // "Members only" currently means "has a user account", so registration signs
         // the user in immediately and verification remains a separate concern.
+        \Illuminate\Support\Facades\Log::info('New user registered', [
+            'user_id' => $user->id,
+            'email' => $user->email,
+            'ip' => request()->ip(),
+        ]);
+
         Auth::login($user);
         Session::regenerate();
         $user->sendEmailVerificationNotification();

--- a/app/Livewire/Auth/ResetPassword.php
+++ b/app/Livewire/Auth/ResetPassword.php
@@ -84,6 +84,15 @@ class ResetPassword extends Component
         $status = Password::reset($data, function (User $user, string $password): void {
             $user->password = Hash::make($password);
             $user->save();
+
+            if ($user->is_admin) {
+                \Illuminate\Support\Facades\Log::warning('Admin password reset', [
+                    'admin_id' => $user->id,
+                    'email' => $user->email,
+                    'ip' => request()->ip(),
+                ]);
+            }
+
             Auth::login($user);
             Session::regenerate();
         });

--- a/tests/Feature/Security/SecurityHeadersTest.php
+++ b/tests/Feature/Security/SecurityHeadersTest.php
@@ -18,7 +18,7 @@ class SecurityHeadersTest extends TestCase
         $response->assertHeader('X-Frame-Options', 'SAMEORIGIN');
         $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
         $response->assertHeader('X-XSS-Protection', '0');
-        $response->assertHeader('Permissions-Policy', 'camera=(), microphone=(), geolocation=(), payment=()');
+        $response->assertHeader('Permissions-Policy', 'accelerometer=(), ambient-light-sensor=(), camera=(), display-capture=(), gamepad=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()');
         $response->assertHeader('Content-Security-Policy');
     }
 
@@ -31,7 +31,7 @@ class SecurityHeadersTest extends TestCase
         $response->assertHeader('X-Frame-Options', 'SAMEORIGIN');
         $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
         $response->assertHeader('X-XSS-Protection', '0');
-        $response->assertHeader('Permissions-Policy', 'camera=(), microphone=(), geolocation=(), payment=()');
+        $response->assertHeader('Permissions-Policy', 'accelerometer=(), ambient-light-sensor=(), camera=(), display-capture=(), gamepad=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()');
         $response->assertHeader('Content-Security-Policy');
     }
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unnecessarily broad `Permissions-Policy` header and lack of visibility into administrative authentication events.
🎯 **Impact:**
- A broad `Permissions-Policy` increases the attack surface for side-channel attacks or unauthorized usage of browser APIs by third-party scripts.
- Lack of audit logging for admin logins and password resets makes it harder to detect and investigate potential account compromises.
🔧 **Fix:**
- Hardened the `Permissions-Policy` header in `SecurityHeaders` middleware to explicitly disable unused browser features (`accelerometer`, `gamepad`, `usb`, etc.).
- Added `Log::warning` audit entries for successful Admin logins and password resets.
- Added `Log::info` audit entries for new user registrations.
- Updated `SecurityHeadersTest.php` to ensure the new policy is enforced.
✅ **Verification:**
- Successfully ran `php artisan test tests/Feature/Security/SecurityHeadersTest.php`.
- Successfully ran the full test suite with `php artisan test --parallel --compact`.
- Verified that `phpstan` and `pint` are clean.

Note: I investigated moving `env('TRUSTED_PROXIES')` to `config()` in `bootstrap/app.php` but reverted it as it violates a core safety check (`CheckBootstrapSafetyScriptTest`) which ensures the config repository isn't used before it is fully bound.

---
*PR created automatically by Jules for task [11169207522533882294](https://jules.google.com/task/11169207522533882294) started by @GarethClarridge*