### PR TITLE
🎨 Palette: sermon copy utilities and input polish

### DIFF
--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -60,7 +60,7 @@ use Spatie\Sitemap\Tags\Url;
  * @property ?float $preacher_confidence
  * @property bool $needs_preacher_review
  * @property ?string $series
- * @property array<int, string>|null $points
+ * @property array<int, mixed>|null $points
  * @property ?string $summary
  * @property bool $show_summary
  * @property bool $show_points

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -189,28 +189,40 @@ class SermonViewPresenter
      */
     public function plainTextOutline(Sermon $sermon): ?string
     {
-        if (! $sermon->points || ! is_array($sermon->points)) {
+        $points = $sermon->points;
+
+        if (! is_array($points) || $points === []) {
             return null;
         }
 
         $outline = '';
-        foreach ($sermon->points as $index => $pointItem) {
-            $prefix = ($index + 1).'. ';
+        $counter = 1;
+
+        foreach ($sermon->points as $pointItem) {
+            $mainText = '';
+            $subLines = [];
+
             if (is_array($pointItem)) {
-                $mainPointText = (isset($pointItem['point']) && is_scalar($pointItem['point'])) ? (string) $pointItem['point'] : null;
-                $subPointsArray = (isset($pointItem['sub_points']) && is_array($pointItem['sub_points'])) ? $pointItem['sub_points'] : [];
+                $mainText = (isset($pointItem['point']) && is_scalar($pointItem['point'])) ? trim((string) $pointItem['point']) : '';
+                $subPoints = (isset($pointItem['sub_points']) && is_array($pointItem['sub_points'])) ? $pointItem['sub_points'] : [];
 
-                if (! empty($mainPointText)) {
-                    $outline .= $prefix.$mainPointText."\n";
-                }
-
-                foreach ($subPointsArray as $subPoint) {
-                    if (is_scalar($subPoint)) {
-                        $outline .= '   - '.(string) $subPoint."\n";
+                foreach ($subPoints as $subPoint) {
+                    if (is_scalar($subPoint) && filled($subPoint)) {
+                        $subLines[] = '   - '.trim((string) $subPoint);
                     }
                 }
             } elseif (is_scalar($pointItem)) {
-                $outline .= $prefix.(string) $pointItem."\n";
+                $mainText = trim((string) $pointItem);
+            }
+
+            if ($mainText !== '' || count($subLines) > 0) {
+                $outline .= "{$counter}. ".($mainText !== '' ? $mainText : '(Untitled point)')."\n";
+
+                foreach ($subLines as $subLine) {
+                    $outline .= "{$subLine}\n";
+                }
+
+                $counter++;
             }
         }
 
@@ -437,6 +449,7 @@ class SermonViewPresenter
      *     thumbnail_url: ?string,
      *     transcript: ?string,
      *     transcript_url: ?string,
+     *     plain_text_outline: ?string,
      *     video_url: ?string
      * }
      */
@@ -445,13 +458,16 @@ class SermonViewPresenter
         $key = $this->cacheKey($sermon, 'full_present');
 
         if (isset($this->memoizedPresents[$key])) {
-            /** @var array{audio_url: ?string, canonical_url: string, card_thumbnail_url: ?string, display_reference: ?string, duration_iso8601: ?string, formatted_duration: ?string, has_transcript: bool, human_date: string, preacher_image_url: ?string, preacher_name: ?string, preacher_url: ?string, public_url: string, series_url: ?string, thumbnail_url: ?string, transcript: ?string, transcript_url: ?string, video_url: ?string} */
+            /** @var array{audio_url: ?string, canonical_url: string, card_thumbnail_url: ?string, display_reference: ?string, duration_iso8601: ?string, formatted_duration: ?string, has_transcript: bool, human_date: string, preacher_image_url: ?string, preacher_name: ?string, preacher_url: ?string, public_url: string, series_url: ?string, thumbnail_url: ?string, transcript: ?string, transcript_url: ?string, plain_text_outline: ?string, video_url: ?string} */
             return $this->memoizedPresents[$key];
         }
 
         return $this->memoizedPresents[$key] = array_merge(
             $this->presentForList($sermon),
-            ['transcript' => $this->transcriptReader->read($sermon)]
+            [
+                'transcript' => $this->transcriptReader->read($sermon),
+                'plain_text_outline' => $this->plainTextOutline($sermon),
+            ]
         );
     }
 

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -185,6 +185,39 @@ class SermonViewPresenter
     }
 
     /**
+     * Get the plain text representation of the sermon points.
+     */
+    public function plainTextOutline(Sermon $sermon): ?string
+    {
+        if (! $sermon->points || ! is_array($sermon->points)) {
+            return null;
+        }
+
+        $outline = '';
+        foreach ($sermon->points as $index => $pointItem) {
+            $prefix = ($index + 1).'. ';
+            if (is_array($pointItem)) {
+                $mainPointText = (isset($pointItem['point']) && is_scalar($pointItem['point'])) ? (string) $pointItem['point'] : null;
+                $subPointsArray = (isset($pointItem['sub_points']) && is_array($pointItem['sub_points'])) ? $pointItem['sub_points'] : [];
+
+                if (! empty($mainPointText)) {
+                    $outline .= $prefix.$mainPointText."\n";
+                }
+
+                foreach ($subPointsArray as $subPoint) {
+                    if (is_scalar($subPoint)) {
+                        $outline .= '   - '.(string) $subPoint."\n";
+                    }
+                }
+            } elseif (is_scalar($pointItem)) {
+                $outline .= $prefix.(string) $pointItem."\n";
+            }
+        }
+
+        return trim($outline) ?: null;
+    }
+
+    /**
      * Get the preacher's profile image URL.
      *
      * Performance Optimization: Only caches when the relation is loaded.

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -88,6 +88,7 @@ $describedBy = implode(' ', $describedBy);
                 class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded"
                 :aria-label="showPassword ? 'Hide password' : 'Show password'"
                 :title="showPassword ? 'Hide password' : 'Show password'"
+                @if($modelName) wire:loading.remove wire:target="{{ $modelName }}" @endif
                 x-cloak>
                 <x-heroicon-o-eye x-show="!showPassword" class="h-5 w-5" />
                 <x-heroicon-o-eye-slash x-show="showPassword" class="h-5 w-5" />

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -98,9 +98,19 @@ $hasPublicVideo = filled($sermonView['video_url']);
       {{-- ── Summary ─────────────────────────────────────────── --}}
       @if ($sermon->show_summary && !empty($sermon->summary))
       <div class="rounded-xl bg-white border border-gray-200 shadow-sm overflow-hidden">
-        <div class="px-6 py-4 border-b border-gray-100 flex items-center gap-2">
-          <x-heroicon-o-document-text class="h-4 w-4 text-cbc-teal flex-shrink-0" aria-hidden="true" />
-          <h2 class="font-display text-xl text-gray-900">Summary</h2>
+        <div class="px-6 py-4 border-b border-gray-100 flex flex-wrap items-center justify-between gap-4">
+          <div class="flex items-center gap-2">
+            <x-heroicon-o-document-text class="h-4 w-4 text-cbc-teal flex-shrink-0" aria-hidden="true" />
+            <h2 class="font-display text-xl text-gray-900">Summary</h2>
+          </div>
+          <x-clipboard-button
+            :content="$sermon->summary"
+            hideLabel
+            label="Copy Summary"
+            title="Copy summary to clipboard"
+            icon="clipboard-document"
+            size="sm"
+          />
         </div>
         <div class="p-6 prose prose-gray max-w-none text-gray-700">
           {{ $sermon->summary }}
@@ -111,9 +121,19 @@ $hasPublicVideo = filled($sermonView['video_url']);
       {{-- ── Sermon Outline ───────────────────────────────────── --}}
       @if ($sermon->show_points && !empty($sermon->points) && is_array($sermon->points))
       <div class="rounded-xl bg-white border border-gray-200 shadow-sm overflow-hidden">
-        <div class="px-6 py-4 border-b border-gray-100 flex items-center gap-2">
-          <x-heroicon-o-list-bullet class="h-4 w-4 text-cbc-teal flex-shrink-0" aria-hidden="true" />
-          <h2 class="font-display text-xl text-gray-900">Sermon Outline</h2>
+        <div class="px-6 py-4 border-b border-gray-100 flex flex-wrap items-center justify-between gap-4">
+          <div class="flex items-center gap-2">
+            <x-heroicon-o-list-bullet class="h-4 w-4 text-cbc-teal flex-shrink-0" aria-hidden="true" />
+            <h2 class="font-display text-xl text-gray-900">Sermon Outline</h2>
+          </div>
+          <x-clipboard-button
+            :content="app(\App\Presenters\SermonViewPresenter::class)->plainTextOutline($sermon)"
+            hideLabel
+            label="Copy Outline"
+            title="Copy outline to clipboard"
+            icon="clipboard-document"
+            size="sm"
+          />
         </div>
         <div class="p-6 prose prose-gray max-w-none">
           <ol class="space-y-3">

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -127,7 +127,7 @@ $hasPublicVideo = filled($sermonView['video_url']);
             <h2 class="font-display text-xl text-gray-900">Sermon Outline</h2>
           </div>
           <x-clipboard-button
-            :content="app(\App\Presenters\SermonViewPresenter::class)->plainTextOutline($sermon)"
+            :content="$sermonView['plain_text_outline']"
             hideLabel
             label="Copy Outline"
             title="Copy outline to clipboard"


### PR DESCRIPTION
✨ **What:** Added helpful "Copy to Clipboard" utilities to the sermon page and polished the `x-input` component's loading behavior.

🎯 **Why:** Users often want to save or share sermon summaries and outlines. Providing a one-click copy utility improves the experience of interacting with AI-generated content. The input polish fixes a minor but annoying visual bug where two icons would overlap during async updates.

♿ **Accessibility:** Added ARIA labels to the new clipboard buttons. Improved the visual clarity of form inputs by removing redundant icons during loading states.

📱 **Responsive:** The new buttons are integrated into the section headers using flexbox, ensuring they remain correctly positioned on all screen sizes.

---
*PR created automatically by Jules for task [9636306762935791219](https://jules.google.com/task/9636306762935791219) started by @GarethClarridge*