### PR TITLE
🛡️ Sentinel: implement job uniqueness for video quality assessment

### DIFF
--- a/app/Jobs/AssessSermonVideoQuality.php
+++ b/app/Jobs/AssessSermonVideoQuality.php
@@ -123,7 +123,9 @@ class AssessSermonVideoQuality extends ProcessingJob implements ShouldBeUnique, 
      */
     public function uniqueId(): string
     {
-        return (string) ($this->sermonId ?? $this->processingLog?->sermon_id ?? '');
+        $id = $this->sermonId ?? $this->processingLog?->sermon_id;
+
+        return (string) ($id ?? '');
     }
 
     /**

--- a/app/Jobs/AssessSermonVideoQuality.php
+++ b/app/Jobs/AssessSermonVideoQuality.php
@@ -8,19 +8,25 @@ use App\Data\SermonVideoQualityAssessmentResult;
 use App\Models\MediaProcessingLog;
 use App\Models\Sermon;
 use App\Services\SermonVideoQualityAssessmentService;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class AssessSermonVideoQuality extends ProcessingJob implements ShouldQueue
+class AssessSermonVideoQuality extends ProcessingJob implements ShouldBeUnique, ShouldQueue
 {
     use InteractsWithQueue, Queueable, SerializesModels;
 
     public int $tries = 1;
 
     public int $timeout = 300;
+
+    /**
+     * The number of seconds the unique lock should be maintained.
+     */
+    public int $uniqueFor = 3600;
 
     public function __construct(
         private ?MediaProcessingLog $processingLog = null,
@@ -110,6 +116,14 @@ class AssessSermonVideoQuality extends ProcessingJob implements ShouldQueue
                 'runtime_ms' => (int) round((microtime(true) - $startedAt) * 1000),
             ]);
         }
+    }
+
+    /**
+     * Get the unique ID for the job.
+     */
+    public function uniqueId(): string
+    {
+        return (string) ($this->sermonId ?? $this->processingLog?->sermon_id ?? '');
     }
 
     /**

--- a/tests/Feature/Security/JobUniquenessTest.php
+++ b/tests/Feature/Security/JobUniquenessTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use App\Jobs\AssessSermonVideoQuality;
+use App\Models\Sermon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class JobUniquenessTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function assess_video_quality_job_is_configured_to_be_unique(): void
+    {
+        $sermon = Sermon::factory()->create();
+
+        $job = new AssessSermonVideoQuality(sermonId: $sermon->id);
+
+        $this->assertInstanceOf(\Illuminate\Contracts\Queue\ShouldBeUnique::class, $job);
+        $this->assertEquals((string) $sermon->id, $job->uniqueId());
+        $this->assertEquals(3600, $job->uniqueFor);
+    }
+
+    #[Test]
+    public function it_can_resolve_unique_id_from_processing_log(): void
+    {
+        $sermon = Sermon::factory()->create();
+        $processingLog = \App\Models\MediaProcessingLog::factory()->create([
+            'sermon_id' => $sermon->id,
+            'processing_id' => \Illuminate\Support\Str::uuid()->toString(),
+        ]);
+
+        $job = new AssessSermonVideoQuality(processingLog: $processingLog);
+
+        $this->assertEquals((string) $sermon->id, $job->uniqueId());
+    }
+}

--- a/tests/Feature/Security/JobUniquenessTest.php
+++ b/tests/Feature/Security/JobUniquenessTest.php
@@ -7,8 +7,8 @@ namespace Tests\Feature\Security;
 use App\Jobs\AssessSermonVideoQuality;
 use App\Models\Sermon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
 
 class JobUniquenessTest extends TestCase
 {
@@ -17,6 +17,7 @@ class JobUniquenessTest extends TestCase
     #[Test]
     public function assess_video_quality_job_is_configured_to_be_unique(): void
     {
+        /** @var Sermon $sermon */
         $sermon = Sermon::factory()->create();
 
         $job = new AssessSermonVideoQuality(sermonId: $sermon->id);
@@ -29,7 +30,10 @@ class JobUniquenessTest extends TestCase
     #[Test]
     public function it_can_resolve_unique_id_from_processing_log(): void
     {
+        /** @var Sermon $sermon */
         $sermon = Sermon::factory()->create();
+
+        /** @var \App\Models\MediaProcessingLog $processingLog */
         $processingLog = \App\Models\MediaProcessingLog::factory()->create([
             'sermon_id' => $sermon->id,
             'processing_id' => \Illuminate\Support\Str::uuid()->toString(),


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Redundant execution of resource-intensive FFmpeg-based video quality assessments.
🎯 **Impact:** Potential Denial of Service (DoS) via CPU and memory exhaustion if multiple assessments are triggered concurrently for the same sermon.
🔧 **Fix:** Implemented `ShouldBeUnique` interface on the `AssessSermonVideoQuality` job, scoping uniqueness to the sermon ID.
✅ **Verification:** Added `tests/Feature/Security/JobUniquenessTest.php` to verify the uniqueness configuration and ID resolution.

---
*PR created automatically by Jules for task [15833808724126838441](https://jules.google.com/task/15833808724126838441) started by @GarethClarridge*