### PR TITLE
Add unit test for CalendarCategorizationResult DTO

### DIFF
--- a/tests/Unit/Services/CalendarCategorizationResultTest.php
+++ b/tests/Unit/Services/CalendarCategorizationResultTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Models\CalendarEvent;
+use App\Services\CalendarCategorizationResult;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CalendarCategorizationResultTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_can_be_instantiated_with_event_and_sync_status(): void
+    {
+        $event = CalendarEvent::factory()->create();
+
+        $result = new CalendarCategorizationResult($event, true);
+
+        $this->assertSame($event, $result->event);
+        $this->assertTrue($result->googleSynced);
+    }
+
+    #[Test]
+    public function it_correctly_stores_google_synced_false(): void
+    {
+        $event = CalendarEvent::factory()->create();
+
+        $result = new CalendarCategorizationResult($event, false);
+
+        $this->assertSame($event, $result->event);
+        $this->assertFalse($result->googleSynced);
+    }
+}


### PR DESCRIPTION
Added a new unit test `tests/Unit/Services/CalendarCategorizationResultTest.php` to provide coverage for the `CalendarCategorizationResult` DTO. This ensures that the readonly class correctly handles its properties, meeting the goal of improving test coverage for under-tested components.

---
*PR created automatically by Jules for task [17874711740563186060](https://jules.google.com/task/17874711740563186060) started by @GarethClarridge*