### PR TITLE
🔦 Lighthouse: Enhance Preacher and Listing Metadata

### DIFF
--- a/app/Models/Preacher.php
+++ b/app/Models/Preacher.php
@@ -174,7 +174,7 @@ class Preacher extends Model implements Sitemapable
     {
         return \Illuminate\Support\Facades\Cache::flexible('public_preacher_list', [86400, 172800], function () {
             return self::active()
-                ->select(['id', 'name', 'slug'])
+                ->select(['id', 'name', 'slug', 'image_path'])
                 ->withCount([
                     'sermons' => fn (Builder $query): Builder => $query->whereSermon(),
                 ])

--- a/app/Presenters/PreacherItemListPresenter.php
+++ b/app/Presenters/PreacherItemListPresenter.php
@@ -31,6 +31,7 @@ class PreacherItemListPresenter
                         '@type' => 'Person',
                         'name' => $preacher->name,
                         'url' => url("/christ/sermons/preachers/{$preacher->slug}"),
+                        'image' => $preacher->profile_image_url,
                         'jobTitle' => 'Preacher',
                         'worksFor' => [
                             '@type' => 'Organization',

--- a/app/Presenters/SermonItemListPresenter.php
+++ b/app/Presenters/SermonItemListPresenter.php
@@ -51,6 +51,7 @@ class SermonItemListPresenter
                         '@type' => 'Person',
                         'name' => $this->sermonViewPresenter->displayPreacherName($sermon),
                         'url' => $this->sermonViewPresenter->preacherUrl($sermon),
+                        'image' => $sermon->preacherProfile?->profile_image_url,
                     ],
                     'publisher' => [
                         '@type' => 'Organization',

--- a/resources/views/sermons/preacher.blade.php
+++ b/resources/views/sermons/preacher.blade.php
@@ -9,6 +9,8 @@
     :title="$heading"
     :description="$description"
     :image="$preacher->profile_image_url"
+    label1="Sermons"
+    :data1="$sermons->count()"
 />
 <x-schema.webpage
     :heading="$heading"

--- a/resources/views/sermons/series.blade.php
+++ b/resources/views/sermons/series.blade.php
@@ -8,6 +8,8 @@
 <x-meta-tags
     :title="$heading"
     :description="$description"
+    :image="asset('/images/headings/large/sermons.webp')"
+    image-alt="Sermon Series: {{ $heading }}"
 />
 <x-schema.webpage
     :heading="$heading"

--- a/resources/views/sermons/service.blade.php
+++ b/resources/views/sermons/service.blade.php
@@ -8,6 +8,8 @@
 <x-meta-tags
     :title="$heading"
     :description="$description"
+    :image="asset('/images/headings/large/sermons.webp')"
+    image-alt="Sermons at Crockenhill Baptist Church"
 />
 <x-schema.webpage
     :heading="$heading"


### PR DESCRIPTION
Improved SEO and social sharing metadata for preachers and sermon listings.

- **JSON-LD Rich Results:** Included preacher profile images in the `Person` schema for both preacher index and sermon listings.
- **Social Sharing:** Added Twitter labels (sermon count) to individual preacher pages and fixed missing social images on sermon service and series listing pages by using the specialized sermons heading image.
- **Data Availability:** Updated the cached preacher listing query to include the `image_path` column.

---
*PR created automatically by Jules for task [14435475048584999164](https://jules.google.com/task/14435475048584999164) started by @GarethClarridge*