### PR TITLE
🎨 Palette: Form component accessibility improvements

### DIFF
--- a/resources/views/components/checkbox.blade.php
+++ b/resources/views/components/checkbox.blade.php
@@ -1,4 +1,4 @@
-@props(['label' => null, 'hint' => null, 'checked' => false])
+@props(['label' => null, 'hint' => null, 'checked' => false, 'required' => false])
 
 @php
 $modelName = $attributes->wire('model')->value();
@@ -22,6 +22,7 @@ $describedBy = implode(' ', $describedBy);
                 'id' => $id
             ]) }}
             @checked($checked)
+            @if($required) required aria-required="true" @endif
             @if($hasError) aria-invalid="true" @endif
             @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
         />

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -18,6 +18,8 @@ if ($hint) $describedBy[] = $id . '-hint';
 if ($hasError) $describedBy[] = $id . '-error';
 if ($maxlength) $describedBy[] = $id . '-counter';
 $describedBy = implode(' ', $describedBy);
+
+$clearLabel = 'Clear ' . ($label ?: ($attributes->get('placeholder') ?: 'input'));
 @endphp
 
 <div x-data="{ count: 0, limit: {{ $maxlength ?? 'null' }}, focused: false, showPassword: false }"
@@ -52,6 +54,7 @@ $describedBy = implode(' ', $describedBy);
                 :type="showPassword ? 'text' : 'password'"
             @endif
             @if($maxlength) maxlength="{{ $maxlength }}" @endif
+            @if($required) required aria-required="true" @endif
             @if($hasError) aria-invalid="true" @endif
             @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
             @if($clearable && $modelName)
@@ -70,8 +73,8 @@ $describedBy = implode(' ', $describedBy);
 
         @if($clearable && $modelName)
             <button type="button"
-                aria-label="Clear input"
-                title="Clear input"
+                aria-label="{{ $clearLabel }}"
+                title="{{ $clearLabel }}"
                 wire:click="$set('{{ $modelName }}', '')"
                 @click="count = 0; $nextTick(() => $refs.input.focus())"
                 class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded"

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -28,6 +28,7 @@ $describedBy = implode(' ', $describedBy);
                 'id' => $id,
                 'aria-label' => (!$label && $placeholder) ? $placeholder : null
             ]) }}
+            @if($required) required aria-required="true" @endif
             @if($hasError) aria-invalid="true" @endif
             @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
             @if($modelName)

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -33,6 +33,7 @@ $describedBy = implode(' ', $describedBy);
                 'aria-label' => (!$label && $attributes->get('placeholder')) ? $attributes->get('placeholder') : null
             ]) }}
             @if($maxlength) maxlength="{{ $maxlength }}" @endif
+            @if($required) required aria-required="true" @endif
             @if($hasError) aria-invalid="true" @endif
             @if($describedBy) aria-describedby="{{ $describedBy }}" @endif
         >{{ $slot }}</textarea>

--- a/tests/Feature/View/Components/FormAccessibilityTest.php
+++ b/tests/Feature/View/Components/FormAccessibilityTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\View\Components;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+use Illuminate\Support\ViewErrorBag;
+use PHPUnit\Framework\Attributes\Test;
+
+class FormAccessibilityTest extends TestCase
+{
+    use InteractsWithViews;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        view()->share('errors', new ViewErrorBag());
+    }
+
+    #[Test]
+    public function input_component_renders_required_attributes(): void
+    {
+        $view = $this->blade('<x-input label="Full Name" required />');
+
+        $view->assertSee('required');
+        $view->assertSeeHtml('aria-required="true"');
+    }
+
+    #[Test]
+    public function input_component_renders_contextual_clear_label_from_label(): void
+    {
+        $view = $this->blade('<x-input label="Search Term" clearable wire:model="search" />');
+
+        $view->assertSee('aria-label="Clear Search Term"', false);
+        $view->assertSee('title="Clear Search Term"', false);
+    }
+
+    #[Test]
+    public function input_component_renders_contextual_clear_label_from_placeholder(): void
+    {
+        $view = $this->blade('<x-input placeholder="Find sermons..." clearable wire:model="search" />');
+
+        $view->assertSee('aria-label="Clear Find sermons..."', false);
+        $view->assertSee('title="Clear Find sermons..."', false);
+    }
+
+    #[Test]
+    public function textarea_component_renders_required_attributes(): void
+    {
+        $view = $this->blade('<x-textarea label="Description" required />');
+
+        $view->assertSee('required');
+        $view->assertSeeHtml('aria-required="true"');
+    }
+
+    #[Test]
+    public function select_component_renders_required_attributes(): void
+    {
+        $view = $this->blade('<x-select label="Category" required :options="[]" />');
+
+        $view->assertSee('required');
+        $view->assertSeeHtml('aria-required="true"');
+    }
+
+    #[Test]
+    public function checkbox_component_renders_required_attributes(): void
+    {
+        $view = $this->blade('<x-checkbox label="Agree to terms" required />');
+
+        $view->assertSee('required');
+        $view->assertSeeHtml('aria-required="true"');
+    }
+}


### PR DESCRIPTION
💡 **What:** Improved the accessibility and validation consistency of the core form components (`x-input`, `x-textarea`, `x-select`, `x-checkbox`).

🎯 **Why:** 
- The `required` prop was previously only visual (red asterisk). Now it correctly applies HTML `required` for browser-level validation and `aria-required="true"` for screen readers.
- The `x-input` clear button had a generic "Clear input" label. It now uses the context of the field (e.g., "Clear Search") to provide better clarity for assistive technology users when multiple clearable fields are present.

♿ **Accessibility:** 
- Ensured mandatory fields are correctly identified by screen readers.
- Provided contextual labels for interactive utility buttons.
- Enabled native browser validation for required fields.

📱 **Responsive:** No layout changes; purely structural and attribute-level improvements.

---
*PR created automatically by Jules for task [4943689536226285700](https://jules.google.com/task/4943689536226285700) started by @GarethClarridge*