### PR TITLE
🏛️ Warden: Fortify meetings table integrity

### DIFF
--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -144,6 +144,90 @@ class Meeting extends Model implements HasMedia, Sitemapable
     }
 
     /**
+     * @return Attribute<string, string>
+     */
+    protected function slug(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value): string => trim($value),
+        );
+    }
+
+    /**
+     * @return Attribute<string, string>
+     */
+    protected function day(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value): string => trim($value),
+        );
+    }
+
+    /**
+     * @return Attribute<string, string>
+     */
+    protected function who(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value): string => trim($value),
+        );
+    }
+
+    /**
+     * @return Attribute<?string, ?string>
+     */
+    protected function location(): Attribute
+    {
+        return Attribute::make(
+            set: function (?string $value): ?string {
+                if ($value === null) {
+                    return null;
+                }
+
+                $trimmed = trim($value);
+
+                return $trimmed === '' ? null : $trimmed;
+            },
+        );
+    }
+
+    /**
+     * @return Attribute<?string, ?string>
+     */
+    protected function leadersPhone(): Attribute
+    {
+        return Attribute::make(
+            set: function (?string $value): ?string {
+                if ($value === null) {
+                    return null;
+                }
+
+                $trimmed = trim($value);
+
+                return $trimmed === '' ? null : $trimmed;
+            },
+        );
+    }
+
+    /**
+     * @return Attribute<?string, ?string>
+     */
+    protected function leadersEmail(): Attribute
+    {
+        return Attribute::make(
+            set: function (?string $value): ?string {
+                if ($value === null) {
+                    return null;
+                }
+
+                $trimmed = trim($value);
+
+                return $trimmed === '' ? null : $trimmed;
+            },
+        );
+    }
+
+    /**
      * Get the route key for the model.
      */
     public function getRouteKeyName(): string

