### PR TITLE
🧹 Tidy: align storage and presenter memoization with project standards

### DIFF
--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -560,13 +560,8 @@ class SermonViewPresenter
     {
         $id = $sermon->id ?? 'u'.spl_object_id($sermon);
 
-        if (! isset($this->memoizedSermonKeys[$id])) {
-            if (! isset($this->memoizedTimestamps[$id])) {
-                $this->memoizedTimestamps[$id] = $sermon->updated_at?->getTimestamp() ?? 0;
-            }
-
-            $this->memoizedSermonKeys[$id] = "{$id}_{$this->memoizedTimestamps[$id]}";
-        }
+        $this->memoizedTimestamps[$id] ??= $sermon->updated_at?->getTimestamp() ?? 0;
+        $this->memoizedSermonKeys[$id] ??= "{$id}_{$this->memoizedTimestamps[$id]}";
 
         return "{$type}_{$this->memoizedSermonKeys[$id]}";
     }

--- a/app/Services/SermonStorageService.php
+++ b/app/Services/SermonStorageService.php
@@ -87,9 +87,17 @@ class SermonStorageService
         // to ensure uniqueness and handle state changes within the request.
         $cacheKey = ($sermon->id ?? 'u'.spl_object_id($sermon))."_{$audioPath}_{$sermon->filetype}";
 
-        if (isset($this->memoizedFileInfo[$cacheKey])) {
-            return $this->memoizedFileInfo[$cacheKey];
-        }
+        return $this->memoizedFileInfo[$cacheKey] ??= $this->resolveFileInfo($sermon);
+    }
+
+    /**
+     * Resolve file information for a sermon based on its storage pattern.
+     *
+     * @return array{type: string, disk: string, path: string, original_path: string}
+     */
+    private function resolveFileInfo(Sermon $sermon): array
+    {
+        $audioPath = $sermon->audio_file_path ?? '';
 
         $this->validatePath($audioPath, 'audio file');
 
@@ -122,7 +130,7 @@ class SermonStorageService
 
         if (str_contains($audioPath, '/')) {
             // Newer Laravel storage pattern
-            return $this->memoizedFileInfo[$cacheKey] = [
+            return [
                 'type' => 'storage',
                 'disk' => $this->sermonDisk,
                 'path' => $audioPath,
@@ -131,7 +139,7 @@ class SermonStorageService
         }
 
         // Current media processing pattern
-        return $this->memoizedFileInfo[$cacheKey] = [
+        return [
             'type' => 'processing',
             'disk' => $this->sermonDisk,
             'path' => $audioPath,


### PR DESCRIPTION
This refactor improves the consistency and readability of request-level memoization across the codebase. It extracts resolution logic into focused private methods and leverages the PHP 8.4 ??= operator to replace manual isset() checks, aligning with modern project standards without altering functionality.

---
*PR created automatically by Jules for task [8064626062114705143](https://jules.google.com/task/8064626062114705143) started by @GarethClarridge*