### PR TITLE
📝 Scribe: Add unit tests for sanitization traits

### DIFF
--- a/tests/Unit/Traits/EscapesLikeWildcardsTest.php
+++ b/tests/Unit/Traits/EscapesLikeWildcardsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Traits;
+
+use App\Traits\EscapesLikeWildcards;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class EscapesLikeWildcardsTest extends TestCase
+{
+    private object $traitInstance;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->traitInstance = new class
+        {
+            use EscapesLikeWildcards;
+
+            public function callEscapeLike(string $value): string
+            {
+                return $this->escapeLike($value);
+            }
+        };
+    }
+
+    #[Test]
+    public function it_leaves_normal_strings_unchanged(): void
+    {
+        $this->assertSame('Normal String', $this->traitInstance->callEscapeLike('Normal String'));
+    }
+
+    #[Test]
+    public function it_escapes_percent_character(): void
+    {
+        $this->assertSame('100\\%', $this->traitInstance->callEscapeLike('100%'));
+    }
+
+    #[Test]
+    public function it_escapes_underscore_character(): void
+    {
+        $this->assertSame('some\\_name', $this->traitInstance->callEscapeLike('some_name'));
+    }
+
+    #[Test]
+    public function it_escapes_backslash_character(): void
+    {
+        $this->assertSame('back\\\\slash', $this->traitInstance->callEscapeLike('back\\slash'));
+    }
+
+    #[Test]
+    public function it_escapes_multiple_special_characters(): void
+    {
+        $this->assertSame('\\%\\_\\\\\\%\\_', $this->traitInstance->callEscapeLike('%_\\%_'));
+    }
+}

--- a/tests/Unit/Traits/SanitizesLogDataTest.php
+++ b/tests/Unit/Traits/SanitizesLogDataTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Traits;
+
+use App\Traits\SanitizesLogData;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SanitizesLogDataTest extends TestCase
+{
+    private object $traitInstance;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->traitInstance = new class
+        {
+            use SanitizesLogData;
+
+            public function callSanitizeForLog(string $value): string
+            {
+                return $this->sanitizeForLog($value);
+            }
+        };
+    }
+
+    #[Test]
+    public function it_leaves_normal_strings_unchanged(): void
+    {
+        $this->assertSame('Normal String', $this->traitInstance->callSanitizeForLog('Normal String'));
+    }
+
+    #[Test]
+    public function it_replaces_newlines_and_carriage_returns_with_spaces(): void
+    {
+        $this->assertSame('Line 1 Line 2', $this->traitInstance->callSanitizeForLog("Line 1\nLine 2"));
+        $this->assertSame('Line 1 Line 2', $this->traitInstance->callSanitizeForLog("Line 1\r\nLine 2"));
+        $this->assertSame('Line 1 Line 2', $this->traitInstance->callSanitizeForLog("Line 1\rLine 2"));
+    }
+
+    #[Test]
+    public function it_replaces_tabs_with_spaces(): void
+    {
+        $this->assertSame('Tab separated values', $this->traitInstance->callSanitizeForLog("Tab\tseparated\tvalues"));
+    }
+
+    #[Test]
+    public function it_collapses_multiple_spaces_into_one(): void
+    {
+        $this->assertSame('Too many spaces', $this->traitInstance->callSanitizeForLog('Too   many  spaces'));
+    }
+
+    #[Test]
+    public function it_trims_leading_and_trailing_whitespace(): void
+    {
+        $this->assertSame('Trimmed', $this->traitInstance->callSanitizeForLog('  Trimmed  '));
+    }
+
+    #[Test]
+    public function it_handles_complex_malicious_input(): void
+    {
+        $input = "  Attempted\nLog\rInjection\tWith   Multiple  Spaces  ";
+        $expected = 'Attempted Log Injection With Multiple Spaces';
+
+        $this->assertSame($expected, $this->traitInstance->callSanitizeForLog($input));
+    }
+}


### PR DESCRIPTION
Identified that the `SanitizesLogData` and `EscapesLikeWildcards` traits, used for security purposes (log injection prevention and LIKE injection prevention), were missing dedicated unit tests. 

Implemented:
- `tests/Unit/Traits/SanitizesLogDataTest.php` covering various sanitization scenarios (newlines, carriage returns, tabs, multiple spaces, and trimming).
- `tests/Unit/Traits/EscapesLikeWildcardsTest.php` covering the escaping of MySQL special characters (`%`, `_`, and `\`).

Verified that the new tests pass and ran code quality tools (`pint`, `phpstan`), ensuring no errors. Confirmed no regressions by running the full test suite.

---
*PR created automatically by Jules for task [500521907312773996](https://jules.google.com/task/500521907312773996) started by @GarethClarridge*