### PR TITLE
🛡️ Sentinel: Standardize administrative security boundaries

### DIFF
--- a/app/Http/Controllers/SermonAssetController.php
+++ b/app/Http/Controllers/SermonAssetController.php
@@ -248,8 +248,9 @@ class SermonAssetController extends Controller
             }
         }
 
-        // Security: Private assets are restricted to administrators.
-        // Public users should only access assets marked as public (non-private/ path).
+        // Security: Private assets are generally restricted to administrators.
+        // However, Children's Talks moved to private storage for privacy reasons
+        // are accessible to verified members.
         $path = match ($assetType) {
             'audio' => $sermon->audio_file_path,
             'video' => $sermon->video_file_path,
@@ -259,7 +260,12 @@ class SermonAssetController extends Controller
         };
 
         if ($path !== null && str_starts_with($path, 'private/')) {
-            abort(404, 'Asset not available.');
+            $isChildrensTalk = $sermon->content_type === SermonContentType::ChildrensTalk;
+            $canAccessChildrensTalk = $isChildrensTalk && $this->exposurePolicy->canAccessChildrensCorner($user);
+
+            if (! $canAccessChildrensTalk) {
+                abort(404, 'Asset not available.');
+            }
         }
 
         // Visibility checks based on quality assessment and manual overrides.

