### PR TITLE
🔦 Lighthouse: Enhance rich metadata for sermons and preachers

### DIFF
--- a/app/Models/Preacher.php
+++ b/app/Models/Preacher.php
@@ -174,7 +174,7 @@ class Preacher extends Model implements Sitemapable
     {
         return \Illuminate\Support\Facades\Cache::flexible('public_preacher_list', [86400, 172800], function () {
             return self::active()
-                ->select(['id', 'name', 'slug'])
+                ->select(['id', 'name', 'slug', 'image_path'])
                 ->withCount([
                     'sermons' => fn (Builder $query): Builder => $query->whereSermon(),
                 ])

--- a/app/Presenters/PreacherItemListPresenter.php
+++ b/app/Presenters/PreacherItemListPresenter.php
@@ -12,7 +12,7 @@ class PreacherItemListPresenter
     /**
      * Convert a collection of preachers into a Schema.org ItemList data array.
      *
-     * @param  Collection<int, Preacher>
+     * @param  Collection<int, Preacher>  $preachers
      * @return array<string, mixed>
      */
     public function toItemList(Collection $preachers): array

--- a/app/Presenters/PreacherItemListPresenter.php
+++ b/app/Presenters/PreacherItemListPresenter.php
@@ -12,7 +12,7 @@ class PreacherItemListPresenter
     /**
      * Convert a collection of preachers into a Schema.org ItemList data array.
      *
-     * @param  Collection<int, Preacher>  $preachers
+     * @param  Collection<int, Preacher>
      * @return array<string, mixed>
      */
     public function toItemList(Collection $preachers): array
@@ -24,19 +24,26 @@ class PreacherItemListPresenter
             '@type' => 'ItemList',
             'numberOfItems' => $preachers->count(),
             'itemListElement' => $preachers->map(function ($preacher, $index) use ($orgName) {
+                $item = [
+                    '@type' => 'Person',
+                    'name' => $preacher->name,
+                    'url' => url("/christ/sermons/preachers/{$preacher->slug}"),
+                    'jobTitle' => 'Preacher',
+                    'worksFor' => [
+                        '@type' => 'Organization',
+                        'name' => $orgName,
+                        '@id' => config('app.url').'/',
+                    ],
+                ];
+
+                if ($preacher->profile_image_url) {
+                    $item['image'] = $preacher->profile_image_url;
+                }
+
                 return [
                     '@type' => 'ListItem',
                     'position' => $index + 1,
-                    'item' => [
-                        '@type' => 'Person',
-                        'name' => $preacher->name,
-                        'url' => url("/christ/sermons/preachers/{$preacher->slug}"),
-                        'jobTitle' => 'Preacher',
-                        'worksFor' => [
-                            '@type' => 'Organization',
-                            'name' => $orgName,
-                        ],
-                    ],
+                    'item' => $item,
                 ];
             })->values()->all(),
         ];

--- a/app/Presenters/SermonItemListPresenter.php
+++ b/app/Presenters/SermonItemListPresenter.php
@@ -32,29 +32,45 @@ class SermonItemListPresenter
             '@type' => 'ItemList',
             'numberOfItems' => $flatSermons->count(),
             'itemListElement' => $flatSermons->values()->map(function (Sermon $sermon, int $index) use ($orgName, $logoUrl) {
-                $thumbnailUrl = $this->sermonViewPresenter->thumbnailUrl($sermon);
-                $publicUrl = $this->sermonViewPresenter->publicUrl($sermon);
+                $sermonView = $this->sermonViewPresenter->present($sermon);
+                $thumbnailUrl = $sermonView['thumbnail_url'];
+                $publicUrl = $sermonView['public_url'];
+                $datePublished = $sermon->date->toIso8601String();
+                $metaDescription = $this->sermonViewPresenter->metaDescription($sermon);
+
+                $author = [
+                    '@type' => 'Person',
+                    'name' => $sermonView['preacher_name'],
+                    'url' => $sermonView['preacher_url'],
+                    'jobTitle' => 'Preacher',
+                    'worksFor' => [
+                        '@type' => 'Organization',
+                        'name' => $orgName,
+                        '@id' => config('app.url').'/',
+                    ],
+                ];
+
+                if ($sermonView['preacher_image_url']) {
+                    $author['image'] = $sermonView['preacher_image_url'];
+                }
 
                 $item = [
                     '@type' => 'Article',
                     'headline' => $sermon->title,
                     'name' => $sermon->title,
                     'url' => $publicUrl,
-                    'description' => $sermon->meta_description,
-                    'datePublished' => $sermon->date->toIso8601String(),
+                    'description' => $metaDescription,
+                    'datePublished' => $datePublished,
                     'inLanguage' => 'en-GB',
                     'contentLocation' => [
                         '@type' => 'Place',
                         'name' => $orgName,
                     ],
-                    'author' => [
-                        '@type' => 'Person',
-                        'name' => $this->sermonViewPresenter->displayPreacherName($sermon),
-                        'url' => $this->sermonViewPresenter->preacherUrl($sermon),
-                    ],
+                    'author' => $author,
                     'publisher' => [
                         '@type' => 'Organization',
                         'name' => $orgName,
+                        '@id' => config('app.url').'/',
                         'logo' => [
                             '@type' => 'ImageObject',
                             'url' => $logoUrl,
@@ -66,6 +82,40 @@ class SermonItemListPresenter
                     ],
                     'image' => $thumbnailUrl ?: $logoUrl,
                 ];
+
+                if ($sermonView['video_url']) {
+                    $video = [
+                        '@type' => 'VideoObject',
+                        'name' => $sermon->title,
+                        'description' => $metaDescription,
+                        'thumbnailUrl' => $thumbnailUrl ?: $logoUrl,
+                        'uploadDate' => $datePublished,
+                        'contentUrl' => $sermonView['video_url'],
+                    ];
+
+                    if ($sermonView['duration_iso8601']) {
+                        $video['duration'] = $sermonView['duration_iso8601'];
+                    }
+
+                    $item['video'] = $video;
+                }
+
+                if ($sermonView['audio_url']) {
+                    $audio = [
+                        '@type' => 'AudioObject',
+                        'name' => $sermon->title,
+                        'contentUrl' => $sermonView['audio_url'],
+                        'description' => $metaDescription,
+                        'encodingFormat' => 'audio/mpeg',
+                        'uploadDate' => $datePublished,
+                    ];
+
+                    if ($sermonView['duration_iso8601']) {
+                        $audio['duration'] = $sermonView['duration_iso8601'];
+                    }
+
+                    $item['audio'] = $audio;
+                }
 
                 return [
                     '@type' => 'ListItem',

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -201,6 +201,8 @@ class SermonViewPresenter
      *
      * Performance Optimization: Memoizes preacher image URL lookups to avoid
      * redundant Storage or relationship lookups for the same preacher.
+     * Only caches results when they are definitively known from a loaded
+     * relation or non-existent profile.
      */
     public function preacherImageUrl(Sermon $sermon): ?string
     {
@@ -216,13 +218,14 @@ class SermonViewPresenter
             return $this->memoizedPreacherImageUrls[$preacherKey] === self::MEMO_NULL ? null : $this->memoizedPreacherImageUrls[$preacherKey];
         }
 
-        $url = ($sermon->relationLoaded('preacherProfile') && $sermon->preacherProfile !== null)
-            ? $sermon->preacherProfile->profile_image_url
-            : null;
+        if ($sermon->relationLoaded('preacherProfile') || $sermon->preacher_id === null) {
+            $url = $sermon->preacherProfile?->profile_image_url;
+            $this->memoizedPreacherImageUrls[$preacherKey] = $url ?? self::MEMO_NULL;
 
-        $this->memoizedPreacherImageUrls[$preacherKey] = $url ?? self::MEMO_NULL;
+            return $url;
+        }
 
-        return $url;
+        return null;
     }
 
     public function canonicalUrl(Sermon $sermon): string

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -216,13 +216,9 @@ class SermonViewPresenter
             return $this->memoizedPreacherImageUrls[$preacherKey] === self::MEMO_NULL ? null : $this->memoizedPreacherImageUrls[$preacherKey];
         }
 
-        $url = (function () use ($sermon) {
-            if ($sermon->relationLoaded('preacherProfile') && $sermon->preacherProfile !== null) {
-                return $sermon->preacherProfile->profile_image_url;
-            }
-
-            return null;
-        })();
+        $url = ($sermon->relationLoaded('preacherProfile') && $sermon->preacherProfile !== null)
+            ? $sermon->preacherProfile->profile_image_url
+            : null;
 
         $this->memoizedPreacherImageUrls[$preacherKey] = $url ?? self::MEMO_NULL;
 
@@ -636,13 +632,8 @@ class SermonViewPresenter
     {
         $id = $sermon->id ?? 'u'.spl_object_id($sermon);
 
-        if (! isset($this->memoizedSermonKeys[$id])) {
-            if (! isset($this->memoizedTimestamps[$id])) {
-                $this->memoizedTimestamps[$id] = $sermon->updated_at?->getTimestamp() ?? 0;
-            }
-
-            $this->memoizedSermonKeys[$id] = "{$id}_{$this->memoizedTimestamps[$id]}";
-        }
+        $this->memoizedTimestamps[$id] ??= $sermon->updated_at?->getTimestamp() ?? 0;
+        $this->memoizedSermonKeys[$id] ??= "{$id}_{$this->memoizedTimestamps[$id]}";
 
         return "{$type}_{$this->memoizedSermonKeys[$id]}";
     }

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -46,6 +46,11 @@ class SermonViewPresenter
     private array $memoizedDurations = [];
 
     /**
+     * @var array<int|string, ?string>
+     */
+    private array $memoizedIsoDurations = [];
+
+    /**
      * @var array<string, array<string, mixed>>
      */
     private array $memoizedPresents = [];
@@ -74,6 +79,11 @@ class SermonViewPresenter
      * @var array<string, string>
      */
     private array $memoizedMetaDescriptions = [];
+
+    /**
+     * @var array<string, ?string>
+     */
+    private array $memoizedPreacherImageUrls = [];
 
     public function __construct(
         private readonly SermonExposurePolicy $exposurePolicy,
@@ -111,6 +121,29 @@ class SermonViewPresenter
     }
 
     /**
+     * Get the ISO 8601 duration string (e.g. PT45M) for the sermon.
+     *
+     * Performance Optimization: Memoizes duration formatting results
+     * to avoid redundant calculations across multiple views and components.
+     */
+    public function durationIso8601(Sermon $sermon): ?string
+    {
+        $key = $this->cacheKey($sermon, 'duration_iso');
+
+        if (isset($this->memoizedIsoDurations[$key])) {
+            return $this->memoizedIsoDurations[$key] === self::MEMO_NULL ? null : $this->memoizedIsoDurations[$key];
+        }
+
+        if ($sermon->duration === null || $sermon->duration <= 0) {
+            $this->memoizedIsoDurations[$key] = self::MEMO_NULL;
+
+            return null;
+        }
+
+        return $this->memoizedIsoDurations[$key] = \Carbon\CarbonInterval::seconds($sermon->duration)->cascade()->spec();
+    }
+
+    /**
      * Get the human-friendly date of the sermon.
      *
      * Performance Optimization: Memoizes date formatting results by timestamp
@@ -142,6 +175,8 @@ class SermonViewPresenter
         $this->memoizedHumanDates = [];
         $this->memoizedSlugs = [];
         $this->memoizedMetaDescriptions = [];
+        $this->memoizedIsoDurations = [];
+        $this->memoizedPreacherImageUrls = [];
     }
 
     public function audioUrl(Sermon $sermon): ?string
@@ -157,6 +192,39 @@ class SermonViewPresenter
             : null;
 
         $this->memoizedUrls[$key] = $url ?? self::MEMO_NULL;
+
+        return $url;
+    }
+
+    /**
+     * Get the preacher's profile image URL.
+     *
+     * Performance Optimization: Memoizes preacher image URL lookups to avoid
+     * redundant Storage or relationship lookups for the same preacher.
+     */
+    public function preacherImageUrl(Sermon $sermon): ?string
+    {
+        $preacherKey = $sermon->preacher_id !== null
+            ? "id_{$sermon->preacher_id}"
+            : (string) $this->displayPreacherName($sermon);
+
+        if ($preacherKey === '') {
+            return null;
+        }
+
+        if (isset($this->memoizedPreacherImageUrls[$preacherKey])) {
+            return $this->memoizedPreacherImageUrls[$preacherKey] === self::MEMO_NULL ? null : $this->memoizedPreacherImageUrls[$preacherKey];
+        }
+
+        $url = (function () use ($sermon) {
+            if ($sermon->relationLoaded('preacherProfile') && $sermon->preacherProfile !== null) {
+                return $sermon->preacherProfile->profile_image_url;
+            }
+
+            return null;
+        })();
+
+        $this->memoizedPreacherImageUrls[$preacherKey] = $url ?? self::MEMO_NULL;
 
         return $url;
     }
@@ -284,8 +352,10 @@ class SermonViewPresenter
      * @return array{
      *     audio_url: ?string,
      *     display_reference: ?string,
+     *     duration_iso8601: ?string,
      *     formatted_duration: ?string,
      *     human_date: string,
+     *     preacher_image_url: ?string,
      *     preacher_name: ?string,
      *     preacher_url: ?string,
      *     series_url: ?string,
@@ -297,12 +367,14 @@ class SermonViewPresenter
     {
         $key = $this->cacheKey($sermon, 'api_present');
 
-        /** @var array{audio_url: ?string, display_reference: ?string, formatted_duration: ?string, human_date: string, preacher_name: ?string, preacher_url: ?string, series_url: ?string, thumbnail_url: ?string, video_url: ?string} */
+        /** @var array{audio_url: ?string, display_reference: ?string, duration_iso8601: ?string, formatted_duration: ?string, human_date: string, preacher_image_url: ?string, preacher_name: ?string, preacher_url: ?string, series_url: ?string, thumbnail_url: ?string, video_url: ?string} */
         return $this->memoizedPresents[$key] ??= [
             'audio_url' => $this->audioUrl($sermon),
             'display_reference' => $this->displayReference($sermon),
+            'duration_iso8601' => $this->durationIso8601($sermon),
             'formatted_duration' => $this->formattedDuration($sermon),
             'human_date' => $this->humanDate($sermon),
+            'preacher_image_url' => $this->preacherImageUrl($sermon),
             'preacher_name' => $this->displayPreacherName($sermon),
             'preacher_url' => $this->preacherUrl($sermon),
             'series_url' => $this->seriesUrl($sermon),
@@ -317,8 +389,10 @@ class SermonViewPresenter
      *     canonical_url: string,
      *     card_thumbnail_url: ?string,
      *     display_reference: ?string,
+     *     duration_iso8601: ?string,
      *     formatted_duration: ?string,
      *     human_date: string,
+     *     preacher_image_url: ?string,
      *     preacher_name: ?string,
      *     preacher_url: ?string,
      *     public_url: string,
@@ -332,14 +406,16 @@ class SermonViewPresenter
     {
         $key = $this->cacheKey($sermon, 'full_present');
 
-        /** @var array{audio_url: ?string, canonical_url: string, card_thumbnail_url: ?string, display_reference: ?string, formatted_duration: ?string, human_date: string, preacher_name: ?string, preacher_url: ?string, public_url: string, series_url: ?string, thumbnail_url: ?string, transcript: ?string, video_url: ?string} */
+        /** @var array{audio_url: ?string, canonical_url: string, card_thumbnail_url: ?string, display_reference: ?string, duration_iso8601: ?string, formatted_duration: ?string, human_date: string, preacher_image_url: ?string, preacher_name: ?string, preacher_url: ?string, public_url: string, series_url: ?string, thumbnail_url: ?string, transcript: ?string, video_url: ?string} */
         return $this->memoizedPresents[$key] ??= [
             'audio_url' => $this->audioUrl($sermon),
             'canonical_url' => $this->canonicalUrl($sermon),
             'card_thumbnail_url' => $this->cardThumbnailUrl($sermon),
             'display_reference' => $this->displayReference($sermon),
+            'duration_iso8601' => $this->durationIso8601($sermon),
             'formatted_duration' => $this->formattedDuration($sermon),
             'human_date' => $this->humanDate($sermon),
+            'preacher_image_url' => $this->preacherImageUrl($sermon),
             'preacher_name' => $this->displayPreacherName($sermon),
             'preacher_url' => $this->preacherUrl($sermon),
             'public_url' => $this->publicUrl($sermon),

--- a/app/Services/PodcastFeedService.php
+++ b/app/Services/PodcastFeedService.php
@@ -61,7 +61,7 @@ class PodcastFeedService
             ->forPodcast()
             ->select(['id', 'title', 'audio_file_path', 'filetype', 'date', 'service', 'series', 'reference', 'preacher', 'preacher_id', 'duration', 'summary', 'slug', 'thumbnail_file_path', 'thumbnail_generated_at', 'transcript_file_path', 'updated_at', 'scripture_passage_id'])
             ->with([
-                'preacherProfile:id,name,slug',
+                'preacherProfile:id,name,slug,image_path',
                 'scripturePassage:id,display_reference,normalized_reference',
             ])
             ->forService($serviceType)

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -103,7 +103,7 @@ class SitemapService
         $sermons = Sermon::query()
             ->select(['id', 'title', 'date', 'slug', 'updated_at', 'video_file_path', 'video_quality_status', 'video_visibility_override', 'thumbnail_file_path', 'thumbnail_generated_at', 'summary', 'show_summary', 'duration', 'preacher', 'preacher_id', 'reference', 'series', 'meta_description', 'content_type', 'scripture_passage_id'])
             ->with([
-                'preacherProfile:id,name,slug',
+                'preacherProfile:id,name,slug,image_path',
                 'scripturePassage:id,display_reference,normalized_reference',
             ])
             ->whereVisibleInSitemap()

--- a/resources/views/components/schema/sermon.blade.php
+++ b/resources/views/components/schema/sermon.blade.php
@@ -8,10 +8,26 @@
     use Illuminate\Support\Str;
 
     $transcript = $sermonView['transcript'] ?? null;
-    $duration = $sermon->duration ? \Carbon\CarbonInterval::seconds($sermon->duration)->cascade()->spec() : null;
+    $duration = $sermonView['duration_iso8601'] ?? null;
     $preacherName = $sermonView['preacher_name'];
     $thumbnailUrl = $sermonView['thumbnail_url'] ?: asset('images/Primary.png');
     $datePublished = $sermon->date->toIso8601String();
+
+    $author = [
+        '@type' => 'Person',
+        'name' => $preacherName,
+        'url' => $sermonView['preacher_url'],
+        'jobTitle' => 'Preacher',
+        'worksFor' => [
+            '@type' => 'Organization',
+            'name' => config('organization.name'),
+            '@id' => config('app.url').'/',
+        ],
+    ];
+
+    if ($sermonView['preacher_image_url']) {
+        $author['image'] = $sermonView['preacher_image_url'];
+    }
 
     $schema = [
         '@context' => 'https://schema.org',
@@ -20,11 +36,7 @@
         'description' => $metaDescription,
         'image' => $thumbnailUrl,
         'datePublished' => $datePublished,
-        'author' => [
-            '@type' => 'Person',
-            'name' => $preacherName,
-            'url' => $sermonView['preacher_url'],
-        ],
+        'author' => $author,
         'publisher' => [
             '@type' => 'Organization',
             'name' => config('organization.name'),

--- a/resources/views/sermons/series.blade.php
+++ b/resources/views/sermons/series.blade.php
@@ -8,6 +8,8 @@
 <x-meta-tags
     :title="$heading"
     :description="$description"
+    :image="asset('/images/headings/large/sermons.webp')"
+    image-alt="Sermons at Crockenhill Baptist Church"
 />
 <x-schema.webpage
     :heading="$heading"
@@ -24,5 +26,6 @@
 @section('full_width_content')
 
   <x-sermon-list :sermons="$sermons" :groupedByDate="false" />
+
 
 @stop

--- a/resources/views/sermons/service.blade.php
+++ b/resources/views/sermons/service.blade.php
@@ -8,6 +8,8 @@
 <x-meta-tags
     :title="$heading"
     :description="$description"
+    :image="asset('/images/headings/large/sermons.webp')"
+    image-alt="Sermons at Crockenhill Baptist Church"
 />
 <x-schema.webpage
     :heading="$heading"

--- a/tests/Unit/Presenters/SermonViewPresenterTest.php
+++ b/tests/Unit/Presenters/SermonViewPresenterTest.php
@@ -36,6 +36,47 @@ class SermonViewPresenterTest extends TestCase
     }
 
     #[Test]
+    public function duration_iso8601_returns_null_when_duration_is_null_or_zero(): void
+    {
+        $sermonNull = Sermon::factory()->make(['duration' => null]);
+        $sermonZero = Sermon::factory()->make(['duration' => 0]);
+
+        $this->assertNull($this->presenter->durationIso8601($sermonNull));
+        $this->assertNull($this->presenter->durationIso8601($sermonZero));
+    }
+
+    #[Test]
+    public function duration_iso8601_formats_correctly(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => 2700]); // 45 minutes
+
+        $this->assertSame('PT45M', $this->presenter->durationIso8601($sermon));
+    }
+
+    #[Test]
+    public function preacher_image_url_returns_null_when_no_profile_or_image(): void
+    {
+        $sermon = Sermon::factory()->make(['preacher_id' => null, 'preacher' => 'John Doe']);
+
+        $this->assertNull($this->presenter->preacherImageUrl($sermon));
+    }
+
+    #[Test]
+    public function preacher_image_url_returns_url_from_profile(): void
+    {
+        $preacher = Preacher::factory()->create([
+            'image_path' => 'preachers/john.jpg',
+        ]);
+        $sermon = Sermon::factory()->create([
+            'preacher_id' => $preacher->id,
+        ]);
+        $sermon->load('preacherProfile');
+
+        $url = $this->presenter->preacherImageUrl($sermon);
+        $this->assertStringContainsString('/storage/preachers/john.jpg', $url ?? '');
+    }
+
+    #[Test]
     public function it_presents_explicit_media_and_link_data(): void
     {
         $preacher = Preacher::factory()->create([
@@ -58,6 +99,7 @@ class SermonViewPresenterTest extends TestCase
             'thumbnail_file_path' => 'thumbnails/test.jpg',
             'thumbnail_metadata' => ['plain_thumbnail_path' => 'thumbnails/test.jpg'],
             'transcript_file_path' => 'transcripts/test.md',
+            'duration' => 3600,
         ]);
 
         $sermon->load('preacherProfile');
@@ -74,6 +116,7 @@ class SermonViewPresenterTest extends TestCase
         $this->assertStringContainsString('?v=', $presented['thumbnail_url'] ?? '');
         $this->assertSame('Transcript body', $presented['transcript']);
         $this->assertStringContainsString('/storage/sermons/test.mp4', $presented['video_url'] ?? '');
+        $this->assertSame('PT1H', $presented['duration_iso8601']);
     }
 
     #[Test]

--- a/tests/Unit/SermonItemListPresenterTest.php
+++ b/tests/Unit/SermonItemListPresenterTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit;
 use App\Models\Sermon;
 use App\Presenters\SermonItemListPresenter;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -12,14 +14,25 @@ class SermonItemListPresenterTest extends TestCase
 {
     use DatabaseTransactions;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('public');
+        Config::set('media-processing.storage.sermon_disk', 'public');
+    }
+
     #[Test]
-    public function it_generates_item_list_json_ld(): void
+    public function it_generates_item_list_json_ld_with_rich_metadata(): void
     {
         $sermon = Sermon::factory()->create([
             'title' => 'Test Sermon',
             'date' => '2024-01-01',
             'preacher' => 'John Doe',
+            'audio_file_path' => 'sermons/test.mp3',
+            'duration' => 1800,
         ]);
+
+        Storage::disk('public')->put('sermons/test.mp3', 'audio');
 
         $presenter = app(SermonItemListPresenter::class);
         $result = $presenter->toItemList(collect([$sermon]));
@@ -33,5 +46,16 @@ class SermonItemListPresenterTest extends TestCase
         $this->assertEquals('Test Sermon', $item['name']);
         $this->assertEquals('John Doe', $item['author']['name']);
         $this->assertEquals('2024-01-01T00:00:00+00:00', $item['datePublished']);
+
+        // Check for rich audio metadata
+        $this->assertArrayHasKey('audio', $item);
+        $this->assertEquals('AudioObject', $item['audio']['@type']);
+        $this->assertEquals('PT30M', $item['audio']['duration']);
+        $this->assertEquals('audio/mpeg', $item['audio']['encodingFormat']);
+
+        // Check for author enrichment
+        $this->assertEquals('Preacher', $item['author']['jobTitle']);
+        $this->assertArrayHasKey('worksFor', $item['author']);
+        $this->assertEquals(config('organization.name'), $item['author']['worksFor']['name']);
     }
 }


### PR DESCRIPTION
This PR implements significant SEO and discovery improvements by enriching the structured data for sermons and preachers.

💡 **What:**
- **Centralized Metadata Logic:** Added `durationIso8601` and `preacherImageUrl` to `SermonViewPresenter` to ensure consistent data across different views.
- **Richer Preacher Schema:** The preachers index now includes profile images in the JSON-LD `Person` objects.
- **Media-Rich Sermon Listings:** Sermon archive pages (and search results) now provide `AudioObject` and `VideoObject` metadata, including ISO 8601 durations and preacher profile images in the author schema.
- **Improved Social Sharing:** Service and Series archive pages now have proper Open Graph images.

🎯 **Why:**
These changes help search engines understand the media content (audio/video) of individual sermons even from listing pages, potentially improving visibility in media-focused search results. Profile images in structured data improve the richness of social shares and the church's knowledge graph.

📊 **Impact:**
- Individual Sermon Pages
- Preacher Index & Profiles
- Sermon Archive Pages (Service, Series)

🔍 **Verification:**
- New unit tests in `SermonViewPresenterTest` and `SermonItemListPresenterTest`.
- Verified passing feature tests for SEO and Social metadata.
- Full test suite passed (4662 tests).
- PHPStan and Pint passed.

---
*PR created automatically by Jules for task [13964495198039750028](https://jules.google.com/task/13964495198039750028) started by @GarethClarridge*