### PR TITLE
🔦 Lighthouse: SEO and metadata improvements

### DIFF
--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -11,6 +11,11 @@
     :image="asset('/images/homepage/may2024wide.webp')"
     image-alt="Crockenhill Baptist Church members outside the church building"
 />
+<x-schema.webpage
+    heading="Church Calendar"
+    description="Upcoming events at Crockenhill Baptist Church."
+    :image="asset('/images/homepage/may2024wide.webp')"
+/>
 
 {{-- JSON-LD Events --}}
 @if($allEvents->isNotEmpty())

--- a/resources/views/childrens-corner/index.blade.php
+++ b/resources/views/childrens-corner/index.blade.php
@@ -5,7 +5,17 @@
 @section('meta_description', $description)
 
 @section('meta_tags')
-    <x-meta-tags :title="$heading" :description="$description" />
+    <x-meta-tags
+        :title="$heading"
+        :description="$description"
+        :image="asset('/images/homepage/may2024wide.webp')"
+        image-alt="Crockenhill Baptist Church members outside the church building"
+    />
+    <x-schema.webpage
+        :heading="$heading"
+        :description="$description"
+        :image="asset('/images/homepage/may2024wide.webp')"
+    />
 
     {{-- JSON-LD ItemList --}}
     @if (isset($json_ld_data))

--- a/resources/views/childrens-corner/show.blade.php
+++ b/resources/views/childrens-corner/show.blade.php
@@ -19,6 +19,11 @@
     />
 
     <x-schema.sermon :$sermon :$sermonView :$metaDescription />
+    <x-schema.webpage
+        :heading="$fullTitle"
+        :description="$metaDescription ?: $sermon->title"
+        :image="$sermonView['thumbnail_url']"
+    />
 @endsection
 
 @section('dynamic_content')

--- a/resources/views/components/meta-tags.blade.php
+++ b/resources/views/components/meta-tags.blade.php
@@ -77,6 +77,9 @@
 <meta name="twitter:title" content="{{ $fullTitle }}">
 <meta name="twitter:description" content="{{ $metaDescription }}">
 <meta name="twitter:image" content="{{ $metaImage }}">
+@if($imageAlt)
+<meta name="twitter:image:alt" content="{{ $imageAlt }}">
+@endif
 @if($label1 && $data1)
 <meta name="twitter:label1" content="{{ $label1 }}">
 <meta name="twitter:data1" content="{{ $data1 }}">

--- a/resources/views/meetings/show.blade.php
+++ b/resources/views/meetings/show.blade.php
@@ -13,6 +13,13 @@
     :title="$heading . ' | ' . $meeting->day . ($meeting->start_time ? ' ' . $meeting->start_time->format('g:ia') : '')"
     :description="$description ?? $heading"
     :image="$headingpicture"
+    :image-alt="'Meeting: ' . $heading"
+/>
+
+<x-schema.webpage
+    :heading="$heading"
+    :description="$description ?? $heading"
+    :image="$headingpicture"
 />
 
 {{-- JSON-LD Recurring Event --}}

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -37,6 +37,7 @@ $hasPublicVideo = filled($sermonView['video_url']);
 <x-schema.webpage
   :heading="$fullTitle"
   :description="$description ?? $metaDescription"
+  :image="$sermonView['thumbnail_url']"
 />
 @endsection
 


### PR DESCRIPTION
💡 **What:** A series of targeted SEO and metadata improvements across key public-facing sections including Sermons, Meetings, Calendar, and Children's Corner.
🎯 **Why:** To improve site discoverability, search engine hierarchy understanding, and social sharing quality (including accessibility via image alt text).
📊 **Impact:** Multiple high-traffic public pages now have better structured data and more descriptive social metadata.
🔍 **Verification:** Verified via `vendor/bin/sail artisan test --parallel --compact` (SEO tests passing), code review, and manual verification of Blade templates.

---
*PR created automatically by Jules for task [8963502530091657378](https://jules.google.com/task/8963502530091657378) started by @GarethClarridge*