### PR TITLE
📝 Scribe: Add tests for Sermon Video serving

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -42,6 +42,10 @@
 **Learning:** Admin user management tests must account for strict `Password::defaults()` (12+ chars, letters, numbers, symbols, uncompromised). Using `Log::shouldReceive` is an effective way to verify that critical administrative actions (deletions, permission changes) are being audited as required.
 **Action:** Use complex strings (e.g., `C0mplex_Passw0rd!`) for test passwords to avoid validation failures. Mock `Log` to assert that `Log::warning` is called with correct metadata for audit trails.
 
+## 2026-04-26 - [Testing Redirects vs Binary Responses for Assets]
+**Learning:** Sermon asset serving logic often involves an internal decision between redirecting to a public delivery URL (for public files) and serving the file directly as a `BinaryFileResponse` (for private files). Testing this requires `assertRedirect()` for public assets and `assertStatus(200)` + `assertHeader('Content-Type', ...)` for private ones.
+**Action:** Always test both public (redirect) and private (binary) serving paths to ensure asset delivery is optimized for the storage disk while maintaining security.
+
 ## 2026-04-12 - [Sermon Model Testing Invariants]
 **Learning:** The `sermons` table has several `NOT NULL` columns with database-level defaults (`video_quality_status`, `video_visibility_override`). When writing tests, avoid passing `null` for these columns as it triggers integrity violations; use explicit enum values. Additionally, `ThumbnailMetadata` object verification requires specific keys (`id`, `timestamp`, `score`, `plain_path`) in each candidate to satisfy the `ThumbnailMetadata::candidateList()` parser.
 **Action:** Ensure sermon test factories or explicit `create()` calls provide valid enum values for status columns and properly structured arrays for metadata fields.

--- a/tests/Feature/SermonVideoServingTest.php
+++ b/tests/Feature/SermonVideoServingTest.php
@@ -136,7 +136,27 @@ class SermonVideoServingTest extends TestCase
 
         $response = $this->actingAs($user)->get("/christ/sermons/{$sermon->slug}/video");
 
-        $response->assertRedirect(); // Should redirect to public delivery URL since it's verified
+        $expectedUrl = app(SermonStorageService::class)->getVideoDeliveryUrl($sermon);
+        $response->assertRedirect($expectedUrl);
+    }
+
+    #[Test]
+    public function unverified_user_cannot_access_childrens_talk_video_when_not_public(): void
+    {
+        Config::set('sermons.childrens_talks.public', false);
+        $user = User::factory()->create(['email_verified_at' => null]);
+
+        $sermon = Sermon::factory()->create([
+            'slug' => 'childrens-talk',
+            'content_type' => SermonContentType::ChildrensTalk,
+            'video_file_path' => 'sermons/kids.mp4',
+        ]);
+
+        Storage::disk('public')->put('sermons/kids.mp4', 'fake content');
+
+        $response = $this->actingAs($user)->get("/christ/sermons/{$sermon->slug}/video");
+
+        $response->assertRedirect(route('login'));
     }
 
     #[Test]
@@ -154,6 +174,7 @@ class SermonVideoServingTest extends TestCase
 
         $response = $this->get("/christ/sermons/{$sermon->slug}/video");
 
-        $response->assertRedirect();
+        $expectedUrl = app(SermonStorageService::class)->getVideoDeliveryUrl($sermon);
+        $response->assertRedirect($expectedUrl);
     }
 }

