### PR TITLE
🎨 Palette: Add loading state to admin sortable headers

### DIFF
--- a/resources/views/components/admin/sortable-header.blade.php
+++ b/resources/views/components/admin/sortable-header.blade.php
@@ -10,19 +10,30 @@
     @if($sortable) aria-sort="{{ $sortBy === $column ? ($sortDirection === 'asc' ? 'ascending' : 'descending') : 'none' }}" @endif>
     @if($sortable)
         <button wire:click="sort('{{ $column }}')"
-                class="group inline-flex items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded px-1 -mx-1 transition-all"
+                wire:loading.attr="disabled"
+                wire:target="sort('{{ $column }}')"
+                class="group inline-flex items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded px-1 -mx-1 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
                 @if($sortBy === $column) aria-label="{{ $label }}: sorted {{ $sortDirection === 'asc' ? 'ascending' : 'descending' }}" @else aria-label="{{ $label }}: click to sort" @endif>
             <span>{{ $label }}</span>
             <span class="flex-none rounded bg-gray-100 text-gray-900 group-hover:bg-gray-200 transition-colors">
-                @if($sortBy === $column)
-                    @if($sortDirection === 'asc')
-                        <x-heroicon-m-chevron-up class="h-3 w-3" aria-hidden="true" />
+                <span wire:loading.remove wire:target="sort('{{ $column }}')">
+                    @if($sortBy === $column)
+                        @if($sortDirection === 'asc')
+                            <x-heroicon-m-chevron-up class="h-3 w-3" aria-hidden="true" />
+                        @else
+                            <x-heroicon-m-chevron-down class="h-3 w-3" aria-hidden="true" />
+                        @endif
                     @else
-                        <x-heroicon-m-chevron-down class="h-3 w-3" aria-hidden="true" />
+                        <x-heroicon-m-chevron-up-down class="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" aria-hidden="true" />
                     @endif
-                @else
-                    <x-heroicon-m-chevron-up-down class="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" aria-hidden="true" />
-                @endif
+                </span>
+                <span wire:loading wire:target="sort('{{ $column }}')" role="status" aria-live="polite">
+                    <svg class="animate-spin h-3 w-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    <span class="sr-only">Loading...</span>
+                </span>
             </span>
         </button>
     @else


### PR DESCRIPTION
💡 **What:** Added a loading state to the \`x-admin.sortable-header\` Blade component.
🎯 **Why:** Provides visual feedback when sorting large tables in the admin area, preventing duplicate clicks and making the interface feel more responsive.
♿ **Accessibility:** Added \`role="status"\`, \`aria-live="polite"\`, and screen-reader-only \"Loading...\" text to ensure the state change is announced to assistive technology.
📱 **Responsive:** No mobile layout changes, but improved touch feedback by disabling the button during loading.

---
*PR created automatically by Jules for task [4523696181028688410](https://jules.google.com/task/4523696181028688410) started by @GarethClarridge*