### PR TITLE
🎨 Palette: Song catalog sharing and search improvements

### DIFF
--- a/resources/views/livewire/church/songs/browse-songs.blade.php
+++ b/resources/views/livewire/church/songs/browse-songs.blade.php
@@ -28,6 +28,7 @@
                 icon="magnifying-glass"
                 clearable
                 autofocus
+                shortcut="slash"
                 class="text-lg py-4"
             />
         </div>
@@ -105,11 +106,16 @@
 
                         <div class="flex flex-col flex-1 p-6 @if (!empty($snippetsBySongId[$song->id])) pb-0 @endif">
                             <div class="flex items-start justify-between gap-4">
-                                <a class="group" href="{{ $songUrl }}" wire:navigate tabindex="-1">
-                                    <h2 class="font-display text-3xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
-                                        {{ $song->title }}
-                                    </h2>
-                                </a>
+                                <div class="flex flex-col gap-2">
+                                    <a class="group" href="{{ $songUrl }}" wire:navigate tabindex="-1">
+                                        <h2 class="font-display text-3xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
+                                            {{ $song->title }}
+                                        </h2>
+                                    </a>
+                                    <div class="relative z-10">
+                                        <x-clipboard-button :url="$songUrl" hideLabel label="Copy link to {{ $song->title }}" title="Copy link to clipboard" />
+                                    </div>
+                                </div>
 
                                 <div class="shrink-0 rounded-2xl bg-cbc-teal-dark px-4 py-3 text-center text-white shadow-sm">
                                     <p class="text-xs uppercase tracking-[0.2em] text-white/75">Uses</p>

--- a/tests/Feature/Livewire/BrowseSongsTest.php
+++ b/tests/Feature/Livewire/BrowseSongsTest.php
@@ -271,4 +271,27 @@ class BrowseSongsTest extends TestCase
             ->assertSee('Unique Title')
             ->assertSee('<mark>Unique</mark> in lyrics', false);
     }
+
+    #[Test]
+    public function search_input_has_slash_shortcut(): void
+    {
+        $this->actingAs($this->user);
+
+        Livewire::test(BrowseSongs::class)
+            ->assertSee('keydown.window.slash', false)
+            ->assertSee('<kbd', false)
+            ->assertSee('/');
+    }
+
+    #[Test]
+    public function each_song_card_has_copy_link_button(): void
+    {
+        $this->actingAs($this->user);
+
+        Song::factory()->create(['title' => 'Copyable Song']);
+
+        Livewire::test(BrowseSongs::class)
+            ->set('range', PublicSongCatalogService::RANGE_ALL)
+            ->assertSee('Copy link to Copyable Song');
+    }
 }


### PR DESCRIPTION
Implemented "Copy link" buttons on song cards and a slash (`/`) keyboard shortcut for search in the public song catalog. These changes improve ease of sharing and navigation while maintaining accessibility standards.

---
*PR created automatically by Jules for task [13893213361524659320](https://jules.google.com/task/13893213361524659320) started by @GarethClarridge*