--- a/tests/Feature/SermonVideoServingTest.php
+++ b/tests/Feature/SermonVideoServingTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\SermonContentType;
+use App\Models\Sermon;
+use App\Models\User;
+use App\Services\SermonStorageService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonVideoServingTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('public');
+        Storage::fake('local');
+
+        Config::set('media-processing.storage.sermon_disk', 'public');
+    }
+
+    #[Test]
+    public function can_serve_public_video_by_redirect(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'slug' => 'test-video',
+            'video_file_path' => 'sermons/test.mp4',
+        ]);
+
+        Storage::disk('public')->put('sermons/test.mp4', 'fake video content');
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/video");
+
+        $expectedUrl = app(SermonStorageService::class)->getVideoDeliveryUrl($sermon);
+        $response->assertRedirect($expectedUrl);
+    }
+
+    #[Test]
+    public function can_serve_private_video_directly(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'slug' => 'test-private-video',
+            'video_file_path' => 'private/sermons/test.mp4',
+        ]);
+
+        Storage::disk('local')->put('private/sermons/test.mp4', 'fake private video content');
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/video");
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'video/mp4');
+        $this->assertStringContainsString('no-store', (string) $response->headers->get('Cache-Control'));
+    }
+
+    #[Test]
+    public function returns_404_when_video_path_is_missing(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'slug' => 'no-video',
+            'video_file_path' => null,
+        ]);
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/video");
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function returns_404_when_video_file_missing_on_disk(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'slug' => 'missing-file',
+            'video_file_path' => 'sermons/nonexistent.mp4',
+        ]);
+
+        // We don't put the file on disk
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/video");
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function prevents_path_traversal_on_video_requests(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'slug' => 'malicious-path',
+            'video_file_path' => '../secret.mp4',
+        ]);
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/video");
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function guest_cannot_access_childrens_talk_video_when_not_public(): void
+    {
+        Config::set('sermons.childrens_talks.public', false);
+
+        $sermon = Sermon::factory()->create([
+            'slug' => 'childrens-talk',
+            'content_type' => SermonContentType::ChildrensTalk,
+            'video_file_path' => 'sermons/kids.mp4',
+        ]);
+
+        Storage::disk('public')->put('sermons/kids.mp4', 'fake content');
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/video");
+
+        $response->assertRedirect(route('login'));
+    }
+
+    #[Test]
+    public function verified_user_can_access_childrens_talk_video_when_not_public(): void
+    {
+        Config::set('sermons.childrens_talks.public', false);
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $sermon = Sermon::factory()->create([
+            'slug' => 'childrens-talk',
+            'content_type' => SermonContentType::ChildrensTalk,
+            'video_file_path' => 'sermons/kids.mp4',
+        ]);
+
+        Storage::disk('public')->put('sermons/kids.mp4', 'fake content');
+
+        $response = $this->actingAs($user)->get("/christ/sermons/{$sermon->slug}/video");
+
+        $response->assertRedirect(); // Should redirect to public delivery URL since it's verified
+    }
+
+    #[Test]
+    public function guest_can_access_childrens_talk_video_when_public(): void
+    {
+        Config::set('sermons.childrens_talks.public', true);
+
+        $sermon = Sermon::factory()->create([
+            'slug' => 'childrens-talk',
+            'content_type' => SermonContentType::ChildrensTalk,
+            'video_file_path' => 'sermons/kids.mp4',
+        ]);
+
+        Storage::disk('public')->put('sermons/kids.mp4', 'fake content');
+
+        $response = $this->get("/christ/sermons/{$sermon->slug}/video");
+
+        $response->assertRedirect();
+    }
+}


### PR DESCRIPTION
This PR adds dedicated feature test coverage for the `SermonAssetController::serveVideo` method, which was previously untested.

### Coverage
The new `SermonVideoServingTest` covers:
- **Public Video serving:** Verifies that public videos redirect to the delivery URL.
- **Private Video serving:** Verifies that private videos (stored in `private/`) are served directly as a `BinaryFileResponse` with appropriate security headers.
- **Error Handling:** Verifies 404 responses when the video path is missing from the model or the file is missing from the disk.
- **Security:** Verifies that path traversal attempts in video paths are rejected with a 404.
- **Access Policy:** Verifies that non-public Children's Corner videos correctly enforce authentication and email verification requirements, redirecting guests to login.

### Journal Update
Updated `.jules/scribe.md` to document the pattern of testing asset serving via redirects vs binary responses.

### Verification
- All new tests pass.
- Pint formatting applied.
- PHPStan static analysis clean.

---
*PR created automatically by Jules for task [9814634738611940097](https://jules.google.com/task/9814634738611940097) started by @GarethClarridge*