### PR TITLE
⚡ Bolt: optimize sermon listing performance

### DIFF
--- a/app/Presenters/SermonItemListPresenter.php
+++ b/app/Presenters/SermonItemListPresenter.php
@@ -32,7 +32,7 @@ class SermonItemListPresenter
             '@type' => 'ItemList',
             'numberOfItems' => $flatSermons->count(),
             'itemListElement' => $flatSermons->values()->map(function (Sermon $sermon, int $index) use ($orgName, $logoUrl) {
-                $sermonView = $this->sermonViewPresenter->present($sermon);
+                $sermonView = $this->sermonViewPresenter->presentForList($sermon);
                 $thumbnailUrl = $sermonView['thumbnail_url'];
                 $publicUrl = $sermonView['public_url'];
                 $datePublished = $sermon->date->toIso8601String();

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -383,6 +383,56 @@ class SermonViewPresenter
     }
 
     /**
+     * Present a lightweight subset of sermon view data for use in listings and JSON-LD.
+     *
+     * Performance Optimization: Omits the expensive transcript content fetching
+     * which is unnecessary for collection views but includes all URLs and metadata.
+     *
+     * @return array{
+     *     audio_url: ?string,
+     *     canonical_url: string,
+     *     card_thumbnail_url: ?string,
+     *     display_reference: ?string,
+     *     duration_iso8601: ?string,
+     *     formatted_duration: ?string,
+     *     has_transcript: bool,
+     *     human_date: string,
+     *     preacher_image_url: ?string,
+     *     preacher_name: ?string,
+     *     preacher_url: ?string,
+     *     public_url: string,
+     *     series_url: ?string,
+     *     thumbnail_url: ?string,
+     *     transcript_url: ?string,
+     *     video_url: ?string
+     * }
+     */
+    public function presentForList(Sermon $sermon): array
+    {
+        $key = $this->cacheKey($sermon, 'list_present');
+
+        /** @var array{audio_url: ?string, canonical_url: string, card_thumbnail_url: ?string, display_reference: ?string, duration_iso8601: ?string, formatted_duration: ?string, has_transcript: bool, human_date: string, preacher_image_url: ?string, preacher_name: ?string, preacher_url: ?string, public_url: string, series_url: ?string, thumbnail_url: ?string, transcript_url: ?string, video_url: ?string} */
+        return $this->memoizedPresents[$key] ??= [
+            'audio_url' => $this->audioUrl($sermon),
+            'canonical_url' => $this->canonicalUrl($sermon),
+            'card_thumbnail_url' => $this->cardThumbnailUrl($sermon),
+            'display_reference' => $this->displayReference($sermon),
+            'duration_iso8601' => $this->durationIso8601($sermon),
+            'formatted_duration' => $this->formattedDuration($sermon),
+            'has_transcript' => $sermon->hasTranscript(),
+            'human_date' => $this->humanDate($sermon),
+            'preacher_image_url' => $this->preacherImageUrl($sermon),
+            'preacher_name' => $this->displayPreacherName($sermon),
+            'preacher_url' => $this->preacherUrl($sermon),
+            'public_url' => $this->publicUrl($sermon),
+            'series_url' => $this->seriesUrl($sermon),
+            'thumbnail_url' => $this->thumbnailUrl($sermon),
+            'transcript_url' => $sermon->hasTranscript() ? route('sermons.transcript', ['sermon' => $sermon->slug]) : null,
+            'video_url' => $this->videoUrl($sermon),
+        ];
+    }
+
+    /**
      * @return array{
      *     audio_url: ?string,
      *     canonical_url: string,
@@ -407,26 +457,15 @@ class SermonViewPresenter
     {
         $key = $this->cacheKey($sermon, 'full_present');
 
-        /** @var array{audio_url: ?string, canonical_url: string, card_thumbnail_url: ?string, display_reference: ?string, duration_iso8601: ?string, formatted_duration: ?string, has_transcript: bool, human_date: string, preacher_image_url: ?string, preacher_name: ?string, preacher_url: ?string, public_url: string, series_url: ?string, thumbnail_url: ?string, transcript: ?string, transcript_url: ?string, video_url: ?string} */
-        return $this->memoizedPresents[$key] ??= [
-            'audio_url' => $this->audioUrl($sermon),
-            'canonical_url' => $this->canonicalUrl($sermon),
-            'card_thumbnail_url' => $this->cardThumbnailUrl($sermon),
-            'display_reference' => $this->displayReference($sermon),
-            'duration_iso8601' => $this->durationIso8601($sermon),
-            'formatted_duration' => $this->formattedDuration($sermon),
-            'has_transcript' => $sermon->hasTranscript(),
-            'human_date' => $this->humanDate($sermon),
-            'preacher_image_url' => $this->preacherImageUrl($sermon),
-            'preacher_name' => $this->displayPreacherName($sermon),
-            'preacher_url' => $this->preacherUrl($sermon),
-            'public_url' => $this->publicUrl($sermon),
-            'series_url' => $this->seriesUrl($sermon),
-            'thumbnail_url' => $this->thumbnailUrl($sermon),
-            'transcript' => $this->transcriptReader->read($sermon),
-            'transcript_url' => $sermon->hasTranscript() ? route('sermons.transcript', ['sermon' => $sermon->slug]) : null,
-            'video_url' => $this->videoUrl($sermon),
-        ];
+        if (isset($this->memoizedPresents[$key])) {
+            /** @var array{audio_url: ?string, canonical_url: string, card_thumbnail_url: ?string, display_reference: ?string, duration_iso8601: ?string, formatted_duration: ?string, has_transcript: bool, human_date: string, preacher_image_url: ?string, preacher_name: ?string, preacher_url: ?string, public_url: string, series_url: ?string, thumbnail_url: ?string, transcript: ?string, transcript_url: ?string, video_url: ?string} */
+            return $this->memoizedPresents[$key];
+        }
+
+        return $this->memoizedPresents[$key] = array_merge(
+            $this->presentForList($sermon),
+            ['transcript' => $this->transcriptReader->read($sermon)]
+        );
     }
 
     public function publicUrl(Sermon $sermon): string


### PR DESCRIPTION
💡 **What:** This PR introduces a lightweight sermon presentation method in `SermonViewPresenter` to optimize collection-level rendering and JSON-LD generation.

🎯 **Why:** Previously, `SermonViewPresenter::present()` fetched the full transcript content for every sermon. While this is necessary for the individual sermon page, it is redundant and expensive for listings (e.g., the archive page with 100+ items) or Schema.org `ItemList` generation. Transcripts are already lazy-loaded on the frontend via a separate API call, making their inclusion in initial collection data structures unnecessary.

📊 **Impact:**
- Significantly reduces memory usage when processing large sermon collections.
- Avoids redundant cache lookups and potential remote storage hits for transcripts during listing renders.
- Improves performance of sermon archive and index pages.

🔬 **Measurement:**
- Verified with unit tests in `SermonViewPresenterTest` and `SermonItemListPresenterTest`.
- Confirmed no regressions in `SermonControllerTest`.
- Validated type safety with `phpstan` and code style with `pint`.

---
*PR created automatically by Jules for task [374175333319336235](https://jules.google.com/task/374175333319336235) started by @GarethClarridge*