### PR TITLE
🧹 Tidy: Refactor InboundEmailStatus keys to TitleCase

### DIFF
--- a/app/Actions/InboundEmail/RejectInboundEmail.php
+++ b/app/Actions/InboundEmail/RejectInboundEmail.php
@@ -16,7 +16,7 @@ class RejectInboundEmail
     {
         $existingMetadata = is_array($inboundEmail->processing_metadata) ? $inboundEmail->processing_metadata : [];
 
-        $inboundEmail->status = InboundEmailStatus::REJECTED;
+        $inboundEmail->status = InboundEmailStatus::Rejected;
         $inboundEmail->processing_metadata = array_replace_recursive($existingMetadata, [
             'review' => [
                 'rejected_at' => now()->toIso8601String(),

--- a/app/Actions/InboundEmail/ReparseInboundEmail.php
+++ b/app/Actions/InboundEmail/ReparseInboundEmail.php
@@ -39,8 +39,8 @@ class ReparseInboundEmail
                 $inboundEmail->processing_metadata = $metadata;
             }
 
-            if ($inboundEmail->status === InboundEmailStatus::FAILED) {
-                $inboundEmail->status = InboundEmailStatus::PENDING;
+            if ($inboundEmail->status === InboundEmailStatus::Failed) {
+                $inboundEmail->status = InboundEmailStatus::Pending;
             }
 
             $inboundEmail->save();

--- a/app/Enums/InboundEmailStatus.php
+++ b/app/Enums/InboundEmailStatus.php
@@ -10,18 +10,18 @@ enum InboundEmailStatus: string
 {
     use HasValues;
 
-    case PENDING = 'pending';
-    case PROCESSED = 'processed';
-    case FAILED = 'failed';
-    case REJECTED = 'rejected';
+    case Pending = 'pending';
+    case Processed = 'processed';
+    case Failed = 'failed';
+    case Rejected = 'rejected';
 
     public function label(): string
     {
         return match ($this) {
-            self::PENDING => 'Pending',
-            self::PROCESSED => 'Processed',
-            self::FAILED => 'Failed',
-            self::REJECTED => 'Rejected',
+            self::Pending => 'Pending',
+            self::Processed => 'Processed',
+            self::Failed => 'Failed',
+            self::Rejected => 'Rejected',
         };
     }
 }

--- a/app/Http/Controllers/Api/MailgunInboundWebhookController.php
+++ b/app/Http/Controllers/Api/MailgunInboundWebhookController.php
@@ -25,7 +25,7 @@ class MailgunInboundWebhookController extends Controller
                 'body_plain' => $request->bodyPlain(),
                 'body_html' => $request->bodyHtml(),
                 'received_at' => $request->receivedAt(),
-                'status' => InboundEmailStatus::PENDING->value,
+                'status' => InboundEmailStatus::Pending->value,
                 'processing_metadata' => $request->processingMetadata(),
             ],
         );
@@ -33,13 +33,13 @@ class MailgunInboundWebhookController extends Controller
         if (! $inboundEmail->wasRecentlyCreated) {
             // Allow recovery: a redelivery of a previously-failed email should trigger
             // reprocessing rather than being silently swallowed as a duplicate.
-            if ($inboundEmail->status !== InboundEmailStatus::FAILED) {
+            if ($inboundEmail->status !== InboundEmailStatus::Failed) {
                 return response()->json([
                     'status' => 'duplicate',
                 ]);
             }
 
-            $inboundEmail->update(['status' => InboundEmailStatus::PENDING]);
+            $inboundEmail->update(['status' => InboundEmailStatus::Pending]);
         }
 
         ProcessInboundOosEmail::dispatch($inboundEmail);

--- a/app/Http/Controllers/MemberController.php
+++ b/app/Http/Controllers/MemberController.php
@@ -18,8 +18,8 @@ class MemberController extends Controller
         $pendingInboundEmailCount = $isAdmin
             ? InboundEmail::query()
                 ->whereIn('status', [
-                    InboundEmailStatus::PENDING->value,
-                    InboundEmailStatus::FAILED->value,
+                    InboundEmailStatus::Pending->value,
+                    InboundEmailStatus::Failed->value,
                 ])
                 ->count()
             : 0;

--- a/app/Jobs/ProcessInboundOosEmail.php
+++ b/app/Jobs/ProcessInboundOosEmail.php
@@ -37,7 +37,7 @@ class ProcessInboundOosEmail implements ShouldQueue
 
         if (! $parseResult->shouldImport) {
             $inboundEmail->refresh();
-            $inboundEmail->status = InboundEmailStatus::PENDING;
+            $inboundEmail->status = InboundEmailStatus::Pending;
             $inboundEmail->save();
 
             return;
@@ -62,7 +62,7 @@ class ProcessInboundOosEmail implements ShouldQueue
             return;
         }
 
-        $inboundEmail->status = InboundEmailStatus::FAILED;
+        $inboundEmail->status = InboundEmailStatus::Failed;
         $inboundEmail->processing_metadata = $this->mergeProcessingMetadata(
             $inboundEmail->processing_metadata,
             [

--- a/app/Livewire/Admin/ChurchServices/ReviewInboundEmails.php
+++ b/app/Livewire/Admin/ChurchServices/ReviewInboundEmails.php
@@ -214,8 +214,8 @@ class ReviewInboundEmails extends Component
     private function reviewableStatuses(): array
     {
         return [
-            InboundEmailStatus::PENDING->value,
-            InboundEmailStatus::FAILED->value,
+            InboundEmailStatus::Pending->value,
+            InboundEmailStatus::Failed->value,
         ];
     }
 

--- a/app/Livewire/Admin/ChurchServices/SubmitEmailText.php
+++ b/app/Livewire/Admin/ChurchServices/SubmitEmailText.php
@@ -71,7 +71,7 @@ class SubmitEmailText extends Component
             'body_plain' => $this->bodyPlain,
             'body_html' => null,
             'received_at' => now(),
-            'status' => InboundEmailStatus::PENDING,
+            'status' => InboundEmailStatus::Pending,
         ]);
 
         ProcessInboundOosEmail::dispatch($inboundEmail);

--- a/app/Services/InboundEmailImportService.php
+++ b/app/Services/InboundEmailImportService.php
@@ -274,7 +274,7 @@ class InboundEmailImportService
                 ],
             ],
         );
