### PR TITLE
🧹 Tidy: Standardize DTOs to use readonly class

### DIFF
--- a/app/Data/ChildrensTalkSpeakerMetadata.php
+++ b/app/Data/ChildrensTalkSpeakerMetadata.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class ChildrensTalkSpeakerMetadata extends JsonData
+final readonly class ChildrensTalkSpeakerMetadata extends JsonData
 {
     /**
      * @param  array<string, mixed>|null  $predicted
@@ -12,9 +12,9 @@ final class ChildrensTalkSpeakerMetadata extends JsonData
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
-        public readonly ?array $predicted = null,
-        public readonly ?array $reviewed = null,
-        public readonly array $raw = [],
+        public ?array $predicted = null,
+        public ?array $reviewed = null,
+        public array $raw = [],
     ) {}
 
     public static function fromArray(mixed $value): ?self

--- a/app/Data/ChurchServiceCanonicalConflictMetadata.php
+++ b/app/Data/ChurchServiceCanonicalConflictMetadata.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class ChurchServiceCanonicalConflictMetadata extends JsonData
+final readonly class ChurchServiceCanonicalConflictMetadata extends JsonData
 {
     /**
      * @param  list<array<string, mixed>>  $changes
@@ -12,14 +12,14 @@ final class ChurchServiceCanonicalConflictMetadata extends JsonData
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
-        public readonly ?string $detectedAt = null,
-        public readonly ?string $incomingSource = null,
-        public readonly ?bool $reviewReopened = null,
-        public readonly ?bool $reviewedPreviously = null,
-        public readonly ?bool $canonicalChanged = null,
-        public readonly array $changes = [],
-        public readonly array $conflicts = [],
-        public readonly array $raw = [],
+        public ?string $detectedAt = null,
+        public ?string $incomingSource = null,
+        public ?bool $reviewReopened = null,
+        public ?bool $reviewedPreviously = null,
+        public ?bool $canonicalChanged = null,
+        public array $changes = [],
+        public array $conflicts = [],
+        public array $raw = [],
     ) {}
 
     public static function fromArray(mixed $value): ?self

--- a/app/Data/ChurchServiceImportMetadata.php
+++ b/app/Data/ChurchServiceImportMetadata.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class ChurchServiceImportMetadata extends JsonData
+final readonly class ChurchServiceImportMetadata extends JsonData
 {
     /**
      * @param  list<string>  $warnings
@@ -13,15 +13,15 @@ final class ChurchServiceImportMetadata extends JsonData
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
-        public readonly ?float $confidenceScore = null,
-        public readonly ?string $parseMethod = null,
-        public readonly array $warnings = [],
-        public readonly array $reviewTriggers = [],
-        public readonly array $canonicalConflictHistory = [],
-        public readonly ?ChurchServiceManualReviewMetadata $manualReview = null,
-        public readonly ?ChurchServiceCanonicalConflictMetadata $canonicalConflict = null,
-        public readonly ?PendingStructureMergeMetadata $pendingStructureMerge = null,
-        public readonly array $raw = [],
+        public ?float $confidenceScore = null,
+        public ?string $parseMethod = null,
+        public array $warnings = [],
+        public array $reviewTriggers = [],
+        public array $canonicalConflictHistory = [],
+        public ?ChurchServiceManualReviewMetadata $manualReview = null,
+        public ?ChurchServiceCanonicalConflictMetadata $canonicalConflict = null,
+        public ?PendingStructureMergeMetadata $pendingStructureMerge = null,
+        public array $raw = [],
     ) {}
 
     public static function fromArray(mixed $value): self

--- a/app/Data/ChurchServiceManualReviewMetadata.php
+++ b/app/Data/ChurchServiceManualReviewMetadata.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class ChurchServiceManualReviewMetadata extends JsonData
+final readonly class ChurchServiceManualReviewMetadata extends JsonData
 {
     /**
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
-        public readonly ?string $reviewedAt = null,
-        public readonly ?int $reviewedByUserId = null,
-        public readonly ?string $reopenedAt = null,
-        public readonly ?string $reopenedBySource = null,
-        public readonly array $raw = [],
+        public ?string $reviewedAt = null,
+        public ?int $reviewedByUserId = null,
+        public ?string $reopenedAt = null,
+        public ?string $reopenedBySource = null,
+        public array $raw = [],
     ) {}
 
     public static function fromArray(mixed $value): ?self

--- a/app/Data/JsonData.php
+++ b/app/Data/JsonData.php
@@ -13,7 +13,7 @@ use LogicException;
  * @implements ArrayAccess<int|string, mixed>
  * @implements Arrayable<int|string, mixed>
  */
-abstract class JsonData implements Arrayable, ArrayAccess, JsonSerializable
+abstract readonly class JsonData implements Arrayable, ArrayAccess, JsonSerializable
 {
     /**
      * @return array<int|string, mixed>

--- a/app/Data/PendingStructureMergeMetadata.php
+++ b/app/Data/PendingStructureMergeMetadata.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class PendingStructureMergeMetadata extends JsonData
+final readonly class PendingStructureMergeMetadata extends JsonData
 {
     /**
      * @param  array{current: string, incoming: string}  $confidence
@@ -14,13 +14,13 @@ final class PendingStructureMergeMetadata extends JsonData
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
-        public readonly ?string $incomingSource = null,
-        public readonly ?string $createdAt = null,
-        public readonly array $confidence = ['current' => 'unknown', 'incoming' => 'unknown'],
-        public readonly array $conflicts = [],
-        public readonly array $proposedItems = [],
-        public readonly array $classification = ['auto_merge' => [], 'review_required' => [], 'unmatched_incoming' => []],
-        public readonly array $raw = [],
+        public ?string $incomingSource = null,
+        public ?string $createdAt = null,
+        public array $confidence = ['current' => 'unknown', 'incoming' => 'unknown'],
+        public array $conflicts = [],
+        public array $proposedItems = [],
+        public array $classification = ['auto_merge' => [], 'review_required' => [], 'unmatched_incoming' => []],
+        public array $raw = [],
     ) {}
 
     public static function fromArray(mixed $value): ?self

--- a/app/Data/ProcessingId3Metadata.php
+++ b/app/Data/ProcessingId3Metadata.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class ProcessingId3Metadata extends JsonData
+final readonly class ProcessingId3Metadata extends JsonData
 {
     /**
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
-        public readonly ?string $title = null,
-        public readonly ?string $preacher = null,
-        public readonly ?string $series = null,
-        public readonly ?string $reference = null,
-        public readonly array $raw = [],
+        public ?string $title = null,
+        public ?string $preacher = null,
+        public ?string $series = null,
+        public ?string $reference = null,
+        public array $raw = [],
     ) {}
 
     public static function fromArray(mixed $value): ?self

--- a/app/Data/ProcessingLogCollection.php
+++ b/app/Data/ProcessingLogCollection.php
@@ -6,17 +6,17 @@ namespace App\Data;
 
 use Illuminate\Support\Collection;
 
-class ProcessingLogCollection
+readonly class ProcessingLogCollection
 {
     /**
      * @param  Collection<int, ProcessingLogEntry>  $entries
      * @param  array<string, mixed>|null  $summary
      */
     public function __construct(
-        public readonly Collection $entries,
-        public readonly int $totalCount,
-        public readonly ?string $nextCursor = null,
-        public readonly ?array $summary = null
+        public Collection $entries,
+        public int $totalCount,
+        public ?string $nextCursor = null,
+        public ?array $summary = null
     ) {}
 
     /**

--- a/app/Data/ProcessingManualReviewMetadata.php
+++ b/app/Data/ProcessingManualReviewMetadata.php
@@ -4,22 +4,22 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class ProcessingManualReviewMetadata extends JsonData
+final readonly class ProcessingManualReviewMetadata extends JsonData
 {
     /**
      * @param  list<array{segment_id:int,start_time:float,end_time:float,duration:float}>  $speechSegments
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
-        public readonly ?string $status = null,
-        public readonly ?string $reasonCode = null,
-        public readonly ?string $reasonMessage = null,
-        public readonly ?string $flaggedAt = null,
-        public readonly array $speechSegments = [],
-        public readonly ?int $confirmedSegmentId = null,
-        public readonly ?int $confirmedByUserId = null,
-        public readonly ?string $confirmedAt = null,
-        public readonly array $raw = [],
+        public ?string $status = null,
+        public ?string $reasonCode = null,
+        public ?string $reasonMessage = null,
+        public ?string $flaggedAt = null,
+        public array $speechSegments = [],
+        public ?int $confirmedSegmentId = null,
+        public ?int $confirmedByUserId = null,
+        public ?string $confirmedAt = null,
+        public array $raw = [],
     ) {}
 
     public static function fromArray(mixed $value): ?self

--- a/app/Data/ProcessingMetadata.php
+++ b/app/Data/ProcessingMetadata.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class ProcessingMetadata extends JsonData
+final readonly class ProcessingMetadata extends JsonData
 {
     /**
      * @param  array<string, mixed>|null  $speakerIdentification
@@ -12,13 +12,13 @@ final class ProcessingMetadata extends JsonData
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
-        public readonly ?ProcessingId3Metadata $id3Metadata = null,
-        public readonly ?ProcessingManualReviewMetadata $manualReview = null,
-        public readonly ?array $speakerIdentification = null,
-        public readonly ?array $videoQuality = null,
-        public readonly ?string $videoProcessingMode = null,
-        public readonly ?bool $trimRequested = null,
-        public readonly array $raw = [],
+        public ?ProcessingId3Metadata $id3Metadata = null,
+        public ?ProcessingManualReviewMetadata $manualReview = null,
+        public ?array $speakerIdentification = null,
+        public ?array $videoQuality = null,
+        public ?string $videoProcessingMode = null,
+        public ?bool $trimRequested = null,
+        public array $raw = [],
     ) {}
 
     public static function fromArray(mixed $value): self

--- a/app/Data/SectionOosAlignment.php
+++ b/app/Data/SectionOosAlignment.php
@@ -4,29 +4,29 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class SectionOosAlignment extends JsonData
+final readonly class SectionOosAlignment extends JsonData
 {
     /**
      * @param  array<string, mixed>|null  $presentationInference
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
-        public readonly ?float $songMatchScore = null,
-        public readonly ?string $songMatchStrategy = null,
-        public readonly ?string $songTitleMatched = null,
-        public readonly ?string $reclassifiedFrom = null,
-        public readonly ?string $reclassifiedBy = null,
-        public readonly ?string $matchedItemType = null,
-        public readonly ?string $matchedItemTitle = null,
-        public readonly ?string $mismatchReason = null,
-        public readonly ?string $expectedItemTitle = null,
-        public readonly ?string $expectedSectionType = null,
-        public readonly ?float $baseConfidence = null,
-        public readonly ?bool $baseNeedsManualReview = null,
-        public readonly ?string $baseTitle = null,
-        public readonly ?int $baseChurchServiceItemId = null,
-        public readonly ?array $presentationInference = null,
-        public readonly array $raw = [],
+        public ?float $songMatchScore = null,
+        public ?string $songMatchStrategy = null,
+        public ?string $songTitleMatched = null,
+        public ?string $reclassifiedFrom = null,
+        public ?string $reclassifiedBy = null,
+        public ?string $matchedItemType = null,
+        public ?string $matchedItemTitle = null,
+        public ?string $mismatchReason = null,
+        public ?string $expectedItemTitle = null,
+        public ?string $expectedSectionType = null,
+        public ?float $baseConfidence = null,
+        public ?bool $baseNeedsManualReview = null,
+        public ?string $baseTitle = null,
+        public ?int $baseChurchServiceItemId = null,
+        public ?array $presentationInference = null,
+        public array $raw = [],
     ) {}
 
     public static function fromArray(mixed $value): ?self

--- a/app/Data/SectionPublicationMetadata.php
+++ b/app/Data/SectionPublicationMetadata.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class SectionPublicationMetadata extends JsonData
+final readonly class SectionPublicationMetadata extends JsonData
 {
     /**
      * @param  list<array<string, mixed>>  $batchApprovals
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
-        public readonly ?string $approvedSignature = null,
-        public readonly ?string $approvedAt = null,
-        public readonly array $batchApprovals = [],
-        public readonly array $raw = [],
+        public ?string $approvedSignature = null,
+        public ?string $approvedAt = null,
+        public array $batchApprovals = [],
+        public array $raw = [],
     ) {}
 
     public static function fromArray(mixed $value): ?self

--- a/app/Data/SermonVideoQualityAssessmentResult.php
+++ b/app/Data/SermonVideoQualityAssessmentResult.php
@@ -6,22 +6,22 @@ namespace App\Data;
 
 use App\Enums\SermonVideoQualityStatus;
 
-final class SermonVideoQualityAssessmentResult
+final readonly class SermonVideoQualityAssessmentResult
 {
     /**
      * @param  list<float>  $sampleTimestamps
      * @param  array<string, mixed>  $metrics
      */
     public function __construct(
-        public readonly SermonVideoQualityStatus $status,
-        public readonly ?string $reason,
-        public readonly int $sampleCount,
-        public readonly array $sampleTimestamps,
-        public readonly float $blankFrameRatio,
-        public readonly float $frozenPairRatio,
-        public readonly float $lowDetailRatio,
-        public readonly float $aggregateScore,
-        public readonly array $metrics = [],
+        public SermonVideoQualityStatus $status,
+        public ?string $reason,
+        public int $sampleCount,
+        public array $sampleTimestamps,
+        public float $blankFrameRatio,
+        public float $frozenPairRatio,
+        public float $lowDetailRatio,
+        public float $aggregateScore,
+        public array $metrics = [],
     ) {}
 
     public static function failed(string $reason = 'analysis_failed'): self

--- a/app/Data/ServiceSectionMetadata.php
+++ b/app/Data/ServiceSectionMetadata.php
@@ -4,26 +4,26 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class ServiceSectionMetadata extends JsonData
+final readonly class ServiceSectionMetadata extends JsonData
 {
     /**
      * @param  list<string>  $reviewFlags
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
-        public readonly ?string $confidenceLevel = null,
-        public readonly ?string $classificationMode = null,
-        public readonly ?string $confidenceSource = null,
-        public readonly ?float $confidenceScore = null,
-        public readonly ?string $reviewReason = null,
-        public readonly array $reviewFlags = [],
-        public readonly ?string $transcript = null,
-        public readonly ?int $songId = null,
-        public readonly ?string $readingReference = null,
-        public readonly ?SectionOosAlignment $oosAlignment = null,
-        public readonly ?ChildrensTalkSpeakerMetadata $childrensTalkSpeaker = null,
-        public readonly ?SectionPublicationMetadata $publication = null,
-        public readonly array $raw = [],
+        public ?string $confidenceLevel = null,
+        public ?string $classificationMode = null,
+        public ?string $confidenceSource = null,
+        public ?float $confidenceScore = null,
+        public ?string $reviewReason = null,
+        public array $reviewFlags = [],
+        public ?string $transcript = null,
+        public ?int $songId = null,
+        public ?string $readingReference = null,
+        public ?SectionOosAlignment $oosAlignment = null,
+        public ?ChildrensTalkSpeakerMetadata $childrensTalkSpeaker = null,
+        public ?SectionPublicationMetadata $publication = null,
+        public array $raw = [],
     ) {}
 
     public static function fromArray(mixed $value): self

--- a/app/Data/SongCluster.php
+++ b/app/Data/SongCluster.php
@@ -4,22 +4,22 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class SongCluster extends JsonData
+final readonly class SongCluster extends JsonData
 {
     /**
      * @param  list<float>  $samples
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
-        public readonly float $startEstimate,
-        public readonly float $endEstimate,
-        public readonly array $samples,
-        public readonly ?int $sampleCount = null,
-        public readonly ?float $confidence = null,
-        public readonly ?float $refinedVisualStart = null,
-        public readonly ?float $refinedVisualEnd = null,
-        public readonly ?int $denseSampleCount = null,
-        public readonly array $raw = [],
+        public float $startEstimate,
+        public float $endEstimate,
+        public array $samples,
+        public ?int $sampleCount = null,
+        public ?float $confidence = null,
+        public ?float $refinedVisualStart = null,
+        public ?float $refinedVisualEnd = null,
+        public ?int $denseSampleCount = null,
+        public array $raw = [],
     ) {}
 
     public static function fromArray(mixed $value): ?self

--- a/app/Data/SongClusterCollection.php
+++ b/app/Data/SongClusterCollection.php
@@ -12,13 +12,13 @@ use Traversable;
 /**
  * @implements IteratorAggregate<int, SongCluster>
  */
-final class SongClusterCollection extends JsonData implements Countable, IteratorAggregate
+final readonly class SongClusterCollection extends JsonData implements Countable, IteratorAggregate
 {
     /**
      * @param  list<SongCluster>  $items
      */
     public function __construct(
-        public readonly array $items,
+        public array $items,
     ) {}
 
     public static function fromArray(mixed $value): ?self

--- a/app/Data/StandardProcessingResponse.php
+++ b/app/Data/StandardProcessingResponse.php
@@ -15,7 +15,7 @@ use Carbon\Carbon;
  * Standardized processing response data structure
  * Used across all processing controllers for consistent API responses
  */
-class StandardProcessingResponse
+readonly class StandardProcessingResponse
 {
     /**
      * @param  array<string, mixed>  $additionalData
@@ -23,21 +23,21 @@ class StandardProcessingResponse
      * @param  array<string, mixed>|null  $errorHistory
      */
     public function __construct(
-        public readonly bool $found,
-        public readonly ?string $processingId = null,
-        public readonly ?string $status = null,
-        public readonly ?string $currentStep = null,
-        public readonly int $progressPercentage = 0,
-        public readonly ?string $errorMessage = null,
-        public readonly ?int $sermonId = null,
-        public readonly ?string $sermonUrl = null,
-        public readonly ?Carbon $startedAt = null,
-        public readonly ?Carbon $updatedAt = null,
-        public readonly ?string $estimatedCompletion = null,
-        public readonly array $additionalData = [],
-        public readonly ?ProcessingLogCollection $recentLogs = null,
-        public readonly ?array $performanceMetrics = null,
-        public readonly ?array $errorHistory = null
+        public bool $found,
+        public ?string $processingId = null,
+        public ?string $status = null,
+        public ?string $currentStep = null,
+        public int $progressPercentage = 0,
+        public ?string $errorMessage = null,
+        public ?int $sermonId = null,
+        public ?string $sermonUrl = null,
+        public ?Carbon $startedAt = null,
+        public ?Carbon $updatedAt = null,
+        public ?string $estimatedCompletion = null,
+        public array $additionalData = [],
+        public ?ProcessingLogCollection $recentLogs = null,
+        public ?array $performanceMetrics = null,
+        public ?array $errorHistory = null
     ) {}
 
     /**

--- a/app/Data/ThumbnailMetadata.php
+++ b/app/Data/ThumbnailMetadata.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class ThumbnailMetadata extends JsonData
+final readonly class ThumbnailMetadata extends JsonData
 {
     /**
      * @param  array<string, mixed>  $videoResolution
@@ -25,21 +25,21 @@ final class ThumbnailMetadata extends JsonData
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
-        public readonly ?float $timestamp,
-        public readonly ?float $videoDuration,
-        public readonly array $videoResolution = [],
-        public readonly array $thumbnailSizes = [],
-        public readonly ?string $generatedAt = null,
-        public readonly ?string $plainThumbnailPath = null,
-        public readonly ?string $cardThumbnailPath = null,
-        public readonly ?string $overlayThumbnailPath = null,
-        public readonly ?string $selectedThumbnailCandidateId = null,
-        public readonly array $thumbnailCandidates = [],
-        public readonly ?string $compositionMode = null,
-        public readonly ?string $foregroundExtractionMethod = null,
-        public readonly array $foregroundBounds = [],
-        public readonly ?float $foregroundCoverage = null,
-        public readonly array $raw = [],
+        public ?float $timestamp,
+        public ?float $videoDuration,
+        public array $videoResolution = [],
+        public array $thumbnailSizes = [],
+        public ?string $generatedAt = null,
+        public ?string $plainThumbnailPath = null,
+        public ?string $cardThumbnailPath = null,
+        public ?string $overlayThumbnailPath = null,
+        public ?string $selectedThumbnailCandidateId = null,
+        public array $thumbnailCandidates = [],
+        public ?string $compositionMode = null,
+        public ?string $foregroundExtractionMethod = null,
+        public array $foregroundBounds = [],
+        public ?float $foregroundCoverage = null,
+        public array $raw = [],
     ) {}
 
     public static function fromArray(mixed $value): ?self

--- a/app/Data/ThumbnailResult.php
+++ b/app/Data/ThumbnailResult.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-final class ThumbnailResult
+final readonly class ThumbnailResult
 {
     /**
      * @param  array<string, mixed>  $metadata
      */
     public function __construct(
-        public readonly bool $success,
-        public readonly ?string $thumbnailPath = null,
-        public readonly ?string $errorMessage = null,
-        public readonly array $metadata = []
+        public bool $success,
+        public ?string $thumbnailPath = null,
+        public ?string $errorMessage = null,
+        public array $metadata = []
     ) {}
 
     /**


### PR DESCRIPTION
### 💡 What:
Converted multiple DTO classes in the `app/Data/` directory to use the `readonly class` modifier and removed redundant `readonly` modifiers from individual properties in these classes. Updated the `JsonData` base class to be `readonly` to support its subclasses.

### 🎯 Why:
To align with modern PHP 8.2+ practices and existing project conventions for immutable Data Transfer Objects. This reduces visual noise and clearly expresses the immutable nature of these classes.

### 🔄 Behavior:
No functional changes. Property immutability was already enforced via per-property `readonly` modifiers.

### ✅ Tests:
- `vendor/bin/sail composer phpstan` passes with 0 relevant errors.
- Unit tests for affected DTO classes passed (`tests/Unit/Data/*`).
- Full test suite passed (where environment permitted).

Note: DTOs extending `Spatie\LaravelData\Data` were intentionally left as non-readonly classes because PHP 8.2+ requires the parent class to also be readonly, which is not currently the case for the vendor package.

---
*PR created automatically by Jules for task [14191253663707034658](https://jules.google.com/task/14191253663707034658) started by @GarethClarridge*