### PR TITLE
🔦 Lighthouse: SEO and metadata improvements

### DIFF
--- a/app/Presenters/PreacherItemListPresenter.php
+++ b/app/Presenters/PreacherItemListPresenter.php
@@ -24,19 +24,25 @@ class PreacherItemListPresenter
             '@type' => 'ItemList',
             'numberOfItems' => $preachers->count(),
             'itemListElement' => $preachers->map(function ($preacher, $index) use ($orgName) {
+                $item = [
+                    '@type' => 'Person',
+                    'name' => $preacher->name,
+                    'url' => url("/christ/sermons/preachers/{$preacher->slug}"),
+                    'jobTitle' => 'Preacher',
+                    'worksFor' => [
+                        '@type' => 'Organization',
+                        'name' => $orgName,
+                    ],
+                ];
+
+                if ($preacher->profile_image_url) {
+                    $item['image'] = $preacher->profile_image_url;
+                }
+
                 return [
                     '@type' => 'ListItem',
                     'position' => $index + 1,
-                    'item' => [
-                        '@type' => 'Person',
-                        'name' => $preacher->name,
-                        'url' => url("/christ/sermons/preachers/{$preacher->slug}"),
-                        'jobTitle' => 'Preacher',
-                        'worksFor' => [
-                            '@type' => 'Organization',
-                            'name' => $orgName,
-                        ],
-                    ],
+                    'item' => $item,
                 ];
             })->values()->all(),
         ];

