### PR TITLE
🏛️ Warden: Fortify sermon and church service item integrity

### DIFF
--- a/app/Models/ChurchServiceItem.php
+++ b/app/Models/ChurchServiceItem.php
@@ -80,6 +80,37 @@ class ChurchServiceItem extends Model
         ];
     }
 
+    /**
+     * @return array<string, list<string|mixed>>
+     */
+    public static function validationRules(?self $item = null, ?int $churchServiceId = null): array
+    {
+        $positionRule = ['required', 'integer', 'min:1'];
+        $uniquePosition = \Illuminate\Validation\Rule::unique('church_service_items', 'position')
+            ->whereNull('deleted_at');
+
+        if ($item) {
+            $uniquePosition->ignore($item->id);
+            $churchServiceId ??= $item->church_service_id;
+        }
+
+        if ($churchServiceId) {
+            $uniquePosition->where('church_service_id', $churchServiceId);
+        }
+
+        $positionRule[] = $uniquePosition;
+
+        return [
+            'church_service_id' => ['required', 'integer', 'exists:church_services,id'],
+            'position' => $positionRule,
+            'title' => ['required', 'string', 'max:255'],
+            'type' => ['required', 'string', 'max:50'],
+            'section_type' => ['nullable', \Illuminate\Validation\Rule::enum(ServiceSectionType::class)],
+            'source' => ['nullable', \Illuminate\Validation\Rule::enum(ChurchServiceItemSource::class)],
+            'song_id' => ['nullable', 'integer', 'exists:songs,id'],
+        ];
+    }
+
     public function semanticSectionType(): ServiceSectionType
     {
         if ($this->section_type instanceof ServiceSectionType) {

--- a/database/migrations/2026_05_01_100000_restore_sermon_scripture_passage_id_foreign_key.php
+++ b/database/migrations/2026_05_01_100000_restore_sermon_scripture_passage_id_foreign_key.php
@@ -16,11 +16,12 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (DB::getDriverName() !== 'mysql') {
+        if (DB::getDriverName() !== 'mysql' || ! Schema::hasTable('sermons')) {
             return;
         }
 
-        // 1. Clean up orphaned scripture_passage_id values that would block the FK
+        // 1. Clean up orphaned scripture_passage_id values that would block the FK.
+        // Orphans could have been introduced while the constraint was missing.
         DB::table('sermons')
             ->whereNotNull('scripture_passage_id')
             ->whereNotExists(function ($query) {
@@ -30,13 +31,14 @@ return new class extends Migration
             })
             ->update(['scripture_passage_id' => null]);
 
-        // 2. Restore the foreign key dropped by a previous migration.
-        // We use a manual statement to ensure consistent naming and parameters.
+        // 2. Restore the foreign key using the Schema builder for better consistency.
         if (! $this->foreignKeyExists()) {
-            DB::statement(sprintf(
-                'ALTER TABLE sermons ADD CONSTRAINT %s FOREIGN KEY (scripture_passage_id) REFERENCES scripture_passages (id) ON DELETE SET NULL',
-                self::CONSTRAINT
-            ));
+            Schema::table('sermons', function (Blueprint $table) {
+                $table->foreign('scripture_passage_id', self::CONSTRAINT)
+                    ->references('id')
+                    ->on('scripture_passages')
+                    ->onDelete('set null');
+            });
         }
     }
 
@@ -45,22 +47,30 @@ return new class extends Migration
      */
     public function down(): void
     {
-        if (DB::getDriverName() !== 'mysql') {
+        if (DB::getDriverName() !== 'mysql' || ! Schema::hasTable('sermons')) {
             return;
         }
 
         if ($this->foreignKeyExists()) {
-            DB::statement(sprintf('ALTER TABLE sermons DROP FOREIGN KEY %s', self::CONSTRAINT));
+            Schema::table('sermons', function (Blueprint $table) {
+                $table->dropForeign(self::CONSTRAINT);
+            });
         }
     }
 
+    /**
+     * Check if the foreign key exists in the database.
+     * Uses DATABASE() to ensure the check is scoped to the current schema.
+     */
     private function foreignKeyExists(): bool
     {
-        return DB::table('information_schema.table_constraints')
-            ->where('table_schema', DB::getDatabaseName())
-            ->where('table_name', 'sermons')
-            ->where('constraint_name', self::CONSTRAINT)
-            ->where('constraint_type', 'FOREIGN KEY')
-            ->exists();
+        return collect(DB::select("
+            SELECT CONSTRAINT_NAME
+            FROM information_schema.TABLE_CONSTRAINTS
+            WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME = 'sermons'
+            AND CONSTRAINT_NAME = ?
+            AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+        ", [self::CONSTRAINT]))->isNotEmpty();
     }
 };

--- a/database/migrations/2026_05_01_100000_restore_sermon_scripture_passage_id_foreign_key.php
+++ b/database/migrations/2026_05_01_100000_restore_sermon_scripture_passage_id_foreign_key.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const CONSTRAINT = 'sermons_scripture_passage_id_foreign';
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        // 1. Clean up orphaned scripture_passage_id values that would block the FK
+        DB::table('sermons')
+            ->whereNotNull('scripture_passage_id')
+            ->whereNotExists(function ($query) {
+                $query->select(DB::raw(1))
+                    ->from('scripture_passages')
+                    ->whereColumn('scripture_passages.id', 'sermons.scripture_passage_id');
+            })
+            ->update(['scripture_passage_id' => null]);
+
+        // 2. Restore the foreign key dropped by a previous migration.
+        // We use a manual statement to ensure consistent naming and parameters.
+        if (! $this->foreignKeyExists()) {
+            DB::statement(sprintf(
+                'ALTER TABLE sermons ADD CONSTRAINT %s FOREIGN KEY (scripture_passage_id) REFERENCES scripture_passages (id) ON DELETE SET NULL',
+                self::CONSTRAINT
+            ));
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        if ($this->foreignKeyExists()) {
+            DB::statement(sprintf('ALTER TABLE sermons DROP FOREIGN KEY %s', self::CONSTRAINT));
+        }
+    }
+
+    private function foreignKeyExists(): bool
+    {
+        return DB::table('information_schema.table_constraints')
+            ->where('table_schema', DB::getDatabaseName())
+            ->where('table_name', 'sermons')
+            ->where('constraint_name', self::CONSTRAINT)
+            ->where('constraint_type', 'FOREIGN KEY')
+            ->exists();
+    }
+};

--- a/database/migrations/2026_05_01_100100_add_integrity_check_to_church_service_items_table.php
+++ b/database/migrations/2026_05_01_100100_add_integrity_check_to_church_service_items_table.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    private const TITLE_FORMAT_CHECK = 'church_service_items_title_format_check';
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        // 1. Data Cleanup: Trim existing text columns and ensure they aren't empty
+        DB::table('church_service_items')->update([
+            'title' => DB::raw('TRIM(title)'),
+            'type' => DB::raw('TRIM(type)'),
+            'source_title' => DB::raw("NULLIF(TRIM(source_title), '')"),
+            'openlp_search_title' => DB::raw("NULLIF(TRIM(openlp_search_title), '')"),
+        ]);
+
+        // Ensure no empty titles/types exist before adding constraints
+        DB::table('church_service_items')
+            ->where('title', '')
+            ->update(['title' => DB::raw("CONCAT('Item ', id)")]);
+
+        DB::table('church_service_items')
+            ->where('type', '')
+            ->update(['type' => 'custom']);
+
+        // 2. Add CHECK constraints
+        // BINARY ensures exact character-for-character comparison for the TRIM check.
+        DB::statement(sprintf(
+            "ALTER TABLE church_service_items ADD CONSTRAINT %s CHECK (BINARY title = TRIM(title) AND title != '')",
+            self::TITLE_FORMAT_CHECK
+        ));
+
+        DB::statement(
+            "ALTER TABLE church_service_items ADD CONSTRAINT church_service_items_type_format_check CHECK (BINARY type = TRIM(type) AND type != '')"
+        );
+
+        DB::statement(
+            "ALTER TABLE church_service_items ADD CONSTRAINT church_service_items_source_title_format_check CHECK (source_title IS NULL OR (BINARY source_title = TRIM(source_title) AND source_title != ''))"
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        DB::statement(sprintf('ALTER TABLE church_service_items DROP CHECK %s', self::TITLE_FORMAT_CHECK));
+        DB::statement('ALTER TABLE church_service_items DROP CHECK church_service_items_type_format_check');
+        DB::statement('ALTER TABLE church_service_items DROP CHECK church_service_items_source_title_format_check');
+    }
+};

--- a/tests/Feature/DataIntegrity/WardenIntegrityFixTest.php
+++ b/tests/Feature/DataIntegrity/WardenIntegrityFixTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\DataIntegrity;
+
+use App\Models\ChurchService;
+use App\Models\ChurchServiceItem;
+use App\Models\ScripturePassage;
+use App\Models\Sermon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class WardenIntegrityFixTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_enforces_scripture_passage_referential_integrity(): void
+    {
+        $passage = ScripturePassage::factory()->create();
+        $sermon = Sermon::factory()->create(['scripture_passage_id' => $passage->id]);
+
+        $this->assertEquals($passage->id, $sermon->fresh()->scripture_passage_id);
+
+        $passage->delete();
+
+        $this->assertNull($sermon->fresh()->scripture_passage_id);
+    }
+
+    #[Test]
+    public function it_prevents_untrimmed_titles_in_church_service_items(): void
+    {
+        $service = ChurchService::factory()->create();
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectExceptionMessage('church_service_items_title_format_check');
+
+        DB::table('church_service_items')->insert([
+            'church_service_id' => $service->id,
+            'position' => 1,
+            'type' => 'custom',
+            'title' => '  untrimmed title  ',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_prevents_empty_titles_in_church_service_items(): void
+    {
+        $service = ChurchService::factory()->create();
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectExceptionMessage('church_service_items_title_format_check');
+
+        DB::table('church_service_items')->insert([
+            'church_service_id' => $service->id,
+            'position' => 1,
+            'type' => 'custom',
+            'title' => '',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_prevents_untrimmed_types_in_church_service_items(): void
+    {
+        $service = ChurchService::factory()->create();
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectExceptionMessage('church_service_items_type_format_check');
+
+        DB::table('church_service_items')->insert([
+            'church_service_id' => $service->id,
+            'position' => 1,
+            'type' => ' untrimmed type ',
+            'title' => 'Valid Title',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_enforces_position_uniqueness_validation(): void
+    {
+        $service = ChurchService::factory()->create();
+        $item = ChurchServiceItem::factory()->create([
+            'church_service_id' => $service->id,
+            'position' => 1,
+        ]);
+
+        $rules = ChurchServiceItem::validationRules(churchServiceId: $service->id);
+
+        $validator = \Illuminate\Support\Facades\Validator::make(
+            ['church_service_id' => $service->id, 'position' => 1, 'title' => 'Test', 'type' => 'custom'],
+            $rules
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('position', $validator->errors()->toArray());
+    }
+}


### PR DESCRIPTION
💡 **What:** This PR addresses two critical data integrity issues: referential integrity for sermon scriptures and format/uniqueness constraints for church service items.

🎯 **Why:** 
1. The `sermons.scripture_passage_id` foreign key was missing from the source code, allowing potential orphaned records.
2. `ChurchServiceItem` columns like `title` and `type` lacked database-level protection against untrimmed or empty strings, which could lead to inconsistent UI and search behavior.
3. Centralizing validation logic in the model ensures consistency between application-level checks and database constraints.

🗄️ **Migration:**
- `2026_05_01_100000_restore_sermon_scripture_passage_id_foreign_key.php`: Re-establishes referential integrity for sermon scriptures.
- `2026_05_01_100100_add_integrity_check_to_church_service_items_table.php`: Adds CHECK constraints to ensure `title`, `type`, and `source_title` are trimmed and non-empty.

✅ **Verification:**
- New test `tests/Feature/DataIntegrity/WardenIntegrityFixTest.php` confirms foreign key behavior and CHECK constraint enforcement.
- Existing `ChurchServiceItemSchemaTest` passes.
- Verified schema state via `SHOW CREATE TABLE` on MySQL 8.0.

⚠️ **Rollback:** `php artisan migrate:rollback --step=2`

---
*PR created automatically by Jules for task [9098614691350687312](https://jules.google.com/task/9098614691350687312) started by @GarethClarridge*