### PR TITLE
🔦 Lighthouse: Dynamic SEO metadata for sermon archive

### DIFF
--- a/app/Http/Controllers/SermonController.php
+++ b/app/Http/Controllers/SermonController.php
@@ -12,11 +12,13 @@ use App\Models\Sermon;
 use App\Presenters\PreacherItemListPresenter;
 use App\Presenters\RelatedPagePresenter;
 use App\Presenters\SeriesItemListPresenter;
+use App\Presenters\SermonArchiveSeoPresenter;
 use App\Presenters\SermonItemListPresenter;
 use App\Presenters\SermonViewPresenter;
 use App\Repositories\SermonRepository;
 use App\Services\SermonExposurePolicy;
 use App\Services\SermonPageContextService;
+use App\Support\BibleCanon;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -30,6 +32,7 @@ class SermonController extends Controller
         private readonly SermonRepository $sermonRepository,
         private readonly SermonItemListPresenter $itemListPresenter,
         private readonly SermonViewPresenter $sermonViewPresenter,
+        private readonly SermonArchiveSeoPresenter $seoPresenter,
     ) {}
 
     /**
@@ -41,16 +44,26 @@ class SermonController extends Controller
      */
     public function index(Request $request): View
     {
-        $canonicalUrl = $request->filled('page')
-            ? route('sermons.index', ['page' => $request->integer('page')])
-            : route('sermons.index');
+        $bibleCanon = app(BibleCanon::class);
+        $filters = $this->sermonRepository->normalizeArchiveFilters(
+            $bibleCanon,
+            $request->query('book'),
+            $request->query('chapter'),
+            $request->query('preacher'),
+            $request->query('series'),
+        );
 
-        $recentSermons = $this->sermonRepository->getRecentSermonsForJsonLd();
+        $recentSermons = $this->sermonRepository->publicBrowseQuery(
+            book: $filters['book'],
+            chapter: $filters['chapter'],
+            preacherId: $filters['preacherId'],
+            series: $filters['series'],
+        )->limit(24)->get();
 
         return view('sermons.index', [
-            'heading' => 'Sermons',
-            'description' => 'Browse sermons from Crockenhill Baptist Church and filter by scripture, preacher, or series.',
-            'canonical_url' => $canonicalUrl,
+            'heading' => $this->seoPresenter->title($filters),
+            'description' => $this->seoPresenter->description($filters),
+            'canonical_url' => $this->seoPresenter->canonical($filters, $request->integer('page', 1)),
             'json_ld_data' => $this->itemListPresenter->toItemList($recentSermons),
             'area' => 'christ',
             'links' => $this->sermonLinks('sermons'),

--- a/app/Livewire/Sermons/BrowseSermons.php
+++ b/app/Livewire/Sermons/BrowseSermons.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Sermons;
 
 use App\Models\Preacher;
 use App\Models\Sermon;
+use App\Presenters\SermonArchiveSeoPresenter;
 use App\Presenters\SermonItemListPresenter;
 use App\Repositories\SermonRepository;
 use App\Support\BibleCanon;
@@ -23,6 +24,9 @@ use Livewire\WithPagination;
  * @property-read array<int, array{id:int, name:string}> $preacherOptions
  * @property-read array<int, array{id:string, name:string}> $seriesOptions
  * @property-read LengthAwarePaginator<int, Sermon> $sermons
+ * @property-read string $seoTitle
+ * @property-read string $seoDescription
+ * @property-read string $seoCanonical
  */
 class BrowseSermons extends Component
 {
@@ -108,22 +112,22 @@ class BrowseSermons extends Component
         $hasActiveFilters = $this->hasActiveFilters();
 
         /** @var LengthAwarePaginator<int, Sermon> $sermons */
-        $sermons = $this->sermons;
+        $sermons = $this->sermons();
 
         return view('livewire.sermons.browse-sermons', [
-            'bookOptions' => $bibleCanon->bookOptions($this->enabledBooks),
+            'bookOptions' => $bibleCanon->bookOptions($this->enabledBooks()),
             'chapterOptions' => $this->bookFilter === null
                 ? []
-                : $bibleCanon->chapterOptions($this->bookFilter, $this->enabledChapters),
-            'preacherOptions' => $this->preacherOptions,
-            'seriesOptions' => $this->seriesOptions,
-            'activeFilterLabels' => $this->activeFilterLabels($this->preacherOptions, $this->seriesOptions),
+                : $bibleCanon->chapterOptions($this->bookFilter, $this->enabledChapters()),
+            'preacherOptions' => $this->preacherOptions(),
+            'seriesOptions' => $this->seriesOptions(),
+            'activeFilterLabels' => $this->activeFilterLabels($this->preacherOptions(), $this->seriesOptions()),
             'sermons' => $sermons,
             'hasActiveFilters' => $hasActiveFilters,
         ]);
     }
 
-    private function hasActiveFilters(): bool
+    public function hasActiveFilters(): bool
     {
         return $this->bookFilter !== null
             || $this->chapterFilter !== null
@@ -161,27 +165,27 @@ class BrowseSermons extends Component
     }
 
     /**
-     * @return array<int, array{id:int, name:string}>
+     * @return list<array{id:int, name:string}>
      */
     #[Computed]
     public function preacherOptions(): array
     {
-        return array_map(
+        return array_values(array_map(
             fn (Preacher $preacher): array => ['id' => $preacher->id, 'name' => $preacher->name],
             Preacher::getForPublicList()->all()
-        );
+        ));
     }
 
     /**
-     * @return array<int, array{id:string, name:string}>
+     * @return list<array{id:string, name:string}>
      */
     #[Computed]
     public function seriesOptions(): array
     {
-        return array_map(
+        return array_values(array_map(
             fn (string $series): array => ['id' => $series, 'name' => $series],
             app(SermonRepository::class)->getSeriesForDisplay()
-        );
+        ));
     }
 
     /**
@@ -191,7 +195,7 @@ class BrowseSermons extends Component
     public function jsonLdData(): array
     {
         return app(SermonItemListPresenter::class)->toItemList(
-            $this->sermons->getCollection()
+            $this->sermons()->getCollection()
         );
     }
 
@@ -209,9 +213,40 @@ class BrowseSermons extends Component
         )->paginate(24);
     }
 
+    #[Computed]
+    public function seoTitle(): string
+    {
+        return app(SermonArchiveSeoPresenter::class)->title($this->activeFilters());
+    }
+
+    #[Computed]
+    public function seoDescription(): string
+    {
+        return app(SermonArchiveSeoPresenter::class)->description($this->activeFilters());
+    }
+
+    #[Computed]
+    public function seoCanonical(): string
+    {
+        return app(SermonArchiveSeoPresenter::class)->canonical($this->activeFilters(), $this->getPage());
+    }
+
     /**
-     * @param  array<int, array{id:int, name:string}>  $preacherOptions
-     * @param  array<int, array{id:string, name:string}>  $seriesOptions
+     * @return array{book: string|null, chapter: int|null, preacherId: int|null, series: string|null}
+     */
+    private function activeFilters(): array
+    {
+        return [
+            'book' => $this->bookFilter,
+            'chapter' => $this->chapterFilter,
+            'preacherId' => $this->preacherFilter,
+            'series' => $this->seriesFilter,
+        ];
+    }
+
+    /**
+     * @param  list<array{id:int, name:string}>  $preacherOptions
+     * @param  list<array{id:string, name:string}>  $seriesOptions
      * @return array<string, string>
      */
     private function activeFilterLabels(array $preacherOptions, array $seriesOptions): array
@@ -236,7 +271,7 @@ class BrowseSermons extends Component
     }
 
     /**
-     * @param  array<int, array{id:int|string, name:string}>  $options
+     * @param  list<array{id:int|string, name:string}>  $options
      */
     private function findOptionName(array $options, int|string $id): ?string
     {

--- a/app/Presenters/SermonArchiveSeoPresenter.php
+++ b/app/Presenters/SermonArchiveSeoPresenter.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presenters;
+
+use App\Models\Preacher;
+
+class SermonArchiveSeoPresenter
+{
+    /**
+     * Generate SEO title based on filters.
+     *
+     * @param  array{book: string|null, chapter: int|null, preacherId: int|null, series: string|null}  $filters
+     */
+    public function title(array $filters): string
+    {
+        if (! array_filter($filters)) {
+            return 'Sermons';
+        }
+
+        $parts = [];
+
+        if ($filters['book']) {
+            $parts[] = $filters['chapter'] ? "{$filters['book']} {$filters['chapter']}" : $filters['book'];
+        }
+
+        if ($filters['preacherId']) {
+            $preacher = Preacher::find($filters['preacherId']);
+            if ($preacher) {
+                $parts[] = $preacher->name;
+            }
+        }
+
+        if ($filters['series']) {
+            $parts[] = $filters['series'];
+        }
+
+        return implode(' | ', $parts).' | Sermons';
+    }
+
+    /**
+     * Generate SEO description based on filters.
+     *
+     * @param  array{book: string|null, chapter: int|null, preacherId: int|null, series: string|null}  $filters
+     */
+    public function description(array $filters): string
+    {
+        if (! array_filter($filters)) {
+            return 'Browse sermons from Crockenhill Baptist Church and filter by scripture, preacher, or series.';
+        }
+
+        $parts = [];
+
+        if ($filters['book']) {
+            $scripture = $filters['chapter'] ? "{$filters['book']} {$filters['chapter']}" : $filters['book'];
+            $parts[] = "on {$scripture}";
+        }
+
+        if ($filters['preacherId']) {
+            $preacher = Preacher::find($filters['preacherId']);
+            if ($preacher) {
+                $parts[] = "by {$preacher->name}";
+            }
+        }
+
+        if ($filters['series']) {
+            $parts[] = "in the {$filters['series']} series";
+        }
+
+        return 'Browse sermons from Crockenhill Baptist Church '.implode(' ', $parts).'.';
+    }
+
+    /**
+     * Generate canonical URL based on filters and page.
+     *
+     * @param  array{book: string|null, chapter: int|null, preacherId: int|null, series: string|null}  $filters
+     */
+    public function canonical(array $filters, int $page = 1): string
+    {
+        $params = array_filter([
+            'book' => $filters['book'],
+            'chapter' => $filters['chapter'],
+            'preacher' => $filters['preacherId'],
+            'series' => $filters['series'],
+            'page' => $page > 1 ? $page : null,
+        ]);
+
+        return route('sermons.index', $params);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,7 @@ use App\Presenters\PageImagePresenter;
 use App\Presenters\PageSitemapPresenter;
 use App\Presenters\PreacherSitemapPresenter;
 use App\Presenters\RelatedPagePresenter;
+use App\Presenters\SermonArchiveSeoPresenter;
 use App\Presenters\SermonItemListPresenter;
 use App\Presenters\SermonSitemapPresenter;
 use App\Presenters\SermonViewPresenter;
@@ -44,6 +45,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(PublicPageReadModelCache::class);
         $this->app->singleton(PublicMeetingReadModelCache::class);
         $this->app->singleton(SermonSitemapPresenter::class);
+        $this->app->singleton(SermonArchiveSeoPresenter::class);
         $this->app->singleton(PageSitemapPresenter::class);
         $this->app->singleton(MeetingSitemapPresenter::class);
         $this->app->singleton(PreacherSitemapPresenter::class);

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -1,4 +1,5 @@
-<div class="pb-12">
+<div class="pb-12" x-init="document.title = @js($this->seoTitle . ' | Crockenhill Baptist Church')">
+
     <a href="#sermon-results" @click.prevent="document.getElementById('sermon-results').focus()" class="sr-only focus:not-sr-only focus:absolute focus:z-30 focus:m-4 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-cbc-teal-dark focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-cbc-teal">
         Skip to results
     </a>
@@ -110,6 +111,12 @@
         @php
             /** @var \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, \App\Models\Sermon> $sermons */
         @endphp
+
+        @if ($this->hasActiveFilters())
+            <script type="application/ld+json">
+            {!! json_encode($this->jsonLdData, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}
+            </script>
+        @endif
 
         @if ($sermons->total() > 0)
             <div class="mx-auto mt-4 max-w-7xl px-6 text-sm text-gray-500" aria-live="polite">

--- a/tests/Feature/SermonBrowseSeoTest.php
+++ b/tests/Feature/SermonBrowseSeoTest.php
@@ -23,14 +23,14 @@ class SermonBrowseSeoTest extends TestCase
         $response->assertSee('<link rel="canonical" href="http://localhost/christ/sermons">', false);
     }
 
-    public function test_filtered_sermons_archive_keeps_the_canonical_unfiltered_seo_data(): void
+    public function test_filtered_sermons_archive_has_dynamic_seo_data(): void
     {
         $response = $this->get('/christ/sermons?book=John&chapter=3');
 
         $response->assertStatus(200);
-        $response->assertSee('<title>Sermons | Crockenhill Baptist Church</title>', false);
-        $response->assertSee('<meta name="description" content="Browse sermons from Crockenhill Baptist Church and filter by scripture, preacher, or series.">', false);
-        $response->assertSee('<link rel="canonical" href="http://localhost/christ/sermons">', false);
+        $response->assertSee('<title>John 3 | Sermons | Crockenhill Baptist Church</title>', false);
+        $response->assertSee('<meta name="description" content="Browse sermons from Crockenhill Baptist Church on John 3.">', false);
+        $response->assertSee('<link rel="canonical" href="http://localhost/christ/sermons?book=John&amp;chapter=3">', false);
     }
 
     public function test_paginated_unfiltered_archive_keeps_its_page_canonical_url(): void


### PR DESCRIPTION
💡 **What:** This change implements dynamic SEO metadata for the sermon archive page. When users filter sermons by Bible book, preacher, or series, the page title, meta description, and canonical URL now update to reflect the specific content being viewed.

🎯 **Why:** Previously, the sermon archive used a generic "Sermons" title regardless of active filters. Descriptive, filter-aware titles (e.g., "Genesis 1 | John Owen | Sermons") improve discoverability in search engines and provide better context when shared on social platforms. Proper canonical URLs for filtered states help search engines index specific collections correctly without penalizing for duplicate content.

📊 **Impact:**
- **Sermon Archive**: Enhanced indexing of filtered results (by book, preacher, series).
- **Social Sharing**: Better previews when sharing specific filtered views of the archive.
- **Crawler Visibility**: Full SEO metadata is present in the initial server-side render.

🔍 **Verification:**
- Verified with `SermonBrowseSeoTest.php` and `SermonSeoTest.php`.
- Visual verification using Playwright confirmed titles update correctly via Alpine.js on the client side and are correctly rendered on the server.
- PHPStan and Pint checks passed.

---
*PR created automatically by Jules for task [9640976438708765932](https://jules.google.com/task/9640976438708765932) started by @GarethClarridge*