### PR TITLE
📝 Scribe: Add tests for SermonStorageMaintenanceService

### DIFF
--- a/tests/Unit/Services/SermonStorageMaintenanceServiceTest.php
+++ b/tests/Unit/Services/SermonStorageMaintenanceServiceTest.php
@@ -9,11 +9,14 @@ use App\Services\SermonStorageMaintenanceService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class SermonStorageMaintenanceServiceTest extends TestCase
 {
     use RefreshDatabase;
+
+    private SermonStorageMaintenanceService $service;
 
     protected function setUp(): void
     {
@@ -28,9 +31,12 @@ class SermonStorageMaintenanceServiceTest extends TestCase
 
         Config::set('media-processing.storage.sermon_disk', 'public');
         Config::set('media-processing.storage.legacy_disk', 'public');
+
+        $this->service = app(SermonStorageMaintenanceService::class);
     }
 
-    public function test_migrate_storage_copies_legacy_sermons_through_shared_service(): void
+    #[Test]
+    public function it_migrates_storage_copies_legacy_sermons_through_shared_service(): void
     {
         Sermon::factory()->create([
             'audio_file_path' => 'legacy-sermon',
@@ -38,7 +44,7 @@ class SermonStorageMaintenanceServiceTest extends TestCase
         ]);
         Storage::disk('public_images')->put('media/sermons/legacy-sermon.mp3', 'legacy-content');
 
-        $result = app(SermonStorageMaintenanceService::class)->migrateStorage(
+        $result = $this->service->migrateStorage(
             targetDisk: 'do_spaces',
             patterns: ['legacy'],
             dryRun: false,
@@ -49,14 +55,15 @@ class SermonStorageMaintenanceServiceTest extends TestCase
         Storage::disk('do_spaces')->assertExists('legacy/sermons/legacy-sermon.mp3');
     }
 
-    public function test_migrate_livestream_audio_can_cleanup_after_success(): void
+    #[Test]
+    public function it_migrates_livestream_audio_can_cleanup_after_success(): void
     {
         Sermon::factory()->create([
             'audio_file_path' => 'sermons/2026/03/example.mp3',
         ]);
         Storage::disk('local')->put('sermons/2026/03/example.mp3', 'audio-content');
 
-        $result = app(SermonStorageMaintenanceService::class)->migrateLivestreamAudio(
+        $result = $this->service->migrateLivestreamAudio(
             dryRun: false,
             cleanup: true,
         );
@@ -66,7 +73,8 @@ class SermonStorageMaintenanceServiceTest extends TestCase
         Storage::disk('local')->assertMissing('sermons/2026/03/example.mp3');
     }
 
-    public function test_verify_storage_reports_missing_files_through_shared_service(): void
+    #[Test]
+    public function it_verifies_storage_reports_missing_files_through_shared_service(): void
     {
         Sermon::factory()->create([
             'audio_file_path' => 'sermons/present.mp3',
@@ -76,10 +84,159 @@ class SermonStorageMaintenanceServiceTest extends TestCase
         ]);
         Storage::disk('public')->put('sermons/present.mp3', 'present');
 
-        $result = app(SermonStorageMaintenanceService::class)->verifyStorage('public');
+        $result = $this->service->verifyStorage('public');
 
         $this->assertSame(1, $result['summary']['accessible']);
         $this->assertSame(1, $result['summary']['missing']);
         $this->assertCount(1, $result['missing']);
+    }
+
+    #[Test]
+    public function it_migrates_local_files_to_target_disk(): void
+    {
+        Storage::disk('public')->put('sermons/file1.mp3', 'content1');
+        Storage::disk('public')->put('sermons/file2.mp3', 'content2');
+
+        $result = $this->service->migrateLocalFiles(
+            dryRun: false,
+            sourceDisk: 'public',
+            targetDisk: 'do_spaces'
+        );
+
+        $this->assertSame(2, $result['summary']['migrated']);
+        Storage::disk('do_spaces')->assertExists('sermons/file1.mp3');
+        Storage::disk('do_spaces')->assertExists('sermons/file2.mp3');
+        $this->assertEquals('content1', Storage::disk('do_spaces')->get('sermons/file1.mp3'));
+    }
+
+    #[Test]
+    public function it_respects_dry_run_for_local_files(): void
+    {
+        Storage::disk('public')->put('sermons/dry-run.mp3', 'content');
+
+        $result = $this->service->migrateLocalFiles(
+            dryRun: true,
+            sourceDisk: 'public',
+            targetDisk: 'do_spaces'
+        );
+
+        $this->assertSame(1, $result['summary']['migrated']);
+        $this->assertTrue($result['dry_run']);
+        Storage::disk('do_spaces')->assertMissing('sermons/dry-run.mp3');
+    }
+
+    #[Test]
+    public function it_skips_existing_files_in_local_migration_unless_forced(): void
+    {
+        Storage::disk('public')->put('sermons/skip.mp3', 'new-content');
+        Storage::disk('do_spaces')->put('sermons/skip.mp3', 'old-content');
+
+        // Without force
+        $result = $this->service->migrateLocalFiles(
+            dryRun: false,
+            sourceDisk: 'public',
+            targetDisk: 'do_spaces',
+            force: false
+        );
+
+        $this->assertSame(1, $result['summary']['skipped']);
+        $this->assertEquals('old-content', Storage::disk('do_spaces')->get('sermons/skip.mp3'));
+
+        // With force
+        $result = $this->service->migrateLocalFiles(
+            dryRun: false,
+            sourceDisk: 'public',
+            targetDisk: 'do_spaces',
+            force: true
+        );
+
+        $this->assertSame(1, $result['summary']['migrated']);
+        $this->assertEquals('new-content', Storage::disk('do_spaces')->get('sermons/skip.mp3'));
+    }
+
+    #[Test]
+    public function it_migrates_referenced_sermon_audio_only(): void
+    {
+        // Referenced in DB
+        Sermon::factory()->create(['audio_file_path' => 'sermons/referenced.mp3']);
+        Storage::disk('public')->put('sermons/referenced.mp3', 'referenced-content');
+
+        // Not referenced in DB but exists in storage
+        Storage::disk('public')->put('sermons/unreferenced.mp3', 'unreferenced-content');
+
+        $result = $this->service->migrateReferencedSermonAudio(
+            dryRun: false,
+            sourceDisk: 'public',
+            targetDisk: 'do_spaces'
+        );
+
+        $this->assertSame(1, $result['summary']['migrated']);
+        Storage::disk('do_spaces')->assertExists('sermons/referenced.mp3');
+        Storage::disk('do_spaces')->assertMissing('sermons/unreferenced.mp3');
+    }
+
+    #[Test]
+    public function it_migrates_referenced_sermon_audio_with_filters(): void
+    {
+        Sermon::factory()->create(['audio_file_path' => 'sermons/2023/test.mp3']);
+        Sermon::factory()->create(['audio_file_path' => 'sermons/2024/test.mp3']);
+        Storage::disk('public')->put('sermons/2023/test.mp3', '2023');
+        Storage::disk('public')->put('sermons/2024/test.mp3', '2024');
+
+        $result = $this->service->migrateReferencedSermonAudio(
+            dryRun: false,
+            sourceDisk: 'public',
+            targetDisk: 'do_spaces',
+            pathPrefix: 'sermons/2024'
+        );
+
+        $this->assertSame(1, $result['summary']['migrated']);
+        Storage::disk('do_spaces')->assertExists('sermons/2024/test.mp3');
+        Storage::disk('do_spaces')->assertMissing('sermons/2023/test.mp3');
+    }
+
+    #[Test]
+    public function it_counts_storage_candidates_accurately(): void
+    {
+        // Legacy: filetype is set, audio_file_path does NOT contain a slash
+        Sermon::factory()->create(['filetype' => 'mp3', 'audio_file_path' => 'legacyfile']);
+
+        // Processing: transcript_file_path or video_file_path is set
+        Sermon::factory()->create([
+            'transcript_file_path' => 'transcripts/test.txt',
+            'audio_file_path' => null,
+            'filetype' => 'mp3',
+        ]);
+
+        $this->assertEquals(1, $this->service->countStorageCandidates(['legacy']));
+        // Note: 'storage' pattern requires NULL filetype which is currently prevented by schema.
+        $this->assertEquals(1, $this->service->countStorageCandidates(['processing']));
+    }
+
+    #[Test]
+    public function it_counts_local_files_accurately(): void
+    {
+        Storage::disk('public')->put('sermons/file1.mp3', 'c1');
+        Storage::disk('public')->put('sermons/file2.mp3', 'c2');
+
+        $this->assertEquals(2, $this->service->countLocalFiles(sourceDisk: 'public'));
+        $this->assertEquals(1, $this->service->countLocalFiles(sourceDisk: 'public', startAfter: 'sermons/file1.mp3'));
+    }
+
+    #[Test]
+    public function it_counts_referenced_sermon_audio_candidates_accurately(): void
+    {
+        Sermon::factory()->create(['audio_file_path' => 'sermons/ref1.mp3']);
+        Sermon::factory()->create(['audio_file_path' => 'sermons/ref2.mp3']);
+
+        $this->assertEquals(2, $this->service->countReferencedSermonAudioCandidates());
+    }
+
+    #[Test]
+    public function it_counts_livestream_audio_candidates_accurately(): void
+    {
+        Sermon::factory()->create(['audio_file_path' => 'sermons/2024/01/livestream.mp3']);
+
+        $this->assertEquals(1, $this->service->countLivestreamAudioCandidates());
     }
 }


### PR DESCRIPTION
This PR adds thorough PHPUnit test coverage for the `SermonStorageMaintenanceService`, which was previously under-tested. 

Key additions:
- Verified that `migrateLocalFiles` correctly copies files between disks and respects `dryRun` and `force` options.
- Verified that `migrateReferencedSermonAudio` only migrates files that actually exist as `audio_file_path` in the `sermons` table.
- Added comprehensive coverage for the various `count*` methods used by the maintenance dashboard.

Tests follow project standards:
- Use of `#[Test]` attribute.
- Use of `RefreshDatabase` for clean state.
- Comprehensive faking of all storage disks (`public`, `do_spaces`, `local`, `public_images`).
- Avoidance of external service dependencies.

Note: One logic path in `countStorageCandidates` (the 'storage' pattern) remains effectively unreachable due to a database schema constraint (`filetype` is `NOT NULL`), which is documented in the test suite and repository memory.

---
*PR created automatically by Jules for task [10462112104928787747](https://jules.google.com/task/10462112104928787747) started by @GarethClarridge*