### PR TITLE
📝 Scribe: Add tests for Sermon processing scopes

### DIFF
--- a/tests/Feature/Models/SermonProcessingScopesTest.php
+++ b/tests/Feature/Models/SermonProcessingScopesTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Enums\ProcessingStatus;
+use App\Models\MediaProcessingLog;
+use App\Models\Sermon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonProcessingScopesTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function scope_automated_finds_sermons_with_transcript_or_processing_logs(): void
+    {
+        /** @var Sermon $automatedByTranscript */
+        $automatedByTranscript = Sermon::factory()->create([
+            'transcript_file_path' => 'transcripts/sermon.txt',
+        ]);
+
+        /** @var Sermon $automatedByLog */
+        $automatedByLog = Sermon::factory()->create([
+            'transcript_file_path' => null,
+        ]);
+        MediaProcessingLog::factory()->create([
+            'sermon_id' => $automatedByLog->id,
+        ]);
+
+        /** @var Sermon $manual */
+        $manual = Sermon::factory()->create([
+            'transcript_file_path' => null,
+        ]);
+
+        $results = Sermon::automated()->get();
+
+        $this->assertTrue($results->contains($automatedByTranscript));
+        $this->assertTrue($results->contains($automatedByLog));
+        $this->assertFalse($results->contains($manual));
+    }
+
+    #[Test]
+    public function scope_manual_finds_sermons_without_transcript_and_without_processing_logs(): void
+    {
+        /** @var Sermon $automatedByTranscript */
+        $automatedByTranscript = Sermon::factory()->create([
+            'transcript_file_path' => 'transcripts/sermon.txt',
+        ]);
+
+        /** @var Sermon $automatedByLog */
+        $automatedByLog = Sermon::factory()->create([
+            'transcript_file_path' => null,
+        ]);
+        MediaProcessingLog::factory()->create([
+            'sermon_id' => $automatedByLog->id,
+        ]);
+
+        /** @var Sermon $manual */
+        $manual = Sermon::factory()->create([
+            'transcript_file_path' => null,
+        ]);
+
+        $results = Sermon::manual()->get();
+
+        $this->assertFalse($results->contains($automatedByTranscript));
+        $this->assertFalse($results->contains($automatedByLog));
+        $this->assertTrue($results->contains($manual));
+    }
+
+    #[Test]
+    public function scope_processing_completed_filters_correctly(): void
+    {
+        /** @var Sermon $completed */
+        $completed = Sermon::factory()->create();
+        MediaProcessingLog::factory()->create([
+            'sermon_id' => $completed->id,
+            'status' => ProcessingStatus::Completed,
+        ]);
+
+        /** @var Sermon $processing */
+        $processing = Sermon::factory()->create();
+        MediaProcessingLog::factory()->create([
+            'sermon_id' => $processing->id,
+            'status' => ProcessingStatus::Processing,
+        ]);
+
+        /** @var Sermon $failed */
+        $failed = Sermon::factory()->create();
+        MediaProcessingLog::factory()->create([
+            'sermon_id' => $failed->id,
+            'status' => ProcessingStatus::Failed,
+        ]);
+
+        $results = Sermon::processingCompleted()->get();
+
+        $this->assertTrue($results->contains($completed));
+        $this->assertFalse($results->contains($processing));
+        $this->assertFalse($results->contains($failed));
+    }
+
+    #[Test]
+    public function scope_processing_failed_filters_correctly(): void
+    {
+        /** @var Sermon $completed */
+        $completed = Sermon::factory()->create();
+        MediaProcessingLog::factory()->create([
+            'sermon_id' => $completed->id,
+            'status' => ProcessingStatus::Completed,
+        ]);
+
+        /** @var Sermon $processing */
+        $processing = Sermon::factory()->create();
+        MediaProcessingLog::factory()->create([
+            'sermon_id' => $processing->id,
+            'status' => ProcessingStatus::Processing,
+        ]);
+
+        /** @var Sermon $failed */
+        $failed = Sermon::factory()->create();
+        MediaProcessingLog::factory()->create([
+            'sermon_id' => $failed->id,
+            'status' => ProcessingStatus::Failed,
+        ]);
+
+        $results = Sermon::processingFailed()->get();
+
+        $this->assertFalse($results->contains($completed));
+        $this->assertFalse($results->contains($processing));
+        $this->assertTrue($results->contains($failed));
+    }
+
+    #[Test]
+    public function scope_processing_in_progress_filters_correctly(): void
+    {
+        /** @var Sermon $completed */
+        $completed = Sermon::factory()->create();
+        MediaProcessingLog::factory()->create([
+            'sermon_id' => $completed->id,
+            'status' => ProcessingStatus::Completed,
+        ]);
+
+        /** @var Sermon $processing */
+        $processing = Sermon::factory()->create();
+        MediaProcessingLog::factory()->create([
+            'sermon_id' => $processing->id,
+            'status' => ProcessingStatus::Processing,
+        ]);
+
+        /** @var Sermon $failed */
+        $failed = Sermon::factory()->create();
+        MediaProcessingLog::factory()->create([
+            'sermon_id' => $failed->id,
+            'status' => ProcessingStatus::Failed,
+        ]);
+
+        $results = Sermon::processingInProgress()->get();
+
+        $this->assertFalse($results->contains($completed));
+        $this->assertTrue($results->contains($processing));
+        $this->assertFalse($results->contains($failed));
+    }
+}


### PR DESCRIPTION
Added comprehensive testing for Sermon model processing scopes (`automated`, `manual`, `processingCompleted`, `processingFailed`, `processingInProgress`). These scopes are critical for filtering sermons in administrative and public views but previously lacked explicit coverage.

Key changes:
- Created `tests/Feature/Models/SermonProcessingScopesTest.php`.
- Verified all 5 new tests pass with 15 assertions.
- Ensured PHPStan passes with 0 errors.
- Formatted code using Pint.
- Cleaned up environment artifacts in the Jules VM.

---
*PR created automatically by Jules for task [11645013517195573268](https://jules.google.com/task/11645013517195573268) started by @GarethClarridge*