### PR TITLE
🔦 Lighthouse: Enhance sermon page metadata and structured data

### DIFF
--- a/app/Presenters/SermonItemListPresenter.php
+++ b/app/Presenters/SermonItemListPresenter.php
@@ -97,6 +97,7 @@ class SermonItemListPresenter
                     'datePublished' => $datePublished,
                     'dateModified' => $sermon->updated_at?->toIso8601String() ?? $datePublished,
                     'inLanguage' => 'en-GB',
+                    'genre' => 'Sermon',
                     'contentLocation' => $contentLocation,
                     'author' => $author,
                     'publisher' => $publisher,

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -819,7 +819,17 @@ class SermonViewPresenter
         }
 
         $preacherName = $this->displayPreacherName($sermon) ?? 'Unknown preacher';
-        $base = "Listen to '{$sermon->title}' by {$preacherName} preached on {$this->humanDate($sermon)}";
+
+        $hasVideo = $this->exposurePolicy->shouldExposeVideo($sermon);
+        $hasAudio = filled($sermon->audio_file_path);
+
+        $verb = match (true) {
+            $hasVideo && $hasAudio => 'Watch or listen to',
+            $hasVideo => 'Watch',
+            default => 'Listen to',
+        };
+
+        $base = "{$verb} '{$sermon->title}' by {$preacherName} preached on {$this->humanDate($sermon)}";
 
         if ($reference = $this->displayReference($sermon)) {
             $base .= " - {$reference}";

--- a/resources/views/components/schema/sermon.blade.php
+++ b/resources/views/components/schema/sermon.blade.php
@@ -36,6 +36,11 @@
         'description' => $metaDescription,
         'image' => $thumbnailUrl,
         'datePublished' => $datePublished,
+        'dateModified' => ($sermon->updated_at instanceof \Carbon\CarbonInterface && $sermon->updated_at->year > 0)
+            ? $sermon->updated_at->toIso8601String()
+            : $datePublished,
+        'inLanguage' => 'en-GB',
+        'genre' => 'Sermon',
         'author' => $author,
         'publisher' => [
             '@type' => 'Organization',


### PR DESCRIPTION
💡 **What:** Improved the SEO and metadata for individual sermon pages and listings.
🎯 **Why:** Dynamic meta descriptions provide better context in search results and social share previews. Expanded structured data helps search engines better understand the content type and its history.
📊 **Impact:** Every individual sermon page and the main sermon archive benefit from more accurate and detailed metadata.
🔍 **Verification:** Verified via Playwright screenshots and JSON-LD inspection, as well as existing feature tests.

---
*PR created automatically by Jules for task [15318584996385434089](https://jules.google.com/task/15318584996385434089) started by @GarethClarridge*