### PR TITLE
🎨 Palette: Add "Skip to results" accessibility link to sermon archive

### DIFF
--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -1,4 +1,8 @@
 <div class="pb-12">
+    <a href="#sermon-results" class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:px-4 focus:py-2 focus:bg-white focus:text-cbc-teal-dark focus:rounded-md focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-cbc-teal">
+        Skip to results
+    </a>
+
     <section class="px-6" x-data="{ expanded: @js($hasActiveFilters) }">
         <div class="mx-auto max-w-2xl lg:max-w-5xl xl:max-w-7xl">
             <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-center">

--- a/tests/Feature/Livewire/Sermons/BrowseSermonsTest.php
+++ b/tests/Feature/Livewire/Sermons/BrowseSermonsTest.php
@@ -26,6 +26,14 @@ class BrowseSermonsTest extends TestCase
     }
 
     #[Test]
+    public function it_contains_a_skip_to_results_link(): void
+    {
+        Livewire::test(BrowseSermons::class)
+            ->assertSeeHtml('href="#sermon-results"')
+            ->assertSee('Skip to results');
+    }
+
+    #[Test]
     public function no_filters_show_flat_paginated_browse_results(): void
     {
         Sermon::factory()->create([


### PR DESCRIPTION
💡 **What:** Added a "Skip to results" anchor link to the `BrowseSermons` Livewire component.
🎯 **Why:** Allows keyboard and screen reader users to bypass the filter panel and jump directly to sermon results.
♿ **Accessibility:** Implements the "Skip link" pattern using `sr-only` and `focus:not-sr-only` classes.
📱 **Responsive:** Hidden by default, only visible on focus.

---
*PR created automatically by Jules for task [4409517066640544282](https://jules.google.com/task/4409517066640544282) started by @GarethClarridge*