### PR TITLE
📝 Scribe: Add tests and fix cache invalidation in SermonRepository

### DIFF
--- a/app/Repositories/SermonRepository.php
+++ b/app/Repositories/SermonRepository.php
@@ -229,45 +229,6 @@ class SermonRepository
     }
 
     /**
-     * Clear all cached sermon listings.
-     */
-    public function clearListingCaches(Sermon|Preacher|null $model = null): void
-    {
-        Cache::forget('latest_sermons');
-        Cache::forget('all_sermons');
-        Cache::forget('sermon_series');
-        Cache::forget('sermon_scripture_books_all_all');
-        Cache::forget('sermons_jsonld_recent_100');
-
-        $this->memoizedSeries = null;
-        $this->memoizedBooks = [];
-        $this->memoizedChapters = [];
-
-        if ($model instanceof Sermon) {
-            $this->clearScriptureChapterCaches($model);
-
-            if ($model->series) {
-                Cache::forget('sermons_series_'.Str::slug($model->series));
-            }
-            if ($model->service) {
-                $serviceValue = $model->service->value;
-                Cache::forget('sermons_service_'.$serviceValue);
-            }
-            if ($model->preacher_id) {
-                // Eager load preacherProfile if not loaded to get the key for cache invalidation
-                $model->loadMissing('preacherProfile');
-                if ($model->preacherProfile) {
-                    Cache::forget($this->preacherCacheKey($model->preacherProfile));
-                }
-            }
-        }
-
-        if ($model instanceof Preacher) {
-            Cache::forget($this->preacherCacheKey($model));
-        }
-    }
-
-    /**
      * Look up an existing Sermon record by date, service, and content type.
      *
      * Content type is part of the match key because the sermons table holds
@@ -461,7 +422,7 @@ class SermonRepository
     public function clearScriptureChapterCaches(Sermon $sermon): void
     {
         // Always clear the global (no-filter) book list
-        Cache::forget('sermon_scripture_books_all_all');
+        $this->forgetFlexible('sermon_scripture_books_all_all');
 
         // Extract all possible values that could be cached
         $preacherIds = array_filter(array_unique([
@@ -478,13 +439,13 @@ class SermonRepository
 
         // Clear book list caches for all combinations of preacher and series
         foreach ($preacherIds as $id) {
-            Cache::forget("sermon_scripture_books_{$id}_all");
+            $this->forgetFlexible("sermon_scripture_books_{$id}_all");
         }
 
         foreach ($seriesSlugs as $slug) {
-            Cache::forget("sermon_scripture_books_all_{$slug}");
+            $this->forgetFlexible("sermon_scripture_books_all_{$slug}");
             foreach ($preacherIds as $id) {
-                Cache::forget("sermon_scripture_books_{$id}_{$slug}");
+                $this->forgetFlexible("sermon_scripture_books_{$id}_{$slug}");
             }
         }
 
@@ -512,18 +473,84 @@ class SermonRepository
 
         foreach ($books as $book) {
             $bookSlug = Str::slug($book);
-            Cache::forget("sermon_scripture_chapters_{$bookSlug}_all_all");
+            $this->forgetFlexible("sermon_scripture_chapters_{$bookSlug}_all_all");
 
             foreach ($preacherIds as $id) {
-                Cache::forget("sermon_scripture_chapters_{$bookSlug}_{$id}_all");
+                $this->forgetFlexible("sermon_scripture_chapters_{$bookSlug}_{$id}_all");
             }
 
             foreach ($seriesSlugs as $slug) {
-                Cache::forget("sermon_scripture_chapters_{$bookSlug}_all_{$slug}");
+                $this->forgetFlexible("sermon_scripture_chapters_{$bookSlug}_all_{$slug}");
                 foreach ($preacherIds as $id) {
-                    Cache::forget("sermon_scripture_chapters_{$bookSlug}_{$id}_{$slug}");
+                    $this->forgetFlexible("sermon_scripture_chapters_{$bookSlug}_{$id}_{$slug}");
                 }
             }
         }
+    }
+
+    /**
+     * Clear all cached sermon listings.
+     */
+    public function clearListingCaches(Sermon|Preacher|null $model = null): void
+    {
+        $this->forgetFlexible('latest_sermons');
+        $this->forgetFlexible('all_sermons');
+        $this->forgetFlexible('sermon_series');
+        $this->forgetFlexible('sermon_scripture_books_all_all');
+        $this->forgetFlexible('sermons_jsonld_recent_100');
+
+        $this->memoizedSeries = null;
+        $this->memoizedBooks = [];
+        $this->memoizedChapters = [];
+
+        if ($model instanceof Sermon) {
+            $this->clearScriptureChapterCaches($model);
+
+            // Invalidate for current and original series
+            $series = array_filter(array_unique([
+                $model->series ?: null,
+                $model->getOriginal('series') ?: null,
+            ]));
+
+            foreach ($series as $s) {
+                $this->forgetFlexible('sermons_series_'.Str::slug($s));
+            }
+
+            // Invalidate for current and original service
+            $services = array_filter(array_unique([
+                $model->service?->value ?: null,
+                $model->getOriginal('service') instanceof SermonService ? $model->getOriginal('service')->value : ($model->getOriginal('service') ?: null),
+            ]));
+
+            foreach ($services as $serviceValue) {
+                $this->forgetFlexible('sermons_service_'.$serviceValue);
+            }
+
+            // Invalidate for current and original preacher
+            $preacherIds = array_filter(array_unique([
+                (int) $model->preacher_id ?: null,
+                (int) $model->getOriginal('preacher_id') ?: null,
+            ]));
+
+            foreach ($preacherIds as $id) {
+                $preacher = Preacher::query()->find($id);
+                if ($preacher) {
+                    $this->forgetFlexible($this->preacherCacheKey($preacher));
+                }
+            }
+        }
+
+        if ($model instanceof Preacher) {
+            $this->forgetFlexible($this->preacherCacheKey($model));
+        }
+    }
+
+    /**
+     * Clear a flexible cache key including its metadata key.
+     */
+    private function forgetFlexible(string $key): void
+    {
+        Cache::forget($key);
+        Cache::forget("illuminate:cache:flexible:created:{$key}");
     }
 }