--- a/database/migrations/2026_05_14_175611_fortify_meetings_identity_columns.php
+++ b/database/migrations/2026_05_14_175611_fortify_meetings_identity_columns.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const SLUG_FORMAT_CHECK = 'meetings_slug_integrity_check';
+    private const DAY_FORMAT_CHECK = 'meetings_day_format_check';
+    private const WHO_FORMAT_CHECK = 'meetings_who_format_check';
+    private const LOCATION_FORMAT_CHECK = 'meetings_location_format_check';
+    private const LEADERS_PHONE_FORMAT_CHECK = 'meetings_leaders_phone_format_check';
+    private const LEADERS_EMAIL_FORMAT_CHECK = 'meetings_leaders_email_format_check';
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // 1. Data Cleanup: Normalize existing data before adding constraints
+        DB::table('meetings')->update([
+            'slug' => DB::raw('TRIM(slug)'),
+            'day' => DB::raw('TRIM(day)'),
+            'who' => DB::raw('TRIM(who)'),
+            'location' => DB::raw('TRIM(location)'),
+            'leaders_phone' => DB::raw('TRIM(leaders_phone)'),
+            'leaders_email' => DB::raw('TRIM(leaders_email)'),
+        ]);
+
+        // Nullify empty strings for nullable columns
+        DB::table('meetings')->where('location', '')->update(['location' => null]);
+        DB::table('meetings')->where('leaders_phone', '')->update(['leaders_phone' => null]);
+        DB::table('meetings')->where('leaders_email', '')->update(['leaders_email' => null]);
+
+        // Resolve any duplicate slugs before adding unique index
+        $this->resolveDuplicateSlugs();
+
+        Schema::table('meetings', function (Blueprint $table) {
+            // 2. Add unique index on slug if it doesn't exist
+            if (!Schema::hasIndex('meetings', 'meetings_slug_unique')) {
+                $table->unique('slug', 'meetings_slug_unique');
+            }
+        });
+
+        if (DB::getDriverName() === 'mysql') {
+            // 3. Add CHECK constraints
+            // required fields: trimmed and not empty
+            DB::statement(sprintf(
+                "ALTER TABLE meetings ADD CONSTRAINT %s CHECK (BINARY slug = TRIM(slug) AND slug != '')",
+                self::SLUG_FORMAT_CHECK
+            ));
+            DB::statement(sprintf(
+                "ALTER TABLE meetings ADD CONSTRAINT %s CHECK (BINARY day = TRIM(day) AND day != '')",
+                self::DAY_FORMAT_CHECK
+            ));
+            DB::statement(sprintf(
+                "ALTER TABLE meetings ADD CONSTRAINT %s CHECK (BINARY who = TRIM(who) AND who != '')",
+                self::WHO_FORMAT_CHECK
+            ));
+
+            // nullable fields: trimmed if not null
+            DB::statement(sprintf(
+                "ALTER TABLE meetings ADD CONSTRAINT %s CHECK (location IS NULL OR BINARY location = TRIM(location))",
+                self::LOCATION_FORMAT_CHECK
+            ));
+            DB::statement(sprintf(
+                "ALTER TABLE meetings ADD CONSTRAINT %s CHECK (leaders_phone IS NULL OR BINARY leaders_phone = TRIM(leaders_phone))",
+                self::LEADERS_PHONE_FORMAT_CHECK
+            ));
+            DB::statement(sprintf(
+                "ALTER TABLE meetings ADD CONSTRAINT %s CHECK (leaders_email IS NULL OR BINARY leaders_email = TRIM(leaders_email))",
+                self::LEADERS_EMAIL_FORMAT_CHECK
+            ));
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement(sprintf('ALTER TABLE meetings DROP CHECK %s', self::SLUG_FORMAT_CHECK));
+            DB::statement(sprintf('ALTER TABLE meetings DROP CHECK %s', self::DAY_FORMAT_CHECK));
+            DB::statement(sprintf('ALTER TABLE meetings DROP CHECK %s', self::WHO_FORMAT_CHECK));
+            DB::statement(sprintf('ALTER TABLE meetings DROP CHECK %s', self::LOCATION_FORMAT_CHECK));
+            DB::statement(sprintf('ALTER TABLE meetings DROP CHECK %s', self::LEADERS_PHONE_FORMAT_CHECK));
+            DB::statement(sprintf('ALTER TABLE meetings DROP CHECK %s', self::LEADERS_EMAIL_FORMAT_CHECK));
+        }
+
+        Schema::table('meetings', function (Blueprint $table) {
+            if (Schema::hasIndex('meetings', 'meetings_slug_unique')) {
+                $table->dropUnique('meetings_slug_unique');
+            }
+        });
+    }
+
+    private function resolveDuplicateSlugs(): void
+    {
+        $duplicates = DB::table('meetings')
+            ->select('slug')
+            ->groupBy('slug')
+            ->havingRaw('COUNT(*) > 1')
+            ->get();
+
+        foreach ($duplicates as $duplicate) {
+            $records = DB::table('meetings')
+                ->where('slug', $duplicate->slug)
+                ->orderBy('id')
+                ->get();
+
+            foreach ($records->skip(1) as $index => $record) {
+                $newSlug = $duplicate->slug . '-' . ($index + 2);
+
+                $counter = 2;
+                while (DB::table('meetings')->where('slug', $newSlug)->exists()) {
+                    $counter++;
+                    $newSlug = $duplicate->slug . '-' . $counter;
+                }
+
+                DB::table('meetings')
+                    ->where('id', $record->id)
+                    ->update(['slug' => $newSlug]);
+            }
+        }
+    }
+};

