### PR TITLE
🧹 Tidy: Standardize Eloquent queries with Model::query()

### DIFF
--- a/app/Actions/ConfirmLivestreamSermonSegment.php
+++ b/app/Actions/ConfirmLivestreamSermonSegment.php
@@ -35,7 +35,8 @@ class ConfirmLivestreamSermonSegment
     {
         $log = DB::transaction(function () use ($processingId, $segmentId, $user): MediaProcessingLog {
             /** @var MediaProcessingLog|null $log */
-            $log = MediaProcessingLog::where('processing_id', $processingId)
+            $log = MediaProcessingLog::query()
+                ->where('processing_id', $processingId)
                 ->lockForUpdate()
                 ->first();
 
@@ -51,7 +52,8 @@ class ConfirmLivestreamSermonSegment
                 throw new \InvalidArgumentException('This run is not currently awaiting manual sermon review.');
             }
 
-            $segment = LivestreamSegment::where('id', $segmentId)
+            $segment = LivestreamSegment::query()
+                ->where('id', $segmentId)
                 ->where('media_processing_log_id', $log->id)
                 ->first();
 

--- a/app/Console/Commands/CreateApiToken.php
+++ b/app/Console/Commands/CreateApiToken.php
@@ -19,7 +19,7 @@ class CreateApiToken extends Command
         $tokenName = $this->argument('name');
         $abilities = $this->option('abilities') ?: ['*'];
 
-        $user = User::where('email', $email)->first();
+        $user = User::query()->where('email', $email)->first();
 
         if (! $user) {
             $this->error("User with email {$email} not found.");

--- a/app/Services/LivestreamSegmentationService.php
+++ b/app/Services/LivestreamSegmentationService.php
@@ -94,7 +94,8 @@ class LivestreamSegmentationService
 
     public function retryProcessing(string $processingId): LivestreamProcessingResult
     {
-        $processingLog = MediaProcessingLog::where('processing_id', $processingId)
+        $processingLog = MediaProcessingLog::query()
+            ->where('processing_id', $processingId)
             ->where('processing_type', MediaType::Livestream)
             ->first();
 
@@ -113,7 +114,8 @@ class LivestreamSegmentationService
 
     public function cancelProcessing(string $processingId): bool
     {
-        $processingLog = MediaProcessingLog::where('processing_id', $processingId)
+        $processingLog = MediaProcessingLog::query()
+            ->where('processing_id', $processingId)
             ->where('processing_type', MediaType::Livestream)
             ->first();
 
@@ -130,7 +132,8 @@ class LivestreamSegmentationService
 
     public function getProcessingStatus(string $processingId): StandardProcessingResponse
     {
-        $processingLog = MediaProcessingLog::where('processing_id', $processingId)
+        $processingLog = MediaProcessingLog::query()
+            ->where('processing_id', $processingId)
             ->with(['segments', 'sermon'])
             ->first();
 
@@ -143,7 +146,8 @@ class LivestreamSegmentationService
 
     public function getProcessingResult(string $processingId): LivestreamProcessingResult
     {
-        $processingLog = MediaProcessingLog::where('processing_id', $processingId)
+        $processingLog = MediaProcessingLog::query()
+            ->where('processing_id', $processingId)
             ->with(['segments', 'sermon'])
             ->first();
 
@@ -159,11 +163,11 @@ class LivestreamSegmentationService
      */
     public function getProcessingSummary(): array
     {
-        $total = MediaProcessingLog::livestream()->count();
-        $pending = MediaProcessingLog::livestream()->where('status', 'pending')->count();
-        $processing = MediaProcessingLog::livestream()->where('status', 'processing')->count();
-        $completed = MediaProcessingLog::livestream()->where('status', 'completed')->count();
-        $failed = MediaProcessingLog::livestream()->where('status', 'failed')->count();
+        $total = MediaProcessingLog::query()->livestream()->count();
+        $pending = MediaProcessingLog::query()->livestream()->where('status', 'pending')->count();
+        $processing = MediaProcessingLog::query()->livestream()->where('status', 'processing')->count();
+        $completed = MediaProcessingLog::query()->livestream()->where('status', 'completed')->count();
+        $failed = MediaProcessingLog::query()->livestream()->where('status', 'failed')->count();
 
         return [
             'total_processing_requests' => $total,


### PR DESCRIPTION
Standardize Eloquent query initiation by using Model::query() instead of magic static calls (e.g., Model::where()) in LivestreamSegmentationService, ConfirmLivestreamSermonSegment, and CreateApiToken. This improves IDE support and aligns with project coding standards.

No functional changes.

---
*PR created automatically by Jules for task [10340240700691510823](https://jules.google.com/task/10340240700691510823) started by @GarethClarridge*