### PR TITLE
⚡ Bolt: Optimize sermon scripture filter option retrieval

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-31 - [Config Caching in Services and Presenters]
 **Learning:** Calling `config()` or `asset()` inside collection loops (like `map()`) can cause measurable overhead when processing large datasets (e.g., sitemap generation or "All Sermons" list).
 **Action:** Resolve and store configuration values in class constructors for long-lived services like `SermonStorageService`. For presenters handling collection mapping, resolve static values or configuration once outside the loop and pass them in via `use`.
+
+## 2026-04-14 - [Scripture Filter Query Optimization]
+**Learning:** The `sermon_scripture_filters` table is only populated for actual sermons (not children's talks). This allows us to skip joining the `sermons` table entirely when retrieving global book/chapter lists for filters, as long as no preacher or series filters are active.
+**Action:** In `SermonRepository`, check if `$preacherId` and `$series` are null before joining `sermons` table in scripture filter option queries.

--- a/app/Livewire/Sermons/BrowseSermons.php
+++ b/app/Livewire/Sermons/BrowseSermons.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace App\Livewire\Sermons;
 
-use App\Enums\SermonContentType;
 use App\Models\Preacher;
-use App\Models\SermonScriptureFilter;
 use App\Repositories\SermonRepository;
 use App\Support\BibleCanon;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\View\View;
@@ -145,10 +142,10 @@ class BrowseSermons extends Component
     #[Computed]
     public function enabledBooks(): Collection
     {
-        return $this->scriptureFilterOptionQuery()
-            ->select('bible_book')
-            ->distinct()
-            ->pluck('bible_book');
+        return app(SermonRepository::class)->getScriptureBooks(
+            preacherId: $this->preacherFilter,
+            series: $this->seriesFilter
+        );
     }
 
     /**
@@ -161,12 +158,11 @@ class BrowseSermons extends Component
             return collect();
         }
 
-        return $this->scriptureFilterOptionQuery()
-            ->where('bible_book', $this->bookFilter)
-            ->select('bible_chapter')
-            ->distinct()
-            ->orderBy('bible_chapter')
-            ->pluck('bible_chapter');
+        return app(SermonRepository::class)->getScriptureChapters(
+            book: $this->bookFilter,
+            preacherId: $this->preacherFilter,
+            series: $this->seriesFilter
+        );
     }
 
     /**
@@ -191,18 +187,6 @@ class BrowseSermons extends Component
             fn (string $series): array => ['id' => $series, 'name' => $series],
             app(SermonRepository::class)->getSeriesForDisplay()
         );
-    }
-
-    /**
-     * @return Builder<SermonScriptureFilter>
-     */
-    private function scriptureFilterOptionQuery(): Builder
-    {
-        return SermonScriptureFilter::query()
-            ->join('sermons', 'sermons.id', '=', 'sermon_scripture_filters.sermon_id')
-            ->where('sermons.content_type', SermonContentType::Sermon->value)
-            ->when($this->preacherFilter, fn (Builder $query): Builder => $query->where('sermons.preacher_id', $this->preacherFilter))
-            ->when($this->seriesFilter, fn (Builder $query): Builder => $query->where('sermons.series', $this->seriesFilter));
     }
 
     /**

--- a/app/Repositories/SermonRepository.php
+++ b/app/Repositories/SermonRepository.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Repositories;
 
+use App\Enums\SermonContentType;
 use App\Enums\SermonService;
 use App\Models\Preacher;
 use App\Models\Sermon;
+use App\Models\SermonScriptureFilter;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
@@ -158,6 +160,64 @@ class SermonRepository
     }
 
     /**
+     * Get all scripture books that have sermons.
+     *
+     * Performance Optimization: Caches the list of books for 24-48 hours.
+     * Avoids joining sermons table if no filters are applied.
+     *
+     * @return Collection<int, string>
+     */
+    public function getScriptureBooks(?int $preacherId = null, ?string $series = null): Collection
+    {
+        $cacheKey = 'sermon_books_'.($preacherId ?? 'all').'_'.(Str::slug($series ?? 'all'));
+
+        return Cache::flexible($cacheKey, [86400, 172800], function () use ($preacherId, $series): Collection {
+            $query = SermonScriptureFilter::query();
+
+            if ($preacherId !== null || $series !== null) {
+                $query->join('sermons', 'sermons.id', '=', 'sermon_scripture_filters.sermon_id')
+                    ->where('sermons.content_type', SermonContentType::Sermon->value)
+                    ->when($preacherId, fn (Builder $q) => $q->where('sermons.preacher_id', $preacherId))
+                    ->when($series, fn (Builder $q) => $q->where('sermons.series', $series));
+            }
+
+            return $query->select('bible_book')
+                ->distinct()
+                ->pluck('bible_book');
+        });
+    }
+
+    /**
+     * Get all chapters for a given book that have sermons.
+     *
+     * Performance Optimization: Caches the list of chapters for 24-48 hours.
+     * Avoids joining sermons table if no filters are applied.
+     *
+     * @return Collection<int, int>
+     */
+    public function getScriptureChapters(string $book, ?int $preacherId = null, ?string $series = null): Collection
+    {
+        $cacheKey = 'sermon_chapters_'.Str::slug($book).'_'.($preacherId ?? 'all').'_'.(Str::slug($series ?? 'all'));
+
+        return Cache::flexible($cacheKey, [86400, 172800], function () use ($book, $preacherId, $series): Collection {
+            $query = SermonScriptureFilter::query()
+                ->where('bible_book', $book);
+
+            if ($preacherId !== null || $series !== null) {
+                $query->join('sermons', 'sermons.id', '=', 'sermon_scripture_filters.sermon_id')
+                    ->where('sermons.content_type', SermonContentType::Sermon->value)
+                    ->when($preacherId, fn (Builder $q) => $q->where('sermons.preacher_id', $preacherId))
+                    ->when($series, fn (Builder $q) => $q->where('sermons.series', $series));
+            }
+
+            return $query->select('bible_chapter')
+                ->distinct()
+                ->orderBy('bible_chapter')
+                ->pluck('bible_chapter');
+        });
+    }
+
+    /**
      * Clear all cached sermon listings.
      */
     public function clearListingCaches(Sermon|Preacher|null $model = null): void
@@ -165,10 +225,12 @@ class SermonRepository
         Cache::forget('latest_sermons');
         Cache::forget('all_sermons');
         Cache::forget('sermon_series');
+        Cache::forget('sermon_books_all_all');
 
         if ($model instanceof Sermon) {
             if ($model->series) {
                 Cache::forget('sermons_series_'.Str::slug($model->series));
+                Cache::forget('sermon_books_all_'.Str::slug($model->series));
             }
             if ($model->service) {
                 $serviceValue = $model->service->value;
@@ -180,11 +242,45 @@ class SermonRepository
                 if ($model->preacherProfile) {
                     Cache::forget($this->preacherCacheKey($model->preacherProfile));
                 }
+                Cache::forget('sermon_books_'.$model->preacher_id.'_all');
+
+                if ($model->series) {
+                    Cache::forget('sermon_books_'.$model->preacher_id.'_'.Str::slug($model->series));
+                }
+            }
+
+            // Invalidate chapter caches for any books associated with this sermon
+            $model->loadMissing('scriptureFilters');
+            foreach ($model->scriptureFilters->pluck('bible_book')->unique() as $book) {
+                $this->clearScriptureChapterCaches($book, $model->preacher_id, $model->series);
             }
         }
 
         if ($model instanceof Preacher) {
             Cache::forget($this->preacherCacheKey($model));
+            Cache::forget('sermon_books_'.$model->id.'_all');
+        }
+    }
+
+    /**
+     * Clear chapter caches for a specific book and optional filters.
+     */
+    private function clearScriptureChapterCaches(string $book, ?int $preacherId = null, ?string $series = null): void
+    {
+        $bookSlug = Str::slug($book);
+        Cache::forget("sermon_chapters_{$bookSlug}_all_all");
+
+        if ($preacherId) {
+            Cache::forget("sermon_chapters_{$bookSlug}_{$preacherId}_all");
+        }
+
+        if ($series) {
+            $seriesSlug = Str::slug($series);
+            Cache::forget("sermon_chapters_{$bookSlug}_all_{$seriesSlug}");
+
+            if ($preacherId) {
+                Cache::forget("sermon_chapters_{$bookSlug}_{$preacherId}_{$seriesSlug}");
+            }
         }
     }
 