-        $inboundEmail->status = InboundEmailStatus::PROCESSED;
+        $inboundEmail->status = InboundEmailStatus::Processed;
         $inboundEmail->save();
     }
 
@@ -292,7 +292,7 @@ class InboundEmailImportService
                 ],
             ],
         );
-        $inboundEmail->status = InboundEmailStatus::PROCESSED;
+        $inboundEmail->status = InboundEmailStatus::Processed;
         $inboundEmail->save();
     }
 

--- a/database/factories/InboundEmailFactory.php
+++ b/database/factories/InboundEmailFactory.php
@@ -27,7 +27,7 @@ class InboundEmailFactory extends Factory
             'body_plain' => $this->faker->paragraph(),
             'body_html' => '<p>'.$this->faker->sentence().'</p>',
             'received_at' => now(),
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => [
                 'recipient' => 'oos@crockenhill.org',
             ],

--- a/database/migrations/2026_03_08_210000_create_inbound_emails_table.php
+++ b/database/migrations/2026_03_08_210000_create_inbound_emails_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->longText('body_plain')->nullable();
             $table->longText('body_html')->nullable();
             $table->timestamp('received_at');
-            $table->enum('status', InboundEmailStatus::values())->default(InboundEmailStatus::PENDING->value);
+            $table->enum('status', InboundEmailStatus::values())->default(InboundEmailStatus::Pending->value);
             $table->json('processing_metadata')->nullable();
             $table->timestamps();
 

--- a/resources/views/livewire/admin/church-services/review-inbound-emails.blade.php
+++ b/resources/views/livewire/admin/church-services/review-inbound-emails.blade.php
@@ -55,7 +55,7 @@
                         <td class="px-4 py-3 text-sm">
                             <p class="font-medium">{{ $inboundEmail->received_at->format('j M Y') }}</p>
                             <p class="text-xs text-gray-500">{{ $inboundEmail->received_at->format('H:i') }}</p>
-                            <span class="mt-2 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $inboundEmail->status === \App\Enums\InboundEmailStatus::FAILED ? 'bg-rose-100 text-rose-800' : 'bg-amber-100 text-amber-800' }}">
+                            <span class="mt-2 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $inboundEmail->status === \App\Enums\InboundEmailStatus::Failed ? 'bg-rose-100 text-rose-800' : 'bg-amber-100 text-amber-800' }}">
                                 {{ $inboundEmail->status->label() }}
                             </span>
                         </td>

--- a/tests/Feature/Actions/InboundEmail/ApproveInboundEmailImportTest.php
+++ b/tests/Feature/Actions/InboundEmail/ApproveInboundEmailImportTest.php
@@ -47,7 +47,7 @@ class ApproveInboundEmailImportTest extends TestCase
         $email = InboundEmail::factory()->create([
             'subject' => 'Order of Service - 2026-06-22 AM',
             'body_plain' => "Welcome\nSermon",
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
         ]);
 
         $result = app(ApproveInboundEmailImport::class)->execute($email, $this->admin->id);
@@ -57,7 +57,7 @@ class ApproveInboundEmailImportTest extends TestCase
         $this->assertFalse($result->needs_review);
 
         $email->refresh();
-        $this->assertSame(InboundEmailStatus::PROCESSED, $email->status);
+        $this->assertSame(InboundEmailStatus::Processed, $email->status);
         $this->assertSame('direct_approve', $email->processing_metadata['review']['mode'] ?? null);
         $this->assertSame($this->admin->id, $email->processing_metadata['review']['approved_by_user_id'] ?? null);
     }
