### PR TITLE
🛡️ Sentinel: Fix IDOR vulnerability on sermon assets

### DIFF
--- a/app/Http/Controllers/SermonAssetController.php
+++ b/app/Http/Controllers/SermonAssetController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Enums\SermonContentType;
 use App\Models\Sermon;
+use App\Models\User;
 use App\Services\SermonExposurePolicy;
 use App\Services\SermonStorageService;
 use Illuminate\Http\RedirectResponse;
@@ -65,6 +66,8 @@ class SermonAssetController extends Controller
             return $authorizationResponse;
         }
 
+        $this->ensureVideoIsExposed($sermon);
+
         if (! $sermon->video_file_path) {
             abort(404, 'Video file not found.');
         }
@@ -103,6 +106,8 @@ class SermonAssetController extends Controller
             return $authorizationResponse;
         }
 
+        $this->ensureThumbnailIsExposed($sermon);
+
         if (! $sermon->thumbnail_file_path) {
             abort(404, 'Thumbnail not found.');
         }
@@ -133,6 +138,8 @@ class SermonAssetController extends Controller
         if ($authorizationResponse instanceof RedirectResponse) {
             return $authorizationResponse;
         }
+
+        $this->ensureThumbnailIsExposed($sermon);
 
         $cardThumbnailPath = $sermon->card_thumbnail_file_path;
 
@@ -188,6 +195,26 @@ class SermonAssetController extends Controller
             'Content-Disposition' => HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_INLINE, $name),
             'Cache-Control' => 'no-store',
         ]);
+    }
+
+    private function ensureVideoIsExposed(Sermon $sermon): void
+    {
+        /** @var User|null $user */
+        $user = Auth::user();
+
+        if (! ($user?->canAccessAdmin() === true) && ! $this->exposurePolicy->shouldExposeVideo($sermon)) {
+            abort(403, 'This video is not publicly available.');
+        }
+    }
+
+    private function ensureThumbnailIsExposed(Sermon $sermon): void
+    {
+        /** @var User|null $user */
+        $user = Auth::user();
+
+        if (! ($user?->canAccessAdmin() === true) && ! $this->exposurePolicy->shouldExposeThumbnail($sermon)) {
+            abort(403, 'This thumbnail is not publicly available.');
+        }
     }
 
     private function authorizeChildrensTalkAssetAccess(Sermon $sermon): ?RedirectResponse

--- a/tests/Feature/SermonAssetVisibilityTest.php
+++ b/tests/Feature/SermonAssetVisibilityTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\SermonVideoQualityStatus;
+use App\Enums\SermonVideoVisibilityOverride;
+use App\Models\Sermon;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonAssetVisibilityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function guest_cannot_access_video_with_force_hide_override(): void
+    {
+        Storage::fake('public');
+
+        $sermon = Sermon::factory()->create([
+            'video_file_path' => 'sermons/hidden-video.mp4',
+            'video_visibility_override' => SermonVideoVisibilityOverride::ForceHide,
+        ]);
+
+        Storage::disk('public')->put('sermons/hidden-video.mp4', 'fake video content');
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/video");
+
+        // This is expected to FAIL until fixed (currently it likely redirects or serves)
+        // Sentinel expects it to be 403 Forbidden if not authorized.
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function guest_cannot_access_video_with_rejected_quality_status(): void
+    {
+        Storage::fake('public');
+        config(['media-processing.video_quality.enforce_public_visibility' => true]);
+
+        $sermon = Sermon::factory()->create([
+            'video_file_path' => 'sermons/rejected-video.mp4',
+            'video_quality_status' => SermonVideoQualityStatus::Rejected,
+            'video_visibility_override' => SermonVideoVisibilityOverride::Default,
+        ]);
+
+        Storage::disk('public')->put('sermons/rejected-video.mp4', 'fake video content');
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/video");
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function guest_cannot_access_thumbnail_of_hidden_video(): void
+    {
+        Storage::fake('public');
+
+        $sermon = Sermon::factory()->create([
+            'video_file_path' => 'sermons/video.mp4',
+            'thumbnail_file_path' => 'thumbnails/thumb.webp',
+            'video_visibility_override' => SermonVideoVisibilityOverride::ForceHide,
+            'thumbnail_metadata' => [
+                'selected_thumbnail_candidate_id' => 'candidate-1',
+            ],
+        ]);
+
+        Storage::disk('public')->put('thumbnails/thumb.webp', 'fake thumb');
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/thumbnail");
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function admin_can_access_hidden_assets(): void
+    {
+        Storage::fake('public');
+        $admin = User::factory()->create(['is_admin' => true]);
+
+        $sermon = Sermon::factory()->create([
+            'video_file_path' => 'sermons/hidden-video.mp4',
+            'thumbnail_file_path' => 'thumbnails/hidden-thumb.webp',
+            'video_visibility_override' => SermonVideoVisibilityOverride::ForceHide,
+            'thumbnail_metadata' => [
+                'selected_thumbnail_candidate_id' => 'candidate-1',
+            ],
+        ]);
+
+        Storage::disk('public')->put('sermons/hidden-video.mp4', 'fake video');
+        Storage::disk('public')->put('thumbnails/hidden-thumb.webp', 'fake thumb');
+
+        $this->actingAs($admin)
+            ->get("/christ/sermons/{$sermon->slug}/video")
+            ->assertRedirect(); // Serving via redirect to public URL is standard for non-private
+
+        $this->actingAs($admin)
+            ->get("/christ/sermons/{$sermon->slug}/thumbnail")
+            ->assertRedirect();
+    }
+}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Insecure Direct Object Reference (IDOR) / Missing Authorization. Sermon assets (video, thumbnails) were accessible via direct URL even if they were marked as hidden (`ForceHide`) or rejected due to quality issues.
🎯 **Impact:** Unauthorized users could watch or download media intended to be private or unreleased.
🔧 **Fix:** Integrated `SermonExposurePolicy` checks into `SermonAssetController` asset serving methods (`serveVideo`, `serveThumbnail`, `serveCardThumbnail`).
✅ **Verification:** Added `tests/Feature/SermonAssetVisibilityTest.php` and verified that guest access is forbidden (403) for hidden assets while admin access is preserved.

---
*PR created automatically by Jules for task [3575369629988632819](https://jules.google.com/task/3575369629988632819) started by @GarethClarridge*