### PR TITLE
⚡ Bolt: optimize sermon scripture filter options

### DIFF
--- a/app/Livewire/Sermons/BrowseSermons.php
+++ b/app/Livewire/Sermons/BrowseSermons.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace App\Livewire\Sermons;
 
-use App\Enums\SermonContentType;
 use App\Models\Preacher;
-use App\Models\SermonScriptureFilter;
 use App\Repositories\SermonRepository;
 use App\Support\BibleCanon;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\View\View;
@@ -145,10 +142,10 @@ class BrowseSermons extends Component
     #[Computed]
     public function enabledBooks(): Collection
     {
-        return $this->scriptureFilterOptionQuery()
-            ->select('bible_book')
-            ->distinct()
-            ->pluck('bible_book');
+        return app(SermonRepository::class)->getScriptureBooks(
+            preacherId: $this->preacherFilter,
+            series: $this->seriesFilter,
+        );
     }
 
     /**
@@ -161,12 +158,11 @@ class BrowseSermons extends Component
             return collect();
         }
 
-        return $this->scriptureFilterOptionQuery()
-            ->where('bible_book', $this->bookFilter)
-            ->select('bible_chapter')
-            ->distinct()
-            ->orderBy('bible_chapter')
-            ->pluck('bible_chapter');
+        return app(SermonRepository::class)->getScriptureChapters(
+            book: $this->bookFilter,
+            preacherId: $this->preacherFilter,
+            series: $this->seriesFilter,
+        );
     }
 
     /**
@@ -191,18 +187,6 @@ class BrowseSermons extends Component
             fn (string $series): array => ['id' => $series, 'name' => $series],
             app(SermonRepository::class)->getSeriesForDisplay()
         );
-    }
-
-    /**
-     * @return Builder<SermonScriptureFilter>
-     */
-    private function scriptureFilterOptionQuery(): Builder
-    {
-        return SermonScriptureFilter::query()
-            ->join('sermons', 'sermons.id', '=', 'sermon_scripture_filters.sermon_id')
-            ->where('sermons.content_type', SermonContentType::Sermon->value)
-            ->when($this->preacherFilter, fn (Builder $query): Builder => $query->where('sermons.preacher_id', $this->preacherFilter))
-            ->when($this->seriesFilter, fn (Builder $query): Builder => $query->where('sermons.series', $this->seriesFilter));
     }
 
     /**

--- a/app/Repositories/SermonRepository.php
+++ b/app/Repositories/SermonRepository.php
@@ -380,18 +380,24 @@ class SermonRepository
             }
         }
 
-        // Resolve all books that need their chapter caches invalidated
-        // We check current filters, original filters, and current reference string
+        // Resolve all books that need their chapter caches invalidated.
+        // We check the current relationship state as a baseline.
         $books = $sermon->scriptureFilters()->distinct()->pluck('bible_book')->all();
 
-        // If the reference just changed, we should also clear for the new reference
-        // to be safe, using the index service to resolve books from the string.
-        if ($sermon->isDirty('reference')) {
-            $newEntries = app(\App\Services\SermonScriptureFilterIndexService::class)
-                ->entriesForReference($sermon->reference);
+        // If the reference changed, we must also clear caches for both the original
+        // and new reference strings. This ensures invalidation works correctly
+        // regardless of whether this is called before or after the filter index sync.
+        if ($sermon->wasChanged('reference') || $sermon->isDirty('reference')) {
+            $indexService = app(\App\Services\SermonScriptureFilterIndexService::class);
+            $references = array_filter(array_unique([
+                (string) $sermon->reference ?: null,
+                (string) $sermon->getOriginal('reference') ?: null,
+            ]));
 
-            foreach ($newEntries as $entry) {
-                $books[] = $entry['bible_book'];
+            foreach ($references as $ref) {
+                foreach ($indexService->entriesForReference($ref) as $entry) {
+                    $books[] = $entry['bible_book'];
+                }
             }
         }
 

--- a/app/Repositories/SermonRepository.php
+++ b/app/Repositories/SermonRepository.php
@@ -345,42 +345,70 @@ class SermonRepository
 
     /**
      * Clear the cached scripture book and chapter lists for a specific sermon.
+     *
+     * Performance Optimization: Invalidates caches for both current and original values
+     * to ensure filter options stay in sync when a sermon's preacher, series, or
+     * scripture reference is modified.
      */
     public function clearScriptureChapterCaches(Sermon $sermon): void
     {
-        // Clear global book list (no filters)
+        // Always clear the global (no-filter) book list
         Cache::forget('sermon_scripture_books_all_all');
 
-        // Clear preacher-specific book list
-        if ($sermon->preacher_id) {
-            Cache::forget("sermon_scripture_books_{$sermon->preacher_id}_all");
+        // Extract all possible values that could be cached
+        $preacherIds = array_filter(array_unique([
+            (int) $sermon->preacher_id ?: null,
+            (int) $sermon->getOriginal('preacher_id') ?: null,
+        ]));
+
+        $seriesNames = array_filter(array_unique([
+            $sermon->series ?: null,
+            $sermon->getOriginal('series') ?: null,
+        ]));
+
+        $seriesSlugs = array_map(fn (string $s) => Str::slug($s), $seriesNames);
+
+        // Clear book list caches for all combinations of preacher and series
+        foreach ($preacherIds as $id) {
+            Cache::forget("sermon_scripture_books_{$id}_all");
         }
 
-        // Clear series-specific book list
-        if ($sermon->series) {
-            $seriesSlug = Str::slug($sermon->series);
-            Cache::forget("sermon_scripture_books_all_{$seriesSlug}");
-            if ($sermon->preacher_id) {
-                Cache::forget("sermon_scripture_books_{$sermon->preacher_id}_{$seriesSlug}");
+        foreach ($seriesSlugs as $slug) {
+            Cache::forget("sermon_scripture_books_all_{$slug}");
+            foreach ($preacherIds as $id) {
+                Cache::forget("sermon_scripture_books_{$id}_{$slug}");
             }
         }
 
-        // Clear chapter lists for books associated with this sermon
-        $books = $sermon->scriptureFilters()->distinct()->pluck('bible_book');
+        // Resolve all books that need their chapter caches invalidated
+        // We check current filters, original filters, and current reference string
+        $books = $sermon->scriptureFilters()->distinct()->pluck('bible_book')->all();
+
+        // If the reference just changed, we should also clear for the new reference
+        // to be safe, using the index service to resolve books from the string.
+        if ($sermon->isDirty('reference')) {
+            $newEntries = app(\App\Services\SermonScriptureFilterIndexService::class)
+                ->entriesForReference($sermon->reference);
+
+            foreach ($newEntries as $entry) {
+                $books[] = $entry['bible_book'];
+            }
+        }
+
+        $books = array_unique($books);
 
         foreach ($books as $book) {
             $bookSlug = Str::slug($book);
             Cache::forget("sermon_scripture_chapters_{$bookSlug}_all_all");
 
-            if ($sermon->preacher_id) {
-                Cache::forget("sermon_scripture_chapters_{$bookSlug}_{$sermon->preacher_id}_all");
+            foreach ($preacherIds as $id) {
+                Cache::forget("sermon_scripture_chapters_{$bookSlug}_{$id}_all");
             }
 
-            if ($sermon->series) {
-                $seriesSlug = Str::slug($sermon->series);
-                Cache::forget("sermon_scripture_chapters_{$bookSlug}_all_{$seriesSlug}");
-                if ($sermon->preacher_id) {
-                    Cache::forget("sermon_scripture_chapters_{$bookSlug}_{$sermon->preacher_id}_{$seriesSlug}");
+            foreach ($seriesSlugs as $slug) {
+                Cache::forget("sermon_scripture_chapters_{$bookSlug}_all_{$slug}");
+                foreach ($preacherIds as $id) {
+                    Cache::forget("sermon_scripture_chapters_{$bookSlug}_{$id}_{$slug}");
                 }
             }
         }

--- a/app/Repositories/SermonRepository.php
+++ b/app/Repositories/SermonRepository.php
@@ -380,25 +380,25 @@ class SermonRepository
             }
         }
 
-        // Resolve all books that need their chapter caches invalidated.
-        // We check the current relationship state as a baseline.
-        $books = $sermon->scriptureFilters()->distinct()->pluck('bible_book')->all();
+        // Resolve all Bible books associated with this sermon (current and previous)
+        // to ensure all relevant chapter caches are invalidated. We parse references
+        // directly to handle new, deleted, or updated states robustly.
+        $indexService = app(\App\Services\SermonScriptureFilterIndexService::class);
+        $references = array_filter(array_unique([
+            (string) $sermon->reference ?: null,
+            (string) $sermon->getOriginal('reference') ?: null,
+        ]));
 
-        // If the reference changed, we must also clear caches for both the original
-        // and new reference strings. This ensures invalidation works correctly
-        // regardless of whether this is called before or after the filter index sync.
-        if ($sermon->wasChanged('reference') || $sermon->isDirty('reference')) {
-            $indexService = app(\App\Services\SermonScriptureFilterIndexService::class);
-            $references = array_filter(array_unique([
-                (string) $sermon->reference ?: null,
-                (string) $sermon->getOriginal('reference') ?: null,
-            ]));
-
-            foreach ($references as $ref) {
-                foreach ($indexService->entriesForReference($ref) as $entry) {
-                    $books[] = $entry['bible_book'];
-                }
+        $books = [];
+        foreach ($references as $ref) {
+            foreach ($indexService->entriesForReference($ref) as $entry) {
+                $books[] = $entry['bible_book'];
             }
+        }
+
+        // We also check the relationship to catch current or deleted filters.
+        foreach ($sermon->scriptureFilters()->distinct()->pluck('bible_book') as $book) {
+            $books[] = (string) $book;
         }
 
         $books = array_unique($books);

--- a/app/Repositories/SermonRepository.php
+++ b/app/Repositories/SermonRepository.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Repositories;
 
+use App\Enums\SermonContentType;
 use App\Enums\SermonService;
 use App\Models\Preacher;
 use App\Models\Sermon;
+use App\Models\SermonScriptureFilter;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
@@ -167,6 +169,8 @@ class SermonRepository
         Cache::forget('sermon_series');
 
         if ($model instanceof Sermon) {
+            $this->clearScriptureChapterCaches($model);
+
             if ($model->series) {
                 Cache::forget('sermons_series_'.Str::slug($model->series));
             }
@@ -266,5 +270,119 @@ class SermonRepository
 
             return $series;
         });
+    }
+
+    /**
+     * Get distinct Bible books that have associated sermons, optionally filtered by preacher or series.
+     *
+     * Performance Optimization: Caches the book list for 24 hours using flexible cache.
+     * If no preacher or series filters are applied, it avoids joining the sermons table.
+     *
+     * @return Collection<int, string>
+     */
+    public function getScriptureBooks(mixed $preacherId = null, mixed $series = null): Collection
+    {
+        $preacherId = (int) $preacherId ?: null;
+        $series = filled($series) ? (string) $series : null;
+
+        $cacheKey = 'sermon_scripture_books_'.($preacherId ?? 'all').'_'.($series ? Str::slug($series) : 'all');
+
+        return Cache::flexible($cacheKey, [86400, 172800], function () use ($preacherId, $series): Collection {
+            $query = SermonScriptureFilter::query();
+
+            if ($preacherId === null && $series === null) {
+                // Entries are only created for ContentType::Sermon, so we can skip the join
+                return $query->select('bible_book')
+                    ->distinct()
+                    ->pluck('bible_book');
+            }
+
+            return $query->join('sermons', 'sermons.id', '=', 'sermon_scripture_filters.sermon_id')
+                ->where('sermons.content_type', SermonContentType::Sermon)
+                ->when($preacherId, fn (Builder $q) => $q->where('sermons.preacher_id', $preacherId))
+                ->when($series, fn (Builder $q) => $q->where('sermons.series', $series))
+                ->select('bible_book')
+                ->distinct()
+                ->pluck('bible_book');
+        });
+    }
+
+    /**
+     * Get distinct chapters for a Bible book that have associated sermons, optionally filtered by preacher or series.
+     *
+     * Performance Optimization: Caches the chapter list for 24 hours using flexible cache.
+     * If no preacher or series filters are applied, it avoids joining the sermons table.
+     *
+     * @return Collection<int, int>
+     */
+    public function getScriptureChapters(string $book, mixed $preacherId = null, mixed $series = null): Collection
+    {
+        $preacherId = (int) $preacherId ?: null;
+        $series = filled($series) ? (string) $series : null;
+
+        $cacheKey = 'sermon_scripture_chapters_'.Str::slug($book).'_'.($preacherId ?? 'all').'_'.($series ? Str::slug($series) : 'all');
+
+        return Cache::flexible($cacheKey, [86400, 172800], function () use ($book, $preacherId, $series): Collection {
+            $query = SermonScriptureFilter::query()->where('bible_book', $book);
+
+            if ($preacherId === null && $series === null) {
+                return $query->select('bible_chapter')
+                    ->distinct()
+                    ->orderBy('bible_chapter')
+                    ->pluck('bible_chapter');
+            }
+
+            return $query->join('sermons', 'sermons.id', '=', 'sermon_scripture_filters.sermon_id')
+                ->where('sermons.content_type', SermonContentType::Sermon)
+                ->when($preacherId, fn (Builder $q) => $q->where('sermons.preacher_id', $preacherId))
+                ->when($series, fn (Builder $q) => $q->where('sermons.series', $series))
+                ->select('bible_chapter')
+                ->distinct()
+                ->orderBy('bible_chapter')
+                ->pluck('bible_chapter');
+        });
+    }
+
+    /**
+     * Clear the cached scripture book and chapter lists for a specific sermon.
+     */
+    public function clearScriptureChapterCaches(Sermon $sermon): void
+    {
+        // Clear global book list (no filters)
+        Cache::forget('sermon_scripture_books_all_all');
+
+        // Clear preacher-specific book list
+        if ($sermon->preacher_id) {
+            Cache::forget("sermon_scripture_books_{$sermon->preacher_id}_all");
+        }
+
+        // Clear series-specific book list
+        if ($sermon->series) {
+            $seriesSlug = Str::slug($sermon->series);
+            Cache::forget("sermon_scripture_books_all_{$seriesSlug}");
+            if ($sermon->preacher_id) {
+                Cache::forget("sermon_scripture_books_{$sermon->preacher_id}_{$seriesSlug}");
+            }
+        }
+
+        // Clear chapter lists for books associated with this sermon
+        $books = $sermon->scriptureFilters()->distinct()->pluck('bible_book');
+
+        foreach ($books as $book) {
+            $bookSlug = Str::slug($book);
+            Cache::forget("sermon_scripture_chapters_{$bookSlug}_all_all");
+
+            if ($sermon->preacher_id) {
+                Cache::forget("sermon_scripture_chapters_{$bookSlug}_{$sermon->preacher_id}_all");
+            }
+
+            if ($sermon->series) {
+                $seriesSlug = Str::slug($sermon->series);
+                Cache::forget("sermon_scripture_chapters_{$bookSlug}_all_{$seriesSlug}");
+                if ($sermon->preacher_id) {
+                    Cache::forget("sermon_scripture_chapters_{$bookSlug}_{$sermon->preacher_id}_{$seriesSlug}");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Optimized the sermon browse page by caching Bible book and chapter filter options and eliminating unnecessary database joins. Added cache invalidation to maintain data integrity when sermons are modified.

---
*PR created automatically by Jules for task [9705832742291377979](https://jules.google.com/task/9705832742291377979) started by @GarethClarridge*