### PR TITLE
🧹 Tidy: Standardize Eloquent query starts

### DIFF
--- a/app/Actions/SaveSermonDetails.php
+++ b/app/Actions/SaveSermonDetails.php
@@ -36,7 +36,7 @@ class SaveSermonDetails
     public function execute(Sermon $sermon, array $validated): void
     {
         if ($validated['preacherId']) {
-            $preacher = Preacher::find($validated['preacherId']);
+            $preacher = Preacher::query()->find($validated['preacherId']);
         } else {
             $preacher = $this->preacherResolutionService->resolve($validated['preacher']);
         }

--- a/app/Jobs/ProcessingJob.php
+++ b/app/Jobs/ProcessingJob.php
@@ -140,7 +140,7 @@ abstract class ProcessingJob
         }
 
         // Check if any processing steps have been cancelled
-        $cancelledSteps = SermonProcessingStep::where('processing_id', $this->processingId)
+        $cancelledSteps = SermonProcessingStep::query()->where('processing_id', $this->processingId)
             ->where('status', ProcessingStatus::Cancelled->value)
             ->count();
 
@@ -208,7 +208,7 @@ abstract class ProcessingJob
      */
     protected function getProcessingIdFromSermon(int $sermonId): ?string
     {
-        $sermon = Sermon::find($sermonId);
+        $sermon = Sermon::query()->find($sermonId);
         if (! $sermon) {
             return null;
         }

--- a/app/Jobs/UpdateSermonRecord.php
+++ b/app/Jobs/UpdateSermonRecord.php
@@ -53,7 +53,7 @@ class UpdateSermonRecord implements ShouldQueue
             ]);
 
             // Get the sermon record
-            $sermon = Sermon::find($this->sermonId);
+            $sermon = Sermon::query()->find($this->sermonId);
             if (! $sermon) {
                 throw new \Exception("Sermon not found with ID: {$this->sermonId}");
             }
