### PR TITLE
Add tests for SongLyricSnippetBuilder

### DIFF
--- a/app/Services/SongLyricSnippetBuilder.php
+++ b/app/Services/SongLyricSnippetBuilder.php
@@ -25,7 +25,7 @@ class SongLyricSnippetBuilder
         $lower = mb_strtolower($lyricsPlain);
 
         foreach ($tokens as $token) {
-            if (! str_contains($lower, $token)) {
+            if (! str_contains($lower, mb_strtolower($token))) {
                 return false;
             }
         }
@@ -72,7 +72,7 @@ class SongLyricSnippetBuilder
             // Only include lines that contain at least one token.
             $hasMatch = false;
             foreach ($tokens as $token) {
-                if (str_contains($lower, $token)) {
+                if (str_contains($lower, mb_strtolower($token))) {
                     $hasMatch = true;
                     break;
                 }
@@ -112,7 +112,11 @@ class SongLyricSnippetBuilder
         $ranges = [];
 
         foreach ($tokens as $token) {
-            $pattern = '/'.preg_quote(e($token), '/').'/iu';
+            $escapedToken = e($token);
+            if ($escapedToken === '') {
+                continue;
+            }
+            $pattern = '/'.preg_quote($escapedToken, '/').'/iu';
             preg_match_all($pattern, $escaped, $matches, PREG_OFFSET_CAPTURE);
 
             foreach ($matches[0] as [$match, $offset]) {

--- a/tests/Feature/Livewire/BrowseSongsTest.php
+++ b/tests/Feature/Livewire/BrowseSongsTest.php
@@ -226,4 +226,21 @@ class BrowseSongsTest extends TestCase
             ->assertSee('Amazing Grace')
             ->assertDontSee('How Great Thou Art');
     }
+
+    #[Test]
+    public function search_displays_lyric_snippets_when_matching(): void
+    {
+        $this->actingAs($this->user);
+
+        Song::factory()->create([
+            'title' => 'Unique Title',
+            'lyrics_plain' => "Line 1\nUnique in lyrics\nLine 3",
+        ]);
+
+        Livewire::test(BrowseSongs::class)
+            ->set('range', PublicSongCatalogService::RANGE_ALL)
+            ->set('search', 'Unique')
+            ->assertSee('Unique Title')
+            ->assertSee('<mark>Unique</mark> in lyrics', false);
+    }
 }

--- a/tests/Unit/Services/SongLyricSnippetBuilderTest.php
+++ b/tests/Unit/Services/SongLyricSnippetBuilderTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Services\SongLyricSnippetBuilder;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SongLyricSnippetBuilderTest extends TestCase
+{
+    private SongLyricSnippetBuilder $builder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->builder = new SongLyricSnippetBuilder();
+    }
+
+    #[Test]
+    public function has_lyric_match_returns_true_when_tokens_are_present(): void
+    {
+        $lyrics = "Amazing grace how sweet the sound\nThat saved a wretch like me";
+        $tokens = collect(['grace', 'saved']);
+
+        $this->assertTrue($this->builder->hasLyricMatch($lyrics, $tokens));
+    }
+
+    #[Test]
+    public function has_lyric_match_returns_false_when_any_token_is_missing(): void
+    {
+        $lyrics = "Amazing grace how sweet the sound";
+        $tokens = collect(['grace', 'notpresent']);
+
+        $this->assertFalse($this->builder->hasLyricMatch($lyrics, $tokens));
+    }
+
+    #[Test]
+    public function has_lyric_match_is_case_insensitive(): void
+    {
+        $lyrics = "AMAZING GRACE";
+        $tokens = collect(['amazing', 'grace']);
+
+        $this->assertTrue($this->builder->hasLyricMatch($lyrics, $tokens));
+    }
+
+    #[Test]
+    public function has_lyric_match_handles_empty_inputs(): void
+    {
+        $this->assertFalse($this->builder->hasLyricMatch("", collect(['grace'])));
+        $this->assertFalse($this->builder->hasLyricMatch("Amazing grace", collect([])));
+    }
+
+    #[Test]
+    public function build_snippets_returns_matching_lines_with_highlights(): void
+    {
+        $lyrics = "Line one\nAmazing grace\nLine three\nHow sweet the sound";
+        $tokens = collect(['grace', 'sweet']);
+
+        $snippets = $this->builder->buildSnippets($lyrics, $tokens);
+
+        $this->assertCount(2, $snippets);
+        $this->assertEquals('Amazing <mark>grace</mark>', $snippets[0]);
+        $this->assertEquals('How <mark>sweet</mark> the sound', $snippets[1]);
+    }
+
+    #[Test]
+    public function build_snippets_limits_to_max_snippets(): void
+    {
+        $lyrics = "Match 1\nMatch 2\nMatch 3\nMatch 4\nMatch 5\nMatch 6";
+        $tokens = collect(['Match']);
+
+        $snippets = $this->builder->buildSnippets($lyrics, $tokens);
+
+        $this->assertCount(5, $snippets);
+    }
+
+    #[Test]
+    public function build_snippets_skips_blank_lines(): void
+    {
+        $lyrics = "Match 1\n\nMatch 2";
+        $tokens = collect(['Match']);
+
+        $snippets = $this->builder->buildSnippets($lyrics, $tokens);
+
+        $this->assertCount(2, $snippets);
+    }
+
+    #[Test]
+    public function build_snippets_deduplicates_lines_case_insensitively(): void
+    {
+        $lyrics = "Amazing grace\nAMAZING GRACE\nAmazing Grace";
+        $tokens = collect(['grace']);
+
+        $snippets = $this->builder->buildSnippets($lyrics, $tokens);
+
+        $this->assertCount(1, $snippets);
+    }
+
+    #[Test]
+    public function build_snippets_escapes_html_and_highlights(): void
+    {
+        $lyrics = "Grace & Peace\n<script>alert('xss')</script>";
+        $tokens = collect(['&', 'alert']);
+
+        $snippets = $this->builder->buildSnippets($lyrics, $tokens);
+
+        $this->assertEquals('Grace <mark>&amp;</mark> Peace', $snippets[0]);
+        $this->assertEquals('&lt;script&gt;<mark>alert</mark>(&#039;xss&#039;)&lt;/script&gt;', $snippets[1]);
+    }
+
+    #[Test]
+    public function highlight_handles_overlapping_or_adjacent_tokens(): void
+    {
+        $lyrics = "Amazing grace";
+        // 'grace' and 'race' overlap
+        $tokens = collect(['grace', 'race']);
+
+        $snippets = $this->builder->buildSnippets($lyrics, $tokens);
+
+        $this->assertEquals('Amazing <mark>grace</mark>', $snippets[0]);
+    }
+
+    #[Test]
+    public function highlight_handles_multiple_tokens_in_one_line(): void
+    {
+        $lyrics = "The grace of God is amazing";
+        $tokens = collect(['grace', 'amazing']);
+
+        $snippets = $this->builder->buildSnippets($lyrics, $tokens);
+
+        $this->assertEquals('The <mark>grace</mark> of God is <mark>amazing</mark>', $snippets[0]);
+    }
+
+    #[Test]
+    public function highlight_is_case_insensitive_for_marking(): void
+    {
+        $lyrics = "Amazing Grace";
+        $tokens = collect(['grace']);
+
+        $snippets = $this->builder->buildSnippets($lyrics, $tokens);
+
+        $this->assertEquals('Amazing <mark>Grace</mark>', $snippets[0]);
+    }
+}


### PR DESCRIPTION
The `SongLyricSnippetBuilder` service was identified as a high-value under-tested component. It is responsible for generating and highlighting snippets from song lyrics in search results.

I implemented:
1.  **Unit Tests**: Comprehensive coverage in `tests/Unit/Services/SongLyricSnippetBuilderTest.php`, including:
    *   Basic matching and snippet extraction.
    *   HTML escaping to prevent XSS.
    *   Case-insensitive matching (fixed a bug here where the service was inconsistently handling case).
    *   Overlapping token handling (ensuring `<mark>` tags don't nest).
    *   Snippet limits (MAX_SNIPPETS = 5).
2.  **Feature Tests**: Added verification to `tests/Feature/Livewire/BrowseSongsTest.php` to ensure snippets are actually rendered in the UI when searching for terms found in lyrics.
3.  **Bug Fixes**:
    *   Normalized tokens to lowercase in `hasLyricMatch` and `buildSnippets` to match the lowercase lyrics haystack.
    *   Added a safety skip for empty tokens in the highlighting regex to avoid invalid patterns.

All tests pass.

---
*PR created automatically by Jules for task [5677570590957264933](https://jules.google.com/task/5677570590957264933) started by @GarethClarridge*