@@ -68,7 +68,7 @@ class ApproveInboundEmailImportTest extends TestCase
         $this->bindFailingExtractor();
 
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
                 resolvedService: SermonService::Morning->value,
@@ -96,7 +96,7 @@ class ApproveInboundEmailImportTest extends TestCase
         $email = InboundEmail::factory()->create([
             'subject' => 'Unparseable email',
             'body_plain' => 'Nothing useful here',
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
         ]);
 
         $result = app(ApproveInboundEmailImport::class)->execute($email, $this->admin->id);
@@ -128,7 +128,7 @@ class ApproveInboundEmailImportTest extends TestCase
         $email = InboundEmail::factory()->create([
             'subject' => 'Order of Service - 2026-06-22 AM',
             'body_plain' => "Welcome\nSermon",
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
         ]);
 
         $result = app(ApproveInboundEmailImport::class)->execute($email, $this->admin->id);

--- a/tests/Feature/Actions/InboundEmail/InboundEmailPreviewFactoryTest.php
+++ b/tests/Feature/Actions/InboundEmail/InboundEmailPreviewFactoryTest.php
@@ -33,7 +33,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
         $email = InboundEmail::factory()->create([
             'body_plain' => "Welcome\nSermon",
             'body_html' => '<p>Welcome</p>',
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-08',
                 resolvedService: SermonService::Morning->value,
@@ -64,7 +64,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
         $email = InboundEmail::factory()->create([
             'body_plain' => null,
             'body_html' => null,
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => null,
         ]);
 
@@ -90,7 +90,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
     public function it_sets_can_approve_true_when_all_required_fields_are_present(): void
     {
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
                 resolvedService: SermonService::Morning->value,
@@ -109,7 +109,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
     public function it_sets_can_approve_false_when_items_are_empty(): void
     {
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
                 resolvedService: SermonService::Morning->value,
@@ -126,7 +126,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
     public function it_sets_can_approve_false_when_resolved_date_is_missing(): void
     {
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '',
                 resolvedService: SermonService::Morning->value,
@@ -144,7 +144,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
     {
         $email = InboundEmail::factory()->create([
             'body_html' => '<p>Safe</p><script>alert("xss")</script><svg><circle/></svg>',
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => null,
         ]);
 
@@ -161,7 +161,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
     {
         $email = InboundEmail::factory()->create([
             'body_plain' => "Line one\r\nLine two\r\nLine three",
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => null,
         ]);
 
@@ -174,7 +174,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
     public function it_exposes_failure_message_from_failure_metadata(): void
     {
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::FAILED->value,
+            'status' => InboundEmailStatus::Failed->value,
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-06-29',
@@ -194,7 +194,7 @@ class InboundEmailPreviewFactoryTest extends TestCase
     public function it_exposes_reparsed_at_timestamp_when_present(): void
     {
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-06-29',

--- a/tests/Feature/Actions/InboundEmail/RejectInboundEmailTest.php
+++ b/tests/Feature/Actions/InboundEmail/RejectInboundEmailTest.php
@@ -31,14 +31,14 @@ class RejectInboundEmailTest extends TestCase
         $admin = User::factory()->create(['is_admin' => true]);
 
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
         ]);
 
         $this->action->execute($email, $admin->id);
 
         $email->refresh();
 
-        $this->assertSame(InboundEmailStatus::REJECTED, $email->status);
+        $this->assertSame(InboundEmailStatus::Rejected, $email->status);
         $this->assertSame($admin->id, $email->processing_metadata['review']['rejected_by_user_id'] ?? null);
         $this->assertNotNull($email->processing_metadata['review']['rejected_at'] ?? null);
     }
@@ -49,7 +49,7 @@ class RejectInboundEmailTest extends TestCase
         $admin = User::factory()->create(['is_admin' => true]);
 
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => [
                 'parsing' => ['resolved_date' => '2026-06-29'],
                 'review' => ['notes' => 'This should be preserved'],
@@ -60,7 +60,7 @@ class RejectInboundEmailTest extends TestCase
 
         $email->refresh();
 
-        $this->assertSame(InboundEmailStatus::REJECTED, $email->status);
+        $this->assertSame(InboundEmailStatus::Rejected, $email->status);
         $this->assertSame('This should be preserved', $email->processing_metadata['review']['notes'] ?? null);
         $this->assertSame($admin->id, $email->processing_metadata['review']['rejected_by_user_id'] ?? null);
         $this->assertSame('2026-06-29', $email->processing_metadata['parsing']['resolved_date'] ?? null);
@@ -72,14 +72,14 @@ class RejectInboundEmailTest extends TestCase
         $admin = User::factory()->create(['is_admin' => true]);
 
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::FAILED->value,
+            'status' => InboundEmailStatus::Failed->value,
         ]);
 
         $this->action->execute($email, $admin->id);
 
         $email->refresh();
 
-        $this->assertSame(InboundEmailStatus::REJECTED, $email->status);
+        $this->assertSame(InboundEmailStatus::Rejected, $email->status);
         $this->assertSame($admin->id, $email->processing_metadata['review']['rejected_by_user_id'] ?? null);
     }
 }

--- a/tests/Feature/Actions/InboundEmail/ReparseInboundEmailTest.php
+++ b/tests/Feature/Actions/InboundEmail/ReparseInboundEmailTest.php
@@ -37,7 +37,7 @@ class ReparseInboundEmailTest extends TestCase
         $email = InboundEmail::factory()->create([
             'subject' => 'Order of Service - 2026-06-29 AM',
             'body_plain' => "Call to Worship\nSermon",
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-06-22',
@@ -57,7 +57,7 @@ class ReparseInboundEmailTest extends TestCase
         $this->assertNull($result);
 
         $email->refresh();
-        $this->assertSame(InboundEmailStatus::PENDING, $email->status);
+        $this->assertSame(InboundEmailStatus::Pending, $email->status);
         $this->assertSame('2026-03-12T11:30:00+00:00', $email->processing_metadata['reparsed_at'] ?? null);
         $this->assertSame('Keep this note', $email->processing_metadata['review']['notes'] ?? null);
         $this->assertSame('2026-06-29', $email->processing_metadata['parsing']['resolved_date'] ?? null);
@@ -82,7 +82,7 @@ class ReparseInboundEmailTest extends TestCase
         $email = InboundEmail::factory()->create([
             'subject' => 'Order of Service - 2026-07-06 PM',
             'body_plain' => "Welcome\nOpening Prayer",
-            'status' => InboundEmailStatus::FAILED->value,
+            'status' => InboundEmailStatus::Failed->value,
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-07-06',
@@ -100,7 +100,7 @@ class ReparseInboundEmailTest extends TestCase
         $this->assertNull($result);
 
         $email->refresh();
-        $this->assertSame(InboundEmailStatus::PENDING, $email->status);
+        $this->assertSame(InboundEmailStatus::Pending, $email->status);
         $this->assertArrayNotHasKey('failure', $email->processing_metadata ?? []);
         $this->assertCount(2, $email->processing_metadata['parsing']['items'] ?? []);
         $this->assertSame(0, ChurchService::count());
@@ -118,7 +118,7 @@ class ReparseInboundEmailTest extends TestCase
         });
 
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
                 resolvedService: SermonService::Morning->value,
@@ -136,7 +136,7 @@ class ReparseInboundEmailTest extends TestCase
         $this->assertStringContainsString('Unable to re-parse', $result);
 
         $email->refresh();
-        $this->assertSame(InboundEmailStatus::PENDING, $email->status);
+        $this->assertSame(InboundEmailStatus::Pending, $email->status);
         $this->assertNull($email->processing_metadata['reparsed_at'] ?? null);
         $this->assertSame('2026-06-29', $email->processing_metadata['parsing']['resolved_date'] ?? null);
         $this->assertSame('Welcome', $email->processing_metadata['parsing']['items'][0]['title'] ?? null);

--- a/tests/Feature/Actions/SaveChurchServiceFromAdminTest.php
+++ b/tests/Feature/Actions/SaveChurchServiceFromAdminTest.php
@@ -218,7 +218,7 @@ class SaveChurchServiceFromAdminTest extends TestCase
     public function it_marks_inbound_email_as_processed_when_provided(): void
     {
         $inboundEmail = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
         ]);
 
         $payload = [[
@@ -240,7 +240,7 @@ class SaveChurchServiceFromAdminTest extends TestCase
         );
 
         $inboundEmail->refresh();
-        $this->assertNotSame(InboundEmailStatus::PENDING->value, $inboundEmail->status->value);
+        $this->assertNotSame(InboundEmailStatus::Pending->value, $inboundEmail->status->value);
     }
 
     #[Test]

--- a/tests/Feature/Api/MailgunInboundWebhookControllerTest.php
+++ b/tests/Feature/Api/MailgunInboundWebhookControllerTest.php
@@ -211,7 +211,7 @@ class MailgunInboundWebhookControllerTest extends TestCase
         // Pre-seed a record in FAILED state — simulates a previously failed processing attempt.
         InboundEmail::factory()->create([
             'message_id' => '<message-1@example.com>',
-            'status' => InboundEmailStatus::FAILED,
+            'status' => InboundEmailStatus::Failed,
             'processing_metadata' => [
                 'failure' => ['message' => 'OOS parser crashed', 'failed_at' => now()->toIso8601String()],
             ],
@@ -223,7 +223,7 @@ class MailgunInboundWebhookControllerTest extends TestCase
 
         $this->assertDatabaseHas('inbound_emails', [
             'message_id' => '<message-1@example.com>',
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
         ]);
         $this->assertDatabaseCount('inbound_emails', 1);
         Queue::assertPushed(ProcessInboundOosEmail::class, 1);

--- a/tests/Feature/ChurchServices/SubmitEmailTextTest.php
+++ b/tests/Feature/ChurchServices/SubmitEmailTextTest.php
@@ -59,7 +59,7 @@ class SubmitEmailTextTest extends TestCase
         $inboundEmail = InboundEmail::query()->firstOrFail();
 
         $this->assertSame($body, $inboundEmail->body_plain);
-        $this->assertSame(InboundEmailStatus::PENDING, $inboundEmail->status);
+        $this->assertSame(InboundEmailStatus::Pending, $inboundEmail->status);
         $this->assertStringStartsWith('manual-', $inboundEmail->message_id);
         $this->assertStringEndsWith('@admin.crockenhill.org', $inboundEmail->message_id);
 

--- a/tests/Feature/Jobs/ProcessInboundOosEmailTest.php
+++ b/tests/Feature/Jobs/ProcessInboundOosEmailTest.php
@@ -48,7 +48,7 @@ class ProcessInboundOosEmailTest extends TestCase
         $email = InboundEmail::factory()->create([
             'subject' => 'Order of Service - 2026-03-16 AM',
             'body_plain' => "Welcome\nBefore the throne of God above\nOpening prayer\nLuke 15:1-32",
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
         ]);
 
         app()->call([new ProcessInboundOosEmail($email), 'handle']);
@@ -68,7 +68,7 @@ class ProcessInboundOosEmailTest extends TestCase
         ]);
 
         $email->refresh();
-        $this->assertSame(InboundEmailStatus::PROCESSED, $email->status);
+        $this->assertSame(InboundEmailStatus::Processed, $email->status);
         $this->assertSame($service->id, $email->processing_metadata['imported_church_service_id']);
         $this->assertCount(4, $email->processing_metadata['parsing']['items']);
         $this->assertSame('morning', $email->processing_metadata['parsing']['resolved_service']);
@@ -97,7 +97,7 @@ class ProcessInboundOosEmailTest extends TestCase
         $email = InboundEmail::factory()->create([
             'subject' => 'Service plan for 16 March',
             'body_plain' => "10.30am service\nWelcome\nHow deep the Father's love for us\nSermon",
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'received_at' => '2026-03-10 09:00:00',
         ]);
 
@@ -108,7 +108,7 @@ class ProcessInboundOosEmailTest extends TestCase
         $this->assertTrue($service->needs_review);
 
         $email->refresh();
-        $this->assertSame(InboundEmailStatus::PROCESSED, $email->status);
+        $this->assertSame(InboundEmailStatus::Processed, $email->status);
         $this->assertTrue($email->processing_metadata['parsing']['confidence_score'] >= 0.75);
         $this->assertTrue($email->processing_metadata['parsing']['confidence_score'] < 0.90);
     }
@@ -137,7 +137,7 @@ class ProcessInboundOosEmailTest extends TestCase
         $email = InboundEmail::factory()->create([
             'subject' => $subject,
             'body_plain' => $bodyPlain,
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'received_at' => '2026-03-10 09:00:00',
         ]);
 
@@ -168,7 +168,7 @@ class ProcessInboundOosEmailTest extends TestCase
         $this->assertSame($service->id, $songHistory->sole()->church_service_id);
 
         $email->refresh();
-        $this->assertSame(InboundEmailStatus::PROCESSED, $email->status);
+        $this->assertSame(InboundEmailStatus::Processed, $email->status);
         $this->assertSame('evening', $email->processing_metadata['parsing']['resolved_service']);
         $this->assertSame($expectedExtractionMethod, $email->processing_metadata['parsing']['service_extraction']['method']);
     }
@@ -185,7 +185,7 @@ class ProcessInboundOosEmailTest extends TestCase
         $email = InboundEmail::factory()->create([
             'subject' => 'hello there',
             'body_plain' => 'just checking in',
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'received_at' => '2026-03-10 09:00:00',
         ]);
 
@@ -194,7 +194,7 @@ class ProcessInboundOosEmailTest extends TestCase
         $this->assertDatabaseCount('church_services', 0);
 
         $email->refresh();
-        $this->assertSame(InboundEmailStatus::PENDING, $email->status);
+        $this->assertSame(InboundEmailStatus::Pending, $email->status);
         $this->assertLessThan(0.75, $email->processing_metadata['parsing']['confidence_score']);
         $this->assertSame([], $email->processing_metadata['parsing']['items']);
     }
@@ -203,7 +203,7 @@ class ProcessInboundOosEmailTest extends TestCase
     public function it_marks_the_email_as_failed_when_the_job_fails(): void
     {
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
         ]);
 
         $job = new ProcessInboundOosEmail($email);
