### PR TITLE
🛡️ Sentinel: Harden administrative logs with consistent sanitization

### DIFF
--- a/app/Http/Controllers/Admin/SermonAdminController.php
+++ b/app/Http/Controllers/Admin/SermonAdminController.php
@@ -24,6 +24,8 @@ class SermonAdminController extends Controller
 
     /**
      * Remove the specified resource from storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
      */
     public function destroy(Sermon $sermon): RedirectResponse
     {
@@ -57,6 +59,9 @@ class SermonAdminController extends Controller
 
     /**
      * Process media upload through unified processing service
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     * Stack traces are sanitized to prevent information leakage.
      */
     public function processMedia(ProcessMediaRequest $request): RedirectResponse
     {
@@ -76,7 +81,7 @@ class SermonAdminController extends Controller
                     'admin_id' => auth()->id(),
                     'type' => $type,
                     'filename' => $this->sanitizeForLog($file->getClientOriginalName()),
-                    'processing_id' => $result->processingId,
+                    'processing_id' => $this->sanitizeForLog((string) $result->processingId),
                 ]);
 
                 return redirect()

--- a/app/Http/Controllers/Api/MediaController.php
+++ b/app/Http/Controllers/Api/MediaController.php
@@ -30,6 +30,9 @@ class MediaController extends Controller
 
     /**
      * Upload and process media file - handles all types (audio, video, livestream)
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     * Stack traces are sanitized to prevent information leakage.
      */
     public function upload(ProcessMediaRequest $request, string $type): JsonResponse
     {
@@ -83,6 +86,9 @@ class MediaController extends Controller
 
     /**
      * Get processing status - unified for all media types
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     * Stack traces are sanitized to prevent information leakage.
      */
     public function status(MediaStatusRequest $request, string $processingId): JsonResponse
     {
@@ -119,6 +125,9 @@ class MediaController extends Controller
 
     /**
      * Cancel processing
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     * Stack traces are sanitized to prevent information leakage.
      */
     public function cancel(CancelMediaProcessingRequest $request, string $processingId): JsonResponse
     {
@@ -147,6 +156,9 @@ class MediaController extends Controller
 
     /**
      * Confirm a sermon segment for a livestream run awaiting manual review
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     * Stack traces are sanitized to prevent information leakage.
      */
     public function confirmSegment(ConfirmMediaSegmentRequest $request, string $processingId, ConfirmLivestreamSermonSegment $action): JsonResponse
     {
@@ -183,6 +195,9 @@ class MediaController extends Controller
 
     /**
      * Retry processing
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     * Stack traces are sanitized to prevent information leakage.
      */
     public function retry(RetryMediaProcessingRequest $request, string $processingId): JsonResponse
     {

--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -82,6 +82,8 @@ class MeetingController extends Controller
 
     /**
      * Update the specified resource in storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
      */
     public function update(UpdateMeetingRequest $request, Meeting $meeting): RedirectResponse
     {
@@ -106,6 +108,8 @@ class MeetingController extends Controller
 
     /**
      * Remove the specified resource from storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
      */
     public function destroy(Meeting $meeting): RedirectResponse
     {

--- a/app/Livewire/Admin/ChurchServices/ShowSong.php
+++ b/app/Livewire/Admin/ChurchServices/ShowSong.php
@@ -9,6 +9,7 @@ use App\Models\ChurchServiceItem;
 use App\Models\Song;
 use App\Models\SongVideo;
 use App\Services\SongVideoService;
+use App\Traits\SanitizesLogData;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
@@ -16,7 +17,7 @@ use Livewire\Component;
 
 class ShowSong extends Component
 {
-    use WithAdminAuthorization;
+    use SanitizesLogData, WithAdminAuthorization;
 
     public Song $song;
 
@@ -90,6 +91,11 @@ class ShowSong extends Component
         app(SongVideoService::class)->unfeatureVideo($video);
     }
 
+    /**
+     * Delete a video associated with the song.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function deleteVideo(int $videoId): void
     {
         $video = SongVideo::query()->where('song_id', $this->song->id)->findOrFail($videoId);
@@ -98,7 +104,7 @@ class ShowSong extends Component
             'admin_id' => auth()->id(),
             'video_id' => $video->id,
             'song_id' => $this->song->id,
-            'song_title' => $this->song->title,
+            'song_title' => $this->sanitizeForLog((string) $this->song->title),
         ]);
 
         app(SongVideoService::class)->deleteVideo($video);

--- a/app/Livewire/Admin/Meetings/CreateMeeting.php
+++ b/app/Livewire/Admin/Meetings/CreateMeeting.php
@@ -8,13 +8,14 @@ use App\Livewire\Forms\MeetingFormData;
 use App\Livewire\Traits\WithAdminAuthorization;
 use App\Livewire\Traits\WithNotifications;
 use App\Livewire\Traits\WithPageOptions;
+use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Component;
 
 class CreateMeeting extends Component
 {
-    use WithAdminAuthorization;
+    use SanitizesLogData, WithAdminAuthorization;
     use WithNotifications;
     use WithPageOptions;
 
@@ -34,7 +35,7 @@ class CreateMeeting extends Component
         Log::warning('New meeting created by admin', [
             'admin_id' => auth()->id(),
             'meeting_id' => $meeting->id,
-            'slug' => $meeting->slug,
+            'slug' => $this->sanitizeForLog((string) $meeting->slug),
         ]);
 
         $this->success('Meeting created', redirectTo: route('admin.meetings.index'));

--- a/app/Livewire/Admin/Meetings/EditMeeting.php
+++ b/app/Livewire/Admin/Meetings/EditMeeting.php
@@ -9,13 +9,14 @@ use App\Livewire\Traits\WithAdminAuthorization;
 use App\Livewire\Traits\WithNotifications;
 use App\Livewire\Traits\WithPageOptions;
 use App\Models\Meeting;
+use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Component;
 
 class EditMeeting extends Component
 {
-    use WithAdminAuthorization;
+    use SanitizesLogData, WithAdminAuthorization;
     use WithNotifications;
     use WithPageOptions;
 
@@ -41,7 +42,7 @@ class EditMeeting extends Component
         Log::warning('Meeting updated by admin', [
             'admin_id' => auth()->id(),
             'meeting_id' => $this->meeting->id,
-            'slug' => ($fresh instanceof Meeting ? $fresh->slug : $this->meeting->slug),
+            'slug' => $this->sanitizeForLog($fresh instanceof Meeting ? (string) $fresh->slug : (string) $this->meeting->slug),
         ]);
 
         $this->success('Meeting updated');

--- a/app/Livewire/Admin/Meetings/ListMeetings.php
+++ b/app/Livewire/Admin/Meetings/ListMeetings.php
@@ -11,6 +11,7 @@ use App\Livewire\Traits\WithNotifications;
 use App\Livewire\Traits\WithSortableListing;
 use App\Models\Meeting;
 use App\Traits\EscapesLikeWildcards;
+use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\Url;
@@ -19,7 +20,7 @@ use Livewire\WithPagination;
 
 class ListMeetings extends Component
 {
-    use EscapesLikeWildcards, WithAdminAuthorization, WithFilterableListing, WithNotifications, WithPagination, WithSortableListing;
+    use EscapesLikeWildcards, SanitizesLogData, WithAdminAuthorization, WithFilterableListing, WithNotifications, WithPagination, WithSortableListing;
 
     protected const DEFAULT_SORT_COLUMN = 'updated_at';
 
@@ -78,6 +79,11 @@ class ListMeetings extends Component
         ];
     }
 
+    /**
+     * Remove the specified meeting from storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function delete(Meeting $meeting): void
     {
 
@@ -86,7 +92,7 @@ class ListMeetings extends Component
         Log::warning('Meeting deleted by admin', [
             'admin_id' => auth()->id(),
             'meeting_id' => $meeting->id,
-            'slug' => $meeting->slug,
+            'slug' => $this->sanitizeForLog((string) $meeting->slug),
         ]);
 
         $meeting->delete();

--- a/app/Livewire/Admin/Pages/CreatePage.php
+++ b/app/Livewire/Admin/Pages/CreatePage.php
@@ -23,6 +23,11 @@ class CreatePage extends Component
         $this->authorizeAdmin();
     }
 
+    /**
+     * Store a newly created page in storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function save(): void
     {
         $this->authorizeAdmin();

--- a/app/Livewire/Admin/Pages/EditPage.php
+++ b/app/Livewire/Admin/Pages/EditPage.php
@@ -29,6 +29,11 @@ class EditPage extends Component
         $this->form->setPage($page);
     }
 
+    /**
+     * Update the specified page in storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function save(): void
     {
         $this->authorizeAdmin();

--- a/app/Livewire/Admin/Pages/ListPages.php
+++ b/app/Livewire/Admin/Pages/ListPages.php
@@ -11,6 +11,7 @@ use App\Livewire\Traits\WithNotifications;
 use App\Livewire\Traits\WithSortableListing;
 use App\Models\Page;
 use App\Traits\EscapesLikeWildcards;
+use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\Url;
@@ -19,7 +20,7 @@ use Livewire\WithPagination;
 
 class ListPages extends Component
 {
-    use EscapesLikeWildcards, WithAdminAuthorization, WithFilterableListing, WithNotifications, WithPagination, WithSortableListing;
+    use EscapesLikeWildcards, SanitizesLogData, WithAdminAuthorization, WithFilterableListing, WithNotifications, WithPagination, WithSortableListing;
 
     protected const DEFAULT_SORT_COLUMN = 'updated_at';
 
@@ -76,6 +77,11 @@ class ListPages extends Component
         ];
     }
 
+    /**
+     * Remove the specified page from storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function delete(Page $page): void
     {
 
@@ -84,13 +90,18 @@ class ListPages extends Component
         Log::warning('Page deleted by admin', [
             'admin_id' => auth()->id(),
             'page_id' => $page->id,
-            'heading' => $page->heading,
+            'heading' => $this->sanitizeForLog((string) $page->heading),
         ]);
 
         $page->delete();
         $this->success('Page deleted');
     }
 
+    /**
+     * Remove selected pages from storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function deleteSelected(): void
     {
         $this->authorizeAdmin();
@@ -111,8 +122,8 @@ class ListPages extends Component
             'admin_id' => auth()->id(),
             'pages' => $pages->map(fn (Page $page) => [
                 'id' => $page->id,
-                'heading' => $page->heading,
-                'slug' => $page->slug,
+                'heading' => $this->sanitizeForLog((string) $page->heading),
+                'slug' => $this->sanitizeForLog((string) $page->slug),
             ])->all(),
         ]);
 

--- a/app/Livewire/Admin/Preachers/CreatePreacher.php
+++ b/app/Livewire/Admin/Preachers/CreatePreacher.php
@@ -51,6 +51,11 @@ class CreatePreacher extends Component
         $this->slug = Str::slug($this->name);
     }
 
+    /**
+     * Store a newly created preacher in storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function save(): void
     {
 

--- a/app/Livewire/Admin/Preachers/EditPreacher.php
+++ b/app/Livewire/Admin/Preachers/EditPreacher.php
@@ -8,10 +8,10 @@ use App\Contracts\SpeakerIdentificationInterface;
 use App\Livewire\Traits\WithAdminAuthorization;
 use App\Livewire\Traits\WithNotifications;
 use App\Models\Preacher;
-use App\Traits\SanitizesLogData;
 use App\Models\PreacherAlias;
 use App\Models\SpeakerProfile;
 use App\Models\SpeakerSample;
+use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
@@ -66,6 +66,11 @@ class EditPreacher extends Component
         $this->slug = Str::slug($this->name);
     }
 
+    /**
+     * Update the specified preacher in storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function save(): void
     {
 
@@ -113,6 +118,11 @@ class EditPreacher extends Component
         $this->preacher->refresh();
     }
 
+    /**
+     * Remove an alias from the preacher.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function removeAlias(int $aliasId): void
     {
 
@@ -176,6 +186,11 @@ class EditPreacher extends Component
         $this->preacher->refresh();
     }
 
+    /**
+     * Deactivate a speaker profile.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function removeProfile(int $profileId): void
     {
 

--- a/app/Livewire/Admin/Preachers/ListPreachers.php
+++ b/app/Livewire/Admin/Preachers/ListPreachers.php
@@ -10,6 +10,7 @@ use App\Livewire\Traits\WithNotifications;
 use App\Livewire\Traits\WithSortableListing;
 use App\Models\Preacher;
 use App\Traits\EscapesLikeWildcards;
+use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\Url;
@@ -18,7 +19,7 @@ use Livewire\WithPagination;
 
 class ListPreachers extends Component
 {
-    use EscapesLikeWildcards, WithAdminAuthorization, WithFilterableListing, WithNotifications, WithPagination, WithSortableListing;
+    use EscapesLikeWildcards, SanitizesLogData, WithAdminAuthorization, WithFilterableListing, WithNotifications, WithPagination, WithSortableListing;
 
     protected const DEFAULT_SORT_COLUMN = 'name';
 
@@ -64,6 +65,11 @@ class ListPreachers extends Component
         ];
     }
 
+    /**
+     * Remove the specified preacher from storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function delete(Preacher $preacher): void
     {
 
@@ -72,7 +78,7 @@ class ListPreachers extends Component
         Log::warning('Preacher deleted by admin', [
             'admin_id' => auth()->id(),
             'preacher_id' => $preacher->id,
-            'name' => $preacher->name,
+            'name' => $this->sanitizeForLog((string) $preacher->name),
         ]);
 
         $preacher->delete();

--- a/app/Livewire/Admin/Sermons/ListSermons.php
+++ b/app/Livewire/Admin/Sermons/ListSermons.php
@@ -14,6 +14,7 @@ use App\Models\Sermon;
 use App\Presenters\SermonViewPresenter;
 use App\Repositories\SermonRepository;
 use App\Traits\EscapesLikeWildcards;
+use App\Traits\SanitizesLogData;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
@@ -23,7 +24,7 @@ use Livewire\WithPagination;
 
 class ListSermons extends Component
 {
-    use EscapesLikeWildcards, WithAdminAuthorization, WithFilterableListing, WithNotifications, WithPagination, WithSortableListing;
+    use EscapesLikeWildcards, SanitizesLogData, WithAdminAuthorization, WithFilterableListing, WithNotifications, WithPagination, WithSortableListing;
 
     private SermonViewPresenter $sermonViewPresenter;
 
@@ -122,6 +123,11 @@ class ListSermons extends Component
         ];
     }
 
+    /**
+     * Remove the specified sermon from storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function delete(Sermon $sermon): void
     {
 
@@ -130,7 +136,7 @@ class ListSermons extends Component
         Log::warning('Sermon deleted by admin', [
             'admin_id' => auth()->id(),
             'sermon_id' => $sermon->id,
-            'title' => $sermon->title,
+            'title' => $this->sanitizeForLog((string) $sermon->title),
         ]);
 
         $sermon->delete();

--- a/app/Livewire/Admin/Users/CreateUser.php
+++ b/app/Livewire/Admin/Users/CreateUser.php
@@ -58,6 +58,11 @@ class CreateUser extends Component
         );
     }
 
+    /**
+     * Store a newly created user in storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function save(): void
     {
 

--- a/app/Livewire/Admin/Users/EditUser.php
+++ b/app/Livewire/Admin/Users/EditUser.php
@@ -69,6 +69,11 @@ class EditUser extends Component
         $this->isAdmin = $user->is_admin;
     }
 
+    /**
+     * Update the specified user in storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function save(): void
     {
 

--- a/app/Livewire/Admin/Users/ListUsers.php
+++ b/app/Livewire/Admin/Users/ListUsers.php
@@ -10,6 +10,7 @@ use App\Livewire\Traits\WithNotifications;
 use App\Livewire\Traits\WithSortableListing;
 use App\Models\User;
 use App\Traits\EscapesLikeWildcards;
+use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\Url;
@@ -18,7 +19,7 @@ use Livewire\WithPagination;
 
 class ListUsers extends Component
 {
-    use EscapesLikeWildcards, WithAdminAuthorization, WithFilterableListing, WithNotifications, WithPagination, WithSortableListing;
+    use EscapesLikeWildcards, SanitizesLogData, WithAdminAuthorization, WithFilterableListing, WithNotifications, WithPagination, WithSortableListing;
 
     protected const DEFAULT_SORT_COLUMN = 'created_at';
 
@@ -66,6 +67,11 @@ class ListUsers extends Component
         ];
     }
 
+    /**
+     * Remove the specified user from storage.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function delete(User $user): void
     {
 
@@ -82,11 +88,16 @@ class ListUsers extends Component
         Log::warning('User deleted by admin', [
             'admin_id' => auth()->id(),
             'deleted_user_id' => $user->id,
-            'deleted_user_email' => $user->email,
+            'deleted_user_email' => $this->sanitizeForLog((string) $user->email),
         ]);
         $this->success('User deleted');
     }
 
+    /**
+     * Toggle administrative privileges for a user.
+     *
+     * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
+     */
     public function toggleAdmin(User $user): void
     {
 
@@ -105,7 +116,7 @@ class ListUsers extends Component
         Log::warning('User admin status toggled', [
             'admin_id' => auth()->id(),
             'target_user_id' => $user->id,
-            'target_user_email' => $user->email,
+            'target_user_email' => $this->sanitizeForLog((string) $user->email),
             'new_is_admin' => $user->is_admin,
         ]);
 


### PR DESCRIPTION
🛡️ **Sentinel: Harden administrative logs with consistent sanitization**

### 🚨 Severity: MEDIUM

### 💡 Vulnerability: Log Injection (CWE-117)
User-controlled strings (like sermon titles, meeting slugs, and user emails) were being written directly to system logs in several administrative components. An attacker could potentially inject control characters (like newlines) to forge log entries or disrupt log processing systems.

### 🎯 Impact:
Exploitation could lead to log forgery, making it difficult for administrators to audit system events accurately or potentially triggering vulnerabilities in log analysis tools.

### 🔧 Fix:
- Applied the `SanitizesLogData::sanitizeForLog()` method to all identified log calls involving user-controlled data.
- Consistently added the `SanitizesLogData` trait to components that lacked it.
- Added PHPDoc comments to explain the security reasoning behind the sanitization, improving transparency for other developers.
- Audited and updated success/failure branches for consistent sanitization.

### ✅ Verification:
- Ran full test suite (`php artisan test --parallel --compact`): 4,970 tests passed.
- Verified static analysis (`vendor/bin/phpstan`): 0 errors.
- Verified code formatting (`vendor/bin/pint --dirty`).
- Manually audited modified files to ensure all `Log::*` calls are sanitized.

---
*PR created automatically by Jules for task [12348331853627119937](https://jules.google.com/task/12348331853627119937) started by @GarethClarridge*