@@ -206,7 +206,7 @@ class UpdateSermonRecord implements ShouldQueue
 
         // Try to update with basic information to avoid leaving sermon in processing state
         try {
-            $sermon = Sermon::find($this->sermonId);
+            $sermon = Sermon::query()->find($this->sermonId);
             if ($sermon) {
                 // Create minimal update to get sermon out of processing state
                 $basicTitle = $this->generateBasicTitle($sermon);
@@ -244,7 +244,7 @@ class UpdateSermonRecord implements ShouldQueue
         }
 
         // Mark processing as failed if basic update also failed
-        $sermon = Sermon::find($this->sermonId);
+        $sermon = Sermon::query()->find($this->sermonId);
         if ($sermon) {
             /** @var MediaProcessingLog|null $processingLog */
             $processingLog = $sermon->processingLogs()->latest()->first();

--- a/app/Livewire/Admin/CalendarEvents/ListCalendarEvents.php
+++ b/app/Livewire/Admin/CalendarEvents/ListCalendarEvents.php
@@ -50,7 +50,7 @@ class ListCalendarEvents extends Component
 
         $this->authorizeAdmin();
 
-        $event = CalendarEvent::find($eventId);
+        $event = CalendarEvent::query()->find($eventId);
 
         if ($event) {
             app(CategorizeCalendarEvent::class)->execute($event, $meetingSlug);

--- a/app/Livewire/Admin/Pages/ListPages.php
+++ b/app/Livewire/Admin/Pages/ListPages.php
@@ -105,7 +105,7 @@ class ListPages extends Component
             return;
         }
 
-        $pages = Page::whereIn('id', $this->selected)->get();
+        $pages = Page::query()->whereIn('id', $this->selected)->get();
 
         if ($pages->isEmpty()) {
             $this->selected = [];

--- a/app/Livewire/Admin/Preachers/EditPreacher.php
+++ b/app/Livewire/Admin/Preachers/EditPreacher.php
@@ -106,7 +106,7 @@ class EditPreacher extends Component
             'newAlias.unique' => 'This alias already exists.',
         ]);
 
-        PreacherAlias::create([
+        PreacherAlias::query()->create([
             'alias' => $this->newAlias,
             'preacher_id' => $this->preacher->id,
         ]);
@@ -125,7 +125,7 @@ class EditPreacher extends Component
 
         $this->authorizeAdmin();
 
-        $alias = PreacherAlias::where('id', $aliasId)
+        $alias = PreacherAlias::query()->where('id', $aliasId)
             ->where('preacher_id', $this->preacher->id)
             ->first();
 
@@ -150,7 +150,7 @@ class EditPreacher extends Component
         $this->authorizeAdmin();
 
         /** @var SpeakerProfile $profile */
-        $profile = SpeakerProfile::where('id', $profileId)
+        $profile = SpeakerProfile::query()->where('id', $profileId)
             ->where('preacher_id', $this->preacher->id)
             ->firstOrFail();
 
@@ -193,7 +193,7 @@ class EditPreacher extends Component
 
         $this->authorizeAdmin();
 
-        $profile = SpeakerProfile::where('id', $profileId)
+        $profile = SpeakerProfile::query()->where('id', $profileId)
             ->where('preacher_id', $this->preacher->id)
             ->first();
 

--- a/app/Livewire/Auth/Login.php
+++ b/app/Livewire/Auth/Login.php
@@ -85,7 +85,7 @@ class Login extends Component
 
         RateLimiter::hit($this->throttleKey($credentials['email']));
 
-        $user = User::where('email', (string) $credentials['email'])->first();
+        $user = User::query()->where('email', (string) $credentials['email'])->first();
 
         if ($user instanceof User && $user->is_admin) {
             Log::warning('Admin login attempt failed', [

--- a/app/Services/GoogleCalendarSyncService.php
+++ b/app/Services/GoogleCalendarSyncService.php
@@ -31,7 +31,7 @@ class GoogleCalendarSyncService
             throw $e;
         }
 
-        $existingEventIds = CalendarEvent::whereBetween('start_datetime', [$startDate, $endDate])
+        $existingEventIds = CalendarEvent::query()->whereBetween('start_datetime', [$startDate, $endDate])
             ->pluck('google_event_id')
             ->toArray();
 
@@ -57,9 +57,9 @@ class GoogleCalendarSyncService
         }
 
         $deletedEventIds = array_diff($existingEventIds, $seenUpstreamIds);
-        CalendarEvent::whereIn('google_event_id', $deletedEventIds)->delete();
+        CalendarEvent::query()->whereIn('google_event_id', $deletedEventIds)->delete();
 
-        $uncategorizedCount = CalendarEvent::whereBetween('start_datetime', [$startDate, $endDate])
+        $uncategorizedCount = CalendarEvent::query()->whereBetween('start_datetime', [$startDate, $endDate])
             ->whereNull('meeting_slug')
             ->count();
 
@@ -118,7 +118,7 @@ class GoogleCalendarSyncService
             $hasManualSlug = isset($extendedProperties['private']['meeting_slug']);
         }
 
-        $calendarEvent = CalendarEvent::updateOrCreate(
+        $calendarEvent = CalendarEvent::query()->updateOrCreate(
             /** @phpstan-ignore-next-line */
             ['google_event_id' => $googleEvent->id],
             [
@@ -219,7 +219,7 @@ class GoogleCalendarSyncService
      */
     public function createEventForMeeting(string $meetingSlug, array $eventData): Event
     {
-        $meeting = Meeting::where('slug', $meetingSlug)->firstOrFail();
+        $meeting = Meeting::query()->where('slug', $meetingSlug)->firstOrFail();
 
         $event = new Event;
         /** @phpstan-ignore-next-line */


### PR DESCRIPTION
Standardized Eloquent query starts across several files to follow the project's preference for `Model::query()`. This improves consistency and assists static analysis. Modified files include `EditPreacher`, `Login`, `UpdateSermonRecord`, `GoogleCalendarSyncService`, `SaveSermonDetails`, `ListPages`, `ListCalendarEvents`, and `ProcessingJob`. Within each file, all relevant model calls were updated to maintain internal consistency. All tests passed and code was formatted with Pint.

---
*PR created automatically by Jules for task [12476583369339733547](https://jules.google.com/task/12476583369339733547) started by @GarethClarridge*