### PR TITLE
🎨 Palette: UX and Accessibility refinements for selects and cards

### DIFF
--- a/resources/views/components/childrens-talk-card.blade.php
+++ b/resources/views/components/childrens-talk-card.blade.php
@@ -10,12 +10,14 @@
     $hasVideo = filled($sermonViewPresenter->videoUrl($sermon));
 @endphp
 
-<article class="flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md">
+<article class="relative group flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md">
     @if ($cardThumbnailUrl)
         <a
             href="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}"
             wire:navigate
-            class="group relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
+            tabindex="-1"
+            aria-hidden="true"
+            class="relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
         >
             <img
                 src="{{ $cardThumbnailUrl }}"
@@ -69,7 +71,7 @@
             @endif
         </dl>
 
-        <div class="mt-auto space-y-4">
+        <div class="mt-auto space-y-4 relative z-10">
             <div class="flex flex-wrap gap-2" aria-label="Media availability">
                 @if ($hasVideo)
                     <span class="inline-flex items-center gap-1 rounded-full bg-cbc-teal/10 px-3 py-1 text-xs font-semibold text-cbc-teal-dark">
@@ -90,7 +92,7 @@
                 @endif
             </div>
 
-            <x-button link="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}" variant="secondary" size="sm" inline>
+            <x-button link="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}" variant="secondary" size="sm" inline class="after:absolute after:inset-0">
                 Open talk
             </x-button>
         </div>

--- a/resources/views/components/page-card.blade.php
+++ b/resources/views/components/page-card.blade.php
@@ -21,9 +21,9 @@
             : '/'.$pageArea.'/'.$pageSlug;
     }
 @endphp
-<div class="group mb-4 flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition duration-300 hover:-translate-y-0.5 hover:shadow-lg">
+<div class="relative group mb-4 flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition duration-300 hover:-translate-y-0.5 hover:shadow-lg">
     <a class="relative block aspect-video overflow-hidden bg-slate-200" href="{{ $pageUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
-        <img class="h-full w-full object-cover brightness-110 contrast-105 transition duration-500 ease-out group-hover:scale-105 group-hover:brightness-115" src="{{ $pageImageUrl }}" alt="{{ $pageHeading }}" onerror="this.onerror=null;this.src='/images/headings/small/default.webp';" loading="lazy" width="300" height="169">
+        <img class="h-full w-full object-cover brightness-110 contrast-105 transition duration-500 ease-out group-hover:scale-105 group-hover:brightness-115" src="{{ $pageImageUrl }}" alt="" onerror="this.onerror=null;this.src='/images/headings/small/default.webp';" loading="lazy" width="300" height="169">
         <div class="absolute inset-0 bg-gradient-to-t from-black/35 via-black/10 to-transparent"></div>
         <h5 class="absolute inset-x-5 top-1/2 -translate-y-1/2 text-center font-display text-3xl leading-[0.95] text-white [text-shadow:0_2px_8px_rgba(0,0,0,0.45)] sm:text-4xl">
             {{ $pageHeading }}
@@ -45,13 +45,15 @@
             iconStyle="solid"
             iconPosition="trailing"
             iconClass="shrink-0 text-white/90"
-            class="w-full justify-between rounded-none text-left font-normal"
+            class="w-full justify-between rounded-none text-left font-normal after:absolute after:inset-0"
             aria-label="Learn about {{ $pageHeading }}"
         >
             Learn about {{ $pageHeading }}
         </x-button>
     </div>
 
-    <x-page-card-admin-overlay slug="{{ $pageSlug }}" />
+    <div class="relative z-10">
+        <x-page-card-admin-overlay slug="{{ $pageSlug }}" />
+    </div>
 </div>
 @endif

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -32,7 +32,7 @@ $describedBy = implode(' ', $describedBy);
             @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
         >
             @if($placeholder)
-                <option value="">{{ $placeholder }}</option>
+                <option value="" disabled selected hidden>{{ $placeholder }}</option>
             @endif
             @foreach($options as $option)
                 <option value="{{ $option['id'] }}" @disabled(($option['disabled'] ?? false) === true)>{{ $option['name'] }}</option>

--- a/resources/views/components/sermon-card.blade.php
+++ b/resources/views/components/sermon-card.blade.php
@@ -17,14 +17,16 @@
     $seriesUrl = $presenter->seriesUrl($sermon);
 @endphp
 
-<div data-sermon-card class="flex h-full max-w-sm flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-shadow hover:shadow-md">
+<div data-sermon-card class="relative group flex h-full max-w-sm flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-shadow hover:shadow-md">
 
   @if($thumbnailUrl)
     <a
       href="{{ $sermonUrl }}"
       wire:navigate
+      tabindex="-1"
+      aria-hidden="true"
       data-sermon-card-thumbnail
-      class="group relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200"
+      class="relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200"
     >
       <img
         src="{{ $thumbnailUrl }}"
@@ -80,7 +82,7 @@
       </li>
       @endif
       @if ($preacherName != null)
-      <li class="flex items-center">
+      <li class="flex items-center relative z-10">
         <x-heroicon-o-user class="h-5 w-5 mr-2 text-gray-500" aria-hidden="true" />
         @if ($preacherUrl)
           <a href="{{ $preacherUrl }}" wire:navigate class="hover:text-cbc-teal-dark transition-colors">{{ $preacherName }}</a>
@@ -90,7 +92,7 @@
       </li>
       @endif
       @if ($sermon->series != null)
-      <li class="flex items-center">
+      <li class="flex items-center relative z-10">
         <x-heroicon-o-tag class="h-5 w-5 mr-2 text-gray-500" aria-hidden="true" />
         <a href="{{ $seriesUrl }}" wire:navigate class="hover:text-cbc-teal-dark transition-colors">{{ $sermon->series }}</a>
       </li>
@@ -112,11 +114,13 @@
       iconStyle="solid"
       iconPosition="trailing"
       iconClass="shrink-0 text-white/90"
-      class="w-full justify-between rounded-none text-left font-normal"
+      class="w-full justify-between rounded-none text-left font-normal after:absolute after:inset-0"
       aria-label="View sermon: {{ $sermon->title }}"
   >
       View Sermon
   </x-button>
 
-  <x-sermon-card-admin-overlay :$sermon />
+  <div class="relative z-10">
+    <x-sermon-card-admin-overlay :$sermon />
+  </div>
 </div>


### PR DESCRIPTION
This PR improves the micro-UX and accessibility of form selects and content cards. Form selects now have non-selectable placeholders to guide user choice. Content cards (sermon, children's talk, and page cards) now implement the 'Stretched Link' pattern, making the entire card clickable while maintaining the accessibility and functionality of nested links and admin controls.

---
*PR created automatically by Jules for task [16427804847372696140](https://jules.google.com/task/16427804847372696140) started by @GarethClarridge*