### PR TITLE
🎨 Palette: Standardize pagination scrollTo behavior

### DIFF
--- a/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
+++ b/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
@@ -31,7 +31,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $events->links() }}
+        {{ $events->links(data: ['scrollTo' => '#admin-list-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">

--- a/resources/views/livewire/admin/church-services/list-church-services.blade.php
+++ b/resources/views/livewire/admin/church-services/list-church-services.blade.php
@@ -59,7 +59,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $churchServices->links() }}
+        {{ $churchServices->links(data: ['scrollTo' => '#admin-list-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">

--- a/resources/views/livewire/admin/church-services/list-section-publications.blade.php
+++ b/resources/views/livewire/admin/church-services/list-section-publications.blade.php
@@ -33,7 +33,7 @@
             class="w-56" />
     </div>
 
-    <x-card>
+    <x-card id="admin-list-results" tabindex="-1" class="focus:outline-none">
         <div class="overflow-x-auto">
             <table class="min-w-full divide-y divide-gray-200">
                 <thead class="bg-gray-50">
@@ -161,7 +161,7 @@
         </div>
 
         <div class="mt-4">
-            {{ $sections->links() }}
+            {{ $sections->links(data: ['scrollTo' => '#admin-list-results']) }}
         </div>
     </x-card>
 </div>

--- a/resources/views/livewire/admin/church-services/list-songs.blade.php
+++ b/resources/views/livewire/admin/church-services/list-songs.blade.php
@@ -53,7 +53,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $songs->links() }}
+        {{ $songs->links(data: ['scrollTo' => '#admin-list-results']) }}
     </x-slot:pagination>
 
     @php

--- a/resources/views/livewire/admin/church-services/processing-review-list.blade.php
+++ b/resources/views/livewire/admin/church-services/processing-review-list.blade.php
@@ -6,7 +6,7 @@
         </div>
     </div>
 
-    <x-card>
+    <x-card id="admin-list-results" tabindex="-1" class="focus:outline-none">
         <div class="overflow-x-auto">
             <table class="min-w-full divide-y divide-gray-200">
                 <thead class="bg-gray-50">
@@ -105,7 +105,7 @@
 
         @if($pendingReviews->hasPages())
             <div class="mt-4">
-                {{ $pendingReviews->links() }}
+                {{ $pendingReviews->links(data: ['scrollTo' => '#admin-list-results']) }}
             </div>
         @endif
     </x-card>

--- a/resources/views/livewire/admin/church-services/review-inbound-emails.blade.php
+++ b/resources/views/livewire/admin/church-services/review-inbound-emails.blade.php
@@ -235,6 +235,6 @@
         </table>
 
     <x-slot:pagination>
-        {{ $inboundEmails->links() }}
+        {{ $inboundEmails->links(data: ['scrollTo' => '#admin-list-results']) }}
     </x-slot:pagination>
 </x-admin.list-shell>

--- a/resources/views/livewire/admin/meetings/list-meetings.blade.php
+++ b/resources/views/livewire/admin/meetings/list-meetings.blade.php
@@ -37,7 +37,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $meetings->links() }}
+        {{ $meetings->links(data: ['scrollTo' => '#admin-list-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">

--- a/resources/views/livewire/admin/pages/list-pages.blade.php
+++ b/resources/views/livewire/admin/pages/list-pages.blade.php
@@ -36,7 +36,7 @@
     </x-slot:filters>
 
     <x-slot:pagination>
-        {{ $pages->links() }}
+        {{ $pages->links(data: ['scrollTo' => '#admin-list-results']) }}
     </x-slot:pagination>
 
     <table class="min-w-full divide-y divide-gray-200">

--- a/resources/views/livewire/church/songs/browse-songs.blade.php
+++ b/resources/views/livewire/church/songs/browse-songs.blade.php
@@ -183,7 +183,7 @@
 
                 @if ($songs->hasPages())
                     <div class="mx-auto mt-8 max-w-2xl">
-                        {{ $songs->links() }}
+                        {{ $songs->links(data: ['scrollTo' => '#song-results']) }}
                     </div>
                 @endif
             </section>

--- a/tests/Feature/Frontend/PaginationScrollTest.php
+++ b/tests/Feature/Frontend/PaginationScrollTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Frontend;
+
+use App\Livewire\Church\Songs\BrowseSongs;
+use App\Livewire\Admin\Meetings\ListMeetings;
+use App\Models\User;
+use App\Models\Meeting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PaginationScrollTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function public_songs_listing_renders_results_container_with_correct_id(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Livewire::test(BrowseSongs::class)
+            ->assertSeeHtml('id="song-results"');
+    }
+
+    #[Test]
+    public function admin_meetings_listing_renders_results_container_with_correct_id(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $this->actingAs($admin);
+
+        Livewire::test(ListMeetings::class)
+            ->assertSeeHtml('id="admin-list-results"');
+    }
+}


### PR DESCRIPTION
This PR implements a micro-UX improvement to standardize the `scrollTo` behavior for paginated listings across the site. This ensures that users are automatically returned to the top of the results set after navigating between pages, providing a smoother and more accessible experience.

Key changes:
- Updated `BrowseSongs` to scroll to `#song-results`.
- Updated multiple admin components (Meetings, Pages, Calendar Events, Services, Inbound Emails, etc.) to scroll to `#admin-list-results`.
- Standardized results container IDs and focus management (`tabindex="-1"`) across these components.
- Added a new feature test `PaginationScrollTest` to verify the presence of the correct container IDs in the rendered HTML.
- Verified that all existing tests pass and code quality is maintained.

---
*PR created automatically by Jules for task [10463346493702048489](https://jules.google.com/task/10463346493702048489) started by @GarethClarridge*