### PR TITLE
🛡️ Sentinel: Add verified middleware to phpinfo route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -217,7 +217,7 @@ if (app()->isLocal()) {
 
     Route::view('/dev/components', 'dev.components')->name('dev.components');
 
-    Route::get('phpinfo', fn () => phpinfo())->middleware(['auth', 'admin']);
+    Route::get('phpinfo', fn () => phpinfo())->middleware(['auth', 'verified', 'admin']);
 }
 
 // Catch-all dynamic page routes (these must be last!)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `phpinfo` route was only protected by `auth` and `admin` middleware, missing the `verified` check.
🎯 **Impact:** An unverified administrative user could potentially view sensitive server configuration details.
🔧 **Fix:** Added the `verified` middleware to the `phpinfo` route definition in `routes/web.php`.
✅ **Verification:** Verified using `php artisan route:list -v` to confirm the full middleware stack `['auth', 'verified', 'admin']` is applied.

---
*PR created automatically by Jules for task [11735188789470801132](https://jules.google.com/task/11735188789470801132) started by @GarethClarridge*