### PR DESCRIPTION
This PR optimizes the retrieval of Bible book and chapter filter options on the sermon browse page.

### 💡 What:
- Moved the logic for fetching available Bible books and chapters from the `BrowseSermons` Livewire component into the `SermonRepository`.
- Wrapped these lookups in `Cache::flexible` to drastically reduce redundant DB queries on every render cycle of the filter panel.
- Optimized the underlying queries to avoid joining the `sermons` table when filtering by book/chapter alone (no preacher or series selected).

### 🎯 Why:
The `BrowseSermons` component was previously performing distinct DB queries on the `sermon_scripture_filters` table (joined with `sermons`) for both the book and chapter dropdowns on every single render. Since these options rarely change, they were a perfect candidate for caching.

### 📊 Impact:
- Reduces the number of database queries on the sermon browse page by 2 on every initial load and filter update.
- Eliminates expensive `JOIN` operations when no specific preacher or series is being filtered.
- Improves perceived performance of the filter panel through multi-layered caching.

### 🔬 Measurement:
- Verified that all 14 tests in `BrowseSermonsTest.php` pass.
- Verified that the full test suite (4658 tests) passes.
- Confirmed that PHPStan remains at 0 errors.

---
*PR created automatically by Jules for task [12847068084566914218](https://jules.google.com/task/12847068084566914218) started by @GarethClarridge*