### PR TITLE
🛡️ Sentinel: Fix unauthorized access to private sermon assets

### DIFF
--- a/app/Http/Controllers/SermonAssetController.php
+++ b/app/Http/Controllers/SermonAssetController.php
@@ -26,13 +26,13 @@ class SermonAssetController extends Controller
      */
     public function serveAudio(Sermon $sermon): BinaryFileResponse|RedirectResponse
     {
-        $authorizationResponse = $this->authorizeChildrensTalkAssetAccess($sermon);
-        if ($authorizationResponse instanceof RedirectResponse) {
-            return $authorizationResponse;
-        }
-
         if (! $sermon->audio_file_path) {
             abort(404, 'Audio file not found.');
+        }
+
+        $authorizationResponse = $this->authorizeAssetAccess($sermon, $sermon->audio_file_path);
+        if ($authorizationResponse instanceof RedirectResponse) {
+            return $authorizationResponse;
         }
 
         $this->abortOnUnsafePath($sermon->audio_file_path, 'audio');
@@ -60,13 +60,13 @@ class SermonAssetController extends Controller
 
     public function serveVideo(Sermon $sermon): BinaryFileResponse|RedirectResponse
     {
-        $authorizationResponse = $this->authorizeChildrensTalkAssetAccess($sermon);
-        if ($authorizationResponse instanceof RedirectResponse) {
-            return $authorizationResponse;
-        }
-
         if (! $sermon->video_file_path) {
             abort(404, 'Video file not found.');
+        }
+
+        $authorizationResponse = $this->authorizeAssetAccess($sermon, $sermon->video_file_path);
+        if ($authorizationResponse instanceof RedirectResponse) {
+            return $authorizationResponse;
         }
 
         $this->abortOnUnsafePath($sermon->video_file_path, 'video');
@@ -98,13 +98,13 @@ class SermonAssetController extends Controller
      */
     public function serveThumbnail(Sermon $sermon): BinaryFileResponse|RedirectResponse
     {
-        $authorizationResponse = $this->authorizeChildrensTalkAssetAccess($sermon);
-        if ($authorizationResponse instanceof RedirectResponse) {
-            return $authorizationResponse;
-        }
-
         if (! $sermon->thumbnail_file_path) {
             abort(404, 'Thumbnail not found.');
+        }
+
+        $authorizationResponse = $this->authorizeAssetAccess($sermon, $sermon->thumbnail_file_path);
+        if ($authorizationResponse instanceof RedirectResponse) {
+            return $authorizationResponse;
         }
 
         $this->abortOnUnsafePath($sermon->thumbnail_file_path, 'thumbnail');
@@ -129,15 +129,15 @@ class SermonAssetController extends Controller
      */
     public function serveCardThumbnail(Sermon $sermon): BinaryFileResponse|RedirectResponse
     {
-        $authorizationResponse = $this->authorizeChildrensTalkAssetAccess($sermon);
-        if ($authorizationResponse instanceof RedirectResponse) {
-            return $authorizationResponse;
-        }
-
         $cardThumbnailPath = $sermon->card_thumbnail_file_path;
 
         if (! $cardThumbnailPath) {
             abort(404, 'Card thumbnail not found.');
+        }
+
+        $authorizationResponse = $this->authorizeAssetAccess($sermon, $cardThumbnailPath);
+        if ($authorizationResponse instanceof RedirectResponse) {
+            return $authorizationResponse;
         }
 
         $this->abortOnUnsafePath($cardThumbnailPath, 'thumbnail');
@@ -190,17 +190,33 @@ class SermonAssetController extends Controller
         ]);
     }
 
-    private function authorizeChildrensTalkAssetAccess(Sermon $sermon): ?RedirectResponse
+    /**
+     * Authorize access to a sermon asset based on content type and storage path.
+     */
+    private function authorizeAssetAccess(Sermon $sermon, ?string $path): ?RedirectResponse
     {
-        if ($sermon->content_type !== SermonContentType::ChildrensTalk) {
+        /** @var \App\Models\User|null $user */
+        $user = Auth::user();
+
+        // 1. Storage-level security: assets in the private/ directory are restricted to administrators.
+        if ($path !== null && str_starts_with($path, 'private/')) {
+            if ($user?->canAccessAdmin() !== true) {
+                abort(403, 'Unauthorized access to private asset.');
+            }
+
             return null;
         }
 
-        if ($this->exposurePolicy->canAccessChildrensCorner(Auth::user())) {
-            return null;
+        // 2. Business logic security: Children's Corner content is restricted via its own policy.
+        if ($sermon->content_type === SermonContentType::ChildrensTalk) {
+            if ($this->exposurePolicy->canAccessChildrensCorner($user)) {
+                return null;
+            }
+
+            return redirect()->guest(route('login'));
         }
 
-        return redirect()->guest(route('login'));
+        return null;
     }
 
     private function abortOnUnsafePath(string $path, string $type): void

--- a/tests/Feature/Security/PrivateSermonAssetSecurityTest.php
+++ b/tests/Feature/Security/PrivateSermonAssetSecurityTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use App\Enums\SermonContentType;
+use App\Models\Sermon;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PrivateSermonAssetSecurityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('local');
+        Storage::fake('public');
+    }
+
+    #[Test]
+    public function guest_cannot_access_regular_sermon_with_private_audio(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'content_type' => SermonContentType::Sermon,
+            'audio_file_path' => 'private/secret-audio.mp3',
+        ]);
+        Storage::disk('local')->put('private/secret-audio.mp3', 'secret content');
+
+        $response = $this->get(route('sermons.audio', $sermon));
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function guest_cannot_access_regular_sermon_with_private_video(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'content_type' => SermonContentType::Sermon,
+            'video_file_path' => 'private/secret-video.mp4',
+        ]);
+        Storage::disk('local')->put('private/secret-video.mp4', 'secret content');
+
+        $response = $this->get(route('sermons.video', $sermon));
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function guest_cannot_access_regular_sermon_with_private_thumbnail(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'content_type' => SermonContentType::Sermon,
+            'thumbnail_file_path' => 'private/secret-thumb.webp',
+        ]);
+        Storage::disk('local')->put('private/secret-thumb.webp', 'secret content');
+
+        $response = $this->get(route('sermons.thumbnail', $sermon));
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function regular_user_cannot_access_regular_sermon_with_private_audio(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+        $sermon = Sermon::factory()->create([
+            'content_type' => SermonContentType::Sermon,
+            'audio_file_path' => 'private/secret-audio.mp3',
+        ]);
+        Storage::disk('local')->put('private/secret-audio.mp3', 'secret content');
+
+        $response = $this->actingAs($user)->get(route('sermons.audio', $sermon));
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function admin_can_access_regular_sermon_with_private_audio(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
+        $sermon = Sermon::factory()->create([
+            'content_type' => SermonContentType::Sermon,
+            'audio_file_path' => 'private/secret-audio.mp3',
+        ]);
+        Storage::disk('local')->put('private/secret-audio.mp3', 'secret content');
+
+        $response = $this->actingAs($admin)->get(route('sermons.audio', $sermon));
+
+        $response->assertStatus(200);
+    }
+
+    #[Test]
+    public function guest_redirected_to_login_for_private_childrens_talk_even_if_not_on_private_disk(): void
+    {
+        // This confirms we still respect Children's Corner policies
+        $sermon = Sermon::factory()->create([
+            'content_type' => SermonContentType::ChildrensTalk,
+            'audio_file_path' => 'sermons/talk.mp3',
+        ]);
+        Storage::disk('public')->put('sermons/talk.mp3', 'public content');
+
+        config(['sermons.childrens_talks.public' => false]);
+
+        $response = $this->get(route('sermons.audio', $sermon));
+
+        $response->assertRedirect(route('login'));
+    }
+}

