### PR TITLE
🔦 Lighthouse: Add BreadcrumbList Structured Data

### DIFF
--- a/app/Presenters/BreadcrumbPresenter.php
+++ b/app/Presenters/BreadcrumbPresenter.php
@@ -111,6 +111,11 @@ class BreadcrumbPresenter
             $items[] = ['name' => 'Members', 'item' => url('church/members')];
         } elseif ($segment2 === 'childrens-corner') {
             $items[] = ['name' => "Children's Corner", 'item' => url('christ/childrens-corner')];
+        } elseif ($segment2 === 'songs' && $this->request->segment(3) !== null) {
+            $items[] = ['name' => 'Songs', 'item' => url('church/songs')];
+        } elseif ($this->request->segment(1) === 'meetings' && $this->request->segment(3) === 'events') {
+            $meetingSlug = (string) $segment2;
+            $items[] = ['name' => Str::title(str_replace('-', ' ', $meetingSlug)), 'item' => url('community/'.$meetingSlug)];
         }
 
         return $items;

--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -17,6 +17,8 @@
     :image="asset('/images/homepage/may2024wide.webp')"
 />
 
+<x-breadcrumbs :area="$area" :heading="$heading" json-only />
+
 {{-- JSON-LD Events --}}
 @if($allEvents->isNotEmpty())
 <script type="application/ld+json">

--- a/resources/views/childrens-corner/index.blade.php
+++ b/resources/views/childrens-corner/index.blade.php
@@ -17,6 +17,8 @@
         :image="asset('/images/homepage/may2024wide.webp')"
     />
 
+    <x-breadcrumbs :area="$area" :heading="$heading" json-only />
+
     {{-- JSON-LD ItemList --}}
     @if (isset($json_ld_data))
         <script type="application/ld+json">

--- a/resources/views/childrens-corner/show.blade.php
+++ b/resources/views/childrens-corner/show.blade.php
@@ -24,6 +24,8 @@
         :description="$metaDescription ?: $sermon->title"
         :image="$sermonView['thumbnail_url']"
     />
+
+    <x-breadcrumbs :area="$area" :heading="$sermon->title" json-only />
 @endsection
 
 @section('dynamic_content')

--- a/resources/views/church/songs/index.blade.php
+++ b/resources/views/church/songs/index.blade.php
@@ -13,6 +13,8 @@
     heading="Songs"
     description="Browse the songs most often sung at Crockenhill Baptist Church."
 />
+
+<x-breadcrumbs :area="$area" :heading="$heading" json-only />
 @endsection
 
 @section('dynamic_content')

--- a/resources/views/church/songs/show.blade.php
+++ b/resources/views/church/songs/show.blade.php
@@ -15,6 +15,8 @@
     :heading="$heading"
     :description="$description"
 />
+
+<x-breadcrumbs :area="$area" :heading="$heading" json-only />
 <x-schema.music-composition :$song />
 @stop
 

--- a/resources/views/meetings/events.blade.php
+++ b/resources/views/meetings/events.blade.php
@@ -14,6 +14,8 @@
     :description="$description"
 />
 
+<x-breadcrumbs :area="$area" :heading="$heading" json-only />
+
 {{-- JSON-LD Events List --}}
 @if($events->isNotEmpty())
 <script type="application/ld+json">

--- a/resources/views/meetings/show.blade.php
+++ b/resources/views/meetings/show.blade.php
@@ -22,6 +22,8 @@
     :image="$headingpicture"
 />
 
+<x-breadcrumbs :area="$area" :heading="$heading" json-only />
+
 {{-- JSON-LD Recurring Event --}}
 @if($meeting->is_recurring && $meeting->frequency)
 <script type="application/ld+json">

--- a/resources/views/sermons/index.blade.php
+++ b/resources/views/sermons/index.blade.php
@@ -19,6 +19,8 @@
     :description="$description"
     :image="asset('/images/headings/large/sermons.webp')"
 />
+
+<x-breadcrumbs :area="$area" :heading="$heading" json-only />
 @endsection
 
 @section('dynamic_content')

--- a/resources/views/sermons/preacher.blade.php
+++ b/resources/views/sermons/preacher.blade.php
@@ -17,6 +17,8 @@
     :image="$share_image"
 />
 
+<x-breadcrumbs :area="$area" :heading="$heading" json-only />
+
 <x-schema.person :$preacher />
 
 {{-- JSON-LD Sermon List --}}

--- a/resources/views/sermons/preachers.blade.php
+++ b/resources/views/sermons/preachers.blade.php
@@ -17,6 +17,8 @@
     :image="asset('/images/headings/large/sermons.webp')"
 />
 
