### PR TITLE
🎨 Palette: Add loading states to select component

### DIFF
--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -1,7 +1,7 @@
 @props(['label' => null, 'options' => [], 'placeholder' => null, 'hint' => null, 'required' => false])
 
 @php
-$modelName = $attributes->wire('model')->value();
+$modelName = $attributes->wire('model')?->value();
 $id = $attributes->get('id', $modelName ? str_replace(['.', ' ', '[', ']'], '-', $modelName) : ($label ? \Illuminate\Support\Str::slug($label) : null));
 $hasError = $modelName && $errors->has($modelName);
 $selectClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2 disabled:opacity-50 disabled:bg-gray-50 disabled:cursor-not-allowed'
@@ -30,6 +30,10 @@ $describedBy = implode(' ', $describedBy);
             ]) }}
             @if($hasError) aria-invalid="true" @endif
             @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
+            @if($modelName)
+                wire:loading.attr="disabled"
+                wire:target="{{ $modelName }}"
+            @endif
         >
             @if($placeholder)
                 <option value="">{{ $placeholder }}</option>


### PR DESCRIPTION
I've implemented a micro-UX improvement to the `x-select` Blade component to enhance the stability and feedback of Livewire-driven dropdowns (such as sermon archive filters).

### 💡 What:
Added `wire:loading.attr="disabled"` and `wire:target` to the base `select` component.

### 🎯 Why:
This prevents race conditions and redundant network requests if a user interacts with a dropdown rapidly before the server has responded to a previous change. It also provides immediate visual feedback by disabling the element during processing.

### ♿ Accessibility & UX:
- **Null-safe:** Uses `$attributes->wire('model')?->value()` to prevent runtime errors when the component is used as a plain HTML select.
- **Scoped:** The loading state is targeted specifically to the field's property, ensuring the dropdown only disables when its own data is being updated, avoiding flickering from unrelated background actions.
- **Consistent:** Improving the base component ensures this polished behavior is applied across the entire application.

### ✅ Verification:
- Verified the rendered HTML attributes using Playwright.
- Confirmed no regressions in existing sermon listing and SEO tests.
- Successfully passed full test suite (4839 tests) in parallel.

---
*PR created automatically by Jules for task [11534132248593374428](https://jules.google.com/task/11534132248593374428) started by @GarethClarridge*