--- a/tests/Feature/Security/SermonPrivateStorageMoveTest.php
+++ b/tests/Feature/Security/SermonPrivateStorageMoveTest.php
@@ -89,7 +89,7 @@ class SermonPrivateStorageMoveTest extends TestCase
     }
 
     #[Test]
-    public function it_serves_private_audio_to_authenticated_user(): void
+    public function it_serves_private_audio_to_admin_user(): void
     {
         Storage::fake('local');
 
@@ -101,9 +101,9 @@ class SermonPrivateStorageMoveTest extends TestCase
             'audio_file_path' => $privatePath,
         ]);
 
-        $user = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
 
-        $response = $this->actingAs($user)->get("/christ/sermons/{$sermon->slug}/audio");
+        $response = $this->actingAs($admin)->get("/christ/sermons/{$sermon->slug}/audio");
 
         $response->assertStatus(200);
     }

--- a/tests/Feature/SermonAssetControllerTest.php
+++ b/tests/Feature/SermonAssetControllerTest.php
@@ -392,6 +392,7 @@ class SermonAssetControllerTest extends TestCase
     public function it_serves_private_audio_file_as_binary_response(): void
     {
         Storage::fake('local');
+        $admin = \App\Models\User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
 
         $sermon = Sermon::factory()->create([
             'slug' => 'private-sermon',
@@ -400,7 +401,7 @@ class SermonAssetControllerTest extends TestCase
 
         Storage::disk('local')->put('private/sermons/test-audio.mp3', 'fake private audio content');
 
-        $response = $this->get("/christ/sermons/{$sermon->slug}/audio");
+        $response = $this->actingAs($admin)->get("/christ/sermons/{$sermon->slug}/audio");
 
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'audio/mpeg');
@@ -410,6 +411,7 @@ class SermonAssetControllerTest extends TestCase
     public function it_serves_private_video_file_as_binary_response(): void
     {
         Storage::fake('local');
+        $admin = \App\Models\User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
 
         $sermon = Sermon::factory()->create([
             'slug' => 'private-video-sermon',
@@ -418,7 +420,7 @@ class SermonAssetControllerTest extends TestCase
 
         Storage::disk('local')->put('private/sermons/test-video.mp4', 'fake private video content');
 
-        $response = $this->get("/christ/sermons/{$sermon->slug}/video");
+        $response = $this->actingAs($admin)->get("/christ/sermons/{$sermon->slug}/video");
 
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'video/mp4');
@@ -429,6 +431,7 @@ class SermonAssetControllerTest extends TestCase
     public function it_serves_private_thumbnail_file_as_binary_response(): void
     {
         Storage::fake('local');
+        $admin = \App\Models\User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
 
         $sermon = Sermon::factory()->create([
             'slug' => 'private-thumb-sermon',
@@ -437,7 +440,7 @@ class SermonAssetControllerTest extends TestCase
 
         Storage::disk('local')->put('private/thumbnails/test-thumb.png', 'fake private png content');
 
-        $response = $this->get("/christ/sermons/{$sermon->slug}/thumbnail");
+        $response = $this->actingAs($admin)->get("/christ/sermons/{$sermon->slug}/thumbnail");
 
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'image/png');
@@ -447,6 +450,7 @@ class SermonAssetControllerTest extends TestCase
     public function it_serves_private_card_thumbnail_file_as_binary_response(): void
     {
         Storage::fake('local');
+        $admin = \App\Models\User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
 
         $sermon = Sermon::factory()->create([
             'slug' => 'private-card-thumb-sermon',
@@ -457,7 +461,7 @@ class SermonAssetControllerTest extends TestCase
 
         Storage::disk('local')->put('private/thumbnails/card.webp', 'fake private webp content');
 
-        $response = $this->get("/christ/sermons/{$sermon->slug}/thumbnail/card");
+        $response = $this->actingAs($admin)->get("/christ/sermons/{$sermon->slug}/thumbnail/card");
 
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'image/webp');

--- a/tests/Feature/SermonPrivateAssetTest.php
+++ b/tests/Feature/SermonPrivateAssetTest.php
@@ -16,6 +16,7 @@ class SermonPrivateAssetTest extends TestCase
     public function it_serves_private_audio_file_directly(): void
     {
         Storage::fake('local');
+        $admin = \App\Models\User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
 
         $sermon = Sermon::factory()->create([
             'slug' => 'private-audio-sermon',
@@ -24,7 +25,7 @@ class SermonPrivateAssetTest extends TestCase
 
         Storage::disk('local')->put('private/sermons/audio/test.mp3', 'fake mp3 content');
 
-        $response = $this->get("/christ/sermons/{$sermon->slug}/audio");
+        $response = $this->actingAs($admin)->get("/christ/sermons/{$sermon->slug}/audio");
 
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'audio/mpeg');
@@ -36,6 +37,7 @@ class SermonPrivateAssetTest extends TestCase
     public function it_serves_private_thumbnail_webp_directly(): void
     {
         Storage::fake('local');
+        $admin = \App\Models\User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
 
         $sermon = Sermon::factory()->create([
             'slug' => 'private-webp-sermon',
@@ -44,7 +46,7 @@ class SermonPrivateAssetTest extends TestCase
 
         Storage::disk('local')->put('private/thumbnails/test.webp', 'fake webp content');
 
-        $response = $this->get("/christ/sermons/{$sermon->slug}/thumbnail");
+        $response = $this->actingAs($admin)->get("/christ/sermons/{$sermon->slug}/thumbnail");
 
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'image/webp');
@@ -55,6 +57,7 @@ class SermonPrivateAssetTest extends TestCase
     public function it_serves_private_thumbnail_jpg_directly(): void
     {
         Storage::fake('local');
+        $admin = \App\Models\User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
 
         $sermon = Sermon::factory()->create([
             'slug' => 'private-jpg-sermon',
@@ -63,7 +66,7 @@ class SermonPrivateAssetTest extends TestCase
 
         Storage::disk('local')->put('private/thumbnails/test.jpg', 'fake jpg content');
 
-        $response = $this->get("/christ/sermons/{$sermon->slug}/thumbnail");
+        $response = $this->actingAs($admin)->get("/christ/sermons/{$sermon->slug}/thumbnail");
 
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'image/jpeg');
@@ -73,6 +76,7 @@ class SermonPrivateAssetTest extends TestCase
     public function it_serves_private_card_thumbnail_directly(): void
     {
         Storage::fake('local');
+        $admin = \App\Models\User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
 
         $sermon = Sermon::factory()->create([
             'slug' => 'private-card-sermon',
@@ -83,7 +87,7 @@ class SermonPrivateAssetTest extends TestCase
 
         Storage::disk('local')->put('private/thumbnails/card.png', 'fake png content');
 
-        $response = $this->get("/christ/sermons/{$sermon->slug}/thumbnail/card");
+        $response = $this->actingAs($admin)->get("/christ/sermons/{$sermon->slug}/thumbnail/card");
 
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'image/png');

--- a/tests/Feature/SermonThumbnailServingTest.php
+++ b/tests/Feature/SermonThumbnailServingTest.php
@@ -99,7 +99,9 @@ class SermonThumbnailServingTest extends TestCase
         // Create a fake thumbnail file
         Storage::disk('local')->put('private/sermons/thumbnails/test-thumbnail.jpg', 'fake image content');
 
-        $response = $this->get("/christ/sermons/{$sermon->slug}/thumbnail");
+        $admin = \App\Models\User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
+
+        $response = $this->actingAs($admin)->get("/christ/sermons/{$sermon->slug}/thumbnail");
 
         $response->assertStatus(200);
         $this->assertStringContainsString('no-store', (string) $response->headers->get('Cache-Control'));


### PR DESCRIPTION
I identified a security gap in `SermonAssetController` where assets stored on the private local disk were only protected by the Children's Corner exposure policy. If a sermon was not a "Children's Talk" but had its assets moved to `private/` (e.g. during a manual administrative task or processing), it could be accessed by guests.

I've implemented a centralized `authorizeAssetAccess` method in `SermonAssetController` that enforces a hard rule: any path starting with `private/` requires admin access. This is checked for audio, video, and all thumbnail variants.

Verification:
- Added `tests/Feature/Security/PrivateSermonAssetSecurityTest.php` covering multiple scenarios.
- Updated 5 existing test files that were previously using guest access for private files.
- Ran the full test suite (4664 tests), all passed.
- Verified with Pint and PHPStan.

---
*PR created automatically by Jules for task [17886978802864092769](https://jules.google.com/task/17886978802864092769) started by @GarethClarridge*