### PR TITLE
🏛️ Warden: fortify PreacherAlias integrity

### DIFF
--- a/app/Models/PreacherAlias.php
+++ b/app/Models/PreacherAlias.php
@@ -63,7 +63,7 @@ class PreacherAlias extends Model
     protected function alias(): Attribute
     {
         return Attribute::make(
-            set: fn (string $value): string => strtolower(trim($value)),
+            set: fn (string $value): string => mb_strtolower(trim($value)),
         );
     }
 

--- a/app/Models/PreacherAlias.php
+++ b/app/Models/PreacherAlias.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -54,6 +55,16 @@ class PreacherAlias extends Model
             'preacher_id' => ['required', 'integer', 'exists:preachers,id'],
             'alias' => ['required', 'string', 'max:255', $uniqueAlias],
         ];
+    }
+
+    /**
+     * @return Attribute<string, string>
+     */
+    protected function alias(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value): string => strtolower(trim($value)),
+        );
     }
 
     /**

--- a/database/migrations/2026_04_23_151722_add_integrity_check_to_preacher_aliases_table_v2.php
+++ b/database/migrations/2026_04_23_151722_add_integrity_check_to_preacher_aliases_table_v2.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        // 1. Ensure existing data is normalized
+        DB::table('preacher_aliases')->update([
+            'alias' => DB::raw('LOWER(TRIM(alias))'),
+        ]);
+
+        // 2. Add the CHECK constraint if it doesn't already exist
+        // We use a raw statement because Laravel's Blueprint doesn't natively support CHECK constraints across all versions/drivers.
+        // The constraint ensures the alias is lowercase, trimmed, and not empty.
+        $constraintExists = DB::select("
+            SELECT CONSTRAINT_NAME
+            FROM information_schema.TABLE_CONSTRAINTS
+            WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME = 'preacher_aliases'
+            AND CONSTRAINT_NAME = 'preacher_aliases_alias_format_check'
+        ");
+
+        if (empty($constraintExists)) {
+            DB::statement("ALTER TABLE preacher_aliases ADD CONSTRAINT preacher_aliases_alias_format_check CHECK (BINARY alias = LOWER(TRIM(alias)) AND alias != '')");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        DB::statement('ALTER TABLE preacher_aliases DROP CHECK IF EXISTS preacher_aliases_alias_format_check');
+    }
+};

--- a/database/migrations/2026_04_23_192858_add_integrity_check_to_preacher_aliases_table.php
+++ b/database/migrations/2026_04_23_192858_add_integrity_check_to_preacher_aliases_table.php
@@ -22,8 +22,6 @@ return new class extends Migration
         ]);
 
         // 2. Add the CHECK constraint if it doesn't already exist
-        // We use a raw statement because Laravel's Blueprint doesn't natively support CHECK constraints across all versions/drivers.
-        // The constraint ensures the alias is lowercase, trimmed, and not empty.
         $constraintExists = DB::select("
             SELECT CONSTRAINT_NAME
             FROM information_schema.TABLE_CONSTRAINTS
@@ -46,6 +44,18 @@ return new class extends Migration
             return;
         }
 
-        DB::statement('ALTER TABLE preacher_aliases DROP CHECK IF EXISTS preacher_aliases_alias_format_check');
+        // MySQL 8.0.x does not support DROP CHECK IF EXISTS
+        // We check manually to ensure rollback safety
+        $constraintExists = DB::select("
+            SELECT CONSTRAINT_NAME
+            FROM information_schema.TABLE_CONSTRAINTS
+            WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME = 'preacher_aliases'
+            AND CONSTRAINT_NAME = 'preacher_aliases_alias_format_check'
+        ");
+
+        if (! empty($constraintExists)) {
+            DB::statement('ALTER TABLE preacher_aliases DROP CHECK preacher_aliases_alias_format_check');
+        }
     }
 };

--- a/tests/Feature/Warden/PreacherAliasIntegrityTest.php
+++ b/tests/Feature/Warden/PreacherAliasIntegrityTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Warden;
+
+use App\Models\Preacher;
+use App\Models\PreacherAlias;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PreacherAliasIntegrityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_normalizes_alias_on_save(): void
+    {
+        $preacher = Preacher::factory()->create();
+
+        $alias = PreacherAlias::create([
+            'preacher_id' => $preacher->id,
+            'alias' => '  Mark Drury  ',
+        ]);
+
+        $this->assertEquals('mark drury', $alias->alias);
+        $this->assertDatabaseHas('preacher_aliases', [
+            'id' => $alias->id,
+            'alias' => 'mark drury',
+        ]);
+
+        $alias2 = PreacherAlias::create([
+            'preacher_id' => $preacher->id,
+            'alias' => 'SPURGEON',
+        ]);
+
+        $this->assertEquals('spurgeon', $alias2->alias);
+        $this->assertDatabaseHas('preacher_aliases', [
+            'id' => $alias2->id,
+            'alias' => 'spurgeon',
+        ]);
+    }
+
+    #[Test]
+    public function it_enforces_database_check_constraint_for_empty_alias(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            $this->markTestSkipped('Database CHECK constraints are only verified for MySQL.');
+        }
+
+        $preacher = Preacher::factory()->create();
+
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('preacher_aliases_alias_format_check');
+
+        // We use raw DB insert to bypass model mutators if we want to test the constraint directly
+        // But here we test that even if the model tries to save an empty string, the DB rejects it.
+        DB::table('preacher_aliases')->insert([
+            'preacher_id' => $preacher->id,
+            'alias' => '',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_enforces_database_check_constraint_for_untrimmed_alias(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            $this->markTestSkipped('Database CHECK constraints are only verified for MySQL.');
+        }
+
+        $preacher = Preacher::factory()->create();
+
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('preacher_aliases_alias_format_check');
+
+        // Using raw DB to bypass mutator
+        DB::table('preacher_aliases')->insert([
+            'preacher_id' => $preacher->id,
+            'alias' => ' untrimmed ',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
🏛️ **Warden: Fortify PreacherAlias Integrity**

This PR strengthens the data integrity of preacher aliases by synchronizing application-level behavior with database-level constraints.

💡 **What:**
- Added an Eloquent Attribute mutator to `App\Models\PreacherAlias` that automatically trims and lowercases (multibyte-safe) aliases before they are persisted.
- Introduced a new migration to ensure the `preacher_aliases_alias_format_check` MySQL `CHECK` constraint is active, providing a final line of defense against malformed data.
- Added `Tests\Feature\Warden\PreacherAliasIntegrityTest` to verify both the model's normalization logic and the database's rejection of invalid data.

🎯 **Why:**
Prevents data fragmentation where the same preacher might be associated with multiple variants of an alias (e.g., " Mark Drury", "mark drury", "MARK DRURY"). This ensures reliable preacher resolution and cleaner search indices.

🗄️ **Migration:**
Adds `preacher_aliases_alias_format_check` to the `preacher_aliases` table.

✅ **Verification:**
- `php8.4 artisan test tests/Feature/Warden/PreacherAliasIntegrityTest.php` (All 3 passed)
- `composer phpstan` (0 errors)
- `bin/pint --dirty` (Formatting synchronized)

⚠️ **Rollback:**
`php8.4 artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [5758635632849286885](https://jules.google.com/task/5758635632849286885) started by @GarethClarridge*