### PR TITLE
🔦 Lighthouse: ItemList JSON-LD for Song Catalog

### DIFF
--- a/app/Livewire/Church/Songs/BrowseSongs.php
+++ b/app/Livewire/Church/Songs/BrowseSongs.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Church\Songs;
 
 use App\Models\Song;
+use App\Presenters\SongItemListPresenter;
 use App\Services\PublicSongCatalogService;
 use App\Services\SongLyricSnippetBuilder;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -16,6 +17,8 @@ use Livewire\WithPagination;
 
 /**
  * @property-read string $seoTitle
+ * @property-read array<string, mixed> $jsonLdData
+ * @property-read LengthAwarePaginator<int, Song> $songs
  */
 class BrowseSongs extends Component
 {
@@ -49,15 +52,35 @@ class BrowseSongs extends Component
             : 'All Songs';
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    #[Computed]
+    public function jsonLdData(): array
+    {
+        return app(SongItemListPresenter::class)->toItemList($this->songs->getCollection());
+    }
+
+    /**
+     * @return LengthAwarePaginator<int, Song>
+     */
+    #[Computed]
+    public function songs(): LengthAwarePaginator
+    {
+        $normalizedRange = app(PublicSongCatalogService::class)->normalizeRange($this->range);
+
+        return app(PublicSongCatalogService::class)->query($normalizedRange, $this->search)
+            ->paginate(24)
+            ->withQueryString();
+    }
+
     public function render(PublicSongCatalogService $catalogService, SongLyricSnippetBuilder $snippetBuilder): View
     {
         $normalizedRange = $catalogService->normalizeRange($this->range);
         $tokens = $catalogService->tokenize($this->search);
 
         /** @var LengthAwarePaginator<int, Song> $songs */
-        $songs = $catalogService->query($normalizedRange, $this->search)
-            ->paginate(24)
-            ->withQueryString();
+        $songs = $this->songs;
 
         // Build lyric snippets only when a search is active and only for songs
         // whose match may be in the lyrics (not already explained by title alone).

--- a/app/Presenters/SongItemListPresenter.php
+++ b/app/Presenters/SongItemListPresenter.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presenters;
+
+use App\Models\Song;
+use Illuminate\Support\Collection;
+
+class SongItemListPresenter
+{
+    /**
+     * @param  Collection<int, Song>  $songs
+     * @return array<string, mixed>
+     */
+    public function toItemList(Collection $songs): array
+    {
+        /** @var list<array<string, mixed>> $itemListElements */
+        $itemListElements = $songs->values()->map(function (Song $song, int $index): array {
+            /** @var list<array<string, string>> $authors */
+            $authors = $song->authors->map(fn ($author): array => [
+                '@type' => 'Person',
+                'name' => (string) $author->display_name,
+            ])->values()->all();
+
+            return [
+                '@type' => 'ListItem',
+                'position' => $index + 1,
+                'item' => [
+                    '@type' => 'MusicComposition',
+                    'name' => $song->title,
+                    'url' => route('church.songs.show', $song->slug),
+                    'author' => $authors,
+                ],
+            ];
+        })->values()->all();
+
+        return [
+            '@context' => 'https://schema.org',
+            '@type' => 'ItemList',
+            'numberOfItems' => $songs->count(),
+            'itemListElement' => $itemListElements,
+        ];
+    }
+}

--- a/resources/views/livewire/church/songs/browse-songs.blade.php
+++ b/resources/views/livewire/church/songs/browse-songs.blade.php
@@ -190,4 +190,8 @@
         @endif
 
     </div>{{-- end wire:loading wrapper --}}
+
+    <script type="application/ld+json">
+    {!! json_encode($this->jsonLdData, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}
+    </script>
 </div>

--- a/tests/Feature/SongSeoTest.php
+++ b/tests/Feature/SongSeoTest.php
@@ -16,7 +16,7 @@ class SongSeoTest extends TestCase
     use DatabaseTransactions;
 
     #[Test]
-    public function song_index_has_correct_metadata()
+    public function song_index_has_correct_metadata(): void
     {
         $user = User::factory()->create();
 
@@ -32,7 +32,7 @@ class SongSeoTest extends TestCase
     }
 
     #[Test]
-    public function song_detail_page_has_correct_metadata_and_structured_data()
+    public function song_detail_page_has_correct_metadata_and_structured_data(): void
     {
         $user = User::factory()->create();
         $author = SongAuthor::factory()->create(['display_name' => 'Stuart Townend']);
@@ -55,5 +55,42 @@ class SongSeoTest extends TestCase
         $response->assertSee('"url": "http://localhost/church/songs/in-christ-alone"', false);
         $response->assertSee('"@type": "Person"', false);
         $response->assertSee('"name": "Stuart Townend"', false);
+    }
+
+    #[Test]
+    public function song_index_has_item_list_structured_data(): void
+    {
+        $user = User::factory()->create();
+        $author = SongAuthor::factory()->create(['display_name' => 'Author Name']);
+        $songs = Song::factory()->count(3)->create();
+
+        foreach ($songs as $song) {
+            $song->authors()->attach($author);
+        }
+
+        $response = $this->actingAs($user)->get(route('church.songs.index', ['range' => 'all']));
+
+        $response->assertStatus(200);
+        $response->assertSee('"@type": "ItemList"', false);
+        $response->assertSee('"numberOfItems": 3', false);
+        $response->assertSee('"@type": "MusicComposition"', false);
+        $response->assertSee($songs->first()->title);
+        $response->assertSee('Author Name');
+    }
+
+    #[Test]
+    public function song_search_results_have_correct_item_list_count(): void
+    {
+        $user = User::factory()->create();
+        Song::factory()->create(['title' => 'Amazing Grace']);
+        Song::factory()->create(['title' => 'How Great Thou Art']);
+
+        $response = $this->actingAs($user)->get(route('church.songs.index', ['q' => 'Grace', 'range' => 'all']));
+
+        $response->assertStatus(200);
+        $response->assertSee('"@type": "ItemList"', false);
+        $response->assertSee('"numberOfItems": 1', false);
+        $response->assertSee('Amazing Grace');
+        $response->assertDontSee('How Great Thou Art');
     }
 }


### PR DESCRIPTION
💡 **What:** Implemented `ItemList` JSON-LD structured data for the Song Catalog index and search results. Individual songs are presented as `MusicComposition` items with titles, authors, and URLs.

🎯 **Why:** To improve the discoverability and search engine presentation of the church's worship music catalog. Search engines can now understand the list of songs as a structured collection rather than just plain HTML.

📊 **Impact:** The `/church/songs` listing and search results now provide rich data for crawlers, enabling potential rich results in search pages.

🔍 **Verification:**
- New feature test `tests/Feature/SongSeoTest.php` verifies the presence of `ItemList` and correct item counts for both index and filtered search.
- Static analysis (`phpstan`) is clean for new and modified files.
- Manual verification via `php artisan tinker` confirmed correctly nested JSON-LD structure including authors.
- Full test suite passed.

---
*PR created automatically by Jules for task [9456186907505326779](https://jules.google.com/task/9456186907505326779) started by @GarethClarridge*