### PR TITLE
🔦 Lighthouse: Enrich XML sitemap metadata and coverage

### DIFF
--- a/app/Presenters/SermonSitemapPresenter.php
+++ b/app/Presenters/SermonSitemapPresenter.php
@@ -55,7 +55,7 @@ class SermonSitemapPresenter
 
         if ($videoUrl !== null && $thumbnailUrl !== null) {
             $videoOptions = [
-                'publication_date' => $sermon->date,
+                'publication_date' => $sermon->date->toIso8601String(),
             ];
             if ($sermon->duration && $sermon->duration > 0) {
                 $videoOptions['duration'] = (int) $sermon->duration;

--- a/app/Presenters/SermonSitemapPresenter.php
+++ b/app/Presenters/SermonSitemapPresenter.php
@@ -54,7 +54,9 @@ class SermonSitemapPresenter
         $videoUrl = $this->sermonViewPresenter->videoUrl($sermon);
 
         if ($videoUrl !== null && $thumbnailUrl !== null) {
-            $videoOptions = [];
+            $videoOptions = [
+                'publication_date' => $sermon->date,
+            ];
             if ($sermon->duration && $sermon->duration > 0) {
                 $videoOptions['duration'] = (int) $sermon->duration;
             }
@@ -62,7 +64,7 @@ class SermonSitemapPresenter
             $url->addVideo(
                 $thumbnailUrl,
                 $sermon->title,
-                $sermon->summary ?? $sermon->title,
+                $this->sermonViewPresenter->metaDescription($sermon),
                 $videoUrl,
                 null,
                 $videoOptions
@@ -72,7 +74,7 @@ class SermonSitemapPresenter
         if ($thumbnailUrl !== null) {
             $url->addImage(
                 $thumbnailUrl,
-                $sermon->meta_description,
+                $this->sermonViewPresenter->metaDescription($sermon),
                 '',
                 $sermon->title
             );

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -51,6 +51,7 @@ class SitemapService
         $this->addMeetings($sitemap);
         $this->addPreachers($sitemap);
         $this->addSeries($sitemap);
+        $this->addBooks($sitemap);
 
         $sitemap->writeToFile($sitemapPath);
 
@@ -63,54 +64,54 @@ class SitemapService
     private function addStaticUrls(Sitemap $sitemap): void
     {
         $sitemap
-            ->add(Url::create('/')
+            ->add(Url::create(route('Home'))
                 ->setPriority(1.0)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
                 ->addImage(asset('/images/homepage/may2024wide.webp'), 'Crockenhill Baptist Church'))
-            ->add(Url::create('/christ')
+            ->add(Url::create(route('christ'))
                 ->setPriority(0.9)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
                 ->addImage(asset('/images/homepage/may2024wide.webp'), 'Learn about Jesus Christ at Crockenhill Baptist Church'))
-            ->add(Url::create('/christmas')
+            ->add(Url::create(route('christmas'))
                 ->setPriority(0.8)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_MONTHLY)
                 ->addImage(asset('/images/homepage/christmas2023.webp'), 'Christmas at Crockenhill Baptist Church'))
-            ->add(Url::create('/church')
+            ->add(Url::create(route('church'))
                 ->setPriority(0.9)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
                 ->addImage(asset('/images/homepage/may2024wide.webp'), 'About Crockenhill Baptist Church'))
-            ->add(Url::create('/community')
+            ->add(Url::create(route('community'))
                 ->setPriority(0.9)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
                 ->addImage(asset('/images/homepage/may2024wide.webp'), 'Community activities at Crockenhill Baptist Church'))
-            ->add(Url::create('/calendar')
+            ->add(Url::create(route('calendar.index'))
                 ->setPriority(0.5)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
                 ->addImage(asset('/images/homepage/may2024wide.webp'), 'Church Calendar'))
-            ->add(Url::create('/christ/sermons')
+            ->add(Url::create(route('sermons.index'))
                 ->setPriority(0.8)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY)
                 ->addImage(asset('/images/headings/large/sermons.webp'), 'Sermons at Crockenhill Baptist Church'))
-            ->add(Url::create('/christ/sermons/preachers')
+            ->add(Url::create(route('sermons.preachers'))
                 ->setPriority(0.7)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
                 ->addImage(asset('/images/headings/large/sermons.webp'), 'Preachers at Crockenhill Baptist Church'))
-            ->add(Url::create('/christ/sermons/series')
+            ->add(Url::create(route('sermons.series'))
                 ->setPriority(0.7)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
                 ->addImage(asset('/images/headings/large/sermons.webp'), 'Sermon Series'))
-            ->add(Url::create('/christ/sermons/morning')
+            ->add(Url::create(route('sermons.service', 'morning'))
                 ->setPriority(0.7)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY)
                 ->addImage(asset('/images/headings/large/sermons.webp'), 'Sunday Morning Services'))
-            ->add(Url::create('/christ/sermons/evening')
+            ->add(Url::create(route('sermons.service', 'evening'))
                 ->setPriority(0.7)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY)
                 ->addImage(asset('/images/headings/large/sermons.webp'), 'Sunday Evening Services'));
 
         if ($this->exposurePolicy->childrensTalksArePublic()) {
             $sitemap->add(
-                Url::create('/christ/childrens-corner')
+                Url::create(route('childrens-corner.index'))
                     ->setPriority(0.7)
                     ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
             );
@@ -197,7 +198,21 @@ class SitemapService
     {
         foreach ($this->sermonRepository->getSeriesForDisplay() as $series) {
             $sitemap->add(
-                Url::create('/christ/sermons/series/'.Str::slug($series))
+                Url::create(route('sermons.series.show', ['series' => Str::slug($series)]))
+                    ->setPriority(0.6)
+                    ->setChangeFrequency(Url::CHANGE_FREQUENCY_MONTHLY)
+            );
+        }
+    }
+
+    /**
+     * Add sermon archive URLs for Bible books to the sitemap.
+     */
+    private function addBooks(Sitemap $sitemap): void
+    {
+        foreach ($this->sermonRepository->getScriptureBooks() as $book) {
+            $sitemap->add(
+                Url::create(route('sermons.index', ['book' => $book]))
                     ->setPriority(0.6)
                     ->setChangeFrequency(Url::CHANGE_FREQUENCY_MONTHLY)
             );

--- a/tests/Unit/Presenters/SermonSitemapPresenterTest.php
+++ b/tests/Unit/Presenters/SermonSitemapPresenterTest.php
@@ -80,8 +80,10 @@ class SermonSitemapPresenterTest extends TestCase
         $this->assertCount(1, $tag->videos);
         $this->assertCount(1, $tag->images);
         $this->assertEquals('Presenter Test Sermon', $tag->videos[0]->title);
-        $this->assertEquals('A test summary.', $tag->videos[0]->description);
+        $this->assertStringContainsString('Presenter Test Sermon', $tag->videos[0]->description);
+        $this->assertStringContainsString('A test summary.', $tag->videos[0]->description);
         $this->assertEquals(1800, $tag->videos[0]->options['duration']);
+        $this->assertEquals($sermon->date->toIso8601String(), $tag->videos[0]->options['publication_date']->toIso8601String());
     }
 
     #[Test]
@@ -125,7 +127,7 @@ class SermonSitemapPresenterTest extends TestCase
     }
 
     #[Test]
-    public function sermon_without_summary_falls_back_to_title_for_video_description(): void
+    public function sermon_without_summary_uses_presenter_meta_description_for_video_description(): void
     {
         Storage::fake('public');
         Storage::fake('sermons');
@@ -145,7 +147,7 @@ class SermonSitemapPresenterTest extends TestCase
         $tag = $this->presenter->toSitemapTag($sermon);
 
         $this->assertCount(1, $tag->videos);
-        $this->assertEquals('No Summary Sermon', $tag->videos[0]->description);
+        $this->assertStringContainsString('No Summary Sermon', $tag->videos[0]->description);
     }
 
     #[Test]

--- a/tests/Unit/Presenters/SermonSitemapPresenterTest.php
+++ b/tests/Unit/Presenters/SermonSitemapPresenterTest.php
@@ -83,7 +83,7 @@ class SermonSitemapPresenterTest extends TestCase
         $this->assertStringContainsString('Presenter Test Sermon', $tag->videos[0]->description);
         $this->assertStringContainsString('A test summary.', $tag->videos[0]->description);
         $this->assertEquals(1800, $tag->videos[0]->options['duration']);
-        $this->assertEquals($sermon->date->toIso8601String(), $tag->videos[0]->options['publication_date']->toIso8601String());
+        $this->assertEquals($sermon->date->toIso8601String(), $tag->videos[0]->options['publication_date']);
     }
 
     #[Test]

--- a/tests/Unit/Services/SitemapServiceTest.php
+++ b/tests/Unit/Services/SitemapServiceTest.php
@@ -97,4 +97,48 @@ class SitemapServiceTest extends TestCase
             }
         }
     }
+
+    #[Test]
+    public function generate_includes_bible_book_archive_urls_in_sitemap(): void
+    {
+        $filePath = tempnam(sys_get_temp_dir(), 'sitemap').'.xml';
+
+        $exposurePolicy = $this->createMock(SermonExposurePolicy::class);
+        $exposurePolicy->method('childrensTalksArePublic')->willReturn(false);
+
+        $sermonRepository = $this->createMock(SermonRepository::class);
+        $sermonRepository->method('getLatestSermons')->willReturn(collect());
+        $sermonRepository->method('getSermonsByService')->willReturn(collect());
+        $sermonRepository->method('getAllSermons')->willReturn(collect());
+        $sermonRepository->method('getExistingSeries')->willReturn([]);
+        $sermonRepository->method('getSeriesForDisplay')->willReturn([]);
+        $sermonRepository->method('getScriptureBooks')->willReturn(collect(['Genesis', 'John']));
+
+        $service = $this->getMockBuilder(SitemapService::class)
+            ->setConstructorArgs([
+                $exposurePolicy,
+                $sermonRepository,
+                $this->createMock(PageSitemapPresenter::class),
+                $this->createMock(SermonSitemapPresenter::class),
+                $this->createMock(MeetingSitemapPresenter::class),
+                $this->createMock(PreacherSitemapPresenter::class),
+            ])
+            ->onlyMethods(['getFilePath'])
+            ->getMock();
+
+        $service->method('getFilePath')->willReturn($filePath);
+
+        try {
+            $service->generate();
+
+            $this->assertFileExists($filePath);
+            $xml = file_get_contents($filePath);
+            $this->assertStringContainsString('book=Genesis', $xml);
+            $this->assertStringContainsString('book=John', $xml);
+        } finally {
+            if (file_exists($filePath)) {
+                unlink($filePath);
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR improves the site's discoverability by enriching the XML sitemap with better metadata and more comprehensive URL coverage.

Key changes:
1.  **Enriched Metadata**: The sitemap now uses `SermonViewPresenter::metaDescription` for image captions and video descriptions, providing search engines with high-quality, descriptive content instead of generic fallbacks.
2.  **Video Publication Dates**: Added the `publication_date` property to video tags in the sitemap, as recommended by Google for Video SEO.
3.  **Filtered Archive Discovery**: Added sermon archive URLs filtered by Bible book (e.g., `/christ/sermons?book=Genesis`) to the sitemap. This helps search engines discover and index these valuable entry points to the sermon archive.
4.  **Maintainability**: Replaced hardcoded static URLs in `SitemapService` with Laravel's `route()` helpers to ensure the sitemap remains in sync with route changes.

Verified by passing updated unit tests in `SermonSitemapPresenterTest`.

---
*PR created automatically by Jules for task [11683861235402068325](https://jules.google.com/task/11683861235402068325) started by @GarethClarridge*