@@ -211,7 +211,7 @@ class ProcessInboundOosEmailTest extends TestCase
 
         $email->refresh();
 
-        $this->assertSame(InboundEmailStatus::FAILED, $email->status);
+        $this->assertSame(InboundEmailStatus::Failed, $email->status);
 
         $failure = $email->processing_metadata['failure'];
         $this->assertSame('Parser exploded', $failure['message']);

--- a/tests/Feature/Livewire/Admin/AdminUrlStateTest.php
+++ b/tests/Feature/Livewire/Admin/AdminUrlStateTest.php
@@ -416,20 +416,20 @@ class AdminUrlStateTest extends TestCase
 
         InboundEmail::factory()->create([
             'subject' => 'Pending service plan',
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
         ]);
 
         InboundEmail::factory()->create([
             'subject' => 'Failed service plan',
-            'status' => InboundEmailStatus::FAILED->value,
+            'status' => InboundEmailStatus::Failed->value,
         ]);
 
         Livewire::withQueryParams([
             'search' => 'Pending',
-            'statusFilter' => InboundEmailStatus::PENDING->value,
+            'statusFilter' => InboundEmailStatus::Pending->value,
         ])->test(ReviewInboundEmails::class)
             ->assertSet('search', 'Pending')
-            ->assertSet('statusFilter', InboundEmailStatus::PENDING->value)
+            ->assertSet('statusFilter', InboundEmailStatus::Pending->value)
             ->assertSee('Pending service plan')
             ->assertDontSee('Failed service plan');
     }