+<x-breadcrumbs :area="$area" :heading="$heading" json-only />
+
 {{-- JSON-LD Preachers List --}}
 @if(isset($json_ld_data))
 <script type="application/ld+json">

--- a/resources/views/sermons/series.blade.php
+++ b/resources/views/sermons/series.blade.php
@@ -17,6 +17,8 @@
     :image="$share_image ?? asset('/images/headings/large/sermons.webp')"
 />
 
+<x-breadcrumbs :area="$area" :heading="$heading" json-only />
+
 {{-- JSON-LD Sermon List --}}
 <script type="application/ld+json">
 {!! json_encode($json_ld_data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}

--- a/resources/views/sermons/serieses.blade.php
+++ b/resources/views/sermons/serieses.blade.php
@@ -17,6 +17,8 @@
     :image="asset('/images/headings/large/sermons.webp')"
 />
 
+<x-breadcrumbs :area="$area" :heading="$heading" json-only />
+
 {{-- JSON-LD Series List --}}
 @if(isset($json_ld_data))
 <script type="application/ld+json">

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -39,6 +39,8 @@ $hasPublicVideo = filled($sermonView['video_url']);
   :description="$description ?? $metaDescription"
   :image="$sermonView['thumbnail_url']"
 />
+
+<x-breadcrumbs :area="$area" :heading="$sermon->title" json-only />
 @endsection
 
 @section('dynamic_content')

--- a/resources/views/sermons/service.blade.php
+++ b/resources/views/sermons/service.blade.php
@@ -17,6 +17,8 @@
     :image="asset('/images/headings/large/sermons.webp')"
 />
 
+<x-breadcrumbs :area="$area" :heading="$heading" json-only />
+
 {{-- JSON-LD Sermon List --}}
 <script type="application/ld+json">
 {!! json_encode($json_ld_data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}

--- a/tests/Feature/BreadcrumbRenderingTest.php
+++ b/tests/Feature/BreadcrumbRenderingTest.php
@@ -102,6 +102,34 @@ class BreadcrumbRenderingTest extends TestCase
     }
 
     #[Test]
+    public function presenter_builds_songs_trail_for_song_detail_page(): void
+    {
+        $this->get('/church/songs/amazing-grace');
+
+        $presenter = app(BreadcrumbPresenter::class);
+        $items = $presenter->items('church', 'Amazing Grace');
+
+        $names = array_column($items, 'name');
+        $this->assertContains('Church', $names);
+        $this->assertContains('Songs', $names);
+        $this->assertContains('Amazing Grace', $names);
+    }
+
+    #[Test]
+    public function presenter_builds_meeting_events_trail_for_meeting_events_page(): void
+    {
+        $this->get('/meetings/buzz-club/events');
+
+        $presenter = app(BreadcrumbPresenter::class);
+        $items = $presenter->items('community', 'Buzz Club - All Events');
+
+        $names = array_column($items, 'name');
+        $this->assertContains('Community', $names);
+        $this->assertContains('Buzz Club', $names);
+        $this->assertContains('Buzz Club - All Events', $names);
+    }
+
+    #[Test]
     public function presenter_builds_admin_trail_for_admin_subsection(): void
     {
         $this->get('/admin/sermons/edit');
@@ -198,6 +226,15 @@ class BreadcrumbRenderingTest extends TestCase
     public function sermon_index_page_serves_breadcrumb_json_ld(): void
     {
         $response = $this->get('/christ/sermons');
+
+        $response->assertStatus(200);
+        $response->assertSee('BreadcrumbList', false);
+    }
+
+    #[Test]
+    public function calendar_page_serves_breadcrumb_json_ld(): void
+    {
+        $response = $this->get('/calendar');
 
         $response->assertStatus(200);
         $response->assertSee('BreadcrumbList', false);


### PR DESCRIPTION
💡 **What:** Added **BreadcrumbList JSON-LD structured data** to primary listing and individual content pages across the website.
🎯 **Why:** To improve search engine discoverability and allow search engines to display the site's hierarchy as breadcrumbs in search results, increasing click-through rates.
📊 **Impact:** Benefits all primary public-facing sections including Sermons, Preachers, Series, Songs, Children's Corner, and Community Meetings.
🔍 **Verification:** Verified that the `<x-breadcrumbs />` component was correctly added to relevant Blade views and that the `BreadcrumbPresenter` correctly generates the expected hierarchy for nested URLs. Ran the full test suite (4894 tests) and all passed. Verified static analysis with PHPStan (0 errors).

---
*PR created automatically by Jules for task [3451788191776066579](https://jules.google.com/task/3451788191776066579) started by @GarethClarridge*