### PR TITLE
🛡️ Sentinel: Harden Log Integrity and Markdown Rendering

### DIFF
--- a/app/Http/Controllers/Admin/SermonAdminController.php
+++ b/app/Http/Controllers/Admin/SermonAdminController.php
@@ -32,7 +32,7 @@ class SermonAdminController extends Controller
         Log::warning('Sermon deleted by admin', [
             'admin_id' => auth()->id(),
             'sermon_id' => $sermon->id,
-            'title' => $sermon->title,
+            'title' => $this->sanitizeForLog((string) $sermon->title),
         ]);
 
         $sermon->delete();
@@ -90,7 +90,7 @@ class SermonAdminController extends Controller
 
         } catch (\Exception $e) {
             Log::error('Sermon upload failed', [
-                'error' => $e->getMessage(),
+                'error' => $this->sanitizeForLog($e->getMessage()),
                 'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
                 'user_id' => $request->user()?->id,
             ]);

--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -9,6 +9,7 @@ use App\Models\Meeting;
 use App\Presenters\RelatedPagePresenter;
 use App\Services\PublicMeetingReadModelCache;
 use App\Services\PublicPageVisibilityGuard;
+use App\Traits\SanitizesLogData;
 use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Log;
@@ -18,6 +19,8 @@ use Illuminate\Support\Facades\View;
 
 class MeetingController extends Controller
 {
+    use SanitizesLogData;
+
     public function __construct(
         private readonly PublicMeetingReadModelCache $publicMeetingReadModelCache,
         private readonly RelatedPagePresenter $relatedPagePresenter,
@@ -90,7 +93,7 @@ class MeetingController extends Controller
         Log::warning('Meeting updated by admin', [
             'admin_id' => auth()->id(),
             'meeting_id' => $meeting->id,
-            'slug' => $fresh instanceof Meeting ? $fresh->slug : $meeting->slug,
+            'slug' => $this->sanitizeForLog($fresh instanceof Meeting ? (string) $fresh->slug : (string) $meeting->slug),
         ]);
 
         $backUrl = Session::get('backUrl');
@@ -111,7 +114,7 @@ class MeetingController extends Controller
         Log::warning('Meeting deleted by admin', [
             'admin_id' => auth()->id(),
             'meeting_id' => $meeting->id,
-            'slug' => $meeting->slug,
+            'slug' => $this->sanitizeForLog((string) $meeting->slug),
         ]);
 
         $meetingSlug = $meeting->slug;

--- a/app/Http/Controllers/SermonAssetController.php
+++ b/app/Http/Controllers/SermonAssetController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers;
 use App\Enums\SermonContentType;
 use App\Models\Sermon;
 use App\Models\User;
+use App\Services\SafeMarkdownRenderer;
 use App\Services\SermonExposurePolicy;
 use App\Services\SermonStorageService;
 use App\Services\SermonTranscriptReader;
@@ -27,6 +28,7 @@ class SermonAssetController extends Controller
         private readonly SermonStorageService $storageService,
         private readonly SermonExposurePolicy $exposurePolicy,
         private readonly SermonTranscriptReader $transcriptReader,
+        private readonly SafeMarkdownRenderer $markdownRenderer,
     ) {}
 
     /**
@@ -46,10 +48,7 @@ class SermonAssetController extends Controller
             abort(404, 'Transcript not found.');
         }
 
-        $html = (string) Str::markdown($transcript, [
-            'html_input' => 'escape',
-            'allow_unsafe_links' => false,
-        ]);
+        $html = $this->markdownRenderer->convert($transcript);
 
         return response($html, 200, [
             'Content-Type' => 'text/html; charset=UTF-8',

--- a/app/Livewire/Admin/ChurchServices/ReviewInboundEmails.php
+++ b/app/Livewire/Admin/ChurchServices/ReviewInboundEmails.php
@@ -13,6 +13,7 @@ use App\Livewire\Traits\WithAdminAuthorization;
 use App\Livewire\Traits\WithNotifications;
 use App\Models\InboundEmail;
 use App\Traits\EscapesLikeWildcards;
+use App\Traits\SanitizesLogData;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
@@ -24,6 +25,7 @@ use Livewire\WithPagination;
 class ReviewInboundEmails extends Component
 {
     use EscapesLikeWildcards;
+    use SanitizesLogData;
     use WithAdminAuthorization;
     use WithNotifications;
     use WithPagination;
@@ -159,9 +161,9 @@ class ReviewInboundEmails extends Component
         Log::warning('Inbound email rejected by admin', [
             'admin_id' => $userId,
             'inbound_email_id' => $inboundEmail->id,
-            'message_id' => $inboundEmail->message_id,
-            'from' => $inboundEmail->from,
-            'subject' => $inboundEmail->subject,
+            'message_id' => $this->sanitizeForLog((string) $inboundEmail->message_id),
+            'from' => $this->sanitizeForLog((string) $inboundEmail->from),
+            'subject' => $this->sanitizeForLog((string) $inboundEmail->subject),
         ]);
 
         $action->execute($inboundEmail, $userId);

--- a/app/Livewire/Admin/Preachers/CreatePreacher.php
+++ b/app/Livewire/Admin/Preachers/CreatePreacher.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Admin\Preachers;
 use App\Livewire\Traits\WithAdminAuthorization;
 use App\Livewire\Traits\WithNotifications;
 use App\Models\Preacher;
+use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
@@ -14,7 +15,7 @@ use Livewire\Component;
 
 class CreatePreacher extends Component
 {
-    use WithAdminAuthorization, WithNotifications;
+    use SanitizesLogData, WithAdminAuthorization, WithNotifications;
 
     public string $name = '';
 
@@ -67,8 +68,8 @@ class CreatePreacher extends Component
         Log::warning('New preacher created by admin', [
             'admin_id' => auth()->id(),
             'preacher_id' => $preacher->id,
-            'name' => $preacher->name,
-            'slug' => $preacher->slug,
+            'name' => $this->sanitizeForLog((string) $preacher->name),
+            'slug' => $this->sanitizeForLog((string) $preacher->slug),
         ]);
 
         $this->success('Preacher created', redirectTo: route('admin.preachers.index'));

--- a/app/Livewire/Admin/Preachers/EditPreacher.php
+++ b/app/Livewire/Admin/Preachers/EditPreacher.php
@@ -8,6 +8,7 @@ use App\Contracts\SpeakerIdentificationInterface;
 use App\Livewire\Traits\WithAdminAuthorization;
 use App\Livewire\Traits\WithNotifications;
 use App\Models\Preacher;
+use App\Traits\SanitizesLogData;
 use App\Models\PreacherAlias;
 use App\Models\SpeakerProfile;
 use App\Models\SpeakerSample;
@@ -18,7 +19,7 @@ use Livewire\Component;
 
 class EditPreacher extends Component
 {
-    use WithAdminAuthorization, WithNotifications;
+    use SanitizesLogData, WithAdminAuthorization, WithNotifications;
 
     public Preacher $preacher;
 
@@ -83,8 +84,8 @@ class EditPreacher extends Component
         Log::warning('Preacher updated by admin', [
             'admin_id' => auth()->id(),
             'preacher_id' => $this->preacher->id,
-            'name' => ($fresh instanceof Preacher ? $fresh->name : $this->preacher->name),
-            'slug' => ($fresh instanceof Preacher ? $fresh->slug : $this->preacher->slug),
+            'name' => $this->sanitizeForLog($fresh instanceof Preacher ? (string) $fresh->name : (string) $this->preacher->name),
+            'slug' => $this->sanitizeForLog($fresh instanceof Preacher ? (string) $fresh->slug : (string) $this->preacher->slug),
         ]);
 
         $this->success('Preacher updated');
@@ -125,9 +126,9 @@ class EditPreacher extends Component
             Log::warning('Preacher alias removed by admin', [
                 'admin_id' => auth()->id(),
                 'preacher_id' => $this->preacher->id,
-                'preacher_name' => $this->preacher->name,
+                'preacher_name' => $this->sanitizeForLog((string) $this->preacher->name),
                 'alias_id' => $alias->id,
-                'alias' => $alias->alias,
+                'alias' => $this->sanitizeForLog((string) $alias->alias),
             ]);
 
             $alias->delete();
@@ -188,7 +189,7 @@ class EditPreacher extends Component
             Log::warning('Speaker profile deactivated by admin', [
                 'admin_id' => auth()->id(),
                 'preacher_id' => $this->preacher->id,
-                'preacher_name' => $this->preacher->name,
+                'preacher_name' => $this->sanitizeForLog((string) $this->preacher->name),
                 'profile_id' => $profile->id,
             ]);
 

--- a/tests/Feature/SermonTranscriptSecurityTest.php
+++ b/tests/Feature/SermonTranscriptSecurityTest.php
@@ -66,7 +66,7 @@ class SermonTranscriptSecurityTest extends TestCase
     }
 
     #[Test]
-    public function transcript_endpoint_escapes_html_in_rendered_output(): void
+    public function transcript_endpoint_strips_html_in_rendered_output(): void
     {
         Storage::fake('public');
 
@@ -87,7 +87,8 @@ class SermonTranscriptSecurityTest extends TestCase
 
         $response->assertOk();
         $response->assertDontSee('</script><script>alert("x")</script>', false);
-        // Confirms angle brackets are HTML-entity encoded in the rendered markdown output
-        $response->assertSee('&lt;/script&gt;', false);
+        // Confirms HTML tags are stripped entirely by SafeMarkdownRenderer
+        $response->assertDontSee('&lt;/script&gt;', false);
+        $response->assertSee('Text alert("x")');
     }
 }


### PR DESCRIPTION
This PR implements several security hardenings focused on log integrity and safe content rendering.

1. **Log Integrity Enforcement**: Standardized the use of `SanitizesLogData` trait in `SermonAdminController`, `MeetingController`, `ReviewInboundEmails`, `CreatePreacher`, and `EditPreacher`. All log entries containing user-provided strings (like titles, slugs, and message IDs) or exception messages are now sanitized to neutralize control characters, preventing log injection.

2. **Harden Markdown Rendering**: Transitioned `SermonAssetController` from direct `Str::markdown` usage to the centralized `SafeMarkdownRenderer` service. This aligns the transcript rendering with the project's security standard of stripping HTML tags entirely rather than just escaping them, providing a more robust defense against XSS.

3. **Verification**: Updated `SermonTranscriptSecurityTest` to verify that HTML tags are stripped from transcript output. All tests, including the full suite (4894 tests), passed successfully.

---
*PR created automatically by Jules for task [2213036252516750026](https://jules.google.com/task/2213036252516750026) started by @GarethClarridge*