--- a/app/Presenters/SermonItemListPresenter.php
+++ b/app/Presenters/SermonItemListPresenter.php
@@ -34,14 +34,19 @@ class SermonItemListPresenter
             'itemListElement' => $flatSermons->values()->map(function (Sermon $sermon, int $index) use ($orgName, $logoUrl) {
                 $thumbnailUrl = $this->sermonViewPresenter->thumbnailUrl($sermon);
                 $publicUrl = $this->sermonViewPresenter->publicUrl($sermon);
+                $videoUrl = $this->sermonViewPresenter->videoUrl($sermon);
+                $audioUrl = $this->sermonViewPresenter->audioUrl($sermon);
+                $duration = $this->sermonViewPresenter->durationIso8601($sermon);
+                $datePublished = $sermon->date->toIso8601String();
+                $description = $this->sermonViewPresenter->metaDescription($sermon);
 
                 $item = [
                     '@type' => 'Article',
                     'headline' => $sermon->title,
                     'name' => $sermon->title,
                     'url' => $publicUrl,
-                    'description' => $sermon->meta_description,
-                    'datePublished' => $sermon->date->toIso8601String(),
+                    'description' => $description,
+                    'datePublished' => $datePublished,
                     'inLanguage' => 'en-GB',
                     'contentLocation' => [
                         '@type' => 'Place',
@@ -66,6 +71,36 @@ class SermonItemListPresenter
                     ],
                     'image' => $thumbnailUrl ?: $logoUrl,
                 ];
+
+                if ($videoUrl) {
+                    $item['video'] = [
+                        '@type' => 'VideoObject',
+                        'name' => $sermon->title,
+                        'description' => $description,
+                        'thumbnailUrl' => $thumbnailUrl ?: $logoUrl,
+                        'uploadDate' => $datePublished,
+                        'contentUrl' => $videoUrl,
+                    ];
+
+                    if ($duration) {
+                        $item['video']['duration'] = $duration;
+                    }
+                }
+
+                if ($audioUrl) {
+                    $item['audio'] = [
+                        '@type' => 'AudioObject',
+                        'name' => $sermon->title,
+                        'description' => $description,
+                        'uploadDate' => $datePublished,
+                        'contentUrl' => $audioUrl,
+                        'encodingFormat' => 'audio/mpeg',
+                    ];
+
+                    if ($duration) {
+                        $item['audio']['duration'] = $duration;
+                    }
+                }
 
                 return [
                     '@type' => 'ListItem',

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -46,6 +46,11 @@ class SermonViewPresenter
     private array $memoizedDurations = [];
 
     /**
+     * @var array<int|string, ?string>
+     */
+    private array $memoizedIso8601Durations = [];
+
+    /**
      * @var array<string, array<string, mixed>>
      */
     private array $memoizedPresents = [];
@@ -136,6 +141,7 @@ class SermonViewPresenter
         $this->memoizedPreacherNames = [];
         $this->memoizedReferences = [];
         $this->memoizedDurations = [];
+        $this->memoizedIso8601Durations = [];
         $this->memoizedPresents = [];
         $this->memoizedTimestamps = [];
         $this->memoizedSermonKeys = [];
@@ -458,6 +464,31 @@ class SermonViewPresenter
         }
 
         return $this->memoizedReferences[$identityKey] = $reference;
+    }
+
+    /**
+     * Get the duration of the sermon in ISO 8601 format (e.g. PT45M12S).
+     *
+     * Performance Optimization: Memoizes ISO 8601 duration strings
+     * to avoid redundant Carbon object creation in listing contexts.
+     */
+    public function durationIso8601(Sermon $sermon): ?string
+    {
+        $key = $this->cacheKey($sermon, 'iso_dur');
+
+        if (isset($this->memoizedIso8601Durations[$key])) {
+            return $this->memoizedIso8601Durations[$key] === self::MEMO_NULL ? null : $this->memoizedIso8601Durations[$key];
+        }
+
+        if ($sermon->duration === null || $sermon->duration <= 0) {
+            $this->memoizedIso8601Durations[$key] = self::MEMO_NULL;
+
+            return null;
+        }
+
+        $duration = \Carbon\CarbonInterval::seconds($sermon->duration)->cascade()->spec();
+
+        return $this->memoizedIso8601Durations[$key] = $duration;
     }
 
     /**

--- a/resources/views/sermons/series.blade.php
+++ b/resources/views/sermons/series.blade.php
@@ -8,6 +8,8 @@
 <x-meta-tags
     :title="$heading"
     :description="$description"
+    :image="asset('/images/headings/large/sermons.webp')"
+    image-alt="Sermons at Crockenhill Baptist Church"
 />
 <x-schema.webpage
     :heading="$heading"

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -36,6 +36,7 @@ $hasPublicVideo = filled($sermonView['video_url']);
 <x-schema.webpage
   :heading="$fullTitle"
   :description="$description ?? $sermonViewPresenter->metaDescription($sermon)"
+  :image="$sermonView['thumbnail_url']"
 />
 @endsection
 

--- a/resources/views/sermons/service.blade.php
+++ b/resources/views/sermons/service.blade.php
@@ -8,6 +8,8 @@
 <x-meta-tags
     :title="$heading"
     :description="$description"
+    :image="asset('/images/headings/large/sermons.webp')"
+    image-alt="Sermons at Crockenhill Baptist Church"
 />
 <x-schema.webpage
     :heading="$heading"

--- a/tests/Unit/Presenters/SermonViewPresenterTest.php
+++ b/tests/Unit/Presenters/SermonViewPresenterTest.php
@@ -265,6 +265,33 @@ class SermonViewPresenterTest extends TestCase
     }
 
     #[Test]
+    public function duration_iso8601_returns_null_when_duration_is_null(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => null]);
+
+        $this->assertNull($this->presenter->durationIso8601($sermon));
+    }
+
+    #[Test]
+    public function duration_iso8601_returns_null_when_duration_is_zero(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => 0]);
+
+        $this->assertNull($this->presenter->durationIso8601($sermon));
+    }
+
+    #[Test]
+    public function duration_iso8601_formats_duration_correctly(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => 1800]); // 30 minutes
+
+        $this->assertSame('PT30M', $this->presenter->durationIso8601($sermon));
+
+        $sermon2 = Sermon::factory()->make(['duration' => 3661]); // 1h 1m 1s
+        $this->assertSame('PT1H1M1S', $this->presenter->durationIso8601($sermon2));
+    }
+
+    #[Test]
     public function meta_description_returns_explicit_attribute_when_set(): void
     {
         $sermon = Sermon::factory()->make([


### PR DESCRIPTION
💡 **What:** Enhanced SEO metadata and structured data across the site.
- Added `AudioObject` and `VideoObject` rich snippets to sermon listing pages.
- Implemented ISO 8601 duration formatting for Schema.org compliance.
- Included preacher profile images in preacher list structured data.
- Added high-quality social sharing images to sermon service and series index pages.
- Improved individual sermon `WebPage` schema with thumbnails.

🎯 **Why:** To make church content more discoverable in media-rich search results and more visually appealing when shared on social platforms.

📊 **Impact:** Sermon listings, preacher profiles, and individual sermon pages benefit from richer search results and better social previews.

🔍 **Verification:** Verified with unit tests for presenters and verified JSON-LD output via Playwright script.

---
*PR created automatically by Jules for task [11222389977927795076](https://jules.google.com/task/11222389977927795076) started by @GarethClarridge*