### PR TITLE
🧹 Tidy: Standardize Rule class usage in models

### DIFF
--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -112,14 +113,14 @@ class Meeting extends Model implements HasMedia, Sitemapable
     public static function validationRules(?self $meeting = null): array
     {
         $slugRule = ['required', 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/'];
-        $uniqueSlug = \Illuminate\Validation\Rule::unique('meetings', 'slug');
+        $uniqueSlug = Rule::unique('meetings', 'slug');
         if ($meeting) {
             $uniqueSlug->ignore($meeting->id);
         }
         $slugRule[] = $uniqueSlug;
 
         $pageIdRule = ['nullable', 'integer', 'exists:pages,id'];
-        $uniquePageId = \Illuminate\Validation\Rule::unique('meetings', 'page_id');
+        $uniquePageId = Rule::unique('meetings', 'page_id');
         if ($meeting) {
             $uniquePageId->ignore($meeting->id);
         }
@@ -127,14 +128,14 @@ class Meeting extends Model implements HasMedia, Sitemapable
 
         return [
             'slug' => $slugRule,
-            'type' => ['required', \Illuminate\Validation\Rule::enum(MeetingType::class)],
+            'type' => ['required', Rule::enum(MeetingType::class)],
             'day' => ['required', 'string', 'max:255'],
             'location' => ['nullable', 'string', 'max:255'],
             'who' => ['required', 'string', 'max:255'],
             'leaders_phone' => ['nullable', 'string', 'max:255'],
             'leaders_email' => ['nullable', 'email', 'max:255'],
             'is_recurring' => ['nullable', 'boolean'],
-            'frequency' => ['nullable', 'required_if:is_recurring,true', \Illuminate\Validation\Rule::enum(MeetingFrequency::class)],
+            'frequency' => ['nullable', 'required_if:is_recurring,true', Rule::enum(MeetingFrequency::class)],
             'page_id' => $pageIdRule,
         ];
     }

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 
 /**
  * @property int $id
@@ -72,7 +73,7 @@ class Song extends Model
     public static function validationRules(?self $song = null): array
     {
         $slugRule = ['required', 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/'];
-        $uniqueSlug = \Illuminate\Validation\Rule::unique('songs', 'slug');
+        $uniqueSlug = Rule::unique('songs', 'slug');
 
         if ($song) {
             $uniqueSlug->ignore($song->id);


### PR DESCRIPTION
This PR addresses a code quality inconsistency where some models used fully qualified class names for the validation `Rule` class while others used imports.

Changes:
- Added `use Illuminate\Validation\Rule;` to `app/Models/Meeting.php` and `app/Models/Song.php`.
- Updated `validationRules` methods in both models to use the `Rule` short name.
- Verified that functionality remains identical via existing feature tests.
- Confirmed no new static analysis errors in the modified files.

---
*PR created automatically by Jules for task [5073160435805825706](https://jules.google.com/task/5073160435805825706) started by @GarethClarridge*