### PR TITLE
🔦 Lighthouse: SEO & Metadata Improvements

### DIFF
--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -78,7 +78,15 @@ class SitemapService
             ->add(Url::create('/christ/sermons/series')
                 ->setPriority(0.7)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
-                ->addImage(asset('/images/headings/large/sermons.webp'), 'Sermon Series'));
+                ->addImage(asset('/images/headings/large/sermons.webp'), 'Sermon Series'))
+            ->add(Url::create('/christ/sermons/morning')
+                ->setPriority(0.7)
+                ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY)
+                ->addImage(asset('/images/headings/large/sermons.webp'), 'Sunday Morning Services'))
+            ->add(Url::create('/christ/sermons/evening')
+                ->setPriority(0.7)
+                ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY)
+                ->addImage(asset('/images/headings/large/sermons.webp'), 'Sunday Evening Services'));
 
         if ($this->exposurePolicy->childrensTalksArePublic()) {
             $sitemap->add(

--- a/resources/views/meetings/show.blade.php
+++ b/resources/views/meetings/show.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.page')
 
 @section('title')
-{{ $heading }} | {{ $meeting->day }}{{ $meeting->start_time ? ' ' . $meeting->start_time->format('g:ia') : '' }} | Crockenhill Baptist Church
+{{ $heading }} | {{ $meeting->day }}{{ $meeting->start_time ? ' ' . $meeting->start_time->format('g:ia') : '' }}
 @stop
 
 @section('meta_description')

--- a/resources/views/sermons/preacher.blade.php
+++ b/resources/views/sermons/preacher.blade.php
@@ -13,6 +13,7 @@
 <x-schema.webpage
     :heading="$heading"
     :description="$description"
+    :image="$preacher->profile_image_url"
 />
 
 <x-schema.person :$preacher />

--- a/resources/views/sermons/series.blade.php
+++ b/resources/views/sermons/series.blade.php
@@ -12,6 +12,7 @@
 <x-schema.webpage
     :heading="$heading"
     :description="$description"
+    :image="asset('/images/headings/large/sermons.webp')"
 />
 
 {{-- JSON-LD Sermon List --}}

--- a/resources/views/sermons/service.blade.php
+++ b/resources/views/sermons/service.blade.php
@@ -12,6 +12,7 @@
 <x-schema.webpage
     :heading="$heading"
     :description="$description"
+    :image="asset('/images/headings/large/sermons.webp')"
 />
 
 {{-- JSON-LD Sermon List --}}

--- a/tests/Feature/SitemapTest.php
+++ b/tests/Feature/SitemapTest.php
@@ -64,6 +64,8 @@ class SitemapTest extends TestCase
         $this->assertStringNotContainsString('<loc>http://localhost/christ/sermons/all</loc>', $content);
         $this->assertStringContainsString('<loc>http://localhost/christ/sermons/preachers</loc>', $content);
         $this->assertStringContainsString('<loc>http://localhost/christ/sermons/series</loc>', $content);
+        $this->assertStringContainsString('<loc>http://localhost/christ/sermons/morning</loc>', $content);
+        $this->assertStringContainsString('<loc>http://localhost/christ/sermons/evening</loc>', $content);
     }
 
     #[Test]


### PR DESCRIPTION
I have implemented several SEO and metadata improvements to make the site more discoverable and shareable:

1.  **Title Optimization**: Removed a redundant site name suffix from the meeting show page. The base layout already appends the site name, so this fix prevents double branding (e.g., "Heading | Day | Church | Church") in browser tabs and search results.
2.  **Sitemap Expansion**: Added the Sunday Morning (`/christ/sermons/morning`) and Sunday Evening (`/christ/sermons/evening`) sermon service index pages to the generated sitemap. These are high-value landing pages that were previously missing from the crawl.
3.  **Enhanced Structured Data**: Added descriptive image metadata to the Schema.org JSON-LD for sermon service, series, and preacher listing pages. This increases the likelihood of rich search results with images.
4.  **Verification**:
    - Updated `tests/Feature/SitemapTest.php` to assert the presence of the new service URLs.
    - Confirmed all relevant tests pass (MeetingSeoTest, SitemapTest, SermonSeoTest, SermonBrowseSeoTest).
    - Verified visual rendering and title consistency via a Playwright script.
    - Maintained 0 errors in PHPStan and followed project formatting with Pint.

---
*PR created automatically by Jules for task [3558253161833445697](https://jules.google.com/task/3558253161833445697) started by @GarethClarridge*