### PR TITLE
⚡ Bolt: Optimize sermon listing performance via memoization

### DIFF
--- a/app/Http/Controllers/Api/SermonApiController.php
+++ b/app/Http/Controllers/Api/SermonApiController.php
@@ -45,7 +45,7 @@ class SermonApiController extends Controller
                 'preacher_source', 'preacher_confidence', 'needs_preacher_review',
                 'series', 'reference', 'scripture_passage_id', 'duration', 'points', 'show_summary', 'show_points', 'audio_file_path', 'video_file_path',
                 'video_quality_status', 'video_visibility_override', 'filetype', 'thumbnail_file_path',
-                'thumbnail_metadata',
+                'thumbnail_metadata', 'updated_at', 'meta_description',
             ])
             ->with([
                 'preacherProfile:id,name,slug,image_path',

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -68,6 +68,11 @@ class SermonViewPresenter
      */
     private array $memoizedSlugs = [];
 
+    /**
+     * @var array<string, string>
+     */
+    private array $memoizedMetaDescriptions = [];
+
     public function __construct(
         private readonly SermonExposurePolicy $exposurePolicy,
         private readonly SermonStorageService $storageService,
@@ -134,6 +139,7 @@ class SermonViewPresenter
         $this->memoizedSermonKeys = [];
         $this->memoizedHumanDates = [];
         $this->memoizedSlugs = [];
+        $this->memoizedMetaDescriptions = [];
     }
 
     public function audioUrl(Sermon $sermon): ?string
@@ -198,21 +204,25 @@ class SermonViewPresenter
 
     public function preacherUrl(Sermon $sermon): ?string
     {
-        $preacherKey = $sermon->preacher_id !== null
-            ? "id_{$sermon->preacher_id}"
-            : (string) $this->displayPreacherName($sermon);
+        $preacherName = null;
+        if ($sermon->preacher_id !== null) {
+            $preacherKey = "id_{$sermon->preacher_id}";
+        } else {
+            $preacherName = $this->displayPreacherName($sermon);
+            $preacherKey = (string) $preacherName;
+        }
 
         if ($preacherKey === '') {
             return null;
         }
 
-        if (! array_key_exists($preacherKey, $this->memoizedPreacherUrls)) {
-            $this->memoizedPreacherUrls[$preacherKey] = (function () use ($sermon) {
+        if (! isset($this->memoizedPreacherUrls[$preacherKey])) {
+            $this->memoizedPreacherUrls[$preacherKey] = (function () use ($sermon, $preacherName) {
                 if ($sermon->relationLoaded('preacherProfile') && $sermon->preacherProfile !== null) {
                     return route('sermons.preacher', ['preacher' => $sermon->preacherProfile->slug]);
                 }
 
-                $preacherName = $this->displayPreacherName($sermon);
+                $preacherName ??= $this->displayPreacherName($sermon);
 
                 return filled($preacherName)
                     ? route('sermons.preacher', ['preacher' => $this->slug($preacherName)])
@@ -411,14 +421,21 @@ class SermonViewPresenter
     /**
      * Generate the SEO meta description for a sermon.
      *
-     * Performance Optimization: Minimizes string operations and avoids redundant
-     * Str::length calls by consolidating the assembly logic.
+     * Performance Optimization: Memoizes generated meta descriptions to avoid
+     * redundant assembly logic for the same sermon within a single request.
+     * Uses getRawOriginal to efficiently check for stored descriptions.
      */
     public function metaDescription(Sermon $sermon): string
     {
+        $key = $this->cacheKey($sermon, 'meta_desc');
+
+        if (isset($this->memoizedMetaDescriptions[$key])) {
+            return $this->memoizedMetaDescriptions[$key];
+        }
+
         $attributes = $sermon->getAttributes();
         if (! empty($attributes['meta_description'])) {
-            return (string) $attributes['meta_description'];
+            return $this->memoizedMetaDescriptions[$key] = (string) $attributes['meta_description'];
         }
 
         $preacherName = $this->displayPreacherName($sermon) ?? 'Unknown preacher';
@@ -449,10 +466,10 @@ class SermonViewPresenter
         $remaining = 155 - Str::length($base) - 2; // 2 for ". "
 
         if ($remaining > 0) {
-            return $base.'. '.Str::limit($summary, $remaining);
+            return $this->memoizedMetaDescriptions[$key] = $base.'. '.Str::limit($summary, $remaining);
         }
 
-        return Str::limit($base, 155);
+        return $this->memoizedMetaDescriptions[$key] = Str::limit($base, 155);
     }
 
     public function videoUrl(Sermon $sermon): ?string
@@ -489,11 +506,12 @@ class SermonViewPresenter
      * Performance Optimization: Memoizes the sermon's combined ID and timestamp
      * within the request to avoid redundant string concatenations and Carbon
      * object method calls when generating keys for multiple sermon attributes.
+     * Uses isset() for faster lookup performance compared to array_key_exists().
      */
     private function cacheKey(Sermon $sermon, string $type): string
     {
-        if (! array_key_exists($sermon->id, $this->memoizedSermonKeys)) {
-            if (! array_key_exists($sermon->id, $this->memoizedTimestamps)) {
+        if (! isset($this->memoizedSermonKeys[$sermon->id])) {
+            if (! isset($this->memoizedTimestamps[$sermon->id])) {
                 $this->memoizedTimestamps[$sermon->id] = $sermon->updated_at?->getTimestamp() ?? 0;
             }
 

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -423,7 +423,8 @@ class SermonViewPresenter
      *
      * Performance Optimization: Memoizes generated meta descriptions to avoid
      * redundant assembly logic for the same sermon within a single request.
-     * Uses getRawOriginal to efficiently check for stored descriptions.
+     * Checks for existing database-stored descriptions before falling back
+     * to dynamic generation.
      */
     public function metaDescription(Sermon $sermon): string
     {
@@ -434,7 +435,7 @@ class SermonViewPresenter
         }
 
         $attributes = $sermon->getAttributes();
-        if (! empty($attributes['meta_description'])) {
+        if (filled($attributes['meta_description'] ?? null)) {
             return $this->memoizedMetaDescriptions[$key] = (string) $attributes['meta_description'];
         }
 
@@ -506,18 +507,21 @@ class SermonViewPresenter
      * Performance Optimization: Memoizes the sermon's combined ID and timestamp
      * within the request to avoid redundant string concatenations and Carbon
      * object method calls when generating keys for multiple sermon attributes.
-     * Uses isset() for faster lookup performance compared to array_key_exists().
+     * Uses isset() for faster lookup performance and handles unpersisted models
+     * by falling back to object hashes.
      */
     private function cacheKey(Sermon $sermon, string $type): string
     {
-        if (! isset($this->memoizedSermonKeys[$sermon->id])) {
-            if (! isset($this->memoizedTimestamps[$sermon->id])) {
-                $this->memoizedTimestamps[$sermon->id] = $sermon->updated_at?->getTimestamp() ?? 0;
+        $id = $sermon->id ?? 'u'.spl_object_id($sermon);
+
+        if (! isset($this->memoizedSermonKeys[$id])) {
+            if (! isset($this->memoizedTimestamps[$id])) {
+                $this->memoizedTimestamps[$id] = $sermon->updated_at?->getTimestamp() ?? 0;
             }
 
-            $this->memoizedSermonKeys[$sermon->id] = "{$sermon->id}_{$this->memoizedTimestamps[$sermon->id]}";
+            $this->memoizedSermonKeys[$id] = "{$id}_{$this->memoizedTimestamps[$id]}";
         }
 
-        return "{$type}_{$this->memoizedSermonKeys[$sermon->id]}";
+        return "{$type}_{$this->memoizedSermonKeys[$id]}";
     }
 }

--- a/app/Services/SermonStorageService.php
+++ b/app/Services/SermonStorageService.php
@@ -83,7 +83,9 @@ class SermonStorageService
     public function getSermonFileInfo(Sermon $sermon): array
     {
         $audioPath = $sermon->audio_file_path ?? '';
-        $cacheKey = "{$sermon->id}_{$audioPath}";
+        // Key by ID (if persisted) or object hash (if unsaved), plus path and filetype
+        // to ensure uniqueness and handle state changes within the request.
+        $cacheKey = ($sermon->id ?? 'u'.spl_object_id($sermon))."_{$audioPath}_{$sermon->filetype}";
 
         if (isset($this->memoizedFileInfo[$cacheKey])) {
             return $this->memoizedFileInfo[$cacheKey];
@@ -389,6 +391,15 @@ class SermonStorageService
     {
         if ($sermon) {
             Cache::forget($this->fileMetadataCacheKey($sermon));
+
+            // Also clear request-level memoization for this sermon
+            $audioPath = $sermon->audio_file_path ?? '';
+            $cacheKey = ($sermon->id ?? 'u'.spl_object_id($sermon))."_{$audioPath}_{$sermon->filetype}";
+            unset($this->memoizedFileInfo[$cacheKey]);
+
+            if ($sermon->thumbnail_file_path) {
+                unset($this->memoizedThumbnailDisks[$sermon->thumbnail_file_path]);
+            }
 
             return;
         }

--- a/app/Services/SermonStorageService.php
+++ b/app/Services/SermonStorageService.php
@@ -31,6 +31,16 @@ class SermonStorageService
      */
     private array $memoizedDiskUrls = [];
 
+    /**
+     * @var array<string, array{type: string, disk: string, path: string, original_path: string}>
+     */
+    private array $memoizedFileInfo = [];
+
+    /**
+     * @var array<string, string>
+     */
+    private array $memoizedThumbnailDisks = [];
+
     public function __construct()
     {
         $this->refreshConfig();
@@ -46,6 +56,8 @@ class SermonStorageService
         $this->clearCachedMetadata();
         $this->memoizedVersions = [];
         $this->memoizedDiskUrls = [];
+        $this->memoizedFileInfo = [];
+        $this->memoizedThumbnailDisks = [];
     }
 
     /**
@@ -62,11 +74,21 @@ class SermonStorageService
     /**
      * Get file information for a sermon based on its storage pattern
      *
+     * Performance Optimization: Memoizes file information lookups within the request
+     * to avoid redundant path validation and storage pattern logic when resolving
+     * multiple URLs (e.g., audio, public, delivery) for the same sermon.
+     *
      * @return array{type: string, disk: string, path: string, original_path: string}
      */
     public function getSermonFileInfo(Sermon $sermon): array
     {
         $audioPath = $sermon->audio_file_path ?? '';
+        $cacheKey = "{$sermon->id}_{$audioPath}";
+
+        if (isset($this->memoizedFileInfo[$cacheKey])) {
+            return $this->memoizedFileInfo[$cacheKey];
+        }
+
         $this->validatePath($audioPath, 'audio file');
 
         // Private files stored on the local disk (unreachable via the public/storage symlink)
@@ -98,7 +120,7 @@ class SermonStorageService
 
         if (str_contains($audioPath, '/')) {
             // Newer Laravel storage pattern
-            return [
+            return $this->memoizedFileInfo[$cacheKey] = [
                 'type' => 'storage',
                 'disk' => $this->sermonDisk,
                 'path' => $audioPath,
@@ -107,7 +129,7 @@ class SermonStorageService
         }
 
         // Current media processing pattern
-        return [
+        return $this->memoizedFileInfo[$cacheKey] = [
             'type' => 'processing',
             'disk' => $this->sermonDisk,
             'path' => $audioPath,
@@ -217,11 +239,22 @@ class SermonStorageService
         ]);
     }
 
+    /**
+     * Resolve the storage disk for a thumbnail path.
+     *
+     * Performance Optimization: Memoizes disk resolution within the request
+     * to avoid redundant path validation and string checks when resolving
+     * multiple thumbnail variants for the same sermon listing.
+     */
     public function resolveThumbnailDisk(string $thumbnailPath): string
     {
+        if (isset($this->memoizedThumbnailDisks[$thumbnailPath])) {
+            return $this->memoizedThumbnailDisks[$thumbnailPath];
+        }
+
         $this->validatePath($thumbnailPath, 'thumbnail');
 
-        return str_starts_with($thumbnailPath, 'private/')
+        return $this->memoizedThumbnailDisks[$thumbnailPath] = str_starts_with($thumbnailPath, 'private/')
             ? 'local'
             : $this->thumbnailDisk;
     }


### PR DESCRIPTION
This PR implements a suite of targeted performance optimizations focused on reducing redundant work during sermon listing rendering and API resource transformation.

### 💡 What:
1.  **SermonViewPresenter**:
    - Implemented request-level memoization for the `metaDescription()` method.
    - Refactored `preacherUrl()` to capture and reuse the preacher name result.
    - Switched internal cache key lookups from `array_key_exists()` to `isset()`.
2.  **SermonStorageService**:
    - Implemented request-level memoization for `getSermonFileInfo()` and `resolveThumbnailDisk()`.
    - This avoids repeating storage pattern logic and path validations when resolving multiple assets (audio, video, card/plain thumbnails) for the same sermon.
3.  **SermonApiController**:
    - Updated the `index` query `select()` list to include `updated_at` (for presenter cache keys) and `meta_description` (to skip PHP-side re-computation).

### 🎯 Why:
In a TALL stack application, sermon listings often iterate over dozens of models, calling various presenter methods multiple times per model (e.g., for standard links, social sharing links, and schema metadata). These changes ensure that expensive logic—like assembling SEO descriptions or determining storage disks—is only executed once per sermon per request.

### 📊 Impact:
- **Reduced Redundancy**: Avoids dozens of redundant string and path operations per sermon listing.
- **Improved Resource Transformation**: API responses for sermon lists are faster as they leverage database-stored descriptions and efficient cache keys.
- **Zero Regression**: All existing logic remains intact, verified by the full test suite.

### 🔬 Measurement:
Verified with:
- `php artisan test --compact tests/Unit/Presenters/SermonViewPresenterTest.php`
- `php artisan test --compact tests/Unit/Services/SermonStorageServiceTest.php`
- `php artisan test --compact tests/Feature/Api/SermonApiTest.php`
- Full parallel test suite (4610 tests).

---
*PR created automatically by Jules for task [10715667202095095009](https://jules.google.com/task/10715667202095095009) started by @GarethClarridge*