### PR TITLE
🎨 Palette: Granular filter removal for sermon browsing

### DIFF
--- a/app/Livewire/Sermons/BrowseSermons.php
+++ b/app/Livewire/Sermons/BrowseSermons.php
@@ -92,6 +92,20 @@ class BrowseSermons extends Component
         $this->resetPage();
     }
 
+    public function removeFilter(string $filter): void
+    {
+        if ($filter === 'book') {
+            $this->bookFilter = null;
+            $this->chapterFilter = null;
+        } elseif ($filter === 'preacher') {
+            $this->preacherFilter = null;
+        } elseif ($filter === 'series') {
+            $this->seriesFilter = null;
+        }
+
+        $this->resetPage();
+    }
+
     public function render(SermonRepository $sermonRepository, BibleCanon $bibleCanon): View
     {
         $hasActiveFilters = $this->hasActiveFilters();
@@ -194,24 +208,24 @@ class BrowseSermons extends Component
     /**
      * @param  array<int, array{id:int, name:string}>  $preacherOptions
      * @param  array<int, array{id:string, name:string}>  $seriesOptions
-     * @return array<int, string>
+     * @return array<string, string>
      */
     private function activeFilterLabels(array $preacherOptions, array $seriesOptions): array
     {
         $labels = [];
 
         if ($this->bookFilter !== null) {
-            $labels[] = $this->chapterFilter !== null
+            $labels['book'] = $this->chapterFilter !== null
                 ? $this->bookFilter.' '.$this->chapterFilter
                 : $this->bookFilter;
         }
 
         if ($this->preacherFilter !== null) {
-            $labels[] = $this->findOptionName($preacherOptions, $this->preacherFilter) ?? 'Selected preacher';
+            $labels['preacher'] = $this->findOptionName($preacherOptions, $this->preacherFilter) ?? 'Selected preacher';
         }
 
         if ($this->seriesFilter !== null) {
-            $labels[] = $this->findOptionName($seriesOptions, $this->seriesFilter) ?? $this->seriesFilter;
+            $labels['series'] = $this->findOptionName($seriesOptions, $this->seriesFilter) ?? $this->seriesFilter;
         }
 
         return $labels;

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -22,8 +22,19 @@
                     <div class="flex flex-wrap items-center justify-center gap-2">
                         <span class="text-sm text-gray-500">Filtered by</span>
 
-                        @foreach ($activeFilterLabels as $activeFilterLabel)
-                            <x-badge variant="teal">{{ $activeFilterLabel }}</x-badge>
+                        @foreach ($activeFilterLabels as $key => $label)
+                            <x-badge variant="teal">
+                                {{ $label }}
+                                <button
+                                    type="button"
+                                    wire:click="removeFilter('{{ $key }}')"
+                                    class="ml-1 -mr-1 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-cbc-teal hover:bg-cbc-teal/20 hover:text-cbc-teal-dark focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal"
+                                    aria-label="Remove filter: {{ $label }}"
+                                    title="Remove filter: {{ $label }}"
+                                >
+                                    <x-heroicon-o-x-mark class="h-3 w-3" />
+                                </button>
+                            </x-badge>
                         @endforeach
                     </div>
 
@@ -78,7 +89,7 @@
         </div>
     </section>
 
-    <div wire:loading.flex wire:target="bookFilter, chapterFilter, preacherFilter, seriesFilter" class="mx-auto mt-4 max-w-7xl items-center gap-2 px-6 text-sm text-gray-500" role="status">
+    <div wire:loading.flex wire:target="bookFilter, chapterFilter, preacherFilter, seriesFilter, removeFilter, clearFilters" class="mx-auto mt-4 max-w-7xl items-center gap-2 px-6 text-sm text-gray-500" role="status">
         <svg class="h-4 w-4 animate-spin text-cbc-teal" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
@@ -86,7 +97,7 @@
         Updating sermon results…
     </div>
 
-    <div id="sermon-results" wire:loading.class="pointer-events-none opacity-60" wire:target="bookFilter, chapterFilter, preacherFilter, seriesFilter">
+    <div id="sermon-results" wire:loading.class="pointer-events-none opacity-60" wire:target="bookFilter, chapterFilter, preacherFilter, seriesFilter, removeFilter, clearFilters">
         @php
             /** @var \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, \App\Models\Sermon> $sermons */
         @endphp

--- a/tests/Feature/Livewire/Sermons/BrowseSermonsTest.php
+++ b/tests/Feature/Livewire/Sermons/BrowseSermonsTest.php
@@ -227,6 +227,28 @@ class BrowseSermonsTest extends TestCase
     }
 
     #[Test]
+    public function individual_filters_can_be_removed(): void
+    {
+        $preacher = Preacher::factory()->create(['name' => 'Remove Test', 'slug' => 'remove-test']);
+
+        Livewire::test(BrowseSermons::class)
+            ->set('bookFilter', 'John')
+            ->set('chapterFilter', 3)
+            ->set('preacherFilter', $preacher->id)
+            ->set('seriesFilter', 'Remove Series')
+            ->call('removeFilter', 'book')
+            ->assertSet('bookFilter', null)
+            ->assertSet('chapterFilter', null)
+            ->assertSet('preacherFilter', $preacher->id)
+            ->assertSet('seriesFilter', 'Remove Series')
+            ->call('removeFilter', 'preacher')
+            ->assertSet('preacherFilter', null)
+            ->assertSet('seriesFilter', 'Remove Series')
+            ->call('removeFilter', 'series')
+            ->assertSet('seriesFilter', null);
+    }
+
+    #[Test]
     public function url_state_round_trips_correctly(): void
     {
         $preacher = Preacher::factory()->create(['name' => 'Url Test', 'slug' => 'url-test']);


### PR DESCRIPTION
This PR implements a micro-UX improvement for the sermon browsing interface by introducing granular filter removal. Users can now remove individual filters (book, preacher, series) directly from the filter badges, providing a more intuitive and efficient way to refine their search.

Key changes:
- **Livewire Component**: Added a `removeFilter` method to `App\Livewire\Sermons\BrowseSermons` and refactored `activeFilterLabels` to return an associative array.
- **Blade Template**: Enhanced the filter badges with a removable 'X' button, styled according to the project's design system using `cbc-teal`.
- **Accessibility**: Ensured the removal buttons have appropriate `aria-label` and `title` attributes, and use `focus-visible` for keyboard navigation.
- **Testing**: Added a new test case `individual_filters_can_be_removed` to `tests/Feature/Livewire/Sermons/BrowseSermonsTest.php` to verify the functionality.
- **Frontend**: Rebuilt assets with `npm run build`.

---
*PR created automatically by Jules for task [3088118945832836816](https://jules.google.com/task/3088118945832836816) started by @GarethClarridge*