### PR TITLE
🔦 Lighthouse: Add social metadata labels to preacher and series pages

### DIFF
--- a/resources/views/sermons/preacher.blade.php
+++ b/resources/views/sermons/preacher.blade.php
@@ -10,6 +10,8 @@
     :description="$description"
     :image="$share_image"
     :image-alt="'Preacher: ' . $preacher->name"
+    label1="Sermons"
+    :data1="$sermons->count()"
 />
 <x-schema.webpage
     :heading="$heading"

--- a/resources/views/sermons/series.blade.php
+++ b/resources/views/sermons/series.blade.php
@@ -10,6 +10,8 @@
     :description="$description"
     :image="$share_image ?? asset('/images/headings/large/sermons.webp')"
     :image-alt="$heading . ' at Crockenhill Baptist Church'"
+    label1="Sermons"
+    :data1="$sermons->count()"
 />
 <x-schema.webpage
     :heading="$heading"

--- a/tests/Feature/SermonSocialMetadataTest.php
+++ b/tests/Feature/SermonSocialMetadataTest.php
@@ -57,4 +57,34 @@ class SermonSocialMetadataTest extends TestCase
         $response->assertDontSee('twitter:label2');
         $response->assertDontSee('twitter:data2');
     }
+
+    #[Test]
+    public function preacher_page_renders_twitter_labels_for_sermon_count(): void
+    {
+        $preacher = Preacher::factory()->create(['name' => 'Charles Spurgeon']);
+        Sermon::factory()->count(5)->create([
+            'preacher_id' => $preacher->id,
+            'preacher' => $preacher->name,
+        ]);
+
+        $response = $this->get("/christ/sermons/preachers/{$preacher->slug}");
+
+        $response->assertStatus(200);
+        $response->assertSee('<meta name="twitter:label1" content="Sermons">', false);
+        $response->assertSee('<meta name="twitter:data1" content="5">', false);
+    }
+
+    #[Test]
+    public function series_page_renders_twitter_labels_for_sermon_count(): void
+    {
+        Sermon::factory()->count(3)->create([
+            'series' => 'Great Doctrines',
+        ]);
+
+        $response = $this->get('/christ/sermons/series/great-doctrines');
+
+        $response->assertStatus(200);
+        $response->assertSee('<meta name="twitter:label1" content="Sermons">', false);
+        $response->assertSee('<meta name="twitter:data1" content="3">', false);
+    }
 }


### PR DESCRIPTION
💡 **What:** Added social metadata labels to display sermon counts on Preacher profile and Sermon Series pages.
🎯 **Why:** This aligns with our SEO standards and makes shared links on social platforms (Twitter/X, Slack) more informative by showing how many sermons are available for a given preacher or series.
📊 **Impact:** Preacher profile pages and Sermon Series listing pages now have enriched social snippets.
🔍 **Verification:** Verified through updated feature tests and Playwright script inspecting the rendered meta tags.

---
*PR created automatically by Jules for task [11729058415211225415](https://jules.google.com/task/11729058415211225415) started by @GarethClarridge*