### PR TITLE
🛡️ Sentinel: Harden path traversal and URI scheme protection

### DIFF
--- a/app/Actions/DeleteLivestreamUpload.php
+++ b/app/Actions/DeleteLivestreamUpload.php
@@ -15,6 +15,7 @@ use App\Services\ChurchServiceReviewStateService;
 use App\Services\ChurchServiceReviewSynchronizer;
 use App\Services\SermonStorageService;
 use App\Services\TranscriptStorageService;
+use App\Traits\HandlesSafePaths;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -22,6 +23,8 @@ use Illuminate\Support\Facades\Storage;
 
 class DeleteLivestreamUpload
 {
+    use HandlesSafePaths;
+
     public function __construct(
         private readonly ChurchServiceReviewStateService $reviewStateService,
         private readonly ChurchServiceReviewSynchronizer $reviewSynchronizer,
@@ -306,7 +309,7 @@ class DeleteLivestreamUpload
      */
     private function addStoredTarget(array &$targets, string $disk, ?string $path): void
     {
-        if (! is_string($path) || trim($path) === '' || str_contains($path, '..')) {
+        if (! is_string($path) || trim($path) === '' || $this->isUnsafePath($path)) {
             return;
         }
 

--- a/app/Http/Controllers/Admin/SermonThumbnailCandidateController.php
+++ b/app/Http/Controllers/Admin/SermonThumbnailCandidateController.php
@@ -7,12 +7,15 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Sermon;
 use App\Services\SermonStorageService;
+use App\Traits\HandlesSafePaths;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 
 class SermonThumbnailCandidateController extends Controller
 {
+    use HandlesSafePaths;
+
     public function __construct(
         private readonly SermonStorageService $storageService,
     ) {}
@@ -29,7 +32,7 @@ class SermonThumbnailCandidateController extends Controller
             abort(404, 'Thumbnail candidate not found.');
         }
 
-        $this->abortOnUnsafePath($thumbnailPath, 'thumbnail');
+        $this->abortIfUnsafe($thumbnailPath, 'thumbnail');
 
         $disk = $this->storageService->resolveThumbnailDisk($thumbnailPath);
 
@@ -55,10 +58,4 @@ class SermonThumbnailCandidateController extends Controller
         ]);
     }
 
-    private function abortOnUnsafePath(string $path, string $type): void
-    {
-        if (str_contains($path, '..') || str_starts_with($path, '/') || str_starts_with($path, '\\')) {
-            abort(404, "Invalid {$type} file path.");
-        }
-    }
 }

--- a/app/Http/Controllers/Admin/SermonThumbnailCandidateController.php
+++ b/app/Http/Controllers/Admin/SermonThumbnailCandidateController.php
@@ -57,5 +57,4 @@ class SermonThumbnailCandidateController extends Controller
             'Cache-Control' => 'no-store',
         ]);
     }
-
 }

--- a/app/Http/Controllers/Admin/ServiceSectionCandidateMediaController.php
+++ b/app/Http/Controllers/Admin/ServiceSectionCandidateMediaController.php
@@ -7,12 +7,15 @@ namespace App\Http\Controllers\Admin;
 use App\Enums\ServiceSectionPublicationStatus;
 use App\Http\Controllers\Controller;
 use App\Models\ServiceSection;
