### PR TITLE
🎨 Palette: Add copy button to sermon slug in admin

### DIFF
--- a/resources/views/livewire/admin/sermons/edit-sermon.blade.php
+++ b/resources/views/livewire/admin/sermons/edit-sermon.blade.php
@@ -29,8 +29,13 @@
             <x-input label="Title" wire:model.live.debounce="form.title" required maxlength="255" autofocus />
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <x-input label="Slug" wire:model="form.slug" required maxlength="255"
-                    hint="URL-friendly identifier (auto-generated from title)" />
+                <div class="flex items-start gap-2">
+                    <div class="flex-1">
+                        <x-input label="Slug" wire:model="form.slug" required maxlength="255"
+                            hint="URL-friendly identifier (auto-generated from title)" />
+                    </div>
+                    <x-clipboard-button js-content="$wire.form.slug" hideLabel label="Copy Slug" title="Copy slug to clipboard" class="mt-7" />
+                </div>
 
                 <x-input type="number" label="Download Count" wire:model="form.downloadCount"
                     hint="Incremented automatically when the audio is downloaded" />


### PR DESCRIPTION
Added a "Copy Slug" button next to the Slug field in the sermon edit form to improve admin workflow. The button uses Livewire state to ensure the copied value is always current.

---
*PR created automatically by Jules for task [18073746291904421457](https://jules.google.com/task/18073746291904421457) started by @GarethClarridge*