### PR TITLE
🏛️ Warden: Add integrity check to pages.description

### DIFF
--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -101,6 +101,24 @@ class Page extends Model implements HasMedia, Sitemapable
     }
 
     /**
+     * @return Attribute<string, string>
+     */
+    protected function description(): Attribute
+    {
+        return Attribute::make(
+            set: function (?string $value): ?string {
+                if ($value === null) {
+                    return null;
+                }
+
+                $trimmed = trim($value);
+
+                return $trimmed === '' ? null : $trimmed;
+            },
+        );
+    }
+
+    /**
      * @return array<string, list<string|mixed>>
      */
     public static function validationRules(?self $page = null, ?string $area = null): array

--- a/database/migrations/2026_05_04_080644_add_integrity_check_to_pages_description.php
+++ b/database/migrations/2026_05_04_080644_add_integrity_check_to_pages_description.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    private const DESCRIPTION_FORMAT_CHECK = 'pages_description_format_check';
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        // 1. Data Cleanup: Trim existing data
+        DB::table('pages')->update([
+            'description' => DB::raw('TRIM(description)'),
+        ]);
+
+        // 2. Ensure no empty descriptions exist before adding constraint.
+        // Fallback to heading if description is empty or whitespace-only.
+        DB::table('pages')
+            ->where('description', '')
+            ->update(['description' => DB::raw('heading')]);
+
+        // If it's STILL empty (heading was also empty), use a generic fallback.
+        DB::table('pages')
+            ->where('description', '')
+            ->update(['description' => 'No description provided.']);
+
+        // 3. Add CHECK constraint
+        // BINARY ensures exact character-for-character match for the trim check.
+        // The constraint implicitly handles NULL because NULL = TRIM(NULL) is UNKNOWN (passes).
+        // However, the column is already NOT NULL in the schema.
+        DB::statement(sprintf(
+            "ALTER TABLE pages ADD CONSTRAINT %s CHECK (BINARY description = TRIM(description) AND description != '')",
+            self::DESCRIPTION_FORMAT_CHECK
+        ));
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        DB::statement(sprintf('ALTER TABLE pages DROP CHECK %s', self::DESCRIPTION_FORMAT_CHECK));
+    }
+};

--- a/tests/Feature/PageDescriptionIntegrityTest.php
+++ b/tests/Feature/PageDescriptionIntegrityTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Page;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PageDescriptionIntegrityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_trims_description_on_model_save(): void
+    {
+        $page = Page::factory()->create([
+            'description' => '  untrimmed description  ',
+        ]);
+
+        $this->assertEquals('untrimmed description', $page->description);
+
+        $this->assertEquals(
+            'untrimmed description',
+            DB::table('pages')->where('id', $page->id)->value('description')
+        );
+    }
+
+    #[Test]
+    public function it_handles_null_description_in_model(): void
+    {
+        $page = new Page;
+        $page->description = null;
+
+        $this->assertNull($page->description);
+    }
+
+    #[Test]
+    public function it_handles_empty_string_description_in_model(): void
+    {
+        $page = new Page;
+        $page->description = '   ';
+
+        $this->assertNull($page->description);
+    }
+
+    #[Test]
+    public function it_rejects_empty_description_at_database_level(): void
+    {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage("Check constraint 'pages_description_format_check' is violated");
+
+        DB::table('pages')->insert([
+            'slug' => 'test-empty-desc',
+            'heading' => 'Test',
+            'description' => '',
+            'area' => 'christ',
+            'body' => 'test',
+            'navigation' => 0,
+        ]);
+    }
+
+    #[Test]
+    public function it_rejects_untrimmed_description_at_database_level(): void
+    {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage("Check constraint 'pages_description_format_check' is violated");
+
+        DB::table('pages')->insert([
+            'slug' => 'test-untrimmed-desc',
+            'heading' => 'Test',
+            'description' => ' untrimmed ',
+            'area' => 'christ',
+            'body' => 'test',
+            'navigation' => 0,
+        ]);
+    }
+}


### PR DESCRIPTION
💡 **What:** Added a database-level `CHECK` constraint and a model-level attribute setter for the `description` field in the `pages` table.

🎯 **Why:** To prevent data corruption and ensure high-quality SEO metadata. The `description` field is required and used for meta tags, so ensuring it's never empty and always trimmed is critical.

🗄️ **Migration:** `2026_05_04_080644_add_integrity_check_to_pages_description.php`
- Trims existing data.
- Falls back to the page `heading` if a description becomes empty after trimming.
- Adds `pages_description_format_check` constraint.

✅ **Verification:** Added `tests/Feature/PageDescriptionIntegrityTest.php` which confirms:
- Model automatically trims descriptions.
- Model handles null and empty strings by converting them to null.
- Database rejects empty strings.
- Database rejects untrimmed strings.

⚠️ **Rollback:** `php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [5369860434658778551](https://jules.google.com/task/5369860434658778551) started by @GarethClarridge*