### PR TITLE
🛡️ Sentinel: Add audit logging for failed admin login attempts

### DIFF
--- a/app/Livewire/Auth/Login.php
+++ b/app/Livewire/Auth/Login.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Livewire\Auth;
 
+use App\Models\User;
+use App\Traits\SanitizesLogData;
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
@@ -17,6 +19,8 @@ use Livewire\Features\SupportRedirects\Redirector;
 
 class Login extends Component
 {
+    use SanitizesLogData;
+
     /**
      * Security: Explicit length constraints are enforced on input fields to provide
      * Defense in Depth against Denial of Service (DoS) attempts with oversized payloads.
@@ -79,6 +83,17 @@ class Login extends Component
         }
 
         RateLimiter::hit($this->throttleKey($credentials['email']));
+
+        $user = User::where('email', (string) $credentials['email'])->first();
+
+        if ($user instanceof User && $user->is_admin) {
+            \Illuminate\Support\Facades\Log::warning('Admin login attempt failed', [
+                'admin_id' => $user->id,
+                'email' => $this->sanitizeForLog($user->email),
+                'ip' => request()->ip(),
+            ]);
+        }
+
         $this->error = trans('auth.failed');
 
         return null;

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -10,6 +10,7 @@ use Illuminate\Auth\Events\Lockout;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
@@ -186,6 +187,47 @@ class LoginTest extends TestCase
             ->assertSet('error', trans('auth.failed'));
 
         $component
+            ->call('login')
+            ->assertSet('error', trans('auth.failed'));
+    }
+
+    #[Test]
+    public function failed_admin_login_is_logged_as_warning(): void
+    {
+        Log::shouldReceive('warning')
+            ->once()
+            ->with('Admin login attempt failed', \Mockery::on(function ($context) {
+                return isset($context['admin_id'])
+                    && isset($context['email'])
+                    && isset($context['ip']);
+            }));
+
+        $admin = User::factory()->create([
+            'is_admin' => true,
+            'password' => bcrypt('correct-password'),
+        ]);
+
+        Livewire::test(LoginComponent::class)
+            ->set('email', $admin->email)
+            ->set('password', 'wrong-password')
+            ->call('login')
+            ->assertSet('error', trans('auth.failed'));
+    }
+
+    #[Test]
+    public function failed_regular_user_login_is_not_logged_as_warning(): void
+    {
+        Log::shouldReceive('warning')
+            ->never();
+
+        $user = User::factory()->create([
+            'is_admin' => false,
+            'password' => bcrypt('correct-password'),
+        ]);
+
+        Livewire::test(LoginComponent::class)
+            ->set('email', $user->email)
+            ->set('password', 'wrong-password')
             ->call('login')
             ->assertSet('error', trans('auth.failed'));
     }


### PR DESCRIPTION
### 🛡️ Sentinel: Security Enhancement

🚨 **Severity:** MEDIUM (Security Enhancement)

💡 **Vulnerability:** Lack of visibility into failed administrative login attempts.

🎯 **Impact:** Without logging failed admin logins, targeted brute-force attacks against privileged accounts might go unnoticed, delaying detection and response to potential compromises.

🔧 **Fix:** 
- Modified `App\Livewire\Auth\Login` to perform a user lookup after a failed `Auth::attempt`.
- If the user exists and has the `is_admin` flag, a `Log::warning` is triggered containing the user ID, email, and requester's IP address.
- Used the existing `SanitizesLogData` trait to ensure the email is safely logged without risk of log injection.

✅ **Verification:**
- Added `failed_admin_login_is_logged_as_warning` test to `tests/Feature/Auth/LoginTest.php`.
- Added `failed_regular_user_login_is_not_logged_as_warning` test to ensure no regression in log noise for standard users.
- All 16 tests in `tests/Feature/Auth/LoginTest.php` pass.
- Verified with `phpstan` and `pint`.

---
*PR created automatically by Jules for task [6295755673564569702](https://jules.google.com/task/6295755673564569702) started by @GarethClarridge*