### PR TITLE
🧹 Tidy: centralize CalendarEvent card column selection

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -16,12 +16,8 @@ class CalendarController extends Controller
 
     public function index(): View
     {
-        /**
-         * Performance Optimization: Limits retrieved columns for calendar events and eager-loaded
-         * meetings to required fields to reduce memory usage and DB I/O.
-         */
         $allEvents = CalendarEvent::query()
-            ->select(['id', 'meeting_slug', 'title', 'description', 'speaker', 'location', 'start_datetime', 'end_datetime'])
+            ->forCard()
             ->with('meeting:id,slug,location')
             ->upcoming()
             ->confirmed()

--- a/app/Models/CalendarEvent.php
+++ b/app/Models/CalendarEvent.php
@@ -83,6 +83,15 @@ class CalendarEvent extends Model
      * @param  Builder<CalendarEvent>  $query
      * @return Builder<CalendarEvent>
      */
+    public function scopeForCard(Builder $query): Builder
+    {
+        return $query->select(['id', 'meeting_slug', 'title', 'description', 'speaker', 'location', 'start_datetime', 'end_datetime']);
+    }
+
+    /**
+     * @param  Builder<CalendarEvent>  $query
+     * @return Builder<CalendarEvent>
+     */
     public function scopeUpcoming(Builder $query): Builder
     {
         return $query->where('start_datetime', '>=', now());

--- a/app/Services/CalendarService.php
+++ b/app/Services/CalendarService.php
@@ -20,12 +20,8 @@ class CalendarService
      */
     public function getEventsForMeeting(string $meetingSlug, ?Carbon $startDate = null, ?Carbon $endDate = null): Collection
     {
-        /**
-         * Performance Optimization: Limits retrieved columns to required fields for cards
-         * to reduce memory usage and DB I/O.
-         */
         $query = CalendarEvent::query()
-            ->select(['id', 'meeting_slug', 'title', 'description', 'speaker', 'location', 'start_datetime', 'end_datetime'])
+            ->forCard()
             ->where('meeting_slug', $meetingSlug)
             ->confirmed()
             ->orderBy('start_datetime');
@@ -46,12 +42,8 @@ class CalendarService
      */
     public function getAllUpcomingEvents(?Carbon $startDate = null, ?Carbon $endDate = null): Collection
     {
-        /**
-         * Performance Optimization: Limits retrieved columns to required fields for cards
-         * to reduce memory usage and DB I/O.
-         */
         $query = CalendarEvent::query()
-            ->select(['id', 'meeting_slug', 'title', 'description', 'speaker', 'location', 'start_datetime', 'end_datetime'])
+            ->forCard()
             ->confirmed()
             ->where('start_datetime', '>=', $startDate ?? now())
             ->orderBy('start_datetime');
@@ -68,12 +60,8 @@ class CalendarService
      */
     public function getUncategorizedEvents(): Collection
     {
-        /**
-         * Performance Optimization: Limits retrieved columns to required fields for cards
-         * to reduce memory usage and DB I/O.
-         */
         return CalendarEvent::query()
-            ->select(['id', 'meeting_slug', 'title', 'description', 'speaker', 'location', 'start_datetime', 'end_datetime'])
+            ->forCard()
             ->whereNull('meeting_slug')
             ->confirmed()
             ->orderBy('start_datetime')

--- a/app/Services/PublicMeetingReadModelCache.php
+++ b/app/Services/PublicMeetingReadModelCache.php
@@ -98,7 +98,7 @@ class PublicMeetingReadModelCache
     private function upcomingEvents(Meeting $meeting): \Illuminate\Database\Eloquent\Collection
     {
         return CalendarEvent::query()
-            ->select(['id', 'meeting_slug', 'title', 'description', 'speaker', 'location', 'start_datetime', 'end_datetime'])
+            ->forCard()
             ->where('meeting_slug', $meeting->slug)
             ->upcoming()
             ->confirmed()


### PR DESCRIPTION
💡 **What:** Extracted duplicated `select()` column arrays for `CalendarEvent` listings into a centralized `scopeForCard()` Eloquent scope.

🎯 **Why:** Multiple locations (Service, Controller, Read Model Cache) were manually defining the same subset of columns for displaying event cards. Centralizing this logic into a scope improves maintainability and ensures consistency.

🔄 **Behavior:** No functional changes. The same columns are selected and passed to the same views.

✅ **Tests:** Ran full suite (`php artisan test --parallel --compact`). All 4627 tests passed. Verified static analysis with `composer phpstan` (0 errors).

---
*PR created automatically by Jules for task [3350175563820096267](https://jules.google.com/task/3350175563820096267) started by @GarethClarridge*