### PR TITLE
Tidy: Correct sermon storage pattern identification logic

### DIFF
--- a/app/Services/SermonStorageMaintenanceService.php
+++ b/app/Services/SermonStorageMaintenanceService.php
@@ -45,11 +45,13 @@ class SermonStorageMaintenanceService
         foreach ($patterns as $pattern) {
             $query = match ($pattern) {
                 'legacy' => Sermon::query()
-                    ->whereNotNull('filetype')
+                    ->whereNotNull('audio_file_path')
+                    ->where('audio_file_path', '!=', '')
                     ->whereRaw('audio_file_path NOT LIKE "%/%"'),
                 'storage' => Sermon::query()
-                    ->whereRaw('audio_file_path LIKE "%/%"')
-                    ->whereNull('filetype'),
+                    ->whereNotNull('audio_file_path')
+                    ->where('audio_file_path', '!=', '')
+                    ->whereRaw('audio_file_path LIKE "%/%"'),
                 'processing' => Sermon::query()
                     ->where(function ($query): void {
                         $query->whereNotNull('transcript_file_path')
@@ -377,12 +379,14 @@ class SermonStorageMaintenanceService
         foreach ($patterns as $pattern) {
             $count += match ($pattern) {
                 'legacy' => Sermon::query()
-                    ->whereNotNull('filetype')
+                    ->whereNotNull('audio_file_path')
+                    ->where('audio_file_path', '!=', '')
                     ->whereRaw('audio_file_path NOT LIKE "%/%"')
                     ->count(),
                 'storage' => Sermon::query()
+                    ->whereNotNull('audio_file_path')
+                    ->where('audio_file_path', '!=', '')
                     ->whereRaw('audio_file_path LIKE "%/%"')
-                    ->whereNull('filetype')
                     ->count(),
                 'processing' => Sermon::query()
                     ->where(function ($query): void {

--- a/tests/Unit/Services/SermonStorageMaintenanceServiceTest.php
+++ b/tests/Unit/Services/SermonStorageMaintenanceServiceTest.php
@@ -198,18 +198,20 @@ class SermonStorageMaintenanceServiceTest extends TestCase
     #[Test]
     public function it_counts_storage_candidates_accurately(): void
     {
-        // Legacy: filetype is set, audio_file_path does NOT contain a slash
-        Sermon::factory()->create(['filetype' => 'mp3', 'audio_file_path' => 'legacyfile']);
+        // Legacy: audio_file_path does NOT contain a slash
+        Sermon::factory()->create(['audio_file_path' => 'legacyfile']);
+
+        // Storage: audio_file_path contains a slash
+        Sermon::factory()->create(['audio_file_path' => 'sermons/storage.mp3']);
 
         // Processing: transcript_file_path or video_file_path is set
         Sermon::factory()->create([
             'transcript_file_path' => 'transcripts/test.txt',
             'audio_file_path' => null,
-            'filetype' => 'mp3',
         ]);
 
         $this->assertEquals(1, $this->service->countStorageCandidates(['legacy']));
-        // Note: 'storage' pattern requires NULL filetype which is currently prevented by schema.
+        $this->assertEquals(1, $this->service->countStorageCandidates(['storage']));
         $this->assertEquals(1, $this->service->countStorageCandidates(['processing']));
     }
 


### PR DESCRIPTION
This refactor addresses a logical inconsistency in `SermonStorageMaintenanceService` where the detection of 'storage' vs 'legacy' sermon files was unreliable.

Previously, the 'storage' pattern looked for records where `filetype` was null, but the database schema enforces `NOT NULL DEFAULT 'mp3'` on this column, rendering that condition always false.

The refactor:
1. Updates `migrateStorage` and `countStorageCandidates` to distinguish patterns based on the presence of a slash in `audio_file_path` (legacy = no slash, storage = slash).
2. Removes redundant `whereNotNull('filetype')` checks.
3. Ensures candidates must have a non-empty `audio_file_path`.
4. Updates unit tests to reflect the functional 'storage' pattern identification.

No functional changes were made to the migration process itself, only to the query logic that identifies candidates for migration.

---
*PR created automatically by Jules for task [2401274628173224589](https://jules.google.com/task/2401274628173224589) started by @GarethClarridge*