### PR TITLE
🔦 Lighthouse: Sermon Social Metadata Enhancement

### DIFF
--- a/resources/views/components/meta-tags.blade.php
+++ b/resources/views/components/meta-tags.blade.php
@@ -13,6 +13,10 @@
     'publishedTime' => null,
     'section' => null,
     'tags' => null,
+    'label1' => null,
+    'data1' => null,
+    'label2' => null,
+    'data2' => null,
 ])
 
 @php
@@ -69,6 +73,14 @@
 <meta name="twitter:title" content="{{ $fullTitle }}">
 <meta name="twitter:description" content="{{ $metaDescription }}">
 <meta name="twitter:image" content="{{ $metaImage }}">
+@if($label1 && $data1)
+<meta name="twitter:label1" content="{{ $label1 }}">
+<meta name="twitter:data1" content="{{ $data1 }}">
+@endif
+@if($label2 && $data2)
+<meta name="twitter:label2" content="{{ $label2 }}">
+<meta name="twitter:data2" content="{{ $data2 }}">
+@endif
 
 @if($canonical)
 @section('canonical')

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -26,7 +26,11 @@ $hasPublicVideo = filled($sermonView['video_url']);
   :author="$sermonView['preacher_url']"
   :published-time="$sermon->date->toIso8601String()"
   section="Sermons"
-  :tags="$sermon->series" />
+  :tags="$sermon->series"
+  label1="Preacher"
+  :data1="$sermonViewPresenter->displayPreacherName($sermon)"
+  :label2="$sermon->series ? 'Series' : null"
+  :data2="$sermon->series" />
 
 <x-schema.sermon :$sermon :$sermonView />
 <x-schema.webpage

--- a/tests/Feature/SermonSocialMetadataTest.php
+++ b/tests/Feature/SermonSocialMetadataTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Preacher;
+use App\Models\Sermon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonSocialMetadataTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function sermon_page_renders_twitter_labels_for_preacher_and_series(): void
+    {
+        $preacher = Preacher::factory()->create(['name' => 'John Owen']);
+        $sermon = Sermon::factory()->create([
+            'title' => 'Social Metadata Sermon',
+            'slug' => 'social-metadata-sermon',
+            'preacher_id' => $preacher->id,
+            'preacher' => $preacher->name,
+            'series' => 'Great Doctrines',
+            'date' => '2024-03-15',
+        ]);
+
+        $response = $this->followingRedirects()->get("/christ/sermons/2024/03/{$sermon->slug}");
+
+        $response->assertStatus(200);
+        $response->assertSee('<meta name="twitter:label1" content="Preacher">', false);
+        $response->assertSee('<meta name="twitter:data1" content="John Owen">', false);
+        $response->assertSee('<meta name="twitter:label2" content="Series">', false);
+        $response->assertSee('<meta name="twitter:data2" content="Great Doctrines">', false);
+    }
+
+    #[Test]
+    public function sermon_page_omits_series_label_when_no_series_is_present(): void
+    {
+        $preacher = Preacher::factory()->create(['name' => 'Charles Spurgeon']);
+        $sermon = Sermon::factory()->create([
+            'title' => 'No Series Sermon',
+            'slug' => 'no-series-sermon',
+            'preacher_id' => $preacher->id,
+            'preacher' => $preacher->name,
+            'series' => null,
+            'date' => '2024-03-15',
+        ]);
+
+        $response = $this->followingRedirects()->get("/christ/sermons/2024/03/{$sermon->slug}");
+
+        $response->assertStatus(200);
+        $response->assertSee('<meta name="twitter:label1" content="Preacher">', false);
+        $response->assertSee('<meta name="twitter:data1" content="Charles Spurgeon">', false);
+        $response->assertDontSee('twitter:label2');
+        $response->assertDontSee('twitter:data2');
+    }
+}


### PR DESCRIPTION
This change adds structured labels and data (Preacher and Series) to individual sermon pages. This ensures that when sermons are shared on platforms like X (Twitter) or Slack, the link preview includes these key details, making the content more discoverable and shareable.

- Updated `x-meta-tags` component to support `twitter:label1`, `twitter:data1`, `twitter:label2`, and `twitter:data2`.
- Updated `sermon.blade.php` to pass Preacher and Series information.
- Added `tests/Feature/SermonSocialMetadataTest.php` to verify the improvement.

---
*PR created automatically by Jules for task [8819745683775478604](https://jules.google.com/task/8819745683775478604) started by @GarethClarridge*