### PR TITLE
🧹 Tidy: Standardize Eloquent query starters

### DIFF
--- a/app/Services/PreacherResolutionService.php
+++ b/app/Services/PreacherResolutionService.php
@@ -24,7 +24,7 @@ class PreacherResolutionService
             $name = 'Visiting Speaker';
         }
 
-        $alias = PreacherAlias::where('alias', $normalizedAlias)->first();
+        $alias = PreacherAlias::query()->where('alias', $normalizedAlias)->first();
 
         if ($alias?->preacher instanceof Preacher) {
             return $alias->preacher;
@@ -56,13 +56,13 @@ class PreacherResolutionService
     private function findOrCreatePreacher(string $slug, string $name): Preacher
     {
         try {
-            return Preacher::firstOrCreate(
+            return Preacher::query()->firstOrCreate(
                 ['name' => $name],
                 ['slug' => $slug, 'is_active' => true]
             );
         } catch (QueryException $e) {
             if ($this->isUniqueConstraintViolation($e)) {
-                $existing = Preacher::where('name', $name)->first();
+                $existing = Preacher::query()->where('name', $name)->first();
                 if ($existing) {
                     return $existing;
                 }
@@ -75,13 +75,13 @@ class PreacherResolutionService
     private function findOrCreateAlias(string $alias, int $preacherId): PreacherAlias
     {
         try {
-            return PreacherAlias::firstOrCreate(
+            return PreacherAlias::query()->firstOrCreate(
                 ['alias' => $alias],
                 ['preacher_id' => $preacherId]
             );
         } catch (QueryException $e) {
             if ($this->isUniqueConstraintViolation($e)) {
-                $existing = PreacherAlias::where('alias', $alias)->first();
+                $existing = PreacherAlias::query()->where('alias', $alias)->first();
                 if ($existing) {
                     return $existing;
                 }

--- a/app/Services/SermonMetadataIntegrationService.php
+++ b/app/Services/SermonMetadataIntegrationService.php
@@ -32,8 +32,8 @@ class SermonMetadataIntegrationService
     public function linkVideoToSermon(string $processingId, int $sermonId, string $finalVideoPath): void
     {
         /** @var MediaProcessingLog $processing */
-        $processing = MediaProcessingLog::where('processing_id', $processingId)->firstOrFail();
-        $sermon = Sermon::findOrFail($sermonId);
+        $processing = MediaProcessingLog::query()->where('processing_id', $processingId)->firstOrFail();
+        $sermon = Sermon::query()->findOrFail($sermonId);
 
         // Update sermon record with livestream information using data from processing log
         $sermon->update([
@@ -101,7 +101,7 @@ class SermonMetadataIntegrationService
     private function extractSermonVideo(string $processingId): ?string
     {
         // First check if the processing log already has the sermon video path
-        $processing = MediaProcessingLog::where('processing_id', $processingId)->first();
+        $processing = MediaProcessingLog::query()->where('processing_id', $processingId)->first();
 
         if ($processing && $processing->video_file_path) {
             // The path from ExtractSermon job is now a relative path, check temp disk first
@@ -289,7 +289,7 @@ class SermonMetadataIntegrationService
      */
     public function getVideoInfo(int $sermonId): array
     {
-        $sermon = Sermon::with('livestreamProcessing.segments')->find($sermonId);
+        $sermon = Sermon::query()->with('livestreamProcessing.segments')->find($sermonId);
 
         if (! $sermon) {
             return ['has_video' => false];
@@ -323,7 +323,7 @@ class SermonMetadataIntegrationService
      */
     public function getVideoPreviewData(int $sermonId): array
     {
-        $sermon = Sermon::find($sermonId);
+        $sermon = Sermon::query()->find($sermonId);
 
         if (! $sermon || ! $sermon->hasVideo()) {
             return ['has_video' => false];

--- a/app/Services/SermonStorageService.php
+++ b/app/Services/SermonStorageService.php
@@ -448,7 +448,7 @@ class SermonStorageService
     private function initializeStorageStats(): array
     {
         return [
-            'total_sermons' => Sermon::count(),
+            'total_sermons' => Sermon::query()->count(),
             'patterns' => [
                 'private' => 0,
                 'legacy' => 0,

--- a/app/Services/SermonValidationService.php
+++ b/app/Services/SermonValidationService.php
@@ -182,7 +182,7 @@ class SermonValidationService
             }
 
             // Check slug uniqueness (if sermon ID provided, exclude it)
-            $slugQuery = Sermon::where('slug', $data['slug']);
+            $slugQuery = Sermon::query()->where('slug', $data['slug']);
             if (! empty($data['sermon_id'])) {
                 $slugQuery->where('id', '!=', $data['sermon_id']);
             }


### PR DESCRIPTION
Replaced direct static model calls (e.g., `Model::where()`) with the explicit `Model::query()->where()` pattern in four service classes to improve code consistency and maintainability. This follows the project's "Good Code" standard for Eloquent queries. All tests pass and static analysis remains at 0 errors.

---
*PR created automatically by Jules for task [7634203851548222788](https://jules.google.com/task/7634203851548222788) started by @GarethClarridge*