### PR TITLE
🧹 Tidy: Extract helper methods in SitemapService

### DIFF
--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -40,9 +40,23 @@ class SitemapService
     public function generate(): bool
     {
         $sitemapPath = $this->getFilePath();
+        $sitemap = Sitemap::create();
 
-        $sitemap = Sitemap::create()
-            // Static high-priority URLs
+        $this->addStaticUrls($sitemap);
+        $this->addSermons($sitemap);
+        $this->addPages($sitemap);
+        $this->addMeetings($sitemap);
+        $this->addPreachers($sitemap);
+        $this->addSeries($sitemap);
+
+        $sitemap->writeToFile($sitemapPath);
+
+        return true;
+    }
+
+    private function addStaticUrls(Sitemap $sitemap): void
+    {
+        $sitemap
             ->add(Url::create('/')
                 ->setPriority(1.0)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
@@ -95,7 +109,10 @@ class SitemapService
                     ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
             );
         }
+    }
 
+    private function addSermons(Sitemap $sitemap): void
+    {
         /**
          * Performance Optimization: Use lazy() to iterate through models one by one,
          * keeping memory usage low for sites with large numbers of sermons.
@@ -111,43 +128,54 @@ class SitemapService
 
         $now = now();
 
-        $sitemap
-            // Dynamic content via Sitemapable models
-            // Eager load relationships to prevent N+1 queries during sitemap generation
-            ->add($sermons->map(fn (Sermon $sermon): Url => $this->sermonSitemapPresenter->toSitemapTag($sermon, $now)))
-            ->add(
-                Page::query()
-                    ->public()
-                    ->where('area', '!=', PageArea::Members->value)
-                    ->select(['id', 'slug', 'area', 'updated_at', 'description', 'heading'])
-                    /**
-                     * Performance Optimization: Only eager load 'media' (needed for images),
-                     * and remove 'meeting' as it is not utilized in sitemap generation.
-                     */
-                    ->with(['media'])
-                    ->lazy()
-                    ->map(fn (Page $page): Url|string|array => $this->pageSitemapPresenter->toSitemapTag($page))
-            )
-            ->add(
-                Meeting::query()
-                    /**
-                     * Performance Optimization: Only select columns required for sitemap generation
-                     * to reduce memory usage.
-                     */
-                    ->select(['id', 'slug', 'updated_at', 'page_id'])
-                    ->with(['media', 'page:id,heading'])
-                    ->publiclyAccessible()
-                    ->lazy()
-                    ->map(fn (Meeting $meeting): Url|string|array => $this->meetingSitemapPresenter->toSitemapTag($meeting))
-            )
-            ->add(
-                Preacher::active()
-                    ->select(['id', 'name', 'slug', 'image_path', 'updated_at'])
-                    ->lazy()
-                    ->map(fn (Preacher $preacher): Url|string|array => $this->preacherSitemapPresenter->toSitemapTag($preacher))
-            );
+        $sitemap->add($sermons->map(fn (Sermon $sermon): Url => $this->sermonSitemapPresenter->toSitemapTag($sermon, $now)));
+    }
 
-        // Add Sermon Series
+    private function addPages(Sitemap $sitemap): void
+    {
+        $sitemap->add(
+            Page::query()
+                ->public()
+                ->where('area', '!=', PageArea::Members->value)
+                ->select(['id', 'slug', 'area', 'updated_at', 'description', 'heading'])
+                /**
+                 * Performance Optimization: Only eager load 'media' (needed for images),
+                 * and remove 'meeting' as it is not utilized in sitemap generation.
+                 */
+                ->with(['media'])
+                ->lazy()
+                ->map(fn (Page $page): Url|string|array => $this->pageSitemapPresenter->toSitemapTag($page))
+        );
+    }
+
+    private function addMeetings(Sitemap $sitemap): void
+    {
+        $sitemap->add(
+            Meeting::query()
+                /**
+                 * Performance Optimization: Only select columns required for sitemap generation
+                 * to reduce memory usage.
+                 */
+                ->select(['id', 'slug', 'updated_at', 'page_id'])
+                ->with(['media', 'page:id,heading'])
+                ->publiclyAccessible()
+                ->lazy()
+                ->map(fn (Meeting $meeting): Url|string|array => $this->meetingSitemapPresenter->toSitemapTag($meeting))
+        );
+    }
+
+    private function addPreachers(Sitemap $sitemap): void
+    {
+        $sitemap->add(
+            Preacher::active()
+                ->select(['id', 'name', 'slug', 'image_path', 'updated_at'])
+                ->lazy()
+                ->map(fn (Preacher $preacher): Url|string|array => $this->preacherSitemapPresenter->toSitemapTag($preacher))
+        );
+    }
+
+    private function addSeries(Sitemap $sitemap): void
+    {
         foreach ($this->sermonRepository->getSeriesForDisplay() as $series) {
             $sitemap->add(
                 Url::create('/christ/sermons/series/'.Str::slug($series))
@@ -155,10 +183,6 @@ class SitemapService
                     ->setChangeFrequency(Url::CHANGE_FREQUENCY_MONTHLY)
             );
         }
-
-        $sitemap->writeToFile($sitemapPath);
-
-        return true;
     }
 
     public function getFilePath(): string


### PR DESCRIPTION
Refactor `SitemapService::generate()` to improve maintainability.
- Extracted `addStaticUrls(Sitemap $sitemap): void`
- Extracted `addSermons(Sitemap $sitemap): void`
- Extracted `addPages(Sitemap $sitemap): void`
- Extracted `addMeetings(Sitemap $sitemap): void`
- Extracted `addPreachers(Sitemap $sitemap): void`
- Extracted `addSeries(Sitemap $sitemap): void`
- Simplified `generate()` to be a high-level orchestrator.
- No functional changes.
- All tests pass.

---
*PR created automatically by Jules for task [15490944828978523169](https://jules.google.com/task/15490944828978523169) started by @GarethClarridge*