--- a/tests/Feature/Repositories/SermonRepositoryCacheInvalidationTest.php
+++ b/tests/Feature/Repositories/SermonRepositoryCacheInvalidationTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Repositories;
+
+use App\Enums\SermonService;
+use App\Models\Preacher;
+use App\Models\Sermon;
+use App\Repositories\SermonRepository;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonRepositoryCacheInvalidationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private SermonRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = app(SermonRepository::class);
+    }
+
+    #[Test]
+    public function it_clears_global_listing_caches(): void
+    {
+        Cache::spy();
+
+        $this->repository->clearListingCaches();
+
+        $keys = [
+            'latest_sermons',
+            'all_sermons',
+            'sermon_series',
+            'sermon_scripture_books_all_all',
+            'sermons_jsonld_recent_100',
+        ];
+
+        foreach ($keys as $key) {
+            Cache::shouldHaveReceived('forget')->with($key)->atLeast()->once();
+            Cache::shouldHaveReceived('forget')->with("illuminate:cache:flexible:created:{$key}")->atLeast()->once();
+        }
+    }
+
+    #[Test]
+    public function it_clears_model_specific_caches_for_a_sermon(): void
+    {
+        $preacher = Preacher::factory()->create(['slug' => 'john-doe']);
+        $sermon = Sermon::factory()->create([
+            'preacher_id' => $preacher->id,
+            'series' => 'My Great Series',
+            'service' => SermonService::Morning,
+        ]);
+
+        Cache::spy();
+
+        $this->repository->clearListingCaches($sermon);
+
+        $modelKeys = [
+            'sermons_series_my-great-series',
+            'sermons_service_morning',
+            'sermons_preacher_john-doe',
+        ];
+
+        foreach ($modelKeys as $key) {
+            Cache::shouldHaveReceived('forget')->with($key)->once();
+            Cache::shouldHaveReceived('forget')->with("illuminate:cache:flexible:created:{$key}")->once();
+        }
+    }
+
+    #[Test]
+    public function it_clears_preacher_specific_cache(): void
+    {
+        $preacher = Preacher::factory()->create(['slug' => 'jane-smith']);
+
+        Cache::spy();
+
+        $this->repository->clearListingCaches($preacher);
+
+        Cache::shouldHaveReceived('forget')->with('sermons_preacher_jane-smith')->once();
+        Cache::shouldHaveReceived('forget')->with('illuminate:cache:flexible:created:sermons_preacher_jane-smith')->once();
+    }
+
+    #[Test]
+    public function it_invalidates_caches_for_both_original_and_new_preacher_and_series(): void
+    {
+        $oldPreacher = Preacher::factory()->create(['slug' => 'old-preacher']);
+        $newPreacher = Preacher::factory()->create(['slug' => 'new-preacher']);
+
+        $sermon = Sermon::factory()->create([
+            'preacher_id' => $oldPreacher->id,
+            'series' => 'Old Series',
+            'service' => SermonService::Morning,
+        ]);
+
+        // Manually set new values without saving yet, so we have "original" vs "current"
+        $sermon->preacher_id = $newPreacher->id;
+        $sermon->series = 'New Series';
+        $sermon->service = SermonService::Evening;
+
+        Cache::spy();
+
+        $this->repository->clearListingCaches($sermon);
+
+        $expectedKeys = [
+            'sermons_preacher_old-preacher',
+            'sermons_preacher_new-preacher',
+            'sermons_series_old-series',
+            'sermons_series_new-series',
+            'sermons_service_morning',
+            'sermons_service_evening',
+        ];
+
+        foreach ($expectedKeys as $key) {
+            Cache::shouldHaveReceived('forget')->with($key)->once();
+            Cache::shouldHaveReceived('forget')->with("illuminate:cache:flexible:created:{$key}")->once();
+        }
+    }
+
+    #[Test]
+    public function it_invalidates_scripture_chapter_caches_for_all_related_bible_books(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'reference' => 'John 3:16, Romans 8:28',
+            'preacher_id' => null,
+            'series' => null,
+        ]);
+
+        Cache::spy();
+
+        $this->repository->clearListingCaches($sermon);
+
+        // Global books list
+        Cache::shouldHaveReceived('forget')->with('sermon_scripture_books_all_all')->atLeast()->once();
+        Cache::shouldHaveReceived('forget')->with('illuminate:cache:flexible:created:sermon_scripture_books_all_all')->atLeast()->once();
+
+        // John chapters
+        Cache::shouldHaveReceived('forget')->with('sermon_scripture_chapters_john_all_all')->once();
+        Cache::shouldHaveReceived('forget')->with('illuminate:cache:flexible:created:sermon_scripture_chapters_john_all_all')->once();
+        // Romans chapters
+        Cache::shouldHaveReceived('forget')->with('sermon_scripture_chapters_romans_all_all')->once();
+        Cache::shouldHaveReceived('forget')->with('illuminate:cache:flexible:created:sermon_scripture_chapters_romans_all_all')->once();
+    }
+
+    #[Test]
+    public function it_invalidates_scripture_chapter_caches_across_preacher_and_series_combinations(): void
+    {
+        $preacher = Preacher::factory()->create(['id' => 123]);
+        $sermon = Sermon::factory()->create([
+            'reference' => 'John 3',
+            'preacher_id' => $preacher->id,
+            'series' => 'The Gospel',
+        ]);
+
+        $pId = 123;
+        $sSlug = 'the-gospel';
+        $bSlug = 'john';
+
+        Cache::spy();
+
+        $this->repository->clearListingCaches($sermon);
+
+        // Book list combinations
+        Cache::shouldHaveReceived('forget')->with("sermon_scripture_books_{$pId}_all")->atLeast()->once();
+        Cache::shouldHaveReceived('forget')->with("illuminate:cache:flexible:created:sermon_scripture_books_{$pId}_all")->atLeast()->once();
+        Cache::shouldHaveReceived('forget')->with("sermon_scripture_books_all_{$sSlug}")->atLeast()->once();
+        Cache::shouldHaveReceived('forget')->with("illuminate:cache:flexible:created:sermon_scripture_books_all_{$sSlug}")->atLeast()->once();
+        Cache::shouldHaveReceived('forget')->with("sermon_scripture_books_{$pId}_{$sSlug}")->atLeast()->once();
+        Cache::shouldHaveReceived('forget')->with("illuminate:cache:flexible:created:sermon_scripture_books_{$pId}_{$sSlug}")->atLeast()->once();
+
+        // Chapter list combinations
+        Cache::shouldHaveReceived('forget')->with("sermon_scripture_chapters_{$bSlug}_all_all")->atLeast()->once();
+        Cache::shouldHaveReceived('forget')->with("illuminate:cache:flexible:created:sermon_scripture_chapters_{$bSlug}_all_all")->atLeast()->once();
+        Cache::shouldHaveReceived('forget')->with("sermon_scripture_chapters_{$bSlug}_{$pId}_all")->atLeast()->once();
+        Cache::shouldHaveReceived('forget')->with("illuminate:cache:flexible:created:sermon_scripture_chapters_{$bSlug}_{$pId}_all")->atLeast()->once();
+        Cache::shouldHaveReceived('forget')->with("sermon_scripture_chapters_{$bSlug}_all_{$sSlug}")->atLeast()->once();
+        Cache::shouldHaveReceived('forget')->with("illuminate:cache:flexible:created:sermon_scripture_chapters_{$bSlug}_all_{$sSlug}")->atLeast()->once();
+        Cache::shouldHaveReceived('forget')->with("sermon_scripture_chapters_{$bSlug}_{$pId}_{$sSlug}")->atLeast()->once();
+        Cache::shouldHaveReceived('forget')->with("illuminate:cache:flexible:created:sermon_scripture_chapters_{$bSlug}_{$pId}_{$sSlug}")->atLeast()->once();
+    }
+}


### PR DESCRIPTION
🎯 **Coverage:**
Added comprehensive coverage for `SermonRepository::clearListingCaches` and `clearScriptureChapterCaches`.

📋 **Changes added:**
- Created `tests/Feature/Repositories/SermonRepositoryCacheInvalidationTest.php` with 6 tests.
- Refactored `SermonRepository` to correctly handle `Cache::flexible` invalidation by clearing metadata keys.
- Fixed a bug where updating a sermon left stale data in the cache for the original series, preacher, or service.

🔍 **Why:**
Correct cache invalidation is critical for data consistency in listing pages. The previous implementation was missing the metadata keys required by Laravel 12's flexible cache and didn't account for attribute changes during updates.

✅ **Results:**
- New tests pass (50 assertions).
- Existing `SermonRepositoryTest` passes.
- PHPStan clean (0 errors).
- Pint formatting applied.

---
*PR created automatically by Jules for task [9124384089826534921](https://jules.google.com/task/9124384089826534921) started by @GarethClarridge*