### PR TITLE
🏛️ Warden: Add foreign key for church_services manual_reviewed_by_user_id

### DIFF
--- a/app/Models/ChurchService.php
+++ b/app/Models/ChurchService.php
@@ -15,8 +15,10 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
+use Illuminate\Validation\Rule;
 
 /**
  * @property int $id
@@ -42,6 +44,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property-read Collection<int, ChurchServiceItem> $items
  * @property-read Collection<int, MediaProcessingLog> $mediaProcessingLogs
+ * @property-read User|null $manualReviewedBy
  *
  * @method static \Database\Factories\ChurchServiceFactory factory(...$parameters)
  * @method static Builder<ChurchService> newModelQuery()
@@ -115,5 +118,26 @@ class ChurchService extends Model
     public function mediaProcessingLogs(): HasMany
     {
         return $this->hasMany(MediaProcessingLog::class);
+    }
+
+    /**
+     * @return array<string, list<string|mixed>>
+     */
+    public static function validationRules(): array
+    {
+        return [
+            'date' => ['required', 'date'],
+            'service' => ['required', Rule::enum(SermonService::class)],
+            'source' => ['required', 'string', 'max:255'],
+            'manual_reviewed_by_user_id' => ['nullable', 'integer', 'exists:users,id'],
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function manualReviewedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'manual_reviewed_by_user_id');
     }
 }

--- a/database/migrations/2026_05_17_053346_add_foreign_key_to_church_services_manual_reviewed_by_user_id.php
+++ b/database/migrations/2026_05_17_053346_add_foreign_key_to_church_services_manual_reviewed_by_user_id.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('church_services', function (Blueprint $table) {
+            $table->foreign('manual_reviewed_by_user_id')
+                ->references('id')
+                ->on('users')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('church_services', function (Blueprint $table) {
+            $table->dropForeign(['manual_reviewed_by_user_id']);
+        });
+    }
+};

--- a/tests/Unit/Database/ChurchServiceIntegrityTest.php
+++ b/tests/Unit/Database/ChurchServiceIntegrityTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Database;
+
+use App\Enums\ChurchServiceReviewState;
+use App\Models\ChurchService;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ChurchServiceIntegrityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_sets_manual_reviewed_by_user_id_to_null_when_user_is_deleted(): void
+    {
+        // 1. Create a user
+        $user = User::factory()->create();
+
+        // 2. Create a church service reviewed by that user
+        $service = ChurchService::factory()->create([
+            'manual_reviewed_by_user_id' => $user->id,
+            'review_state' => ChurchServiceReviewState::REVIEWED,
+            'manual_reviewed_at' => now(),
+        ]);
+
+        $this->assertEquals($user->id, $service->manual_reviewed_by_user_id);
+
+        // 3. Delete the user
+        $user->delete();
+
+        // 4. Refresh the service and assert the user ID is null
+        $service->refresh();
+
+        $this->assertNull($service->manual_reviewed_by_user_id);
+    }
+}


### PR DESCRIPTION
This PR adds a missing foreign key constraint to the `church_services.manual_reviewed_by_user_id` column, ensuring data integrity when a user who has reviewed a service is deleted.

Key changes:
- Created a migration to add the foreign key constraint with `ON DELETE SET NULL`.
- Updated the `ChurchService` model with the `manualReviewedBy` relationship.
- Added `validationRules` to the `ChurchService` model to enforce the existence of the reviewer.
- Added a unit test `Tests\Unit\Database\ChurchServiceIntegrityTest` to verify the constraint's behavior.

Following "Warden" safety standards, the migration does not attempt to modify existing data, ensuring that any existing integrity issues are surfaced rather than silently fixed.

---
*PR created automatically by Jules for task [3662275310172679736](https://jules.google.com/task/3662275310172679736) started by @GarethClarridge*