### PR TITLE
🏛️ Warden: fortify song_authors integrity

### DIFF
--- a/app/Models/SongAuthor.php
+++ b/app/Models/SongAuthor.php
@@ -6,11 +6,13 @@ namespace App\Models;
 
 use Database\Factories\SongAuthorFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Carbon;
+use Illuminate\Validation\Rule;
 
 /**
  * @property int $id
@@ -41,6 +43,57 @@ class SongAuthor extends Model
         'first_name',
         'last_name',
     ];
+
+    /**
+     * @return Attribute<string, string>
+     */
+    protected function displayName(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value): string => trim($value),
+        );
+    }
+
+    /**
+     * @return Attribute<?string, ?string>
+     */
+    protected function firstName(): Attribute
+    {
+        return Attribute::make(
+            set: fn (?string $value): ?string => $value !== null ? trim($value) : null,
+        );
+    }
+
+    /**
+     * @return Attribute<?string, ?string>
+     */
+    protected function lastName(): Attribute
+    {
+        return Attribute::make(
+            set: fn (?string $value): ?string => $value !== null ? trim($value) : null,
+        );
+    }
+
+    /**
+     * @return array<string, list<string|mixed>>
+     */
+    public static function validationRules(?self $author = null): array
+    {
+        $displayNameRule = ['required', 'string', 'max:255'];
+        $uniqueDisplayName = Rule::unique('song_authors', 'display_name');
+
+        if ($author) {
+            $uniqueDisplayName->ignore($author->id);
+        }
+
+        $displayNameRule[] = $uniqueDisplayName;
+
+        return [
+            'display_name' => $displayNameRule,
+            'first_name' => ['nullable', 'string', 'max:255'],
+            'last_name' => ['nullable', 'string', 'max:255'],
+        ];
+    }
 
     /**
      * @return BelongsToMany<Song, $this>

--- a/database/migrations/2026_05_10_053328_fortify_song_authors_integrity.php
+++ b/database/migrations/2026_05_10_053328_fortify_song_authors_integrity.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const DISPLAY_NAME_FORMAT_CHECK = 'song_authors_display_name_format_check';
+
+    private const FIRST_NAME_FORMAT_CHECK = 'song_authors_first_name_format_check';
+
+    private const LAST_NAME_FORMAT_CHECK = 'song_authors_last_name_format_check';
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasTable('song_authors')) {
+            return;
+        }
+
+        if (DB::getDriverName() === 'mysql') {
+            // Add CHECK constraints
+            // BINARY ensures exact character-for-character match for the trim check.
+            DB::statement(sprintf(
+                "ALTER TABLE song_authors ADD CONSTRAINT %s CHECK (BINARY display_name = TRIM(display_name) AND display_name != '')",
+                self::DISPLAY_NAME_FORMAT_CHECK
+            ));
+
+            DB::statement(sprintf(
+                'ALTER TABLE song_authors ADD CONSTRAINT %s CHECK (first_name IS NULL OR BINARY first_name = TRIM(first_name))',
+                self::FIRST_NAME_FORMAT_CHECK
+            ));
+
+            DB::statement(sprintf(
+                'ALTER TABLE song_authors ADD CONSTRAINT %s CHECK (last_name IS NULL OR BINARY last_name = TRIM(last_name))',
+                self::LAST_NAME_FORMAT_CHECK
+            ));
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (! Schema::hasTable('song_authors')) {
+            return;
+        }
+
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement(sprintf('ALTER TABLE song_authors DROP CHECK %s', self::DISPLAY_NAME_FORMAT_CHECK));
+            DB::statement(sprintf('ALTER TABLE song_authors DROP CHECK %s', self::FIRST_NAME_FORMAT_CHECK));
+            DB::statement(sprintf('ALTER TABLE song_authors DROP CHECK %s', self::LAST_NAME_FORMAT_CHECK));
+        }
+    }
+};

--- a/tests/Feature/DataIntegrity/SongAuthorIntegrityTest.php
+++ b/tests/Feature/DataIntegrity/SongAuthorIntegrityTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\DataIntegrity;
+
+use App\Models\SongAuthor;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SongAuthorIntegrityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_trims_names_automatically_via_model_attributes(): void
+    {
+        $author = new SongAuthor([
+            'display_name' => '  John Doe  ',
+            'first_name' => '  John  ',
+            'last_name' => '  Doe  ',
+        ]);
+
+        $this->assertEquals('John Doe', $author->display_name);
+        $this->assertEquals('John', $author->first_name);
+        $this->assertEquals('Doe', $author->last_name);
+    }
+
+    #[Test]
+    public function it_prevents_empty_display_name_at_database_level(): void
+    {
+        $this->expectException(QueryException::class);
+
+        // Using DB::table to bypass Eloquent attribute setters
+        DB::table('song_authors')->insert([
+            'display_name' => '',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_prevents_untrimmed_display_name_at_database_level(): void
+    {
+        $this->expectException(QueryException::class);
+
+        // Using DB::table to bypass Eloquent attribute setters
+        DB::table('song_authors')->insert([
+            'display_name' => ' Untrimmed ',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_prevents_untrimmed_first_name_at_database_level(): void
+    {
+        $this->expectException(QueryException::class);
+
+        // Using DB::table to bypass Eloquent attribute setters
+        DB::table('song_authors')->insert([
+            'display_name' => 'Valid Name',
+            'first_name' => ' Untrimmed ',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_prevents_untrimmed_last_name_at_database_level(): void
+    {
+        $this->expectException(QueryException::class);
+
+        // Using DB::table to bypass Eloquent attribute setters
+        DB::table('song_authors')->insert([
+            'display_name' => 'Valid Name',
+            'last_name' => ' Untrimmed ',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_validates_display_name_uniqueness(): void
+    {
+        SongAuthor::factory()->create(['display_name' => 'Unique Author']);
+
+        $rules = SongAuthor::validationRules();
+        $validator = Validator::make(['display_name' => 'Unique Author'], $rules);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('display_name', $validator->errors()->toArray());
+    }
+
+    #[Test]
+    public function it_validates_required_fields(): void
+    {
+        $rules = SongAuthor::validationRules();
+        $validator = Validator::make(['display_name' => ''], $rules);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('display_name', $validator->errors()->toArray());
+    }
+
+    #[Test]
+    public function it_allows_null_first_and_last_names(): void
+    {
+        $author = SongAuthor::create([
+            'display_name' => 'Minimal Author',
+            'first_name' => null,
+            'last_name' => null,
+        ]);
+
+        $this->assertDatabaseHas('song_authors', [
+            'id' => $author->id,
+            'display_name' => 'Minimal Author',
+            'first_name' => null,
+            'last_name' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
This PR fortifies the data integrity of the `song_authors` table and model. Following the project's "Three-Layer Pattern", it introduces:

1.  **Database Layer**: A migration adding MySQL `CHECK` constraints to ensure `display_name` is non-empty and correctly trimmed (using `BINARY` comparison), and ensuring `first_name` and `last_name` are trimmed if provided.
2.  **Model Layer**: Attribute setters in the `SongAuthor` model that automatically trim input values, preventing accidental whitespace corruption.
3.  **Application Layer**: A centralized `validationRules()` method in the model that enforces uniqueness on `display_name` and length constraints.

Existing data was checked, and while the table was empty in this environment, the migration is safe for deployment. Pre-existing unique indexes on `display_name` were confirmed via schema inspection.

**Verification**:
- New feature test `tests/Feature/DataIntegrity/SongAuthorIntegrityTest.php` covers all new constraints and logic.
- Full test suite passed (4981 tests).
- PHPStan at 0 errors.
- Pint formatting applied.

**Rollback**:
`php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [273324713616853779](https://jules.google.com/task/273324713616853779) started by @GarethClarridge*