### PR TITLE
🔦 Lighthouse: SEO & metadata enhancements

### DIFF
--- a/app/Http/Controllers/SermonController.php
+++ b/app/Http/Controllers/SermonController.php
@@ -165,6 +165,11 @@ class SermonController extends Controller
          */
         $sermons = $this->sermonRepository->getSermonsByPreacher($preacher);
 
+        $shareImage = $preacher->profile_image_url;
+        if ($shareImage === null && $sermons->isNotEmpty()) {
+            $shareImage = $this->sermonViewPresenter->thumbnailUrl($sermons->first());
+        }
+
         return view('sermons.preacher', [
             'preacher' => $preacher,
             'sermons' => $sermons,
@@ -174,6 +179,7 @@ class SermonController extends Controller
             'area' => 'christ',
             'links' => $this->sermonLinks('preachers'),
             'slug' => 'preachers',
+            'share_image' => $shareImage,
         ]);
     }
 
@@ -206,6 +212,11 @@ class SermonController extends Controller
          */
         $sermons = $this->sermonRepository->getSermonsBySeries($series_name);
 
+        $shareImage = null;
+        if ($sermons->isNotEmpty()) {
+            $shareImage = $this->sermonViewPresenter->thumbnailUrl($sermons->first());
+        }
+
         return view('sermons.series', [
             'sermons' => $sermons,
             'json_ld_data' => $this->itemListPresenter->toItemList($sermons),
@@ -214,6 +225,7 @@ class SermonController extends Controller
             'area' => 'christ',
             'links' => $this->sermonLinks('series'),
             'slug' => 'series',
+            'share_image' => $shareImage,
         ]);
     }
 