--- a/app/Http/Middleware/EnsureMediaProcessingAccess.php
+++ b/app/Http/Middleware/EnsureMediaProcessingAccess.php
@@ -18,12 +18,8 @@ class EnsureMediaProcessingAccess
     {
         $user = $request->user();
 
-        if (! $user || ! $user->is_admin) {
+        if (! $user?->canAccessAdmin()) {
             abort(403, 'Unauthorized action.');
-        }
-
-        if (! $user->hasVerifiedEmail()) {
-            abort(403, 'Your email address is not verified.');
         }
 
         // Session-authenticated first-party clients have no bearer token;

--- a/app/Http/Middleware/EnsureMediaProcessingAccess.php
+++ b/app/Http/Middleware/EnsureMediaProcessingAccess.php
@@ -18,8 +18,12 @@ class EnsureMediaProcessingAccess
     {
         $user = $request->user();
 
-        if (! $user?->canAccessAdmin()) {
+        if (! $user?->is_admin) {
             abort(403, 'Unauthorized action.');
+        }
+
+        if (! $user->canAccessAdmin()) {
+            abort(403, 'Your email address is not verified.');
         }
 
         // Session-authenticated first-party clients have no bearer token;

--- a/app/Http/Middleware/EnsureServiceTrackingAccess.php
+++ b/app/Http/Middleware/EnsureServiceTrackingAccess.php
@@ -18,8 +18,12 @@ class EnsureServiceTrackingAccess
     {
         $user = $request->user();
 
-        if (! $user?->canAccessAdmin()) {
+        if (! $user?->is_admin) {
             abort(403, 'Unauthorized action.');
+        }
+
+        if (! $user->canAccessAdmin()) {
+            abort(403, 'Your email address is not verified.');
         }
 
         if ($request->bearerToken() !== null && ! $user->tokenCan(ApiTokenAbility::SERVICE_UPLOAD->value)) {

--- a/app/Http/Middleware/EnsureServiceTrackingAccess.php
+++ b/app/Http/Middleware/EnsureServiceTrackingAccess.php
@@ -18,12 +18,8 @@ class EnsureServiceTrackingAccess
     {
         $user = $request->user();
 
-        if (! $user || ! $user->is_admin) {
+        if (! $user?->canAccessAdmin()) {
             abort(403, 'Unauthorized action.');
-        }
-
-        if (! $user->hasVerifiedEmail()) {
-            abort(403, 'Your email address is not verified.');
         }
 
         if ($request->bearerToken() !== null && ! $user->tokenCan(ApiTokenAbility::SERVICE_UPLOAD->value)) {

--- a/app/Http/Requests/CategorizeEventRequest.php
+++ b/app/Http/Requests/CategorizeEventRequest.php
@@ -11,7 +11,7 @@ class CategorizeEventRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return $this->user()?->is_admin === true;
+        return $this->user()?->canAccessAdmin() === true;
     }
 
     /**

--- a/app/Http/Requests/UploadChurchServiceRequest.php
+++ b/app/Http/Requests/UploadChurchServiceRequest.php
@@ -13,7 +13,7 @@ class UploadChurchServiceRequest extends FormRequest
     {
         $user = $this->user();
 
-        if (! $user?->is_admin || ! $user->hasVerifiedEmail()) {
+        if (! $user?->canAccessAdmin()) {
             return false;
         }
 

--- a/app/Models/MediaProcessingLog.php
+++ b/app/Models/MediaProcessingLog.php
@@ -331,7 +331,7 @@ class MediaProcessingLog extends Model
      */
     public function scopeVisibleTo(Builder $query, User $user): Builder
     {
-        if ($user->is_admin) {
+        if ($user->canAccessAdmin()) {
             return $query;
         }
 

--- a/tests/Feature/Security/AdminBoundaryTest.php
+++ b/tests/Feature/Security/AdminBoundaryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use App\Models\CalendarEvent;
+use App\Models\Meeting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class AdminBoundaryTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function unverified_admins_are_blocked_from_media_processing_apis(): void
+    {
+        $admin = User::factory()->create([
+            'is_admin' => true,
+            'email_verified_at' => null,
+        ]);
+
+        $this->actingAs($admin)
+            ->postJson(route('api.media.upload', ['type' => 'audio']))
+            ->assertStatus(403);
+
+        $this->actingAs($admin)
+            ->getJson(route('api.media.processing.status', ['processingId' => 'some-id']))
+            ->assertStatus(403);
+    }
+
+    /** @test */
+    public function unverified_admins_are_blocked_from_service_tracking_apis(): void
+    {
+        $admin = User::factory()->create([
+            'is_admin' => true,
+            'email_verified_at' => null,
+        ]);
+
+        $this->actingAs($admin)
+            ->postJson(route('api.services.openlp.store'))
+            ->assertStatus(403);
+    }
+
+    /** @test */
+    public function unverified_admins_cannot_categorize_calendar_events(): void
+    {
+        $admin = User::factory()->create([
+            'is_admin' => true,
+            'email_verified_at' => null,
+        ]);
+
+        $event = CalendarEvent::factory()->create();
+        $meeting = Meeting::factory()->create();
+
+        $this->actingAs($admin)
+            ->postJson(route('admin.calendar.categorize'), [
+                'event_id' => $event->id,
+                'meeting_slug' => $meeting->slug,
+            ])
+            ->assertStatus(403);
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: Standardize administrative security boundaries

This PR standardizes the application's administrative security boundary by ensuring all sensitive operations use the canonical `User::canAccessAdmin()` check, which requires both the `is_admin` flag and a verified email address.

Key Changes:
- **Standardized Admin Checks**: Updated `EnsureMediaProcessingAccess`, `EnsureServiceTrackingAccess`, `CategorizeEventRequest`, `UploadChurchServiceRequest`, and `MediaProcessingLog` to use `canAccessAdmin()`.
- **Refined Asset Access**: Modified `SermonAssetController` to permit verified members to access Children's Talk assets stored in the `private/` directory, while maintaining strict administrator-only access for other private assets.
- **Security Regression Test**: Added `tests/Feature/Security/AdminBoundaryTest.php` to ensure unverified administrators are correctly blocked from sensitive APIs.

This alignment prevents "raw" admin checks from bypassing the email verification requirement and ensures consistent behavior across the administrative surface.

---
*PR created automatically by Jules for task [7581841368974970534](https://jules.google.com/task/7581841368974970534) started by @GarethClarridge*