@@ -440,7 +440,7 @@ class AdminUrlStateTest extends TestCase
         $this->actingAs($this->admin);
 
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-07-06',
                 resolvedService: SermonService::Morning->value,

--- a/tests/Feature/Livewire/AdminInboundEmailReviewTest.php
+++ b/tests/Feature/Livewire/AdminInboundEmailReviewTest.php
@@ -42,7 +42,7 @@ class AdminInboundEmailReviewTest extends TestCase
 
         $pendingEmail = InboundEmail::factory()->create([
             'subject' => 'Pending service plan',
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-08',
                 resolvedService: SermonService::Morning->value,
@@ -55,7 +55,7 @@ class AdminInboundEmailReviewTest extends TestCase
 
         $failedEmail = InboundEmail::factory()->create([
             'subject' => 'Failed email',
-            'status' => InboundEmailStatus::FAILED->value,
+            'status' => InboundEmailStatus::Failed->value,
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-06-15',
@@ -72,7 +72,7 @@ class AdminInboundEmailReviewTest extends TestCase
 
         $processedEmail = InboundEmail::factory()->create([
             'subject' => 'Already imported',
-            'status' => InboundEmailStatus::PROCESSED->value,
+            'status' => InboundEmailStatus::Processed->value,
         ]);
 
         Livewire::test(ReviewInboundEmails::class)
@@ -93,7 +93,7 @@ class AdminInboundEmailReviewTest extends TestCase
             'subject' => 'Plain text review email',
             'body_plain' => "Welcome\nSong One\nPrayer",
             'body_html' => null,
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-08',
                 resolvedService: SermonService::Morning->value,
@@ -130,7 +130,7 @@ class AdminInboundEmailReviewTest extends TestCase
                 <a href="javascript:alert('bad')">Unsafe link</a>
                 <svg><circle /></svg>
             HTML,
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-08',
                 resolvedService: SermonService::Morning->value,
@@ -160,7 +160,7 @@ class AdminInboundEmailReviewTest extends TestCase
             'subject' => 'No bodies stored',
             'body_plain' => null,
             'body_html' => null,
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => null,
         ]);
 
@@ -187,7 +187,7 @@ class AdminInboundEmailReviewTest extends TestCase
         $email = InboundEmail::factory()->create([
             'subject' => 'Order of Service - 2026-06-22 AM',
             'body_plain' => "Welcome\nSermon",
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
         ]);
 
         $component = Livewire::test(ReviewInboundEmails::class)
@@ -204,7 +204,7 @@ class AdminInboundEmailReviewTest extends TestCase
         $this->assertFalse($service->needs_review);
 
         $email->refresh();
-        $this->assertSame(InboundEmailStatus::PROCESSED, $email->status);
+        $this->assertSame(InboundEmailStatus::Processed, $email->status);
         $this->assertSame($service->id, $email->processing_metadata['imported_church_service_id'] ?? null);
         $this->assertSame('direct_approve', $email->processing_metadata['review']['mode'] ?? null);
         $this->assertSame($this->admin->id, $email->processing_metadata['review']['approved_by_user_id'] ?? null);
@@ -218,7 +218,7 @@ class AdminInboundEmailReviewTest extends TestCase
         $this->bindFailingExtractor();
 
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
                 resolvedService: SermonService::Morning->value,
@@ -262,7 +262,7 @@ class AdminInboundEmailReviewTest extends TestCase
         $email = InboundEmail::factory()->create([
             'subject' => 'Order of Service - 2026-06-29 AM',
             'body_plain' => "Call to Worship\nSermon",
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-06-22',
@@ -289,7 +289,7 @@ class AdminInboundEmailReviewTest extends TestCase
 
         $email->refresh();
 
-        $this->assertSame(InboundEmailStatus::PENDING, $email->status);
+        $this->assertSame(InboundEmailStatus::Pending, $email->status);
         $this->assertSame('2026-03-12T11:30:00+00:00', $email->processing_metadata['reparsed_at'] ?? null);
         $this->assertSame('Keep this note', $email->processing_metadata['review']['notes'] ?? null);
         $this->assertSame('2026-06-29', $email->processing_metadata['parsing']['resolved_date'] ?? null);
@@ -318,7 +318,7 @@ class AdminInboundEmailReviewTest extends TestCase
         $email = InboundEmail::factory()->create([
             'subject' => 'Order of Service - 2026-07-06 PM',
             'body_plain' => "Welcome\nOpening Prayer",
-            'status' => InboundEmailStatus::FAILED->value,
+            'status' => InboundEmailStatus::Failed->value,
             'processing_metadata' => array_replace_recursive(
                 $this->processingMetadata(
                     resolvedDate: '2026-07-06',
@@ -342,7 +342,7 @@ class AdminInboundEmailReviewTest extends TestCase
 
         $email->refresh();
 
-        $this->assertSame(InboundEmailStatus::PENDING, $email->status);
+        $this->assertSame(InboundEmailStatus::Pending, $email->status);
         $this->assertNull($email->processing_metadata['failure'] ?? null);
         $this->assertSame('evening', $email->processing_metadata['parsing']['resolved_service'] ?? null);
         $this->assertCount(2, $email->processing_metadata['parsing']['items'] ?? []);
@@ -361,7 +361,7 @@ class AdminInboundEmailReviewTest extends TestCase
         $email = InboundEmail::factory()->create([
             'subject' => 'Order of Service - 2026-06-29 AM',
             'body_plain' => "Welcome\nSermon",
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
                 resolvedService: SermonService::Morning->value,
@@ -377,7 +377,7 @@ class AdminInboundEmailReviewTest extends TestCase
 
         $email->refresh();
 
-        $this->assertSame(InboundEmailStatus::PENDING, $email->status);
+        $this->assertSame(InboundEmailStatus::Pending, $email->status);
         $this->assertNull($email->processing_metadata['reparsed_at'] ?? null);
         $this->assertSame('2026-06-29', $email->processing_metadata['parsing']['resolved_date'] ?? null);
         $this->assertSame('Welcome', $email->processing_metadata['parsing']['items'][0]['title'] ?? null);
@@ -391,7 +391,7 @@ class AdminInboundEmailReviewTest extends TestCase
         $this->actingAs($this->admin);
 
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
         ]);
 
         Livewire::test(ReviewInboundEmails::class)
@@ -400,7 +400,7 @@ class AdminInboundEmailReviewTest extends TestCase
 
         $email->refresh();
 
-        $this->assertSame(InboundEmailStatus::REJECTED, $email->status);
+        $this->assertSame(InboundEmailStatus::Rejected, $email->status);
         $this->assertSame($this->admin->id, $email->processing_metadata['review']['rejected_by_user_id'] ?? null);
     }
 
@@ -410,7 +410,7 @@ class AdminInboundEmailReviewTest extends TestCase
         $this->actingAs($this->admin);
 
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-06-29',
                 resolvedService: SermonService::Morning->value,
@@ -431,7 +431,7 @@ class AdminInboundEmailReviewTest extends TestCase
         $this->actingAs($this->admin);
 
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'processing_metadata' => $this->processingMetadata(
                 resolvedDate: '2026-07-06',
                 resolvedService: SermonService::Morning->value,
@@ -459,7 +459,7 @@ class AdminInboundEmailReviewTest extends TestCase
         $this->assertSame('manual', $service->source);
 
         $email->refresh();
-        $this->assertSame(InboundEmailStatus::PROCESSED, $email->status);
+        $this->assertSame(InboundEmailStatus::Processed, $email->status);
         $this->assertSame('manual_edit', $email->processing_metadata['review']['mode'] ?? null);
         $this->assertSame($service->id, $email->processing_metadata['imported_church_service_id'] ?? null);
     }

--- a/tests/Feature/MemberControllerTest.php
+++ b/tests/Feature/MemberControllerTest.php
@@ -87,7 +87,7 @@ class MemberControllerTest extends TestCase
         ]);
 
         InboundEmail::factory()->count(2)->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
         ]);
 
         $this->actingAs($admin);

--- a/tests/Feature/Security/AuditLoggingTest.php
+++ b/tests/Feature/Security/AuditLoggingTest.php
@@ -320,7 +320,7 @@ class AuditLoggingTest extends TestCase
     {
         Log::spy();
         $email = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING->value,
+            'status' => InboundEmailStatus::Pending->value,
             'subject' => 'Suspicious Email',
         ]);
 
@@ -329,7 +329,7 @@ class AuditLoggingTest extends TestCase
             ->call('reject', $email->id);
 
         $email->refresh();
-        $this->assertSame(InboundEmailStatus::REJECTED, $email->status);
+        $this->assertSame(InboundEmailStatus::Rejected, $email->status);
 
         Log::assertLogged('warning', fn (string $message, array $context): bool => $message === 'Inbound email rejected by admin' &&
             $context['inbound_email_id'] === $email->id &&

--- a/tests/Unit/Models/InboundEmailTest.php
+++ b/tests/Unit/Models/InboundEmailTest.php
@@ -34,7 +34,7 @@ class InboundEmailTest extends TestCase
         $receivedAt = now()->subMinutes(10)->startOfSecond();
         $email = InboundEmail::factory()->create([
             'received_at' => $receivedAt,
-            'status' => InboundEmailStatus::PROCESSED,
+            'status' => InboundEmailStatus::Processed,
             'processing_metadata' => ['key' => 'value'],
         ]);
 
@@ -44,7 +44,7 @@ class InboundEmailTest extends TestCase
         $this->assertInstanceOf(Carbon::class, $email->received_at);
         $this->assertTrue($email->received_at->equalTo($receivedAt));
         $this->assertInstanceOf(InboundEmailStatus::class, $email->status);
-        $this->assertSame(InboundEmailStatus::PROCESSED, $email->status);
+        $this->assertSame(InboundEmailStatus::Processed, $email->status);
         $this->assertIsArray($email->processing_metadata);
         $this->assertSame(['key' => 'value'], $email->processing_metadata);
     }
@@ -59,7 +59,7 @@ class InboundEmailTest extends TestCase
             'body_plain' => 'Plain body',
             'body_html' => '<p>HTML body</p>',
             'received_at' => now()->startOfSecond(),
-            'status' => InboundEmailStatus::PENDING,
+            'status' => InboundEmailStatus::Pending,
             'processing_metadata' => ['foo' => 'bar'],
         ];
 

--- a/tests/Unit/Services/InboundEmailImportServiceTest.php
+++ b/tests/Unit/Services/InboundEmailImportServiceTest.php
@@ -240,14 +240,14 @@ class InboundEmailImportServiceTest extends TestCase
     #[Test]
     public function test_marks_an_email_as_processed_from_manual_review(): void
     {
-        $inboundEmail = InboundEmail::factory()->create(['status' => InboundEmailStatus::PENDING->value]);
+        $inboundEmail = InboundEmail::factory()->create(['status' => InboundEmailStatus::Pending->value]);
         $churchService = ChurchService::factory()->create();
         $user = \App\Models\User::factory()->create();
 
         $this->service->markAsProcessedFromManualReview($inboundEmail, $churchService, $user->id);
 
         $inboundEmail->refresh();
-        $this->assertSame(InboundEmailStatus::PROCESSED->value, $inboundEmail->status->value);
+        $this->assertSame(InboundEmailStatus::Processed->value, $inboundEmail->status->value);
         $this->assertSame($churchService->id, $inboundEmail->processing_metadata['imported_church_service_id']);
         $this->assertSame('manual_edit', $inboundEmail->processing_metadata['review']['mode']);
         $this->assertSame($user->id, $inboundEmail->processing_metadata['review']['approved_by_user_id']);

--- a/tests/Unit/Services/StructureMergeIntegrationTest.php
+++ b/tests/Unit/Services/StructureMergeIntegrationTest.php
@@ -136,7 +136,7 @@ class StructureMergeIntegrationTest extends TestCase
         ]);
 
         $inboundEmail = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING,
