### PR TITLE
🧹 Tidy: Standardize Eloquent queries using Model::query()

### DIFF
--- a/app/Console/Commands/BootstrapSpeakerProfilesCommand.php
+++ b/app/Console/Commands/BootstrapSpeakerProfilesCommand.php
@@ -107,7 +107,7 @@ class BootstrapSpeakerProfilesCommand extends Command
                 continue;
             }
 
-            $profile = SpeakerProfile::firstOrCreate(
+            $profile = SpeakerProfile::query()->firstOrCreate(
                 [
                     'preacher_id' => $preacher->id,
                     'provider' => $provider,
@@ -138,7 +138,7 @@ class BootstrapSpeakerProfilesCommand extends Command
                     continue;
                 }
 
-                SpeakerSample::updateOrCreate(
+                SpeakerSample::query()->updateOrCreate(
                     [
                         'speaker_profile_id' => $profile->id,
                         'sermon_id' => $sermon->id,

--- a/app/Console/Commands/MoveChildrensTalksToPrivateStorage.php
+++ b/app/Console/Commands/MoveChildrensTalksToPrivateStorage.php
@@ -21,7 +21,7 @@ class MoveChildrensTalksToPrivateStorage extends Command
         $isDryRun = (bool) $this->option('dry-run');
         $batchSize = (int) $this->option('batch-size');
 
-        $query = Sermon::whereChildrensTalk()
+        $query = Sermon::query()->whereChildrensTalk()
             ->where(function ($q) {
                 $q->where('audio_file_path', 'not like', 'private/%')
                     ->orWhereNull('audio_file_path');

--- a/app/Jobs/AssessSermonVideoQuality.php
+++ b/app/Jobs/AssessSermonVideoQuality.php
@@ -167,7 +167,7 @@ class AssessSermonVideoQuality extends ProcessingJob implements ShouldBeUnique, 
     private function resolveSermon(?MediaProcessingLog $processingLog): ?Sermon
     {
         if ($this->sermonId !== null) {
-            return Sermon::find($this->sermonId);
+            return Sermon::query()->find($this->sermonId);
         }
 
         if (! $processingLog instanceof MediaProcessingLog || $processingLog->sermon_id === null) {
@@ -176,7 +176,7 @@ class AssessSermonVideoQuality extends ProcessingJob implements ShouldBeUnique, 
 
         $this->sermonId = $processingLog->sermon_id;
 
-        return Sermon::find($processingLog->sermon_id);
+        return Sermon::query()->find($processingLog->sermon_id);
     }
 
     private function persistResult(

--- a/app/Jobs/GenerateThumbnail.php
+++ b/app/Jobs/GenerateThumbnail.php
@@ -99,7 +99,7 @@ class GenerateThumbnail implements ShouldQueue
             ]);
 
             // Get the sermon record
-            $sermon = Sermon::find($this->sermonId);
+            $sermon = Sermon::query()->find($this->sermonId);
             if (! $sermon) {
                 Log::warning('Sermon not found for thumbnail generation', [
                     'sermon_id' => $this->sermonId,
@@ -187,7 +187,7 @@ class GenerateThumbnail implements ShouldQueue
 
             // Fallback to sermon record's video_file_path if processing log doesn't have it
             if (! $this->videoPath && $this->sermonId) {
-                $sermon = Sermon::find($this->sermonId);
+                $sermon = Sermon::query()->find($this->sermonId);
                 $this->videoPath = $sermon?->video_file_path;
 
                 Log::debug('Resolved video path from sermon record for livestream', [
@@ -221,7 +221,7 @@ class GenerateThumbnail implements ShouldQueue
         } elseif ($this->processingLog->processing_type === MediaType::Video) {
             // Direct video: Get video path from sermon record or processing log
             if ($this->sermonId) {
-                $sermon = Sermon::find($this->sermonId);
+                $sermon = Sermon::query()->find($this->sermonId);
                 $this->videoPath = $sermon?->video_file_path;
             }
 

--- a/app/Jobs/IdentifySpeaker.php
+++ b/app/Jobs/IdentifySpeaker.php
@@ -85,7 +85,7 @@ class IdentifySpeaker extends ProcessingJob implements ShouldQueue
                 return;
             }
 
-            $sermon = Sermon::find($this->processingLog->sermon_id);
+            $sermon = Sermon::query()->find($this->processingLog->sermon_id);
 
             if (! $sermon) {
                 $this->storeDecision('skipped', 'Sermon record not found');
@@ -116,7 +116,7 @@ class IdentifySpeaker extends ProcessingJob implements ShouldQueue
             $provider = (string) config('media-processing.speaker_identification.provider', 'null');
             $modelVersion = (string) config('media-processing.speaker_identification.model_version', '');
 
-            $profilesQuery = SpeakerProfile::active()->with('preacher');
+            $profilesQuery = SpeakerProfile::query()->active()->with('preacher');
 
             if ($provider !== '' && $provider !== 'null') {
                 $profilesQuery->where('provider', $provider);
@@ -279,7 +279,7 @@ class IdentifySpeaker extends ProcessingJob implements ShouldQueue
             ->first();
 
         if (! $fallbackPreacher) {
-            $fallbackPreacher = Preacher::create([
+            $fallbackPreacher = Preacher::query()->create([
                 'name' => 'Visiting Speaker',
                 'slug' => 'visiting-speaker',
                 'is_active' => true,

--- a/app/Jobs/MoveSermonToPrivateStorage.php
+++ b/app/Jobs/MoveSermonToPrivateStorage.php
@@ -27,7 +27,7 @@ class MoveSermonToPrivateStorage implements ShouldQueue
 
     public function handle(): void
     {
-        $sermon = Sermon::find($this->sermonId);
+        $sermon = Sermon::query()->find($this->sermonId);
 
         if ($sermon === null) {
             Log::warning('MoveSermonToPrivateStorage: sermon not found', ['sermon_id' => $this->sermonId]);

--- a/app/Jobs/SendCompletionNotification.php
+++ b/app/Jobs/SendCompletionNotification.php
@@ -77,7 +77,7 @@ class SendCompletionNotification implements ShouldQueue
             // Get the sermon record if it was created
             $sermon = null;
             if ($this->processingLog->sermon_id) {
-                $sermon = Sermon::find($this->processingLog->sermon_id);
+                $sermon = Sermon::query()->find($this->processingLog->sermon_id);
             }
 
             // Prepare notification data

--- a/app/Jobs/SubmitToProcessing.php
+++ b/app/Jobs/SubmitToProcessing.php
@@ -167,7 +167,7 @@ class SubmitToProcessing implements ShouldQueue
 
             // Validate that the sermon record has a valid audio file path
             if ($sermonId) {
-                $sermon = Sermon::find($sermonId);
+                $sermon = Sermon::query()->find($sermonId);
                 if ($sermon && $sermon->audio_file_path) {
                     // Verify the audio file is accessible for web serving
                     if (! Storage::disk('public')->exists($sermon->audio_file_path)) {

--- a/app/Livewire/Admin/ChurchServices/ProcessingReview.php
+++ b/app/Livewire/Admin/ChurchServices/ProcessingReview.php
@@ -45,7 +45,7 @@ class ProcessingReview extends Component
 
         $this->confirming = true;
 
-        $log = MediaProcessingLog::findOrFail($this->processingLogId);
+        $log = MediaProcessingLog::query()->findOrFail($this->processingLogId);
 
         /** @var User $user */
         $user = Auth::user();
@@ -71,7 +71,7 @@ class ProcessingReview extends Component
 
     public function render(): View
     {
-        $log = MediaProcessingLog::with('segments')->findOrFail($this->processingLogId);
+        $log = MediaProcessingLog::query()->with('segments')->findOrFail($this->processingLogId);
 
         $segments = $log->segments
             ->sortBy('start_time')

--- a/app/Livewire/Admin/ChurchServices/ServiceReviewDashboard.php
+++ b/app/Livewire/Admin/ChurchServices/ServiceReviewDashboard.php
@@ -260,7 +260,7 @@ class ServiceReviewDashboard extends Component
     #[Computed]
     public function preacherOptions(): array
     {
-        return Preacher::active()
+        return Preacher::query()->active()
             ->orderBy('name')
             ->get(['id', 'name'])
             ->map(fn (Preacher $preacher): array => [

--- a/app/Livewire/Admin/ChurchServices/SubmitEmailText.php
+++ b/app/Livewire/Admin/ChurchServices/SubmitEmailText.php
@@ -64,7 +64,7 @@ class SubmitEmailText extends Component
 
         $syntheticId = 'manual-'.Str::uuid().'@admin.crockenhill.org';
 
-        $inboundEmail = InboundEmail::create([
+        $inboundEmail = InboundEmail::query()->create([
             'message_id' => $syntheticId,
             'from' => $this->from ?: 'admin@manual-entry',
             'subject' => $this->subject ?: 'Manual entry',

--- a/app/Livewire/Admin/Preachers/CreatePreacher.php
+++ b/app/Livewire/Admin/Preachers/CreatePreacher.php
@@ -57,7 +57,7 @@ class CreatePreacher extends Component
 
         $validated = $this->validate();
 
-        $preacher = Preacher::create([
+        $preacher = Preacher::query()->create([
             'name' => $validated['name'],
             'slug' => $validated['slug'],
             'bio' => $validated['bio'],

--- a/app/Livewire/Admin/Sermons/EditSermon.php
+++ b/app/Livewire/Admin/Sermons/EditSermon.php
@@ -51,7 +51,7 @@ class EditSermon extends Component
 
         $this->isChildrensTalk = $sermon->content_type === SermonContentType::ChildrensTalk;
         $this->contentTypeLabel = $sermon->content_type->label();
-        $this->preacherOptions = Preacher::active()->orderBy('name')->pluck('name', 'id');
+        $this->preacherOptions = Preacher::query()->active()->orderBy('name')->pluck('name', 'id');
         $this->loadThumbnailCandidates();
     }
 

--- a/app/Livewire/Auth/Register.php
+++ b/app/Livewire/Auth/Register.php
@@ -75,7 +75,7 @@ class Register extends Component
 
         RateLimiter::hit($this->throttleKey());
 
-        $user = User::create([
+        $user = User::query()->create([
             'name' => $this->name,
             'email' => $this->email,
             'password' => Hash::make($this->password),

--- a/app/Livewire/Forms/MeetingFormData.php
+++ b/app/Livewire/Forms/MeetingFormData.php
@@ -113,7 +113,7 @@ class MeetingFormData extends Form
 
         $validated = $this->validate();
 
-        return Meeting::create($this->meetingPayload($validated));
+        return Meeting::query()->create($this->meetingPayload($validated));
     }
 
     public function update(): void

--- a/app/Livewire/Forms/PageFormData.php
+++ b/app/Livewire/Forms/PageFormData.php
@@ -85,7 +85,7 @@ class PageFormData extends Form
     {
         $this->normalizeForSave();
 
-        return Page::create($this->pagePayload($this->validate()));
+        return Page::query()->create($this->pagePayload($this->validate()));
     }
 
     public function update(): void

--- a/app/Livewire/MediaUpload/Form.php
+++ b/app/Livewire/MediaUpload/Form.php
@@ -174,7 +174,7 @@ class Form extends Component
             ]);
 
             if ($this->processingId) {
-                $log = MediaProcessingLog::where('processing_id', $this->processingId)->first();
+                $log = MediaProcessingLog::query()->where('processing_id', $this->processingId)->first();
                 if ($log instanceof MediaProcessingLog) {
                     app(MediaProcessingRunTransitionService::class)
                         ->markAsFailed($log, 'Processing failed: '.$e->getMessage());

--- a/app/Mail/ManualReviewRequired.php
+++ b/app/Mail/ManualReviewRequired.php
@@ -47,7 +47,7 @@ class ManualReviewRequired extends Mailable
 
     private function reviewUrl(): string
     {
-        $log = MediaProcessingLog::where('processing_id', $this->processingId)->first();
+        $log = MediaProcessingLog::query()->where('processing_id', $this->processingId)->first();
 
         if ($log !== null) {
             return route('admin.services.processing.review', $log);

--- a/app/Presenters/SermonArchiveSeoPresenter.php
+++ b/app/Presenters/SermonArchiveSeoPresenter.php
@@ -117,7 +117,7 @@ class SermonArchiveSeoPresenter
         }
 
         // Fallback to direct lookup for inactive preachers
-        $preacher = Preacher::find($preacherId);
+        $preacher = Preacher::query()->find($preacherId);
 
         return $this->memoizedPreacherNames[$preacherId] = $preacher?->name;
     }

--- a/app/Repositories/PreacherListRepository.php
+++ b/app/Repositories/PreacherListRepository.php
@@ -27,7 +27,7 @@ class PreacherListRepository
     public function forAdminList(): Collection
     {
         return Cache::flexible(self::ADMIN_LIST_CACHE_KEY, self::CACHE_TTL, function (): Collection {
-            return Preacher::active()->orderBy('name')->pluck('name', 'id');
+            return Preacher::query()->active()->orderBy('name')->pluck('name', 'id');
         });
     }
 
@@ -40,7 +40,7 @@ class PreacherListRepository
     public function forPublicList(): EloquentCollection
     {
         return Cache::flexible(self::PUBLIC_LIST_CACHE_KEY, self::CACHE_TTL, function (): EloquentCollection {
-            return Preacher::active()
+            return Preacher::query()->active()
                 ->select(['id', 'name', 'slug', 'image_path'])
                 ->withCount([
                     'sermons' => fn (Builder $query): Builder => $query->whereSermon(),

--- a/app/Services/CalendarService.php
+++ b/app/Services/CalendarService.php
@@ -91,7 +91,7 @@ class CalendarService
 
     public function manuallyCategorizeEvent(int $eventId, string $meetingSlug): CalendarCategorizationResult
     {
-        $event = CalendarEvent::findOrFail($eventId);
+        $event = CalendarEvent::query()->findOrFail($eventId);
 
         $event->update([
             'meeting_slug' => $meetingSlug,
@@ -112,7 +112,7 @@ class CalendarService
 
     public function manuallyUnCategorizeEvent(int $eventId): CalendarCategorizationResult
     {
-        $event = CalendarEvent::findOrFail($eventId);
+        $event = CalendarEvent::query()->findOrFail($eventId);
 
         $event->update([
             'meeting_slug' => null,

--- a/app/Services/ChurchServiceItemSyncService.php
+++ b/app/Services/ChurchServiceItemSyncService.php
@@ -720,7 +720,7 @@ class ChurchServiceItemSyncService
                 continue;
             }
 
-            ChurchServiceItem::withTrashed()
+            ChurchServiceItem::query()->withTrashed()
                 ->whereKey($item->id)
                 ->update(['position' => $temporaryPosition]);
         }
@@ -729,7 +729,7 @@ class ChurchServiceItemSyncService
         foreach ($activeItems->values() as $index => $item) {
             $expectedPosition = $index + 1;
 
-            ChurchServiceItem::withTrashed()
+            ChurchServiceItem::query()->withTrashed()
                 ->whereKey($item->id)
                 ->update(['position' => $expectedPosition]);
         }
@@ -761,7 +761,7 @@ class ChurchServiceItemSyncService
             return;
         }
 
-        $maxPosition = (int) ChurchServiceItem::withTrashed()
+        $maxPosition = (int) ChurchServiceItem::query()->withTrashed()
             ->where('church_service_id', $churchService->id)
             ->max('position');
 
@@ -769,7 +769,7 @@ class ChurchServiceItemSyncService
             $temporaryPosition = $maxPosition + $index + 1;
             $existingItem = $pendingUpdate['existing_item'];
 
-            ChurchServiceItem::withTrashed()
+            ChurchServiceItem::query()->withTrashed()
                 ->whereKey($existingItem->id)
                 ->update(['position' => $temporaryPosition]);
 

--- a/app/Services/LegacySermonImporter.php
+++ b/app/Services/LegacySermonImporter.php
@@ -128,7 +128,7 @@ final class LegacySermonImporter
 
         $storedPath = $this->storeFile($absolutePath, $filename, $date);
 
-        $processingLog = MediaProcessingLog::create([
+        $processingLog = MediaProcessingLog::query()->create([
             'processing_id' => (string) Str::uuid(),
             'processing_type' => MediaType::Audio,
             'original_filename' => $filename,

--- a/app/Services/ProcessingInitiator.php
+++ b/app/Services/ProcessingInitiator.php
@@ -98,7 +98,7 @@ class ProcessingInitiator
             'processing_metadata' => array_merge($baseMetadata, $extraMetadata),
         ], $extractedIdentity, $additionalLogData);
 
-        return MediaProcessingLog::create($logData);
+        return MediaProcessingLog::query()->create($logData);
     }
 
     /**

--- a/app/Services/SermonProcessingStepTransitions.php
+++ b/app/Services/SermonProcessingStepTransitions.php
@@ -11,7 +11,7 @@ class SermonProcessingStepTransitions
 {
     public function markAsStarted(string $processingId, string $step, ?string $message = null): SermonProcessingStep
     {
-        return SermonProcessingStep::updateOrCreate(
+        return SermonProcessingStep::query()->updateOrCreate(
             [
                 'processing_id' => $processingId,
                 'step' => $step,
@@ -57,7 +57,7 @@ class SermonProcessingStepTransitions
 
     public function markAsCancelled(string $processingId, string $step, ?string $message = null): SermonProcessingStep
     {
-        $stepLog = SermonProcessingStep::firstOrNew([
+        $stepLog = SermonProcessingStep::query()->firstOrNew([
             'processing_id' => $processingId,
             'step' => $step,
         ]);
@@ -78,7 +78,7 @@ class SermonProcessingStepTransitions
         ProcessingStatus $status,
         ?string $message,
     ): SermonProcessingStep {
-        $stepLog = SermonProcessingStep::firstOrNew([
+        $stepLog = SermonProcessingStep::query()->firstOrNew([
             'processing_id' => $processingId,
             'step' => $step,
         ]);

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -208,7 +208,7 @@ class SitemapService
      */
     private function addPreachers(Sitemap $sitemap): void
     {
-        $preachers = Preacher::active()
+        $preachers = Preacher::query()->active()
             ->select(['id', 'name', 'slug', 'image_path', 'updated_at'])
             ->with([
                 'sermons' => fn ($query) => $query->whereSermon()->orderBy('date', 'desc')->limit(1),

--- a/app/Services/SongVideoService.php
+++ b/app/Services/SongVideoService.php
@@ -72,7 +72,7 @@ class SongVideoService
             basename($storagePath),
         );
 
-        return SongVideo::create([
+        return SongVideo::query()->create([
             'song_id' => $song->id,
             'video_file_path' => $storagePath,
             'is_featured' => false,
@@ -89,7 +89,7 @@ class SongVideoService
         $processingLog = $section->processingLog;
         $churchService = $processingLog->churchService;
 
-        return SongVideo::create([
+        return SongVideo::query()->create([
             'song_id' => $item->song_id,
             'service_section_id' => $section->id,
             'church_service_id' => $processingLog->church_service_id,
@@ -102,7 +102,7 @@ class SongVideoService
 
     private function resetLinkedSectionForReExtraction(int $sectionId): void
     {
-        $section = ServiceSection::find($sectionId);
+        $section = ServiceSection::query()->find($sectionId);
         if (! $section instanceof ServiceSection) {
             return;
         }

--- a/app/View/Components/Layout/Header.php
+++ b/app/View/Components/Layout/Header.php
@@ -31,7 +31,7 @@ class Header extends Component
         $this->user = $user;
         $this->pages = Cache::rememberForever(
             'nav_pages',
-            fn (): Collection => Page::isNavigation()
+            fn (): Collection => Page::query()->isNavigation()
                 ->public()
                 ->select(['id', 'slug', 'heading', 'area'])
                 ->get(),

--- a/tests/Feature/ChristmasSeoTest.php
+++ b/tests/Feature/ChristmasSeoTest.php
@@ -36,25 +36,25 @@ class ChristmasSeoTest extends TestCase
         $response->assertSee('"name": "Christmas"', false);
 
         // Event ItemList Schema
-        $response->assertSee('"@type":"ItemList"', false);
-        $response->assertSee('"@type":"Event"', false);
+        $response->assertSee('"@type": "ItemList"', false);
+        $response->assertSee('"@type": "Event"', false);
 
         // Check specific events
-        $response->assertSee('"name":"Preparing Room"', false);
-        $response->assertSee('"startDate":"2024-11-30T15:00:00"', false);
-        $response->assertSee('"endDate":"2024-11-30T18:00:00"', false);
+        $response->assertSee('"name": "Preparing Room"', false);
+        $response->assertSee('"startDate": "2024-11-30T15:00:00"', false);
+        $response->assertSee('"endDate": "2024-11-30T18:00:00"', false);
 
-        $response->assertSee('"name":"Coffee Cup Carols"', false);
-        $response->assertSee('"startDate":"2024-12-12T10:30:00"', false);
+        $response->assertSee('"name": "Coffee Cup Carols"', false);
+        $response->assertSee('"startDate": "2024-12-12T10:30:00"', false);
 
-        $response->assertSee('"name":"Carols in the Chequers"', false);
-        $response->assertSee('"startDate":"2024-12-18T19:30:00"', false);
-        $response->assertSee('"name":"The Chequers, Crockenhill"', false);
+        $response->assertSee('"name": "Carols in the Chequers"', false);
+        $response->assertSee('"startDate": "2024-12-18T19:30:00"', false);
+        $response->assertSee('"name": "The Chequers, Crockenhill"', false);
 
-        $response->assertSee('"name":"Carols by Candlelight"', false);
-        $response->assertSee('"startDate":"2024-12-22T18:00:00"', false);
+        $response->assertSee('"name": "Carols by Candlelight"', false);
+        $response->assertSee('"startDate": "2024-12-22T18:00:00"', false);
 
-        $response->assertSee('"name":"Christmas Morning Service"', false);
-        $response->assertSee('"startDate":"2024-12-25T10:30:00"', false);
+        $response->assertSee('"name": "Christmas Morning Service"', false);
+        $response->assertSee('"startDate": "2024-12-25T10:30:00"', false);
     }
 }


### PR DESCRIPTION
Standardized Eloquent queries by replacing direct static model calls (e.g., `Sermon::find()`) with `Sermon::query()->find()`. This change covers multiple domains including media processing jobs, services, admin Livewire components, and repositories. A minor fix was also applied to `ChristmasSeoTest.php` to ensure assertions match the project's pretty-printed JSON output. All tests pass and static analysis remains at 0 errors.

---
*PR created automatically by Jules for task [8429590409646975087](https://jules.google.com/task/8429590409646975087) started by @GarethClarridge*