### PR TITLE
Standardize admin list accessibility and navigation

### DIFF
--- a/resources/views/components/admin/list-shell.blade.php
+++ b/resources/views/components/admin/list-shell.blade.php
@@ -1,12 +1,20 @@
 @props([
     'title',
     'description' => null,
+    'paginator' => null,
+    'itemsName' => 'item',
 ])
 
-<x-admin.page :title="$title" :description="$description" {{ $attributes }}>
+<x-admin.page :title="$title" :description="$description" {{ $attributes->except('paginator') }}>
     <x-slot:actions>
         @isset($actions){{ $actions }}@endisset
     </x-slot:actions>
+
+    @if($paginator && method_exists($paginator, 'total') && $paginator->total() > 0)
+        <a href="#admin-list-results" @click.prevent="document.getElementById('admin-list-results').focus()" class="sr-only focus:not-sr-only focus:absolute focus:z-30 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-cbc-teal-dark focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-cbc-teal">
+            Skip to results
+        </a>
+    @endif
 
     @isset($filters)
         <div class="mb-4">
@@ -14,7 +22,17 @@
         </div>
     @endisset
 
-    <x-card wire:loading.class.delay.200ms="opacity-50">
+    @if($paginator && method_exists($paginator, 'total') && $paginator->total() > 0)
+        <div class="mb-4 text-sm text-gray-500" aria-live="polite">
+            @if (method_exists($paginator, 'hasPages') && $paginator->hasPages())
+                Showing <span class="font-medium text-gray-700">{{ $paginator->firstItem() }}</span> to <span class="font-medium text-gray-700">{{ $paginator->lastItem() }}</span> of <span class="font-medium text-gray-700">{{ $paginator->total() }}</span> {{ Str::plural($itemsName, $paginator->total()) }}
+            @else
+                Showing <span class="font-medium text-gray-700">{{ $paginator->total() }}</span> {{ Str::plural($itemsName, $paginator->total()) }}
+            @endif
+        </div>
+    @endif
+
+    <x-card id="admin-list-results" tabindex="-1" wire:loading.class.delay.200ms="opacity-50" class="focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2">
         <div class="overflow-x-auto">
             {{ $slot }}
         </div>

--- a/resources/views/livewire/admin/preachers/list-preachers.blade.php
+++ b/resources/views/livewire/admin/preachers/list-preachers.blade.php
@@ -1,6 +1,8 @@
 <x-admin.list-shell
     title="Preachers"
     description="Manage preachers and their aliases"
+    :paginator="$preachers"
+    itemsName="preacher"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.preachers.create') }}" variant="primary" icon="plus" inline>
@@ -20,7 +22,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $preachers->links() }}
+        {{ $preachers->links(data: ['scrollTo' => '#admin-list-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">

--- a/resources/views/livewire/admin/sermons/list-sermons.blade.php
+++ b/resources/views/livewire/admin/sermons/list-sermons.blade.php
@@ -1,6 +1,8 @@
 <x-admin.list-shell
     title="Sermons &amp; Talks"
     description="Manage sermon recordings and published children's talks."
+    :paginator="$sermons"
+    itemsName="sermon"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.sermon-upload.create') }}" variant="primary" icon="cloud-arrow-up" inline>
@@ -32,7 +34,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $sermons->links() }}
+        {{ $sermons->links(data: ['scrollTo' => '#admin-list-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">

--- a/resources/views/livewire/admin/users/list-users.blade.php
+++ b/resources/views/livewire/admin/users/list-users.blade.php
@@ -1,6 +1,8 @@
 <x-admin.list-shell
     title="Users"
     description="Manage user accounts"
+    :paginator="$users"
+    itemsName="user"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.users.create') }}" variant="primary" icon="plus" inline>
@@ -32,7 +34,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $users->links() }}
+        {{ $users->links(data: ['scrollTo' => '#admin-list-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">

--- a/tests/Feature/Livewire/Admin/AdminListAccessibilityTest.php
+++ b/tests/Feature/Livewire/Admin/AdminListAccessibilityTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire\Admin;
+
+use App\Models\Sermon;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AdminListAccessibilityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_renders_accessibility_features_when_paginator_is_provided(): void
+    {
+        /** @var User $admin */
+        $admin = User::factory()->admin()->create();
+        Sermon::factory()->count(5)->create(['date' => now()->subMonths(2)]);
+
+        Livewire::actingAs($admin)
+            ->test(\App\Livewire\Admin\Sermons\ListSermons::class)
+            ->assertSeeHtml('Skip to results')
+            ->assertSeeHtml('Showing <span class="font-medium text-gray-700">5</span> sermons')
+            ->assertSeeHtml('id="admin-list-results"')
+            ->assertSeeHtml('tabindex="-1"');
+    }
+
+    #[Test]
+    public function it_renders_paginated_accessibility_features(): void
+    {
+        /** @var User $admin */
+        $admin = User::factory()->admin()->create();
+        // Create 25 sermons to trigger pagination (default 20 per page)
+        Sermon::factory()->count(25)->create(['date' => now()->subMonths(2)]);
+
+        Livewire::actingAs($admin)
+            ->test(\App\Livewire\Admin\Sermons\ListSermons::class)
+            ->assertSeeHtml('Showing <span class="font-medium text-gray-700">1</span> to <span class="font-medium text-gray-700">20</span> of <span class="font-medium text-gray-700">25</span> sermons')
+            ->call('setPage', 2)
+            ->assertSeeHtml('Showing <span class="font-medium text-gray-700">21</span> to <span class="font-medium text-gray-700">25</span> of <span class="font-medium text-gray-700">25</span> sermons');
+    }
+}


### PR DESCRIPTION
I've standardized and enhanced the admin list accessibility and navigation by updating the `x-admin.list-shell` component and the main admin listing views (Sermons, Preachers, Users).

The improvements include:
- A "Skip to results" link for keyboard users.
- An `aria-live="polite"` result count summary.
- Improved focus management with a dedicated results ID and tabindex.
- Smooth scrolling for pagination using Livewire's `scrollTo` feature.

I've also added a new feature test to ensure these features continue to work as expected.

---
*PR created automatically by Jules for task [9270339820051470056](https://jules.google.com/task/9270339820051470056) started by @GarethClarridge*