### PR TITLE
🏛️ Warden: Fortify sermon preacher name integrity

### DIFF
--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -210,12 +210,17 @@ class Sermon extends Model implements Sitemapable
     }
 
     /**
+     * Preacher name attribute.
+     *
+     * Note: The relationship is named 'preacherProfile' to avoid conflict with
+     * this attribute setter which ensures the denormalized name is trimmed.
+     *
      * @return Attribute<string, string>
      */
     protected function preacher(): Attribute
     {
         return Attribute::make(
-            set: fn (string $value): string => trim($value),
+            set: fn (?string $value): ?string => $value !== null ? trim($value) : null,
         );
     }
 
@@ -259,7 +264,7 @@ class Sermon extends Model implements Sitemapable
             'service' => ['nullable', Rule::enum(SermonService::class)],
             'series' => ['nullable', 'string', 'max:255'],
             'reference' => ['nullable', 'string', 'max:255'],
-            'preacher' => ['required', 'string', 'max:255'],
+            'preacher' => ['required', 'string', 'max:255'], // Matches database varchar length and non-empty constraint
             'preacher_id' => ['nullable', 'integer', 'exists:preachers,id'],
             'preacher_source' => ['nullable', Rule::enum(PreacherSource::class)],
             'preacher_confidence' => ['nullable', 'numeric', 'min:0', 'max:1'],

--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -210,6 +210,16 @@ class Sermon extends Model implements Sitemapable
     }
 
     /**
+     * @return Attribute<string, string>
+     */
+    protected function preacher(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value): string => trim($value),
+        );
+    }
+
+    /**
      * @return Attribute<?string, ?string>
      */
     protected function series(): Attribute

--- a/database/migrations/2026_05_08_115011_add_integrity_check_to_sermons_preacher.php
+++ b/database/migrations/2026_05_08_115011_add_integrity_check_to_sermons_preacher.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    private const PREACHER_FORMAT_CHECK = 'sermons_preacher_format_check';
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        // 1. Data Cleanup: Trim existing data
+        DB::table('sermons')->update([
+            'preacher' => DB::raw('TRIM(preacher)'),
+        ]);
+
+        // 2. Ensure no empty preacher names exist before adding constraint.
+        // If it's empty (after trimming), use a generic fallback.
+        DB::table('sermons')
+            ->where('preacher', '')
+            ->update(['preacher' => 'Unknown Preacher']);
+
+        // 3. Add CHECK constraint
+        // BINARY ensures exact character-for-character match for the trim check.
+        DB::statement(sprintf(
+            "ALTER TABLE sermons ADD CONSTRAINT %s CHECK (BINARY preacher = TRIM(preacher) AND preacher != '')",
+            self::PREACHER_FORMAT_CHECK
+        ));
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        DB::statement(sprintf('ALTER TABLE sermons DROP CHECK %s', self::PREACHER_FORMAT_CHECK));
+    }
+};

--- a/tests/Feature/SermonPreacherIntegrityTest.php
+++ b/tests/Feature/SermonPreacherIntegrityTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Sermon;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonPreacherIntegrityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function preacher_attribute_is_trimmed_by_model_setter(): void
+    {
+        $sermon = Sermon::factory()->make([
+            'preacher' => '  Mark Drury  ',
+        ]);
+
+        $this->assertEquals('Mark Drury', $sermon->preacher);
+
+        $sermon->save();
+        $this->assertEquals('Mark Drury', $sermon->refresh()->preacher);
+    }
+
+    #[Test]
+    public function database_rejects_untrimmed_preacher_via_raw_query(): void
+    {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('sermons_preacher_format_check');
+
+        DB::table('sermons')->insert([
+            'title' => 'Test Sermon',
+            'slug' => 'test-sermon',
+            'date' => now()->toDateString(),
+            'preacher' => '  Mark Drury  ',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function database_rejects_empty_preacher_via_raw_query(): void
+    {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('sermons_preacher_format_check');
+
+        DB::table('sermons')->insert([
+            'title' => 'Test Sermon',
+            'slug' => 'test-sermon',
+            'date' => now()->toDateString(),
+            'preacher' => '',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function database_accepts_valid_preacher_via_raw_query(): void
+    {
+        DB::table('sermons')->insert([
+            'title' => 'Test Sermon',
+            'slug' => 'test-sermon',
+            'date' => now()->toDateString(),
+            'preacher' => 'Mark Drury',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->assertDatabaseHas('sermons', [
+            'preacher' => 'Mark Drury',
+        ]);
+    }
+}


### PR DESCRIPTION
🏛️ Warden: Fortify sermon preacher name integrity

Implemented the three-layer data integrity pattern for the `preacher` column in the `Sermon` model.

### 💡 What
- Added a MySQL `CHECK` constraint to the `sermons` table ensuring the `preacher` column is trimmed and not empty.
- Added an Eloquent attribute setter in the `Sermon` model for automatic trimming.
- Added a feature test to verify both the model-level logic and the database-level constraint.

### 🎯 Why
Prevents data corruption where leading/trailing whitespace or empty strings are stored in the `preacher` column, which is a key identity field used in filtering and display.

### 🗄️ Migration
`2026_05_08_115011_add_integrity_check_to_sermons_preacher.php`
- Trims existing `preacher` values.
- Fallback for empty values: 'Unknown Preacher'.
- Adds `sermons_preacher_format_check`.

### ✅ Verification
- `php artisan test tests/Feature/SermonPreacherIntegrityTest.php` (4 passed)
- `composer phpstan` (0 errors)
- `./vendor/bin/pint --dirty` (Applied)

### ⚠️ Rollback
`php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [15711096046494058421](https://jules.google.com/task/15711096046494058421) started by @GarethClarridge*