### PR TITLE
🎨 Palette: Stretched Link pattern and accessibility improvements

### DIFF
--- a/resources/views/components/childrens-talk-card.blade.php
+++ b/resources/views/components/childrens-talk-card.blade.php
@@ -6,12 +6,14 @@
     'hasVideo',
 ])
 
-<article class="flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md">
+<article class="relative group flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-md">
     @if ($cardThumbnailUrl)
         <a
             href="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}"
             wire:navigate
-            class="group relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
+            tabindex="-1"
+            aria-hidden="true"
+            class="relative z-10 block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200"
         >
             <img
                 src="{{ $cardThumbnailUrl }}"
@@ -31,12 +33,14 @@
 
     <div class="flex flex-1 flex-col gap-5 p-6">
         @unless ($cardThumbnailUrl)
-            <div class="space-y-2">
+            <div class="space-y-2 relative z-10">
                 <p class="text-xs font-semibold uppercase tracking-[0.24em] text-cbc-teal-dark/80">Children's Corner</p>
                 <a
                     href="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}"
                     wire:navigate
-                    class="block rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
+                    tabindex="-1"
+                    aria-hidden="true"
+                    class="block"
                 >
                     <h2 class="font-display text-2xl leading-tight text-gray-900 transition-colors hover:text-cbc-teal-dark">
                         {{ $sermon->title }}
@@ -86,7 +90,14 @@
                 @endif
             </div>
 
-            <x-button link="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}" variant="secondary" size="sm" inline>
+            <x-button
+                link="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}"
+                variant="secondary"
+                size="sm"
+                inline
+                class="after:absolute after:inset-0"
+                aria-label="View children's talk: {{ $sermon->title }}"
+            >
                 Open talk
             </x-button>
         </div>

--- a/resources/views/components/page-card.blade.php
+++ b/resources/views/components/page-card.blade.php
@@ -21,8 +21,8 @@
             : '/'.$pageArea.'/'.$pageSlug;
     }
 @endphp
-<div class="group mb-4 flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition duration-300 hover:-translate-y-0.5 hover:shadow-lg">
-    <a class="relative block aspect-video overflow-hidden bg-slate-200" href="{{ $pageUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
+<div class="relative group mb-4 flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
+    <a class="relative z-10 block aspect-video overflow-hidden bg-slate-200" href="{{ $pageUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
         <img class="h-full w-full object-cover brightness-110 contrast-105 transition duration-500 ease-out group-hover:scale-105 group-hover:brightness-115" src="{{ $pageImageUrl }}" alt="{{ $pageHeading }}" onerror="this.onerror=null;this.src='/images/headings/small/default.webp';" loading="lazy" width="300" height="169">
         <div class="absolute inset-0 bg-gradient-to-t from-black/35 via-black/10 to-transparent"></div>
         <h5 class="absolute inset-x-5 top-1/2 -translate-y-1/2 text-center font-display text-3xl leading-[0.95] text-white [text-shadow:0_2px_8px_rgba(0,0,0,0.45)] sm:text-4xl">
@@ -45,7 +45,7 @@
             iconStyle="solid"
             iconPosition="trailing"
             iconClass="shrink-0 text-white/90"
-            class="w-full justify-between rounded-none text-left font-normal"
+            class="w-full justify-between rounded-none text-left font-normal after:absolute after:inset-0"
             aria-label="Learn about {{ $pageHeading }}"
         >
             Learn about {{ $pageHeading }}

--- a/resources/views/components/sermon-card.blade.php
+++ b/resources/views/components/sermon-card.blade.php
@@ -9,14 +9,16 @@
 'seriesUrl',
 ])
 
-<div data-sermon-card class="flex h-full max-w-sm flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-shadow hover:shadow-md">
+<div data-sermon-card class="relative group flex h-full max-w-sm flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-md">
 
   @if($thumbnailUrl)
     <a
       href="{{ $sermonUrl }}"
       wire:navigate
+      tabindex="-1"
+      aria-hidden="true"
       data-sermon-card-thumbnail
-      class="group relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200"
+      class="relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200"
     >
       <img
         src="{{ $thumbnailUrl }}"
@@ -36,13 +38,13 @@
 
   <div class="flex flex-col flex-1 p-6">
     @if (($sermon->title != null) && ! $thumbnailUrl)
-      <a class="group" href="{{ $sermonUrl }}" wire:navigate>
+      <a class="relative z-10" href="{{ $sermonUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
         <h4 class="font-display text-2xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
           {{$sermon->title}}
         </h4>
       </a>
     @elseif ($sermon->title != null)
-      <a class="group hidden" href="{{ $sermonUrl }}" wire:navigate data-sermon-card-title-fallback>
+      <a class="relative z-10 hidden" href="{{ $sermonUrl }}" wire:navigate data-sermon-card-title-fallback tabindex="-1" aria-hidden="true">
         <h4 class="font-display text-2xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
           {{$sermon->title}}
         </h4>
@@ -75,7 +77,7 @@
       <li class="flex items-center">
         <x-heroicon-o-user class="h-5 w-5 mr-2 text-gray-500" aria-hidden="true" />
         @if ($preacherUrl)
