### PR TITLE
🛡️ Sentinel: Harden log sanitization and standardize safe markdown rendering

### DIFF
--- a/app/Http/Controllers/Admin/SermonAdminController.php
+++ b/app/Http/Controllers/Admin/SermonAdminController.php
@@ -91,7 +91,7 @@ class SermonAdminController extends Controller
         } catch (\Exception $e) {
             Log::error('Sermon upload failed', [
                 'error' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
                 'user_id' => $request->user()?->id,
             ]);
 

--- a/app/Http/Controllers/Api/MediaController.php
+++ b/app/Http/Controllers/Api/MediaController.php
@@ -68,7 +68,8 @@ class MediaController extends Controller
         } catch (\Exception $e) {
             Log::error('Media upload failed', [
                 'type' => $type,
-                'error' => $e->getMessage(),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
                 'user_id' => $request->user()?->id,
             ]);
 
@@ -103,9 +104,9 @@ class MediaController extends Controller
 
         } catch (\Exception $e) {
             Log::error('Status check failed', [
-                'processing_id' => $processingId,
-                'error' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
+                'processing_id' => $this->sanitizeForLog($processingId),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
             ]);
 
             $message = $e instanceof ProvidesSafeMessage
@@ -126,7 +127,7 @@ class MediaController extends Controller
 
             if ($result['success']) {
                 Log::warning('Media processing cancelled via API', [
-                    'processing_id' => $processingId,
+                    'processing_id' => $this->sanitizeForLog($processingId),
                     'user_id' => $request->user()?->id,
                 ]);
             }
@@ -134,9 +135,9 @@ class MediaController extends Controller
             return response()->json($result, $result['success'] ? 200 : 400);
         } catch (\Exception $e) {
             Log::error('Media cancellation failed', [
-                'processing_id' => $processingId,
-                'error' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
+                'processing_id' => $this->sanitizeForLog($processingId),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
                 'user_id' => $request->user()?->id,
             ]);
 
@@ -156,7 +157,7 @@ class MediaController extends Controller
             $action->execute($processingId, (int) $request->input('segment_id'), $user);
 
             Log::warning('Sermon segment confirmed via API', [
-                'processing_id' => $processingId,
+                'processing_id' => $this->sanitizeForLog($processingId),
                 'segment_id' => $request->input('segment_id'),
                 'user_id' => $user->id,
             ]);
@@ -164,15 +165,15 @@ class MediaController extends Controller
             return response()->json([
                 'success' => true,
                 'message' => 'Sermon segment confirmed. Processing has been resumed.',
-                'status_url' => route('api.media.processing.status', ['processingId' => $processingId]),
+                'status_url' => route('api.media.processing.status', ['processingId' => $this->sanitizeForLog($processingId)]),
             ], 202);
         } catch (\InvalidArgumentException $e) {
             return response()->json(['success' => false, 'message' => $e->getMessage()], 422);
         } catch (\Exception $e) {
             Log::error('Segment confirmation failed', [
-                'processing_id' => $processingId,
-                'error' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
+                'processing_id' => $this->sanitizeForLog($processingId),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
                 'user_id' => $request->user()?->id,
             ]);
 
@@ -190,7 +191,7 @@ class MediaController extends Controller
 
             if ($result->success) {
                 Log::warning('Media processing retry initiated via API', [
-                    'processing_id' => $processingId,
+                    'processing_id' => $this->sanitizeForLog($processingId),
                     'user_id' => $request->user()?->id,
                 ]);
             }
@@ -198,9 +199,9 @@ class MediaController extends Controller
             return response()->json($result->toArray(), $result->success ? 202 : 422);
         } catch (\Exception $e) {
             Log::error('Media retry failed', [
-                'processing_id' => $processingId,
-                'error' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
+                'processing_id' => $this->sanitizeForLog($processingId),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
                 'user_id' => $request->user()?->id,
             ]);
 

--- a/app/Mail/LivestreamProcessingFailed.php
+++ b/app/Mail/LivestreamProcessingFailed.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Mail;
 
+use App\Traits\SanitizesLogData;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
@@ -12,7 +13,7 @@ use Illuminate\Queue\SerializesModels;
 
 class LivestreamProcessingFailed extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable, SanitizesLogData, SerializesModels;
 
     public string $errorMessage;
 
@@ -35,7 +36,7 @@ class LivestreamProcessingFailed extends Mailable
         // so the mailable can be safely queued without closure serialization issues.
         if ($exception instanceof \Throwable) {
             $this->errorMessage = $exception->getMessage();
-            $this->stackTrace = $this->sanitiseStackTrace($exception->getTraceAsString());
+            $this->stackTrace = $this->sanitizeStackTrace($exception->getTraceAsString());
             $this->file = str_replace(base_path().'/', '', $exception->getFile());
             $this->line = $exception->getLine();
         } else {
@@ -44,22 +45,6 @@ class LivestreamProcessingFailed extends Mailable
             $this->file = 'Unknown';
             $this->line = 'Unknown';
         }
-    }
-
-    /**
-     * Sanitise a stack trace before storing or emailing it.
-     * Strips server base paths and redacts credential-like patterns.
-     */
-    private function sanitiseStackTrace(string $trace): string
-    {
-        // Strip absolute server paths to avoid leaking server structure
-        $trace = str_replace(base_path().'/', '', $trace);
-
-        // Redact values that look like credentials (password=, secret=, key=, token=)
-        $trace = preg_replace('/\b(password|secret|token|api_key|apikey|auth)[=:]\S+/i', '$1=[REDACTED]', $trace) ?? $trace;
-
-        // Truncate to a safe length
-        return mb_substr($trace, 0, 3000);
     }
 
     public function envelope(): Envelope

