### PR TITLE
🏛️ Warden: add index to sermons.date

### DIFF
--- a/database/migrations/2026_04_30_053545_add_date_index_to_sermons_table.php
+++ b/database/migrations/2026_04_30_053545_add_date_index_to_sermons_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sermons', function (Blueprint $table) {
+            if (! $this->indexExists('sermons', 'sermons_date_index')) {
+                $table->index('date', 'sermons_date_index');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sermons', function (Blueprint $table) {
+            if ($this->indexExists('sermons', 'sermons_date_index')) {
+                $table->dropIndex('sermons_date_index');
+            }
+        });
+    }
+
+    /**
+     * Check if an index exists on a table
+     */
+    private function indexExists(string $table, string $indexName): bool
+    {
+        return Schema::hasIndex($table, $indexName);
+    }
+};


### PR DESCRIPTION
💡 **What:** Added a missing index on the `sermons.date` column.
🎯 **Why:** This column is used in `ORDER BY` on every sermon listing and archive page. Adding a dedicated index improves query performance for these high-traffic pages.
🗄️ **Migration:** `2026_04_30_053545_add_date_index_to_sermons_table.php` adds `sermons_date_index` using `Schema::table`.
✅ **Verification:**
- Ran `php artisan migrate` successfully.
- Verified index existence with `SHOW INDEX FROM sermons`.
- Ran relevant tests (`tests/Feature/Warden/`) and all passed.
- Static analysis (`phpstan`) and formatting (`pint`) are clean.
⚠️ **Rollback:** `php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [14478366571994328106](https://jules.google.com/task/14478366571994328106) started by @GarethClarridge*