--- a/tests/Feature/Warden/MeetingIntegrityTest.php
+++ b/tests/Feature/Warden/MeetingIntegrityTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Warden;
+
+use App\Models\Meeting;
+use App\Enums\MeetingType;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MeetingIntegrityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_trims_identity_columns_via_model_attributes(): void
+    {
+        $meeting = Meeting::factory()->create([
+            'slug' => '  test-meeting  ',
+            'day' => '  Monday  ',
+            'who' => '  Everyone  ',
+            'location' => '  Church Hall  ',
+            'leaders_phone' => '  0123456789  ',
+            'leaders_email' => '  test@example.com  ',
+        ]);
+
+        $this->assertEquals('test-meeting', $meeting->slug);
+        $this->assertEquals('Monday', $meeting->day);
+        $this->assertEquals('Everyone', $meeting->who);
+        $this->assertEquals('Church Hall', $meeting->location);
+        $this->assertEquals('0123456789', $meeting->leaders_phone);
+        $this->assertEquals('test@example.com', $meeting->leaders_email);
+
+        $dbMeeting = DB::table('meetings')->where('id', $meeting->id)->first();
+        $this->assertEquals('test-meeting', $dbMeeting->slug);
+        $this->assertEquals('Monday', $dbMeeting->day);
+        $this->assertEquals('Everyone', $dbMeeting->who);
+        $this->assertEquals('Church Hall', $dbMeeting->location);
+        $this->assertEquals('0123456789', $dbMeeting->leaders_phone);
+        $this->assertEquals('test@example.com', $dbMeeting->leaders_email);
+    }
+
+    #[Test]
+    public function it_converts_empty_strings_to_null_for_nullable_columns(): void
+    {
+        $meeting = Meeting::factory()->create([
+            'location' => '   ',
+            'leaders_phone' => '',
+            'leaders_email' => null,
+        ]);
+
+        $this->assertNull($meeting->location);
+        $this->assertNull($meeting->leaders_phone);
+        $this->assertNull($meeting->leaders_email);
+
+        $dbMeeting = DB::table('meetings')->where('id', $meeting->id)->first();
+        $this->assertNull($dbMeeting->location);
+        $this->assertNull($dbMeeting->leaders_phone);
+        $this->assertNull($dbMeeting->leaders_email);
+    }
+
+    #[Test]
+    public function it_rejects_untrimmed_day_at_database_level(): void
+    {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectExceptionMessage('meetings_day_format_check');
+
+        DB::table('meetings')->insert([
+            'slug' => 'test-untrimmed-day',
+            'type' => MeetingType::Adults->value,
+            'day' => ' Monday ',
+            'who' => 'Everyone',
+            'pictures' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_rejects_empty_who_at_database_level(): void
+    {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectExceptionMessage('meetings_who_format_check');
+
+        DB::table('meetings')->insert([
+            'slug' => 'test-empty-who',
+            'type' => MeetingType::Adults->value,
+            'day' => 'Monday',
+            'who' => '',
+            'pictures' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_rejects_untrimmed_location_at_database_level(): void
+    {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectExceptionMessage('meetings_location_format_check');
+
+        DB::table('meetings')->insert([
+            'slug' => 'test-location',
+            'type' => MeetingType::Adults->value,
+            'day' => 'Monday',
+            'who' => 'Everyone',
+            'location' => ' untrimmed ',
+            'pictures' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_enforces_unique_slug_at_database_level(): void
+    {
+        Meeting::factory()->create(['slug' => 'unique-slug']);
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        // MySQL error for unique constraint violation usually mentions 'Duplicate entry'
+        $this->expectExceptionMessage('Duplicate entry');
+
+        DB::table('meetings')->insert([
+            'slug' => 'unique-slug',
+            'type' => MeetingType::Adults->value,
+            'day' => 'Tuesday',
+            'who' => 'Everyone',
+            'pictures' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
This PR fortifies the data integrity of the `meetings` table by implementing the project's "three-layer pattern" for user-visible identity columns.

### Changes:
1.  **Model Layer**: Added Eloquent Attribute setters to `App\Models\Meeting` to ensure `slug`, `day`, `who`, `location`, `leaders_phone`, and `leaders_email` are automatically trimmed before being saved to the database. Nullable fields are converted to `NULL` if they are empty strings.
2.  **Database Layer**: Created a migration that:
    *   Normalizes existing data (trimming and nullifying).
    *   Resolves any duplicate slugs by appending numeric increments.
    *   Adds a unique index on the `slug` column.
    *   Adds `BINARY CHECK` constraints for `slug`, `day`, and `who` to enforce they are trimmed and not empty.
    *   Adds `CHECK` constraints for `location`, `leaders_phone`, and `leaders_email` to enforce they are trimmed (or NULL).
3.  **Verification**: Added `Tests\Feature\Warden\MeetingIntegrityTest` which verifies both model-level normalization and database-level rejection of invalid data.

This ensures that critical identity data for meetings remains clean and consistent, preventing URL issues or display bugs caused by untrimmed or empty strings.

---
*PR created automatically by Jules for task [1242836348915453542](https://jules.google.com/task/1242836348915453542) started by @GarethClarridge*