--- a/app/Traits/SanitizesLogData.php
+++ b/app/Traits/SanitizesLogData.php
@@ -16,4 +16,20 @@ trait SanitizesLogData
 
         return trim((string) preg_replace('/\s+/', ' ', $withoutControlChars));
     }
+
+    /**
+     * Sanitise a stack trace before writing to logs.
+     * Strips server base paths and redacts credential-like patterns.
+     */
+    protected function sanitizeStackTrace(string $trace): string
+    {
+        // Strip absolute server paths to avoid leaking server structure
+        $trace = str_replace(base_path().'/', '', $trace);
+
+        // Redact values that look like credentials (password=, secret=, key=, token=)
+        $trace = preg_replace('/\b(password|secret|token|api_key|apikey|auth)[=:]\S+/i', '$1=[REDACTED]', $trace) ?? $trace;
+
+        // Truncate to a safe length
+        return mb_substr($trace, 0, 3000);
+    }
 }


### PR DESCRIPTION
I have implemented a set of security enhancements focused on log integrity and safe content rendering. 

Key changes:
- **Centralized Sanitization:** Added `sanitizeStackTrace()` to the `SanitizesLogData` trait to provide a unified way to strip server paths and redact credentials from logged exception traces.
- **Log Hardening:** Updated `MeetingController`, `SermonAdminController`, and `MediaController` to consistently sanitize user-input data and exception messages/traces before they hit the logs, preventing log injection and info leakage.
- **Safe Markdown Rendering:** Migrated `SermonAssetController` to use `SafeMarkdownRenderer` for transcripts. This ensures consistent security across the app and upgrades the transcript policy from HTML-escaping to HTML-stripping for better defense in depth.
- **Improved Maintainability:** Refactored the `LivestreamProcessingFailed` mailable to use the shared trait logic, removing duplicated sanitization code.
- **Test Alignment:** Verified the changes with the full test suite (4,882 tests) and updated security tests to reflect the new, stricter rendering policy.

---
*PR created automatically by Jules for task [808807009473614077](https://jules.google.com/task/808807009473614077) started by @GarethClarridge*