+            'status' => InboundEmailStatus::Pending,
         ]);
 
         $parseResult = new \App\Data\OosEmailParseResult(
@@ -166,7 +166,7 @@ class StructureMergeIntegrationTest extends TestCase
         $this->assertSame('Sermon', $items[1]->title);
 
         $inboundEmail->refresh();
-        $this->assertSame(InboundEmailStatus::PROCESSED, $inboundEmail->status);
+        $this->assertSame(InboundEmailStatus::Processed, $inboundEmail->status);
     }
 
     #[Test]
@@ -187,7 +187,7 @@ class StructureMergeIntegrationTest extends TestCase
         ]);
 
         $inboundEmail = InboundEmail::factory()->create([
-            'status' => InboundEmailStatus::PENDING,
+            'status' => InboundEmailStatus::Pending,
         ]);
 
         $parseResult = new \App\Data\OosEmailParseResult(


### PR DESCRIPTION
Refactored the `InboundEmailStatus` enum to use `TitleCase` keys, aligning it with the project's coding standards. Updated all references across the codebase, including models, services, controllers, Livewire components, database migrations, factories, and Blade templates. Verified the changes with static analysis and existing automated tests.

---
*PR created automatically by Jules for task [7725857402991071616](https://jules.google.com/task/7725857402991071616) started by @GarethClarridge*