+use App\Traits\HandlesSafePaths;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 
 class ServiceSectionCandidateMediaController extends Controller
 {
+    use HandlesSafePaths;
+
     public function serveAudio(ServiceSection $serviceSection): BinaryFileResponse
     {
         return $this->serveAsset(
@@ -43,9 +46,11 @@ class ServiceSectionCandidateMediaController extends Controller
             'Candidate media is no longer available.',
         );
 
-        if (! is_string($path) || $path === '' || str_contains($path, '..')) {
+        if (! is_string($path) || $path === '') {
             abort(404, 'Candidate media not found.');
         }
+
+        $this->abortIfUnsafe($path, 'candidate media');
 
         $disk = $serviceSection->extractedAssetDisk($path);
 

--- a/app/Http/Controllers/SermonAssetController.php
+++ b/app/Http/Controllers/SermonAssetController.php
@@ -9,6 +9,7 @@ use App\Models\Sermon;
 use App\Services\SermonExposurePolicy;
 use App\Services\SermonStorageService;
 use App\Services\SermonTranscriptReader;
+use App\Traits\HandlesSafePaths;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
@@ -19,6 +20,8 @@ use Symfony\Component\HttpFoundation\HeaderUtils;
 
 class SermonAssetController extends Controller
 {
+    use HandlesSafePaths;
+
     public function __construct(
         private readonly SermonStorageService $storageService,
         private readonly SermonExposurePolicy $exposurePolicy,
@@ -67,7 +70,7 @@ class SermonAssetController extends Controller
             abort(404, 'Audio file not found.');
         }
 
-        $this->abortOnUnsafePath($sermon->audio_file_path, 'audio');
+        $this->abortIfUnsafe($sermon->audio_file_path, 'audio');
 
         $storageService = $this->storageService;
         $fileInfo = $storageService->getSermonFileInfo($sermon);
@@ -101,7 +104,7 @@ class SermonAssetController extends Controller
             abort(404, 'Video file not found.');
         }
 
-        $this->abortOnUnsafePath($sermon->video_file_path, 'video');
+        $this->abortIfUnsafe($sermon->video_file_path, 'video');
 
         $disk = str_starts_with($sermon->video_file_path, 'private/')
             ? 'local'
@@ -139,7 +142,7 @@ class SermonAssetController extends Controller
             abort(404, 'Thumbnail not found.');
         }
 
-        $this->abortOnUnsafePath($sermon->thumbnail_file_path, 'thumbnail');
+        $this->abortIfUnsafe($sermon->thumbnail_file_path, 'thumbnail');
 
         $disk = str_starts_with($sermon->thumbnail_file_path, 'private/')
             ? 'local'
@@ -172,7 +175,7 @@ class SermonAssetController extends Controller
             abort(404, 'Card thumbnail not found.');
         }
 
-        $this->abortOnUnsafePath($cardThumbnailPath, 'thumbnail');
+        $this->abortIfUnsafe($cardThumbnailPath, 'thumbnail');
 
         $disk = str_starts_with($cardThumbnailPath, 'private/')
             ? 'local'
@@ -281,13 +284,6 @@ class SermonAssetController extends Controller
         }
 
         return null;
-    }
-
-    private function abortOnUnsafePath(string $path, string $type): void
-    {
-        if (str_contains($path, '..') || str_starts_with($path, '/') || str_starts_with($path, '\\')) {
-            abort(404, "Invalid {$type} file path.");
-        }
     }
 
     private function videoContentType(string $name): string

--- a/app/Http/Controllers/SermonAssetController.php
+++ b/app/Http/Controllers/SermonAssetController.php
@@ -40,6 +40,12 @@ class SermonAssetController extends Controller
             return $authorizationResponse;
         }
 
+        if (! $sermon->transcript_file_path) {
+            abort(404, 'Transcript not found.');
+        }
+
+        $this->abortIfUnsafe($sermon->transcript_file_path, 'transcript');
+
         $transcript = $this->transcriptReader->read($sermon);
 
         if ($transcript === null || trim($transcript) === '') {
@@ -260,6 +266,7 @@ class SermonAssetController extends Controller
             'video' => $sermon->video_file_path,
             'thumbnail' => $sermon->thumbnail_file_path,
             'card_thumbnail' => $sermon->card_thumbnail_file_path,
+            'transcript' => $sermon->transcript_file_path,
             default => null,
         };
 

--- a/app/Http/Controllers/SermonAssetController.php
+++ b/app/Http/Controllers/SermonAssetController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Enums\SermonContentType;
 use App\Models\Sermon;
+use App\Models\User;
 use App\Services\SermonExposurePolicy;
 use App\Services\SermonStorageService;
 use App\Services\SermonTranscriptReader;
