### PR TITLE
🎨 Palette: Standardize Stretched Link pattern and accessibility

### DIFF
--- a/resources/views/components/childrens-talk-card.blade.php
+++ b/resources/views/components/childrens-talk-card.blade.php
@@ -6,12 +6,14 @@
     'hasVideo',
 ])
 
-<article class="flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md">
+<article class="group relative flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
     @if ($cardThumbnailUrl)
         <a
             href="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}"
             wire:navigate
-            class="group relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
+            tabindex="-1"
+            aria-hidden="true"
+            class="relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
         >
             <img
                 src="{{ $cardThumbnailUrl }}"
@@ -36,6 +38,8 @@
                 <a
                     href="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}"
                     wire:navigate
+                    tabindex="-1"
+                    aria-hidden="true"
                     class="block rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
                 >
                     <h2 class="font-display text-2xl leading-tight text-gray-900 transition-colors hover:text-cbc-teal-dark">
@@ -86,7 +90,14 @@
                 @endif
             </div>
 
-            <x-button link="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}" variant="secondary" size="sm" inline>
+            <x-button
+                link="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}"
+                variant="secondary"
+                size="sm"
+                inline
+                class="after:absolute after:inset-0"
+                aria-label="View children's talk: {{ $sermon->title }}"
+            >
                 Open talk
             </x-button>
         </div>

--- a/resources/views/components/page-card.blade.php
+++ b/resources/views/components/page-card.blade.php
@@ -21,7 +21,7 @@
             : '/'.$pageArea.'/'.$pageSlug;
     }
 @endphp
-<div class="group mb-4 flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition duration-300 hover:-translate-y-0.5 hover:shadow-lg">
+<div class="group relative mb-4 flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
     <a class="relative block aspect-video overflow-hidden bg-slate-200" href="{{ $pageUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
         <img class="h-full w-full object-cover brightness-110 contrast-105 transition duration-500 ease-out group-hover:scale-105 group-hover:brightness-115" src="{{ $pageImageUrl }}" alt="{{ $pageHeading }}" onerror="this.onerror=null;this.src='/images/headings/small/default.webp';" loading="lazy" width="300" height="169">
         <div class="absolute inset-0 bg-gradient-to-t from-black/35 via-black/10 to-transparent"></div>
@@ -45,13 +45,15 @@
             iconStyle="solid"
             iconPosition="trailing"
             iconClass="shrink-0 text-white/90"
-            class="w-full justify-between rounded-none text-left font-normal"
+            class="w-full justify-between rounded-none text-left font-normal after:absolute after:inset-0"
             aria-label="Learn about {{ $pageHeading }}"
         >
             Learn about {{ $pageHeading }}
         </x-button>
     </div>
 
-    <x-page-card-admin-overlay slug="{{ $pageSlug }}" />
+    <div class="relative z-10">
+        <x-page-card-admin-overlay slug="{{ $pageSlug }}" />
+    </div>
 </div>
 @endif

--- a/resources/views/components/sermon-card.blade.php
+++ b/resources/views/components/sermon-card.blade.php
@@ -9,14 +9,16 @@
 'seriesUrl',
 ])
 
-<div data-sermon-card class="flex h-full max-w-sm flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-shadow hover:shadow-md">
+<div data-sermon-card class="group relative flex h-full max-w-sm flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
 
   @if($thumbnailUrl)
     <a
       href="{{ $sermonUrl }}"
       wire:navigate
+      tabindex="-1"
+      aria-hidden="true"
       data-sermon-card-thumbnail
-      class="group relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200"
+      class="relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200"
     >
       <img
         src="{{ $thumbnailUrl }}"
@@ -36,7 +38,7 @@
 
   <div class="flex flex-col flex-1 p-6">
     @if (($sermon->title != null) && ! $thumbnailUrl)
-      <a class="group" href="{{ $sermonUrl }}" wire:navigate>
+      <a class="group" href="{{ $sermonUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
         <h4 class="font-display text-2xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
           {{$sermon->title}}
         </h4>
@@ -75,7 +77,7 @@
       <li class="flex items-center">
         <x-heroicon-o-user class="h-5 w-5 mr-2 text-gray-500" aria-hidden="true" />
         @if ($preacherUrl)
-          <a href="{{ $preacherUrl }}" wire:navigate class="hover:text-cbc-teal-dark transition-colors">{{ $preacherName }}</a>
+          <a href="{{ $preacherUrl }}" wire:navigate class="relative z-10 hover:text-cbc-teal-dark transition-colors">{{ $preacherName }}</a>
         @else
           <span>{{ $preacherName }}</span>
         @endif
@@ -84,7 +86,7 @@
       @if ($sermon->series != null)
       <li class="flex items-center">
         <x-heroicon-o-tag class="h-5 w-5 mr-2 text-gray-500" aria-hidden="true" />
-        <a href="{{ $seriesUrl }}" wire:navigate class="hover:text-cbc-teal-dark transition-colors">{{ $sermon->series }}</a>
+        <a href="{{ $seriesUrl }}" wire:navigate class="relative z-10 hover:text-cbc-teal-dark transition-colors">{{ $sermon->series }}</a>
       </li>
       @endif
       @if ($reference != null)
@@ -104,11 +106,13 @@
       iconStyle="solid"
       iconPosition="trailing"
       iconClass="shrink-0 text-white/90"
