### PR TITLE
🎨 Palette: Improve admin listing accessibility and UX

### DIFF
--- a/resources/views/components/admin/list-shell.blade.php
+++ b/resources/views/components/admin/list-shell.blade.php
@@ -1,6 +1,7 @@
 @props([
     'title',
     'description' => null,
+    'items' => null,
 ])
 
 <x-admin.page :title="$title" :description="$description" {{ $attributes }}>
@@ -9,12 +10,33 @@
     </x-slot:actions>
 
     @isset($filters)
+        <a href="#admin-results" @click.prevent="document.getElementById('admin-results').focus()" class="sr-only focus:not-sr-only focus:absolute focus:z-30 focus:m-4 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-cbc-teal-dark focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-cbc-teal">
+            Skip to results
+        </a>
+
         <div class="mb-4">
             {{ $filters }}
         </div>
     @endisset
 
-    <x-card wire:loading.class.delay.200ms="opacity-50">
+    @if($items instanceof \Illuminate\Contracts\Pagination\Paginator)
+        <div class="mb-4 text-sm text-gray-500" aria-live="polite">
+            @if($items->count() > 0)
+                @if($items instanceof \Illuminate\Contracts\Pagination\LengthAwarePaginator)
+                    @if($items->hasPages())
+                        Showing <span class="font-medium text-gray-700">{{ $items->firstItem() }}</span> to <span class="font-medium text-gray-700">{{ $items->lastItem() }}</span> of <span class="font-medium text-gray-700">{{ $items->total() }}</span> results
+                    @else
+                        Showing <span class="font-medium text-gray-700">{{ $items->total() }}</span> {{ Str::plural('result', $items->total()) }}
+                    @endif
+                @else
+                    {{-- Simple pagination --}}
+                    Showing <span class="font-medium text-gray-700">{{ $items->firstItem() }}</span> to <span class="font-medium text-gray-700">{{ $items->lastItem() }}</span> results
+                @endif
+            @endif
+        </div>
+    @endif
+
+    <x-card id="admin-results" tabindex="-1" class="focus:outline-none" wire:loading.class.delay.200ms="opacity-50">
         <div class="overflow-x-auto">
             {{ $slot }}
         </div>

--- a/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
+++ b/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
@@ -1,6 +1,7 @@
 <x-admin.list-shell
     title="Calendar Events"
     description="Manage and categorize calendar events"