@@ -235,7 +236,7 @@ class SermonAssetController extends Controller
      */
     private function authorizeAssetAccess(Sermon $sermon, string $assetType): ?RedirectResponse
     {
-        /** @var \App\Models\User|null $user */
+        /** @var User|null $user */
         $user = Auth::user();
 
         // Security: Administrators are exempt from exposure policies to allow for review.

--- a/app/Services/SermonStorageService.php
+++ b/app/Services/SermonStorageService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\Sermon;
+use App\Traits\HandlesSafePaths;
 use Exception;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
@@ -14,6 +15,8 @@ use LogicException;
 
 class SermonStorageService
 {
+    use HandlesSafePaths;
+
     private const STATS_CHUNK_SIZE = 100;
 
     private string $legacyDisk;
@@ -611,7 +614,7 @@ class SermonStorageService
 
     private function validatePath(?string $path, string $type): void
     {
-        if (is_string($path) && str_contains($path, '..')) {
+        if (is_string($path) && $this->isUnsafePath($path)) {
             throw new InvalidArgumentException("Invalid {$type} path: Path traversal detected.");
         }
     }

--- a/app/Services/SermonTranscriptReader.php
+++ b/app/Services/SermonTranscriptReader.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\Sermon;
+use App\Traits\HandlesSafePaths;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
 class SermonTranscriptReader
 {
+    use HandlesSafePaths;
+
     public function __construct(
         private readonly TranscriptStorageService $transcriptStorageService,
     ) {}
@@ -33,7 +36,7 @@ class SermonTranscriptReader
 
         $path = trim((string) $sermon->transcript_file_path);
 
-        if (str_contains($path, '..')) {
+        if ($this->isUnsafePath($path)) {
             Log::warning('Path traversal attempt detected in transcript path', [
                 'sermon_id' => $sermon->id,
                 'path' => $path,

--- a/app/Services/SermonValidationService.php
+++ b/app/Services/SermonValidationService.php
@@ -66,7 +66,7 @@ class SermonValidationService
             $filename = $metadata['original_filename'];
 
             // Check for potentially dangerous file patterns
-            if ($this->isUnsafePath($filename)) {
+            if ($this->isUnsafeFilename($filename)) {
                 $errors[] = 'Filename contains invalid characters';
             }
 

--- a/app/Services/SermonValidationService.php
+++ b/app/Services/SermonValidationService.php
@@ -10,11 +10,15 @@ use App\Exceptions\InvalidFileException;
 use App\Models\MediaProcessingLog;
 use App\Models\Sermon;
 use App\Repositories\SermonRepository;
+use App\Traits\HandlesSafePaths;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class SermonValidationService
 {
+    use HandlesSafePaths;
+
     public function __construct(
         private readonly MediaValidationService $mediaValidation,
         private readonly SermonRepository $sermonRepository,
@@ -62,7 +66,7 @@ class SermonValidationService
             $filename = $metadata['original_filename'];
 
             // Check for potentially dangerous file patterns
-            if (str_contains($filename, '..') || str_contains($filename, '/') || str_contains($filename, '\\')) {
+            if ($this->isUnsafePath($filename)) {
                 $errors[] = 'Filename contains invalid characters';
             }
 
@@ -214,7 +218,7 @@ class SermonValidationService
             }
         } catch (\Exception $e) {
             // If we can't check disk space, log but don't fail
-            \Illuminate\Support\Facades\Log::warning('Could not check disk space', [
+            Log::warning('Could not check disk space', [
                 'disk' => $disk,
                 'error' => $e->getMessage(),
             ]);

--- a/app/Traits/HandlesSafePaths.php
+++ b/app/Traits/HandlesSafePaths.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Traits;
+
+/**
+ * Trait HandlesSafePaths
+ *
+ * Provides centralized path validation to prevent path traversal, absolute path exposure,
+ * and URI scheme injection in file-serving and storage-related components.
+ */
+trait HandlesSafePaths
+{
+    /**
+     * Determine if a path is unsafe.
+     *
+     * Blocks:
+     * 1. Relative traversal (..)
+     * 2. Absolute paths (/ or \)
+     * 3. URI schemes (://)
+     */
+    public function isUnsafePath(string $path): bool
+    {
+        return str_contains($path, '..')
+            || str_starts_with($path, '/')
+            || str_starts_with($path, '\\')
+            || str_contains($path, '://');
+    }
+
+    /**
+     * Abort the request with a 404 if the path is unsafe.
+     *
+     * @param  string  $path  The path to validate
+     * @param  string  $type  The type of asset for the error message
+     */
+    public function abortIfUnsafe(string $path, string $type = 'file'): void
+    {
+        if ($this->isUnsafePath($path)) {
+            abort(404, "Invalid {$type} file path.");
+        }
+    }
+}

--- a/app/Traits/HandlesSafePaths.php
+++ b/app/Traits/HandlesSafePaths.php
@@ -29,6 +29,20 @@ trait HandlesSafePaths
     }
 
     /**
+     * Determine if a filename is unsafe.
+     *
+     * Stricter than isUnsafePath: it also forbids directory separators
+     * anywhere in the string.
+     */
+    public function isUnsafeFilename(string $filename): bool
+    {
+        return str_contains($filename, '..')
+            || str_contains($filename, '/')
+            || str_contains($filename, '\\')
+            || str_contains($filename, '://');
+    }
+
+    /**
      * Abort the request with a 404 if the path is unsafe.
      *
      * @param  string  $path  The path to validate

--- a/tests/Feature/Security/RobustPathProtectionTest.php
+++ b/tests/Feature/Security/RobustPathProtectionTest.php
@@ -91,7 +91,7 @@ class RobustPathProtectionTest extends TestCase
         $response = $this->actingAs($admin)->get(route('admin.sermons.thumbnails.preview', [
             'sermon' => $sermon->slug,
             'candidateId' => 'candidate-1',
-            'variant' => 'plain'
+            'variant' => 'plain',
         ]));
 
         $response->assertStatus(404);

--- a/tests/Feature/Security/RobustPathProtectionTest.php
+++ b/tests/Feature/Security/RobustPathProtectionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use App\Models\Sermon;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class RobustPathProtectionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_blocks_uri_schemes_in_audio_paths(): void
+    {
+        Storage::fake('public');
+        $sermon = Sermon::factory()->create([
+            'audio_file_path' => 'http://malicious.com/shell.php',
+        ]);
+
+        $response = $this->get(route('sermons.audio', ['sermon' => $sermon->slug]));
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function it_blocks_uri_schemes_in_video_paths(): void
+    {
+        Storage::fake('public');
+        $sermon = Sermon::factory()->create([
+            'video_file_path' => 'https://attacker.com/payload.mp4',
+        ]);
+
+        $response = $this->get(route('sermons.video', ['sermon' => $sermon->slug]));
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function it_blocks_uri_schemes_in_thumbnail_paths(): void
+    {
+        Storage::fake('public');
+        $sermon = Sermon::factory()->create([
+            'thumbnail_file_path' => 'ftp://evil.com/thumb.jpg',
+        ]);
+
+        $response = $this->get(route('sermons.thumbnail', ['sermon' => $sermon->slug]));
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function it_blocks_absolute_paths_in_transcript_reader(): void
+    {
+        Storage::fake('public');
+        $sermon = Sermon::factory()->create([
+            'transcript_file_path' => '/etc/passwd',
+        ]);
+
+        // The transcript serving route uses SermonTranscriptReader
+        $response = $this->get(route('sermons.transcript', ['sermon' => $sermon->slug]));
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function it_blocks_uri_schemes_in_transcript_reader(): void
+    {
+        Storage::fake('public');
+        $sermon = Sermon::factory()->create([
+            'transcript_file_path' => 's3://bucket/secret.txt',
+        ]);
+
+        $response = $this->get(route('sermons.transcript', ['sermon' => $sermon->slug]));
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function it_blocks_malicious_thumbnail_candidates(): void
+    {
+        Storage::fake('public');
+        $admin = User::factory()->admin()->create();
+        $sermon = Sermon::factory()->create();
+
+        $response = $this->actingAs($admin)->get(route('admin.sermons.thumbnails.preview', [
+            'sermon' => $sermon->slug,
+            'candidateId' => 'candidate-1',
+            'variant' => 'plain'
+        ]));
+
+        $response->assertStatus(404);
+    }
+}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Duplicated and inconsistent path traversal protection. Previous checks were scattered across controllers and services, with some missing protection against URI scheme injection (e.g., `s3://` or `http://`) and absolute paths.
🎯 **Impact:** Potential for path traversal attacks, unauthorized access to system files, or server-side request forgery (SSRF) if malicious URI schemes were processed by storage drivers.
🔧 **Fix:** Centralized path validation into a reusable `HandlesSafePaths` trait. This trait enforces a strict whitelist-style rejection of paths containing `..`, starting with `/` or `\`, or containing `://`. All identified file-handling components now use this robust, unified validation.
✅ **Verification:** Added `tests/Feature/Security/RobustPathProtectionTest.php` which specifically tests the new URI scheme and absolute path blocking across audio, video, and transcript serving routes. Verified file persistence and integration via code inspection.

---
*PR created automatically by Jules for task [9083236297002807930](https://jules.google.com/task/9083236297002807930) started by @GarethClarridge*