### PR TITLE
🎨 Palette: Stretched links and accessible cards

### DIFF
--- a/resources/views/components/childrens-talk-card.blade.php
+++ b/resources/views/components/childrens-talk-card.blade.php
@@ -6,11 +6,13 @@
     'hasVideo',
 ])
 
-<article class="flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md">
+<article class="group relative flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md">
     @if ($cardThumbnailUrl)
         <a
             href="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}"
             wire:navigate
+            tabindex="-1"
+            aria-hidden="true"
             class="group relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
         >
             <img
@@ -36,7 +38,7 @@
                 <a
                     href="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}"
                     wire:navigate
-                    class="block rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
+                    class="relative z-10 block rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
                 >
                     <h2 class="font-display text-2xl leading-tight text-gray-900 transition-colors hover:text-cbc-teal-dark">
                         {{ $sermon->title }}
@@ -86,7 +88,7 @@
                 @endif
             </div>
 
-            <x-button link="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}" variant="secondary" size="sm" inline>
+            <x-button link="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}" variant="secondary" size="sm" inline class="after:absolute after:inset-0">
                 Open talk
             </x-button>
         </div>

--- a/resources/views/components/page-card.blade.php
+++ b/resources/views/components/page-card.blade.php
@@ -21,7 +21,7 @@
             : '/'.$pageArea.'/'.$pageSlug;
     }
 @endphp
-<div class="group mb-4 flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition duration-300 hover:-translate-y-0.5 hover:shadow-lg">
+<div class="group relative mb-4 flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition duration-300 hover:-translate-y-0.5 hover:shadow-lg">
     <a class="relative block aspect-video overflow-hidden bg-slate-200" href="{{ $pageUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
         <img class="h-full w-full object-cover brightness-110 contrast-105 transition duration-500 ease-out group-hover:scale-105 group-hover:brightness-115" src="{{ $pageImageUrl }}" alt="{{ $pageHeading }}" onerror="this.onerror=null;this.src='/images/headings/small/default.webp';" loading="lazy" width="300" height="169">
         <div class="absolute inset-0 bg-gradient-to-t from-black/35 via-black/10 to-transparent"></div>
@@ -45,7 +45,7 @@
             iconStyle="solid"
             iconPosition="trailing"
             iconClass="shrink-0 text-white/90"
-            class="w-full justify-between rounded-none text-left font-normal"
+            class="w-full justify-between rounded-none text-left font-normal after:absolute after:inset-0"
             aria-label="Learn about {{ $pageHeading }}"
         >
             Learn about {{ $pageHeading }}

--- a/resources/views/components/sermon-card.blade.php
+++ b/resources/views/components/sermon-card.blade.php
@@ -9,13 +9,15 @@
 'seriesUrl',
 ])
 
-<div data-sermon-card class="flex h-full max-w-sm flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-shadow hover:shadow-md">
+<div data-sermon-card class="group relative flex h-full max-w-sm flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-shadow hover:shadow-md">
 
   @if($thumbnailUrl)
     <a
       href="{{ $sermonUrl }}"
       wire:navigate
       data-sermon-card-thumbnail
+      tabindex="-1"
+      aria-hidden="true"
       class="group relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200"
     >
       <img
@@ -36,13 +38,13 @@
 
   <div class="flex flex-col flex-1 p-6">
     @if (($sermon->title != null) && ! $thumbnailUrl)
-      <a class="group" href="{{ $sermonUrl }}" wire:navigate>
+      <a class="relative z-10" href="{{ $sermonUrl }}" wire:navigate>
         <h4 class="font-display text-2xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
           {{$sermon->title}}
         </h4>
       </a>
     @elseif ($sermon->title != null)
-      <a class="group hidden" href="{{ $sermonUrl }}" wire:navigate data-sermon-card-title-fallback>
+      <a class="relative z-10 hidden" href="{{ $sermonUrl }}" wire:navigate data-sermon-card-title-fallback>
         <h4 class="font-display text-2xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
           {{$sermon->title}}
         </h4>
@@ -75,7 +77,7 @@
       <li class="flex items-center">
         <x-heroicon-o-user class="h-5 w-5 mr-2 text-gray-500" aria-hidden="true" />
         @if ($preacherUrl)
-          <a href="{{ $preacherUrl }}" wire:navigate class="hover:text-cbc-teal-dark transition-colors">{{ $preacherName }}</a>
+          <a href="{{ $preacherUrl }}" wire:navigate class="relative z-10 hover:text-cbc-teal-dark transition-colors">{{ $preacherName }}</a>
         @else
           <span>{{ $preacherName }}</span>
         @endif
@@ -84,7 +86,7 @@
       @if ($sermon->series != null)
       <li class="flex items-center">
         <x-heroicon-o-tag class="h-5 w-5 mr-2 text-gray-500" aria-hidden="true" />
-        <a href="{{ $seriesUrl }}" wire:navigate class="hover:text-cbc-teal-dark transition-colors">{{ $sermon->series }}</a>
+        <a href="{{ $seriesUrl }}" wire:navigate class="relative z-10 hover:text-cbc-teal-dark transition-colors">{{ $sermon->series }}</a>
       </li>
       @endif
       @if ($reference != null)
@@ -104,7 +106,7 @@
       iconStyle="solid"
       iconPosition="trailing"
       iconClass="shrink-0 text-white/90"
-      class="w-full justify-between rounded-none text-left font-normal"
+      class="w-full justify-between rounded-none text-left font-normal after:absolute after:inset-0"
       aria-label="View sermon: {{ $sermon->title }}"
   >
       View Sermon

--- a/resources/views/livewire/church/songs/browse-songs.blade.php
+++ b/resources/views/livewire/church/songs/browse-songs.blade.php
@@ -74,11 +74,11 @@
                         $authorNames = $song->authors->pluck('display_name')->implode(', ') ?: null;
                         $bookEntries = $song->books->map(fn ($book) => $book->name . ($book->pivot->entry ? ' #' . $book->pivot->entry : ''))->implode(', ') ?: null;
                     @endphp
-                    <article wire:key="song-{{ $song->id }}" class="flex h-full flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-shadow hover:shadow-md">
+                    <article wire:key="song-{{ $song->id }}" class="group relative flex h-full flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-shadow hover:shadow-md">
 
                         <div class="flex flex-col flex-1 p-6 @if (!empty($snippetsBySongId[$song->id])) pb-0 @endif">
                             <div class="flex items-start justify-between gap-4">
-                                <a class="group" href="{{ $songUrl }}" wire:navigate>
+                                <a class="relative z-10" href="{{ $songUrl }}" wire:navigate>
                                     <h2 class="font-display text-3xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
                                         {{ $song->title }}
                                     </h2>
@@ -145,7 +145,7 @@
                             iconStyle="solid"
                             iconPosition="trailing"
                             iconClass="shrink-0 text-white/90"
-                            class="w-full justify-between rounded-none text-left font-normal"
+                            class="w-full justify-between rounded-none text-left font-normal after:absolute after:inset-0"
                             aria-label="View song: {{ $song->title }}"
                         >
                             View Song


### PR DESCRIPTION
Implemented the "stretched link" pattern across several card components (`sermon-card`, `page-card`, `childrens-talk-card`, and `browse-songs`). This makes the entire card clickable, improving the user experience especially on mobile devices. Accessibility was also improved by removing redundant links from the tab order.

---
*PR created automatically by Jules for task [4995858833903532474](https://jules.google.com/task/4995858833903532474) started by @GarethClarridge*