### PR TITLE
🛡️ Sentinel: sanitize logs and standardize JSON-LD

### DIFF
--- a/app/Services/SermonAnalysisService.php
+++ b/app/Services/SermonAnalysisService.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use App\Contracts\SermonAnalysisInterface;
 use App\Data\SermonAnalysis;
 use App\Repositories\SermonRepository;
+use App\Traits\SanitizesLogData;
 use Exception;
 use Illuminate\Support\Facades\Log;
 use OpenAI\Exceptions\ErrorException;
@@ -16,6 +17,8 @@ use OpenAI\Responses\Chat\CreateResponse;
 
 class SermonAnalysisService implements SermonAnalysisInterface
 {
+    use SanitizesLogData;
+
     public function __construct(
         private readonly SermonProcessingLogger $logger,
         private readonly SermonRepository $sermonRepository,
@@ -159,7 +162,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
 
         if ($this->validator->isTitleTooLong($validatedData['title'])) {
             Log::info('AI-generated title exceeds character limit, retrying', [
-                'title' => $validatedData['title'],
+                'title' => self::sanitizeForLog($validatedData['title']),
                 'length' => strlen($validatedData['title']),
                 'max' => SermonAnalysisValidator::MAX_TITLE_CHARACTERS,
                 'attempt' => $attempt,
@@ -202,7 +205,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
                 'processing_id' => $processingId,
                 'attempt' => $attempt,
                 'error_code' => $e->getCode(),
-                'error_message' => $e->getMessage(),
+                'error_message' => self::sanitizeForLog($e->getMessage()),
                 'api_time_ms' => round($apiTime * 1000, 2),
                 'exception_class' => get_class($e),
                 'status_code' => $e->getStatusCode(),
@@ -316,8 +319,8 @@ class SermonAnalysisService implements SermonAnalysisInterface
             Log::error('OpenAI API response parsing failed (malformed response)', [
                 'processing_id' => $processingId,
                 'attempt' => $attempt,
-                'error' => $e->getMessage(),
-                'model' => $model,
+                'error' => self::sanitizeForLog($e->getMessage()),
+                'model' => self::sanitizeForLog($model),
                 'exception_file' => $e->getFile(),
                 'exception_line' => $e->getLine(),
             ]);
@@ -338,10 +341,10 @@ class SermonAnalysisService implements SermonAnalysisInterface
             Log::error('OpenAI API call failed', [
                 'processing_id' => $processingId,
                 'attempt' => $attempt,
-                'error' => $e->getMessage(),
-                'model' => $model,
+                'error' => self::sanitizeForLog($e->getMessage()),
+                'model' => self::sanitizeForLog($model),
             ]);
-            throw new Exception('OpenAI API call failed: '.$e->getMessage());
+            throw new Exception('OpenAI API call failed.');
         }
     }
 
@@ -356,7 +359,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
 
         Log::info('Retrieved existing series from database', [
             'count' => count($series),
-            'series' => $series,
+            'series' => array_map(fn (string $s) => self::sanitizeForLog($s), $series),
         ]);
 
         return $series;
@@ -382,7 +385,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
             return $analysis->title;
         } catch (Exception $e) {
             Log::warning('Failed to generate title via full analysis, using fallback', [
-                'error' => $e->getMessage(),
+                'error' => self::sanitizeForLog($e->getMessage()),
             ]);
 
             return $this->promptBuilder->generateFallbackTitle($transcript);
@@ -410,7 +413,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
             return $analysis->series;
         } catch (Exception $e) {
             Log::warning('Failed to identify series via full analysis', [
-                'error' => $e->getMessage(),
+                'error' => self::sanitizeForLog($e->getMessage()),
             ]);
 
             return null;
@@ -437,7 +440,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
             return $analysis->reference;
         } catch (Exception $e) {
             Log::warning('Failed to extract Bible passage via full analysis', [
-                'error' => $e->getMessage(),
+                'error' => self::sanitizeForLog($e->getMessage()),
             ]);
 
             return null;
@@ -464,7 +467,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
             return $analysis->points;
         } catch (Exception $e) {
             Log::warning('Failed to extract sermon points via full analysis, using fallback', [
-                'error' => $e->getMessage(),
+                'error' => self::sanitizeForLog($e->getMessage()),
             ]);
 
             return ['Main Message'];

--- a/app/Services/SermonCreationService.php
+++ b/app/Services/SermonCreationService.php
@@ -15,11 +15,14 @@ use App\Models\MediaProcessingLog;
 use App\Models\Preacher;
 use App\Models\Sermon;
 use App\Repositories\SermonRepository;
+use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class SermonCreationService
 {
+    use SanitizesLogData;
+
     public function __construct(
         private readonly PreacherResolutionService $preacherResolutionService,
         private readonly SermonRepository $sermonRepository,
@@ -512,7 +515,7 @@ class SermonCreationService
             Log::info('SermonCreationService: Using date extracted from file metadata', [
                 'processing_id' => $processingLog->processing_id,
                 'extracted_date' => $extractedDate,
-                'extraction_method' => $processingMetadata['date_extraction_method'] ?? 'unknown',
+                'extraction_method' => self::sanitizeForLog((string) ($processingMetadata['date_extraction_method'] ?? 'unknown')),
             ]);
 
             return $extractedDate;
@@ -522,7 +525,7 @@ class SermonCreationService
 
         Log::info('SermonCreationService: Using date extracted from filename', [
             'processing_id' => $processingLog->processing_id,
-            'filename' => $filename,
+            'filename' => self::sanitizeForLog($filename),
             'extracted_date' => $filenameDate,
         ]);
 
@@ -545,7 +548,7 @@ class SermonCreationService
             Log::info('SermonCreationService: Using service extracted from file metadata', [
                 'processing_id' => $processingLog->processing_id,
                 'extracted_service' => $processingLog->extracted_service->value,
-                'extraction_method' => $processingMetadata['service_extraction_method'] ?? 'unknown',
+                'extraction_method' => self::sanitizeForLog((string) ($processingMetadata['service_extraction_method'] ?? 'unknown')),
             ]);
 
             return $processingLog->extracted_service;
@@ -558,7 +561,7 @@ class SermonCreationService
         if (str_contains($filename, 'evening') || preg_match('/[-_\s]pm\b/i', $filename)) {
             Log::info('SermonCreationService: Detected evening service from filename', [
                 'processing_id' => $processingLog->processing_id,
-                'filename' => $filename,
+                'filename' => self::sanitizeForLog($filename),
             ]);
 
             return SermonService::Evening;
@@ -568,7 +571,7 @@ class SermonCreationService
         if (str_contains($filename, 'morning') || preg_match('/[-_\s]am\b/i', $filename)) {
             Log::info('SermonCreationService: Detected morning service from filename', [
                 'processing_id' => $processingLog->processing_id,
-                'filename' => $filename,
+                'filename' => self::sanitizeForLog($filename),
             ]);
 
             return SermonService::Morning;
@@ -580,7 +583,7 @@ class SermonCreationService
             $service = $hour < 12 ? SermonService::Morning : SermonService::Evening;
             Log::info('SermonCreationService: Detected service from time in filename', [
                 'processing_id' => $processingLog->processing_id,
-                'filename' => $filename,
+                'filename' => self::sanitizeForLog($filename),
                 'extracted_hour' => $hour,
                 'service' => $service->value,
             ]);
@@ -591,7 +594,7 @@ class SermonCreationService
         // Strategy 4: Default to morning if no service pattern found
         Log::info('SermonCreationService: Defaulting to morning service', [
             'processing_id' => $processingLog->processing_id,
-            'filename' => $filename,
+            'filename' => self::sanitizeForLog($filename),
         ]);
 
         return SermonService::Morning;

--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -67,7 +67,7 @@
 
                         return $eventData;
                     })->values()->all(),
-                ], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}
+                ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}
             </script>
         @endif
     @endpush

--- a/resources/views/meetings/events.blade.php
+++ b/resources/views/meetings/events.blade.php
@@ -64,7 +64,7 @@
 
                         return $eventData;
                     })->all(),
