### PR TITLE
📝 Scribe: Add tests for NullSpeakerIdentificationService

### DIFF
--- a/tests/Unit/Services/NullSpeakerIdentificationServiceTest.php
+++ b/tests/Unit/Services/NullSpeakerIdentificationServiceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Models\SpeakerProfile;
+use App\Services\NullSpeakerIdentificationService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class NullSpeakerIdentificationServiceTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private NullSpeakerIdentificationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new NullSpeakerIdentificationService;
+    }
+
+    #[Test]
+    public function it_returns_failed_embedding_result(): void
+    {
+        $result = $this->service->extractEmbedding('path/to/audio.mp3');
+
+        $this->assertFalse($result->success);
+        $this->assertEquals('Null provider: speaker identification not configured', $result->errorMessage);
+    }
+
+    #[Test]
+    public function it_returns_no_match_result(): void
+    {
+        $result = $this->service->identify('path/to/audio.mp3', new Collection);
+
+        $this->assertFalse($result->matched);
+        $this->assertEquals('Null provider: speaker identification not configured', $result->reason);
+    }
+
+    #[Test]
+    public function it_returns_unchanged_profile_when_updating(): void
+    {
+        $profile = SpeakerProfile::factory()->create();
+
+        $result = $this->service->updateProfile($profile, [[0.1, 0.2, 0.3]]);
+
+        $this->assertTrue($profile->is($result));
+        $this->assertSame($profile, $result);
+    }
+}


### PR DESCRIPTION
I have identified that `NullSpeakerIdentificationService` was lacks a dedicated unit test. I have written a thorough PHPUnit unit test covering all its methods and verified it passes.

🎯 **Coverage:** `App\Services\NullSpeakerIdentificationService`
📋 **Tests added:**
- `it_returns_failed_embedding_result`
- `it_returns_no_match_result`
- `it_returns_unchanged_profile_when_updating`
🔍 **Why:** `NullSpeakerIdentificationService` is used as a fallback/off-switch for speaker identification. Testing its behavior ensures that even when identification is disabled, the pipeline handles the results predictably.
✅ **Results:** All new tests pass. PHPStan is clean for the new test file.

---
*PR created automatically by Jules for task [14321186333774944411](https://jules.google.com/task/14321186333774944411) started by @GarethClarridge*