### PR TITLE
🔦 Lighthouse: Add SEO metadata and structured data to Song pages

### DIFF
--- a/resources/views/church/songs/index.blade.php
+++ b/resources/views/church/songs/index.blade.php
@@ -1,5 +1,20 @@
 @extends('layouts.page')
 
+@section('title', 'Songs')
+
+@section('meta_description', 'Browse the songs most often sung at Crockenhill Baptist Church.')
+
+@section('meta_tags')
+<x-meta-tags
+    title="Songs"
+    description="Browse the songs most often sung at Crockenhill Baptist Church."
+/>
+<x-schema.webpage
+    heading="Songs"
+    description="Browse the songs most often sung at Crockenhill Baptist Church."
+/>
+@endsection
+
 @section('dynamic_content')
     <livewire:church.songs.browse-songs />
 @endsection

--- a/resources/views/church/songs/show.blade.php
+++ b/resources/views/church/songs/show.blade.php
@@ -1,5 +1,23 @@
 @extends('layouts.page')
 
+@section('title')
+{{ $heading }} | Songs
+@stop
+
+@section('meta_description'){{ $description }}@stop
+
+@section('meta_tags')
+<x-meta-tags
+    :title="$heading . ' | Songs'"
+    :description="$description"
+/>
+<x-schema.webpage
+    :heading="$heading"
+    :description="$description"
+/>
+<x-schema.music-composition :$song />
+@stop
+
 @section('dynamic_content')
     <section class="space-y-8">
         <div class="overflow-hidden rounded-2xl border border-cbc-teal/15 bg-[linear-gradient(135deg,rgba(36,154,151,0.12)_0%,rgba(29,104,106,0.08)_50%,rgba(20,85,87,0.16)_100%)] p-8 shadow-sm">

--- a/resources/views/components/schema/music-composition.blade.php
+++ b/resources/views/components/schema/music-composition.blade.php
@@ -1,0 +1,24 @@
+@props([
+    'song',
+])
+
+@php
+    $authors = $song->authors->map(function ($author) {
+        return [
+            '@type' => 'Person',
+            'name' => $author->display_name,
+        ];
+    })->values()->all();
+
+    $schema = [
+        '@context' => 'https://schema.org',
+        '@type' => 'MusicComposition',
+        'name' => $song->title,
+        'url' => route('church.songs.show', $song->slug),
+        'author' => $authors,
+    ];
+@endphp
+
+<script type="application/ld+json">
+    {!! json_encode($schema, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}
+</script>

--- a/tests/Feature/SongSeoTest.php
+++ b/tests/Feature/SongSeoTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Song;
+use App\Models\SongAuthor;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SongSeoTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function song_index_has_correct_metadata()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('church.songs.index'));
+
+        $response->assertStatus(200);
+        $response->assertSee('<title>Songs | Crockenhill Baptist Church</title>', false);
+        $response->assertSee('<meta name="description" content="Browse the songs most often sung at Crockenhill Baptist Church.">', false);
+        $response->assertSee('<meta property="og:title" content="Songs | Crockenhill Baptist Church">', false);
+        $response->assertSee('<meta property="og:description" content="Browse the songs most often sung at Crockenhill Baptist Church.">', false);
+        $response->assertSee('"@type": "WebPage"', false);
+        $response->assertSee('"name": "Songs"', false);
+    }
+
+    #[Test]
+    public function song_detail_page_has_correct_metadata_and_structured_data()
+    {
+        $user = User::factory()->create();
+        $author = SongAuthor::factory()->create(['display_name' => 'Stuart Townend']);
+        $song = Song::factory()->create([
+            'title' => 'In Christ Alone',
+            'slug' => 'in-christ-alone',
+        ]);
+        $song->authors()->attach($author);
+
+        $response = $this->actingAs($user)->get(route('church.songs.show', $song));
+
+        $response->assertStatus(200);
+        $response->assertSee('<title>In Christ Alone | Songs | Crockenhill Baptist Church</title>', false);
+        $response->assertSee('<meta name="description" content="Lyrics and recent usage for In Christ Alone at Crockenhill Baptist Church.">', false);
+        $response->assertSee('<meta property="og:title" content="In Christ Alone | Songs | Crockenhill Baptist Church">', false);
+
+        // MusicComposition Schema
+        $response->assertSee('"@type": "MusicComposition"', false);
+        $response->assertSee('"name": "In Christ Alone"', false);
+        $response->assertSee('"url": "http://localhost/church/songs/in-christ-alone"', false);
+        $response->assertSee('"@type": "Person"', false);
+        $response->assertSee('"name": "Stuart Townend"', false);
+    }
+}


### PR DESCRIPTION
I have implemented SEO and metadata improvements for the Songs section of the website. 

### Key Changes:
- **New Schema Component**: Created `resources/views/components/schema/music-composition.blade.php` to render `MusicComposition` JSON-LD structured data, including title, URL, and authors.
- **Song Detail Page**: Updated `resources/views/church/songs/show.blade.php` to include unique titles (e.g., "Song Title | Songs | Crockenhill Baptist Church"), meta descriptions, and Open Graph tags.
- **Song Index Page**: Added proper SEO metadata to the song listing page in `resources/views/church/songs/index.blade.php`.
- **Testing**: Added `tests/Feature/SongSeoTest.php` which verifies that both the listing and detail pages have the correct metadata and structured data.

### Verification:
- Ran `php artisan test --compact tests/Feature/SongSeoTest.php` (Passed).
- Ran `php artisan test --parallel --compact --filter=Song` (Passed).
- Ran `composer phpstan` (No errors).
- Ran `./vendor/bin/pint --dirty` (Formatted).
- Visually verified page titles using a Playwright script.
- Confirmed that all temporary debug routes and unrelated dependency changes were removed before submission.

---
*PR created automatically by Jules for task [12605701091708209630](https://jules.google.com/task/12605701091708209630) started by @GarethClarridge*