### PR TITLE
🎨 Palette: UX & Accessibility Polish

### DIFF
--- a/resources/views/components/back-to-top.blade.php
+++ b/resources/views/components/back-to-top.blade.php
@@ -13,7 +13,7 @@
 >
     <button
         type="button"
-        @click="window.scrollTo({ top: 0, behavior: 'smooth' })"
+        @click="window.scrollTo({ top: 0, behavior: 'smooth' }); document.getElementById('main-content')?.focus()"
         aria-label="Back to top"
         title="Back to top"
         class="flex h-12 w-12 items-center justify-center rounded-full bg-cbc-teal text-white shadow-lg transition-all hover:bg-cbc-teal-dark hover:shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 active:scale-95"

--- a/resources/views/components/sermon-card.blade.php
+++ b/resources/views/components/sermon-card.blade.php
@@ -66,7 +66,7 @@
           {{ $sermon->service instanceof \App\Enums\SermonService ? $sermon->service->label() : \Illuminate\Support\Str::title($sermon->service) }}
         </span>
         @if ($formattedDuration)
-          <span class="flex items-center text-xs font-medium text-gray-400 bg-gray-50 px-2 py-0.5 rounded-full border border-gray-100 ml-2" title="Sermon duration">
+          <span class="flex items-center text-xs font-medium text-gray-500 bg-gray-50 px-2 py-0.5 rounded-full border border-gray-100 ml-2" title="Sermon duration">
             <x-heroicon-o-play-circle class="h-3.5 w-3.5 mr-1" aria-hidden="true" />
             {{ $formattedDuration }}
           </span>

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -96,6 +96,27 @@
 </head>
 
 <body class="bg-slate-200">
+  {{-- Navigation Progress Bar --}}
+  <div
+    x-data="{ navigating: false }"
+    x-on:livewire:navigating.window="navigating = true"
+    x-on:livewire:navigated.window="navigating = false"
+    class="fixed top-0 left-0 right-0 z-[110] h-1"
+    aria-hidden="true"
+  >
+    <div
+      x-show="navigating"
+      x-transition:enter="transition ease-out duration-300"
+      x-transition:enter-start="opacity-0"
+      x-transition:enter-end="opacity-100"
+      x-transition:leave="transition ease-in duration-500"
+      x-transition:leave-start="opacity-100"
+      x-transition:leave-end="opacity-0"
+      class="h-full bg-cbc-teal shadow-[0_0_8px_theme(colors.cbc-teal.light)] animate-progress"
+      style="width: 0%;"
+    ></div>
+  </div>
+
   <div wire:offline class="fixed top-0 left-0 right-0 z-[100] bg-red-600 text-white text-center py-2 text-sm font-medium shadow-md" role="alert">
     You are currently offline. Some features may not be available.
   </div>

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -194,7 +194,7 @@ $hasPublicVideo = filled($sermonView['video_url']);
           <div class="flex items-center gap-2">
             <x-heroicon-o-document-text class="h-4 w-4 text-cbc-teal flex-shrink-0" aria-hidden="true" />
             <h2 class="font-display text-xl text-gray-900">Automated transcript</h2>
-            <span class="text-xs text-gray-400 font-sans">(may contain errors)</span>
+            <span class="text-xs text-gray-500 font-sans">(may contain errors)</span>
           </div>
           <div class="flex items-center gap-2">
             <div x-show="loaded" x-cloak>
@@ -360,7 +360,7 @@ $hasPublicVideo = filled($sermonView['video_url']);
               data-fums-token="{{ $sermon->scripturePassage->fums_token }}">
               {!! $sermon->scripturePassage->html_content !!}
             </div>
-            <p class="mt-2 text-xs text-gray-400">{{ $sermon->scripturePassage->copyright }}</p>
+            <p class="mt-2 text-xs text-gray-500">{{ $sermon->scripturePassage->copyright }}</p>
           </div>
           @endif
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,6 +27,16 @@ module.exports = {
         'cbc-crimson': '#6b0f1a',
         'cbc-rose-muted': '#c07c84',
       },
+      keyframes: {
+        progress: {
+          '0%': { width: '0%' },
+          '50%': { width: '70%' },
+          '100%': { width: '100%' },
+        }
+      },
+      animation: {
+        progress: 'progress 2s ease-in-out infinite',
+      }
     }
   },
   plugins: [


### PR DESCRIPTION
I have implemented three micro-UX and accessibility improvements to the church website:

1.  **Navigation Progress Bar**: Added a subtle, brand-colored (`cbc-teal`) progress bar at the top of the viewport that appears during Livewire navigation (`wire:navigate`). This provides immediate visual feedback for page transitions.
2.  **Back-to-top Accessibility**: Updated the `x-back-to-top` component to move keyboard focus to `#main-content` when clicked. This prevents keyboard users from being "stranded" at the bottom of the page after scrolling.
3.  **Color Contrast Improvements**: Updated several instances of `text-gray-400` (which has insufficient contrast) to `text-gray-500` in sermon listings and details. This improves readability for users with low vision while maintaining a distinct visual hierarchy for secondary information.

All changes have been verified visually and passed the full test suite (4803 tests).

---
*PR created automatically by Jules for task [17701098296573919935](https://jules.google.com/task/17701098296573919935) started by @GarethClarridge*