-          <a href="{{ $preacherUrl }}" wire:navigate class="hover:text-cbc-teal-dark transition-colors">{{ $preacherName }}</a>
+          <a href="{{ $preacherUrl }}" wire:navigate class="relative z-10 hover:text-cbc-teal-dark transition-colors">{{ $preacherName }}</a>
         @else
           <span>{{ $preacherName }}</span>
         @endif
@@ -84,7 +86,7 @@
       @if ($sermon->series != null)
       <li class="flex items-center">
         <x-heroicon-o-tag class="h-5 w-5 mr-2 text-gray-500" aria-hidden="true" />
-        <a href="{{ $seriesUrl }}" wire:navigate class="hover:text-cbc-teal-dark transition-colors">{{ $sermon->series }}</a>
+        <a href="{{ $seriesUrl }}" wire:navigate class="relative z-10 hover:text-cbc-teal-dark transition-colors">{{ $sermon->series }}</a>
       </li>
       @endif
       @if ($reference != null)
@@ -104,7 +106,7 @@
       iconStyle="solid"
       iconPosition="trailing"
       iconClass="shrink-0 text-white/90"
-      class="w-full justify-between rounded-none text-left font-normal"
+      class="w-full justify-between rounded-none text-left font-normal after:absolute after:inset-0"
       aria-label="View sermon: {{ $sermon->title }}"
   >
       View Sermon

--- a/resources/views/livewire/church/songs/browse-songs.blade.php
+++ b/resources/views/livewire/church/songs/browse-songs.blade.php
@@ -74,17 +74,17 @@
                         $authorNames = $song->authors->pluck('display_name')->implode(', ') ?: null;
                         $bookEntries = $song->books->map(fn ($book) => $book->name . ($book->pivot->entry ? ' #' . $book->pivot->entry : ''))->implode(', ') ?: null;
                     @endphp
-                    <article wire:key="song-{{ $song->id }}" class="flex h-full flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-shadow hover:shadow-md">
+                    <article wire:key="song-{{ $song->id }}" class="relative group flex h-full flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-md">
 
                         <div class="flex flex-col flex-1 p-6 @if (!empty($snippetsBySongId[$song->id])) pb-0 @endif">
                             <div class="flex items-start justify-between gap-4">
-                                <a class="group" href="{{ $songUrl }}" wire:navigate>
+                                <a class="relative z-10" href="{{ $songUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
                                     <h2 class="font-display text-3xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
                                         {{ $song->title }}
                                     </h2>
                                 </a>
 
-                                <div class="shrink-0 rounded-2xl bg-cbc-teal-dark px-4 py-3 text-center text-white shadow-sm">
+                                <div class="shrink-0 relative z-10 rounded-2xl bg-cbc-teal-dark px-4 py-3 text-center text-white shadow-sm">
                                     <p class="text-xs uppercase tracking-[0.2em] text-white/75">Uses</p>
                                     <p class="font-display text-4xl leading-none">{{ (int) ($song->usage_count ?? 0) }}</p>
                                 </div>
@@ -145,7 +145,7 @@
                             iconStyle="solid"
                             iconPosition="trailing"
                             iconClass="shrink-0 text-white/90"
-                            class="w-full justify-between rounded-none text-left font-normal"
+                            class="w-full justify-between rounded-none text-left font-normal after:absolute after:inset-0"
                             aria-label="View song: {{ $song->title }}"
                         >
                             View Song

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -1,5 +1,9 @@
 <div class="pb-12">
-    <section class="px-6" x-data="{ expanded: @js($hasActiveFilters) }">
+    <a href="#sermon-results" class="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-1/2 focus:-translate-x-1/2 focus:z-50 focus:px-4 focus:py-2 focus:bg-white focus:text-cbc-teal-dark focus:rounded-b-md focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-cbc-teal">
+        Skip to results
+    </a>
+
+    <section class="px-6" x-data="{ expanded: @js($hasActiveFilters) }" @keydown.escape.window="expanded = false">
         <div class="mx-auto max-w-2xl lg:max-w-5xl xl:max-w-7xl">
             <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-center">
                 <x-form-button


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility enhancements to the church website:

1. **Stretched Link Pattern**: I've implemented the "Stretched Link" pattern for `SermonCard`, `PageCard`, `ChildrensTalkCard`, and the song articles in `BrowseSongs`. This makes the entire card clickable, which is more intuitive for mouse and touch users. I've carefully used `relative z-10` on nested interactive elements (like preacher and series links) to ensure they remain functional.

2. **Keyboard Accessibility**:
   - Added a "Skip to results" link in the `BrowseSermons` component to allow keyboard users to bypass the filter panel.
   - Added an Escape key handler (`@keydown.escape.window`) to the filter panel in `BrowseSermons` for easy dismissal.
   - Removed redundant links (thumbnails and titles) from the tab order using `tabindex="-1"` and `aria-hidden="true"` to reduce "tab fatigue" for screen reader and keyboard users.

3. **Visual Consistency**: Standardized the hover effect across all card components to `hover:-translate-y-1` with a smooth 300ms transition.

4. **ARIA Labels**: Added or improved `aria-label` attributes on primary action buttons to provide better context (e.g., "View children's talk: [Title]" instead of just "Open talk").

All changes have been verified with Playwright screenshots and the full PHPUnit test suite.

---
*PR created automatically by Jules for task [3003329241274557715](https://jules.google.com/task/3003329241274557715) started by @GarethClarridge*