### PR TITLE
🧹 Tidy: Remove redundant empty boot methods in Service Providers

### DIFF
--- a/app/Providers/AiServiceProvider.php
+++ b/app/Providers/AiServiceProvider.php
@@ -41,6 +41,4 @@ class AiServiceProvider extends ServiceProvider
 
         $this->app->bind(OosEmailItemExtractor::class, OpenAiOosEmailItemExtractor::class);
     }
-
-    public function boot(): void {}
 }

--- a/app/Providers/MediaProcessingServiceProvider.php
+++ b/app/Providers/MediaProcessingServiceProvider.php
@@ -58,6 +58,4 @@ class MediaProcessingServiceProvider extends ServiceProvider
         });
 
     }
-
-    public function boot(): void {}
 }


### PR DESCRIPTION
### 💡 What:
Removed redundant empty `boot(): void {}` methods from `AiServiceProvider` and `MediaProcessingServiceProvider`.

### 🎯 Why:
In Laravel, the `boot` method is optional in Service Providers. If it's empty, it provides no benefit and adds unnecessary boilerplate. Removing these improves code clarity and follows the 'Tidy' principle of reducing clutter.

### 🔄 Behavior:
No functional changes. The application behavior remains identical as these were no-op methods.

### ✅ Tests:
- Static analysis: `composer phpstan` (0 errors)
- Formatting: `./vendor/bin/pint --dirty`
- Unit tests: `php artisan test --compact tests/Unit/Repositories/SermonRepositoryTest.php` (Pass)
- Verified that files `app/Providers/AiServiceProvider.php` and `app/Providers/MediaProcessingServiceProvider.php` no longer contain the `boot` method.

---
*PR created automatically by Jules for task [7750532308181953122](https://jules.google.com/task/7750532308181953122) started by @GarethClarridge*