### PR TITLE
🏛️ Warden: Add text integrity checks to sermons, preachers, and pages

### DIFF
--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -88,6 +88,16 @@ class Page extends Model implements HasMedia, Sitemapable
     }
 
     /**
+     * @return Attribute<string, string>
+     */
+    protected function heading(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value): string => trim($value),
+        );
+    }
+
+    /**
      * @return array<string, list<string|mixed>>
      */
     public static function validationRules(?self $page = null, ?string $area = null): array

--- a/app/Models/Preacher.php
+++ b/app/Models/Preacher.php
@@ -61,6 +61,16 @@ class Preacher extends Model implements Sitemapable
     }
 
     /**
+     * @return Attribute<string, string>
+     */
+    protected function name(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value): string => trim($value),
+        );
+    }
+
+    /**
      * @return array<string, list<string|mixed>>
      */
     public static function validationRules(?self $preacher = null): array

--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -197,6 +197,34 @@ class Sermon extends Model implements Sitemapable
     }
 
     /**
+     * @return Attribute<string, string>
+     */
+    protected function title(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value): string => trim($value),
+        );
+    }
+
+    /**
+     * @return Attribute<?string, ?string>
+     */
+    protected function series(): Attribute
+    {
+        return Attribute::make(
+            set: function (?string $value): ?string {
+                if ($value === null) {
+                    return null;
+                }
+
+                $trimmed = trim($value);
+
+                return $trimmed === '' ? null : $trimmed;
+            },
+        );
+    }
+
+    /**
      * @return array<string, list<string|mixed>>
      */
     public static function validationRules(?self $sermon = null): array

--- a/database/migrations/2026_04_27_052406_add_text_integrity_checks.php
+++ b/database/migrations/2026_04_27_052406_add_text_integrity_checks.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        // 1. Data Cleanup: Trim existing data and convert whitespace-only to NULL for series
+        DB::table('sermons')->update([
+            'title' => DB::raw('TRIM(title)'),
+            'series' => DB::raw("NULLIF(TRIM(series), '')"),
+        ]);
+
+        DB::table('preachers')->update([
+            'name' => DB::raw('TRIM(name)'),
+        ]);
+
+        DB::table('pages')->update([
+            'heading' => DB::raw('TRIM(heading)'),
+        ]);
+
+        // 2. Add CHECK constraints
+        // BINARY is used to ensure exact match for the trim check.
+        DB::statement("ALTER TABLE sermons ADD CONSTRAINT sermons_title_format_check CHECK (BINARY title = TRIM(title) AND title != '')");
+        DB::statement("ALTER TABLE sermons ADD CONSTRAINT sermons_series_format_check CHECK (series IS NULL OR (BINARY series = TRIM(series) AND series != ''))");
+        DB::statement("ALTER TABLE preachers ADD CONSTRAINT preachers_name_format_check CHECK (BINARY name = TRIM(name) AND name != '')");
+        DB::statement("ALTER TABLE pages ADD CONSTRAINT pages_heading_format_check CHECK (BINARY heading = TRIM(heading) AND heading != '')");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        DB::statement('ALTER TABLE sermons DROP CHECK sermons_title_format_check');
+        DB::statement('ALTER TABLE sermons DROP CHECK sermons_series_format_check');
+        DB::statement('ALTER TABLE preachers DROP CHECK preachers_name_format_check');
+        DB::statement('ALTER TABLE pages DROP CHECK pages_heading_format_check');
+    }
+};

--- a/tests/Feature/Warden/TextIntegrityTest.php
+++ b/tests/Feature/Warden/TextIntegrityTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Warden;
+
+use App\Models\Page;
+use App\Models\Preacher;
+use App\Models\Sermon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TextIntegrityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function sermon_title_is_automatically_trimmed()
+    {
+        $sermon = Sermon::factory()->create([
+            'title' => '  Trimmed Title  ',
+        ]);
+
+        $this->assertEquals('Trimmed Title', $sermon->fresh()->title);
+    }
+
+    #[Test]
+    public function sermon_series_is_automatically_trimmed_and_empty_becomes_null()
+    {
+        $sermon = Sermon::factory()->create([
+            'series' => '  Trimmed Series  ',
+        ]);
+
+        $this->assertEquals('Trimmed Series', $sermon->fresh()->series);
+
+        $sermon->series = '   ';
+        $sermon->save();
+        $this->assertNull($sermon->fresh()->series);
+    }
+
+    #[Test]
+    public function preacher_name_is_automatically_trimmed()
+    {
+        $preacher = Preacher::factory()->create([
+            'name' => '  Trimmed Preacher  ',
+        ]);
+
+        $this->assertEquals('Trimmed Preacher', $preacher->fresh()->name);
+    }
+
+    #[Test]
+    public function page_heading_is_automatically_trimmed()
+    {
+        $page = Page::factory()->create([
+            'heading' => '  Trimmed Heading  ',
+        ]);
+
+        $this->assertEquals('Trimmed Heading', $page->fresh()->heading);
+    }
+
+    #[Test]
+    public function empty_sermon_title_is_rejected_by_database()
+    {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        // We use DB::table to bypass model mutators
+        DB::table('sermons')->insert(
+            array_merge(
+                Sermon::factory()->make()->toArray(),
+                [
+                    'title' => '',
+                    'points' => null,
+                    'thumbnail_metadata' => null,
+                ]
+            )
+        );
+    }
+
+    #[Test]
+    public function untrimmed_sermon_title_is_rejected_by_database()
+    {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        DB::table('sermons')->insert(
+            array_merge(
+                Sermon::factory()->make()->toArray(),
+                [
+                    'title' => ' Untrimmed ',
+                    'points' => null,
+                    'thumbnail_metadata' => null,
+                ]
+            )
+        );
+    }
+
+    #[Test]
+    public function empty_preacher_name_is_rejected_by_database()
+    {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        DB::table('preachers')->insert(
+            array_merge(
+                Preacher::factory()->make()->toArray(),
+                ['name' => '']
+            )
+        );
+    }
+
+    #[Test]
+    public function untrimmed_preacher_name_is_rejected_by_database()
+    {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        DB::table('preachers')->insert(
+            array_merge(
+                Preacher::factory()->make()->toArray(),
+                ['name' => ' Untrimmed ']
+            )
+        );
+    }
+}


### PR DESCRIPTION
This PR strengthens the data integrity of the church website by ensuring that core text fields representing entity identities are always trimmed and non-empty.

### 💡 What:
- Added MySQL `CHECK` constraints to `sermons.title`, `sermons.series`, `preachers.name`, and `pages.heading`.
- Added Eloquent attribute mutators to automatically trim these fields on set.
- For the nullable `sermons.series` column, empty or whitespace-only strings are automatically converted to `null` to satisfy the database constraint.

### 🎯 Why:
- Prevents leading/trailing whitespace from affecting search and display consistency.
- Prevents empty strings from being saved as valid titles or names, which would cause UI issues.
- Ensures a single source of truth for "no series" (NULL instead of mixed NULL and empty strings).

### 🗄️ Migration:
- `2026_04_27_052406_add_text_integrity_checks.php`: Performs `TRIM` on existing data (and `NULLIF` for series) before applying `CHECK` constraints.

### ✅ Verification:
- New test `tests/Feature/Warden/TextIntegrityTest.php` verifies model normalization and database rejection of invalid data.
- Full parallel test suite (4666 tests) passed successfully.

### ⚠️ Rollback:
- `php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [6766160856059838235](https://jules.google.com/task/6766160856059838235) started by @GarethClarridge*