+    :items="$events"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.calendar.sync') }}" variant="secondary" icon="arrow-path" inline>
@@ -31,7 +32,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $events->links() }}
+        {{ $events->links(data: ['scrollTo' => '#admin-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">

--- a/resources/views/livewire/admin/church-services/list-church-services.blade.php
+++ b/resources/views/livewire/admin/church-services/list-church-services.blade.php
@@ -1,6 +1,7 @@
 <x-admin.list-shell
     title="Services"
     description="View imported order-of-service records"
+    :items="$churchServices"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.services.review') }}" variant="outline" inline>
@@ -59,7 +60,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $churchServices->links() }}
+        {{ $churchServices->links(data: ['scrollTo' => '#admin-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">

--- a/resources/views/livewire/admin/church-services/list-songs.blade.php
+++ b/resources/views/livewire/admin/church-services/list-songs.blade.php
@@ -1,6 +1,7 @@
 <x-admin.list-shell
     title="Songs"
     description="Most-used songs linked from imported service orders"
+    :items="$songs"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.services.upload') }}" variant="primary" icon="arrow-up-tray" inline>
@@ -53,7 +54,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $songs->links() }}
+        {{ $songs->links(data: ['scrollTo' => '#admin-results']) }}
     </x-slot:pagination>
 
     @php

--- a/resources/views/livewire/admin/church-services/review-inbound-emails.blade.php
+++ b/resources/views/livewire/admin/church-services/review-inbound-emails.blade.php
@@ -1,6 +1,7 @@
 <x-admin.list-shell
     title="Inbound email review"
     description="Review low-confidence or failed order-of-service emails before they become canonical."
+    :items="$inboundEmails"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.services.index') }}" variant="outline" inline>
@@ -235,6 +236,6 @@
         </table>
 
     <x-slot:pagination>
-        {{ $inboundEmails->links() }}
+        {{ $inboundEmails->links(data: ['scrollTo' => '#admin-results']) }}
     </x-slot:pagination>
 </x-admin.list-shell>

--- a/resources/views/livewire/admin/meetings/list-meetings.blade.php
+++ b/resources/views/livewire/admin/meetings/list-meetings.blade.php
@@ -1,6 +1,7 @@
 <x-admin.list-shell
     title="Meetings"
     description="Manage church meetings and events"
+    :items="$meetings"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.meetings.create') }}" variant="primary" icon="plus" inline>
@@ -37,7 +38,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $meetings->links() }}
+        {{ $meetings->links(data: ['scrollTo' => '#admin-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">

--- a/resources/views/livewire/admin/pages/list-pages.blade.php
+++ b/resources/views/livewire/admin/pages/list-pages.blade.php
@@ -1,6 +1,7 @@
 <x-admin.list-shell
     title="Pages"
     description="Manage website pages"
+    :items="$pages"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.pages.create') }}" variant="primary" icon="plus" inline>
@@ -36,7 +37,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $pages->links() }}
+        {{ $pages->links(data: ['scrollTo' => '#admin-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">

--- a/resources/views/livewire/admin/preachers/list-preachers.blade.php
+++ b/resources/views/livewire/admin/preachers/list-preachers.blade.php
@@ -1,6 +1,7 @@
 <x-admin.list-shell
     title="Preachers"
     description="Manage preachers and their aliases"
+    :items="$preachers"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.preachers.create') }}" variant="primary" icon="plus" inline>
@@ -20,7 +21,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $preachers->links() }}
+        {{ $preachers->links(data: ['scrollTo' => '#admin-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">

--- a/resources/views/livewire/admin/sermons/list-sermons.blade.php
+++ b/resources/views/livewire/admin/sermons/list-sermons.blade.php
@@ -1,6 +1,7 @@
 <x-admin.list-shell
     title="Sermons &amp; Talks"
     description="Manage sermon recordings and published children's talks."
+    :items="$sermons"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.sermon-upload.create') }}" variant="primary" icon="cloud-arrow-up" inline>
@@ -32,7 +33,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $sermons->links() }}
+        {{ $sermons->links(data: ['scrollTo' => '#admin-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">

--- a/resources/views/livewire/admin/users/list-users.blade.php
+++ b/resources/views/livewire/admin/users/list-users.blade.php
@@ -1,6 +1,7 @@
 <x-admin.list-shell
     title="Users"
     description="Manage user accounts"
+    :items="$users"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.users.create') }}" variant="primary" icon="plus" inline>
@@ -32,7 +33,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $users->links() }}
+        {{ $users->links(data: ['scrollTo' => '#admin-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">


### PR DESCRIPTION
This PR improves the accessibility and user experience of all admin listing pages in the application.

### Key Changes:
- **`x-admin.list-shell` Enhancement**: 
    - Added a **"Skip to results" link** that appears only on focus, allowing keyboard users to bypass large filter bars.
    - Integrated an **accessible results count** (e.g., "Showing 1 to 20 of 100 results") wrapped in an `aria-live="polite"` container. This ensures screen reader users are immediately informed of result changes after filtering or pagination.
    - Added a stable **`id="admin-results"`** and **`tabindex="-1"`** to the results card to facilitate smooth scrolling and programmatic focus.
- **Admin View Updates**:
    - Refactored 9 admin listing components (Sermons, Users, Meetings, Pages, Preachers, Songs, etc.) to pass their paginator collections to the base shell.
    - Updated Livewire pagination links to use `scrollTo: '#admin-results'`, maintaining the user's focus and scroll position at the top of the table after navigation.

### Verification:
- **Static Analysis**: `phpstan` passed with 0 errors.
- **Code Style**: `pint` applied to all changed files.
- **Automated Tests**: Full suite of 4,970 tests passed.
- **Visual Verification**: Confirmed results count and skip link functionality via browser automation.

---
*PR created automatically by Jules for task [10932650332719607999](https://jules.google.com/task/10932650332719607999) started by @GarethClarridge*