--- a/app/Presenters/PreacherSitemapPresenter.php
+++ b/app/Presenters/PreacherSitemapPresenter.php
@@ -9,6 +9,10 @@ use Spatie\Sitemap\Tags\Url;
 
 class PreacherSitemapPresenter
 {
+    public function __construct(
+        private readonly SermonViewPresenter $sermonViewPresenter,
+    ) {}
+
     /**
      * Convert a preacher to a sitemap tag.
      *
@@ -24,8 +28,17 @@ class PreacherSitemapPresenter
             $url->setLastModificationDate($preacher->updated_at);
         }
 
-        if ($preacher->profile_image_url) {
-            $url->addImage($preacher->profile_image_url, "Preacher: {$preacher->name}");
+        $imageUrl = $preacher->profile_image_url;
+
+        if (! $imageUrl && $preacher->relationLoaded('sermons')) {
+            $latestSermon = $preacher->sermons->first();
+            if ($latestSermon) {
+                $imageUrl = $this->sermonViewPresenter->thumbnailUrl($latestSermon);
+            }
+        }
+
+        if ($imageUrl) {
+            $url->addImage($imageUrl, "Preacher: {$preacher->name}");
         }
 
         return $url;

--- a/app/Presenters/PreacherSitemapPresenter.php
+++ b/app/Presenters/PreacherSitemapPresenter.php
@@ -9,10 +9,6 @@ use Spatie\Sitemap\Tags\Url;
 
 class PreacherSitemapPresenter
 {
-    public function __construct(
-        private readonly SermonViewPresenter $sermonViewPresenter,
-    ) {}
-
     /**
      * Convert a preacher to a sitemap tag.
      *
@@ -33,7 +29,7 @@ class PreacherSitemapPresenter
         if (! $imageUrl && $preacher->relationLoaded('sermons')) {
             $latestSermon = $preacher->sermons->first();
             if ($latestSermon) {
-                $imageUrl = $this->sermonViewPresenter->thumbnailUrl($latestSermon);
+                $imageUrl = app(SermonViewPresenter::class)->thumbnailUrl($latestSermon);
             }
         }
 

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -14,6 +14,7 @@ use App\Presenters\PageSitemapPresenter;
 use App\Presenters\PreacherSitemapPresenter;
 use App\Presenters\SermonSitemapPresenter;
 use App\Repositories\SermonRepository;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Spatie\Sitemap\Sitemap;
 use Spatie\Sitemap\Tags\Url;
@@ -119,7 +120,7 @@ class SitemapService
     /**
      * Add dynamic sermon URLs to the sitemap.
      */
-    private function addSermons(Sitemap $sitemap, \Illuminate\Support\Carbon $now): void
+    private function addSermons(Sitemap $sitemap, Carbon $now): void
     {
         /**
          * Performance Optimization: Use lazy() to iterate through models one by one,
@@ -181,6 +182,9 @@ class SitemapService
     {
         $preachers = Preacher::active()
             ->select(['id', 'name', 'slug', 'image_path', 'updated_at'])
+            ->with([
+                'sermons' => fn ($query) => $query->whereSermon()->orderBy('date', 'desc')->limit(1),
+            ])
             ->lazy();
 
         $sitemap->add($preachers->map(fn (Preacher $preacher): Url|string|array => $this->preacherSitemapPresenter->toSitemapTag($preacher)));

--- a/resources/views/components/meta-tags.blade.php
+++ b/resources/views/components/meta-tags.blade.php
@@ -11,6 +11,7 @@
     'video' => null,
     'author' => null,
     'publishedTime' => null,
+    'modifiedTime' => null,
     'section' => null,
     'tags' => null,
     'label1' => null,
@@ -57,6 +58,9 @@
 @endif
 @if($publishedTime)
 <meta property="article:published_time" content="{{ $publishedTime }}">
+@endif
+@if($modifiedTime)
+<meta property="article:modified_time" content="{{ $modifiedTime }}">
 @endif
 @if($section)
 <meta property="article:section" content="{{ $section }}">

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en-GB">
 
 <head>
   <meta charset="utf-8">

--- a/resources/views/sermons/preacher.blade.php
+++ b/resources/views/sermons/preacher.blade.php
@@ -8,12 +8,13 @@
 <x-meta-tags
     :title="$heading"
     :description="$description"
-    :image="$preacher->profile_image_url"
+    :image="$share_image"
+    :image-alt="'Preacher: ' . $preacher->name"
 />
 <x-schema.webpage
     :heading="$heading"
     :description="$description"
-    :image="$preacher->profile_image_url"
+    :image="$share_image"
 />
 
 <x-schema.person :$preacher />

--- a/resources/views/sermons/series.blade.php
+++ b/resources/views/sermons/series.blade.php
@@ -8,13 +8,13 @@
 <x-meta-tags
     :title="$heading"
     :description="$description"
-    :image="asset('/images/headings/large/sermons.webp')"
-    image-alt="Sermons at Crockenhill Baptist Church"
+    :image="$share_image ?? asset('/images/headings/large/sermons.webp')"
+    :image-alt="$heading . ' at Crockenhill Baptist Church'"
 />
 <x-schema.webpage
     :heading="$heading"
     :description="$description"
-    :image="asset('/images/headings/large/sermons.webp')"
+    :image="$share_image ?? asset('/images/headings/large/sermons.webp')"
 />
 
 {{-- JSON-LD Sermon List --}}

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -25,6 +25,7 @@ $hasPublicVideo = filled($sermonView['video_url']);
   :canonical="$sermonView['canonical_url']"
   :author="$sermonView['preacher_url']"
   :published-time="$sermon->date->toIso8601String()"
+  :modified-time="$sermon->updated_at?->year > 0 ? $sermon->updated_at->toIso8601String() : null"
   section="Sermons"
   :tags="$sermon->series"
   label1="Preacher"


### PR DESCRIPTION
💡 What:
Implemented a series of SEO and metadata improvements to make the site's content more discoverable and shareable.

🎯 Why:
- article:modified_time helps search engines and social platforms understand when a sermon's metadata (like transcripts or AI analysis) was last updated.
- Fallback social sharing images ensure that preacher and series list pages have engaging visual previews, even when dedicated images aren't available.
- Including thumbnails in the sitemap for more preachers improves their visibility in image search results.
- Setting the lang attribute to en-GB provides a clear signal to search engines about the site's intended audience.

📊 Impact:
- Individual sermon pages benefit from richer metadata.
- Preacher profile and series listing pages now have improved social sharing previews.
- The sitemap is more comprehensive.
- Overall regional SEO is strengthened for the UK market.

🔍 Verification:
- Verified the presence of modified_time and improved image logic in the Blade templates.
- Confirmed the lang attribute update in the base layout.
- Reviewed controller and presenter logic for correct fallback handling.

---
*PR created automatically by Jules for task [15357694230672701053](https://jules.google.com/task/15357694230672701053) started by @GarethClarridge*