-      class="w-full justify-between rounded-none text-left font-normal"
+      class="w-full justify-between rounded-none text-left font-normal after:absolute after:inset-0"
       aria-label="View sermon: {{ $sermon->title }}"
   >
       View Sermon
   </x-button>
 
-  <x-sermon-card-admin-overlay :$sermon />
+  <div class="relative z-10">
+    <x-sermon-card-admin-overlay :$sermon />
+  </div>
 </div>

--- a/resources/views/livewire/church/songs/browse-songs.blade.php
+++ b/resources/views/livewire/church/songs/browse-songs.blade.php
@@ -74,11 +74,11 @@
                         $authorNames = $song->authors->pluck('display_name')->implode(', ') ?: null;
                         $bookEntries = $song->books->map(fn ($book) => $book->name . ($book->pivot->entry ? ' #' . $book->pivot->entry : ''))->implode(', ') ?: null;
                     @endphp
-                    <article wire:key="song-{{ $song->id }}" class="flex h-full flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-shadow hover:shadow-md">
+                    <article wire:key="song-{{ $song->id }}" class="group relative flex h-full flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
 
                         <div class="flex flex-col flex-1 p-6 @if (!empty($snippetsBySongId[$song->id])) pb-0 @endif">
                             <div class="flex items-start justify-between gap-4">
-                                <a class="group" href="{{ $songUrl }}" wire:navigate>
+                                <a class="group" href="{{ $songUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
                                     <h2 class="font-display text-3xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
                                         {{ $song->title }}
                                     </h2>
@@ -145,7 +145,7 @@
                             iconStyle="solid"
                             iconPosition="trailing"
                             iconClass="shrink-0 text-white/90"
-                            class="w-full justify-between rounded-none text-left font-normal"
+                            class="w-full justify-between rounded-none text-left font-normal after:absolute after:inset-0"
                             aria-label="View song: {{ $song->title }}"
                         >
                             View Song

--- a/resources/views/livewire/church/songs/browse-songs.blade.php
+++ b/resources/views/livewire/church/songs/browse-songs.blade.php
@@ -78,7 +78,7 @@
 
                         <div class="flex flex-col flex-1 p-6 @if (!empty($snippetsBySongId[$song->id])) pb-0 @endif">
                             <div class="flex items-start justify-between gap-4">
-                                <a class="group" href="{{ $songUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
+                                <a class="group" href="{{ $songUrl }}" wire:navigate tabindex="-1">
                                     <h2 class="font-display text-3xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
                                         {{ $song->title }}
                                     </h2>

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -1,5 +1,14 @@
 <div class="pb-12">
-    <section class="px-6" x-data="{ expanded: @js($hasActiveFilters) }">
+    <a href="#sermon-results" class="sr-only focus:not-sr-only focus:absolute focus:z-30 focus:m-4 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-cbc-teal-dark focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-cbc-teal">
+        Skip to results
+    </a>
+
+    <section
+        class="px-6"
+        x-data="{ expanded: @js($hasActiveFilters) }"
+        @keydown.escape.window="expanded = false"
+        @click.away="expanded = false"
+    >
         <div class="mx-auto max-w-2xl lg:max-w-5xl xl:max-w-7xl">
             <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-center">
                 <x-form-button

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -1,5 +1,5 @@
 <div class="pb-12">
-    <a href="#sermon-results" class="sr-only focus:not-sr-only focus:absolute focus:z-30 focus:m-4 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-cbc-teal-dark focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-cbc-teal">
+    <a href="#sermon-results" @click.prevent="document.getElementById('sermon-results').focus()" class="sr-only focus:not-sr-only focus:absolute focus:z-30 focus:m-4 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-cbc-teal-dark focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-cbc-teal">
         Skip to results
     </a>
 
@@ -106,7 +106,7 @@
         Updating sermon results…
     </div>
 
-    <div id="sermon-results" wire:loading.class="pointer-events-none opacity-60" wire:target="bookFilter, chapterFilter, preacherFilter, seriesFilter, removeFilter, clearFilters">
+    <div id="sermon-results" tabindex="-1" wire:loading.class="pointer-events-none opacity-60" wire:target="bookFilter, chapterFilter, preacherFilter, seriesFilter, removeFilter, clearFilters">
         @php
             /** @var \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, \App\Models\Sermon> $sermons */
         @endphp


### PR DESCRIPTION
💡 **What:** This PR standardizes the "Stretched Link" pattern across all main card components and adds several accessibility improvements to the sermon browsing interface.

🎯 **Why:** 
- The "Stretched Link" pattern makes the entire card clickable, which is a better UX for users on all devices, especially mobile.
- Unified hover effects and transitions provide a more consistent and polished feel.
- Accessibility enhancements like skip links and improved keyboard support make the site more usable for everyone.

♿ **Accessibility:**
- Added a "Skip to results" link to the sermon browse page.
- Added keyboard `Escape` support to close the sermon filter panel.
- Removed redundant tab stops from decorative thumbnails (`tabindex="-1" aria-hidden="true"`).
- Added descriptive `aria-label` to buttons (e.g., "View sermon: {title}").
- Maintained functionality of nested links and admin controls using `relative z-10`.

📱 **Responsive:**
- Hover effects and clickable areas are optimized for both touch and mouse interactions.
- Improved the focus-visible states for keyboard navigation.

---
*PR created automatically by Jules for task [14939522344999879201](https://jules.google.com/task/14939522344999879201) started by @GarethClarridge*