-                ], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}
+                ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}
             </script>
         @endif
     @endpush


### PR DESCRIPTION
This PR implements security enhancements and standardization across the sermon processing pipeline and public views.

### 🛡️ Security Enhancements
- **Log Sanitization**: Incorporated `SanitizesLogData` into `SermonCreationService` and `SermonAnalysisService`. Audited all `Log::*` calls to sanitize user-controlled variables (e.g., filenames, extraction methods, AI-generated titles).
- **Observability Balance**: Crucially, machine-generated correlation IDs like `processing_id` and `sermon_id` are *not* sanitized, preserving their value for system monitoring and auditing.
- **API Error Redaction**: Updated exception handling in `SermonAnalysisService`. Raw error messages from OpenAI (which could leak transcript fragments or technical details) are now logged (sanitized) but replaced with a generic "API call failed." message for the end-user.

### ✨ Standardization
- **JSON-LD Formatting**: Added the `JSON_PRETTY_PRINT` flag to `json_encode` calls in `calendar/index.blade.php` and `meetings/events.blade.php`. This satisfies the project's SEO testing standards and ensures consistency with other public-facing script blocks.

### ✅ Verification
- Ran `vendor/bin/sail bin pint --dirty` for formatting.
- Ran `vendor/bin/sail composer phpstan` (0 errors).
- Ran relevant tests in `tests/Feature/Api/MediaControllerTest.php`, `tests/Integration/Models/MeetingTest.php`, and `tests/Feature/Livewire/AdminMeetingTest.php` (all passed).
- Executed the full test suite in batches (Feature, Integration, Unit) with no regressions.

---
*PR created automatically by Jules for task [13380150406155875425](https://jules.google.com/task/13380150406155875425) started by @GarethClarridge*