### PR TITLE
📝 Scribe: Add tests for PageController

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -49,3 +49,7 @@
 ## 2026-04-12 - [Sermon Model Testing Invariants]
 **Learning:** The `sermons` table has several `NOT NULL` columns with database-level defaults (`video_quality_status`, `video_visibility_override`). When writing tests, avoid passing `null` for these columns as it triggers integrity violations; use explicit enum values. Additionally, `ThumbnailMetadata` object verification requires specific keys (`id`, `timestamp`, `score`, `plain_path`) in each candidate to satisfy the `ThumbnailMetadata::candidateList()` parser.
 **Action:** Ensure sermon test factories or explicit `create()` calls provide valid enum values for status columns and properly structured arrays for metadata fields.
+
+## 2026-05-01 - [Testing Dynamic Routes with Static Overrides]
+**Learning:** Catch-all dynamic routes (e.g., `/{area}`) are superseded by static route definitions (e.g., `Route::view('/christ', ...)`) regardless of their order in the route file if they are more specific. When testing fallback logic in a catch-all controller, ensure the test cases use parameters that do not match any static overrides.
+**Action:** Use `php artisan route:list --path=parameter` to verify if a path is handled by a static view or a controller before writing assertions for catch-all behavior.

--- a/tests/Feature/PageControllerTest.php
+++ b/tests/Feature/PageControllerTest.php
@@ -17,13 +17,14 @@ class PageControllerTest extends TestCase
     #[Test]
     public function show_page_returns_200_for_valid_area_with_landing_page(): void
     {
-        // Use an area that doesn't have a static Route::view override
+        // Use 'sermons' area because '/christ', '/church', and '/community' have static Route::view overrides in web.php.
+        // /sermons is handled dynamically by PageController::showPage.
         Page::factory()->create([
-            'area' => PageArea::Community,
-            'slug' => 'community',
+            'area' => PageArea::Sermons,
+            'slug' => 'sermons',
         ]);
 
-        $response = $this->get('/community');
+        $response = $this->get('/sermons');
 
         $response->assertStatus(200);
     }

--- a/tests/Feature/PageControllerTest.php
+++ b/tests/Feature/PageControllerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\PageArea;
+use App\Models\Page;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PageControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function show_page_returns_200_for_valid_area_with_landing_page(): void
+    {
+        // Use an area that doesn't have a static Route::view override
+        Page::factory()->create([
+            'area' => PageArea::Community,
+            'slug' => 'community',
+        ]);
+
+        $response = $this->get('/community');
+
+        $response->assertStatus(200);
+    }
+
+    #[Test]
+    public function show_page_returns_404_for_invalid_area(): void
+    {
+        // Areas like 'foo' are not in PageArea enum, so PageController::showPage should abort(404)
+        $response = $this->get('/foo');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function show_page_redirects_unauthenticated_guest_for_members_area_landing_page(): void
+    {
+        // No landing page exists
+        $response = $this->get('/members');
+
+        $response->assertRedirect(route('login'));
+    }
+
+    #[Test]
+    public function show_page_returns_404_when_landing_page_is_missing_for_non_members_area(): void
+    {
+        // Both christ and community have Route::view in web.php.
+        // Let's use 'sermons' area which only has dynamic PageController route for /sermons
+        Page::query()->where('area', PageArea::Sermons)->where('slug', 'sermons')->delete();
+
+        $response = $this->get('/sermons');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function show_resolves_default_view_for_standard_page(): void
+    {
+        $page = Page::factory()->create([
+            'area' => PageArea::Christ,
+            'slug' => 'standard-page',
+        ]);
+
+        $response = $this->get('/christ/standard-page');
+
+        $response->assertStatus(200);
+        $response->assertViewIs('pages.show');
+    }
+
+    #[Test]
+    public function show_resolves_custom_override_view_when_it_exists(): void
+    {
+        // pages.christ.free-bible exists in resources/views/pages/christ/free-bible.blade.php
+        $page = Page::factory()->create([
+            'area' => PageArea::Christ,
+            'slug' => 'free-bible',
+        ]);
+
+        $response = $this->get('/christ/free-bible');
+
+        $response->assertStatus(200);
+        $response->assertViewIs('pages.christ.free-bible');
+    }
+
+    #[Test]
+    public function show_returns_404_for_non_existent_page(): void
+    {
+        $response = $this->get('/christ/non-existent');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function show_returns_404_when_area_and_slug_do_not_match(): void
+    {
+        Page::factory()->create([
+            'area' => PageArea::Church,
+            'slug' => 'some-page',
+        ]);
+
+        $response = $this->get('/christ/some-page');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function show_respects_visibility_guard(): void
+    {
+        $page = Page::factory()->admin()->create([
+            'area' => PageArea::Church,
+            'slug' => 'admin-only',
+        ]);
+
+        $response = $this->get('/church/admin-only');
+
+        // PublicPageVisibilityGuard::enforce returns a 403 (ForbiddenResponse) for admin pages if guest
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
🎯 **Coverage:** `App\Http\Controllers\PageController`
📋 **Tests added:**
- `show_page_returns_200_for_valid_area_with_landing_page`
- `show_page_returns_404_for_invalid_area`
- `show_page_redirects_unauthenticated_guest_for_members_area_landing_page`
- `show_page_returns_404_when_landing_page_is_missing_for_non_members_area`
- `show_resolves_default_view_for_standard_page`
- `show_resolves_custom_override_view_when_it_exists`
- `show_returns_404_for_non_existent_page`
- `show_returns_404_when_area_and_slug_do_not_match`
- `show_respects_visibility_guard`
🔍 **Why:** `PageController` handles critical dynamic routing and visibility logic for the public-facing pages but lacked direct feature test coverage.
✅ **Results:** All tests pass, PHPStan clean.

---
*PR created automatically by Jules for task [4625288695308710188](https://jules.google.com/task/4625288695308710188) started by @GarethClarridge*