### PR TITLE
🛡️ Sentinel: Harden log sanitization and exception redaction

### DIFF
--- a/app/Services/SermonAnalysisService.php
+++ b/app/Services/SermonAnalysisService.php
@@ -113,12 +113,12 @@ class SermonAnalysisService implements SermonAnalysisInterface
                 'failed',
                 [
                     'total_attempts' => 1,
-                    'final_error' => $e->getMessage(),
+                    'final_error' => self::sanitizeForLog($e->getMessage()),
                 ]
             );
 
             throw $e instanceof \TypeError
-                ? new Exception('OpenAI API response malformed: '.$e->getMessage(), 0, $e)
+                ? new Exception('OpenAI API response malformed.', 0, $e)
                 : $e;
         }
     }
@@ -169,10 +169,9 @@ class SermonAnalysisService implements SermonAnalysisInterface
             ]);
 
             throw new Exception(sprintf(
-                'AI title exceeds %d characters (%d chars): "%s"',
+                'AI title exceeds %d characters (%d chars).',
                 SermonAnalysisValidator::MAX_TITLE_CHARACTERS,
-                strlen($validatedData['title']),
-                $validatedData['title']
+                strlen($validatedData['title'])
             ));
         }
 
@@ -202,7 +201,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
 
         if ($e instanceof ErrorException) {
             Log::error('OpenAI API ErrorException details', [
-                'processing_id' => $processingId,
+                'processing_id' => self::sanitizeForLog($processingId),
                 'attempt' => $attempt,
                 'error_code' => $e->getCode(),
                 'error_message' => self::sanitizeForLog($e->getMessage()),
@@ -266,7 +265,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
         // Validate response structure
         if (empty($response->choices)) {
             Log::error('Invalid OpenAI response structure', [
-                'processing_id' => $processingId,
+                'processing_id' => self::sanitizeForLog($processingId),
                 'response_type' => gettype($response),
             ]);
 
@@ -317,11 +316,11 @@ class SermonAnalysisService implements SermonAnalysisInterface
         } catch (\TypeError $e) {
             // Handle malformed API response (e.g., non-JSON response body)
             Log::error('OpenAI API response parsing failed (malformed response)', [
-                'processing_id' => $processingId,
+                'processing_id' => self::sanitizeForLog($processingId),
                 'attempt' => $attempt,
                 'error' => self::sanitizeForLog($e->getMessage()),
                 'model' => self::sanitizeForLog($model),
-                'exception_file' => $e->getFile(),
+                'exception_file' => self::sanitizeForLog($e->getFile()),
                 'exception_line' => $e->getLine(),
             ]);
 
@@ -336,10 +335,10 @@ class SermonAnalysisService implements SermonAnalysisInterface
                 }
             }
 
-            throw new Exception('OpenAI API response malformed: '.$e->getMessage());
+            throw new Exception('OpenAI API response malformed.');
         } catch (Exception $e) {
             Log::error('OpenAI API call failed', [
-                'processing_id' => $processingId,
+                'processing_id' => self::sanitizeForLog($processingId),
                 'attempt' => $attempt,
                 'error' => self::sanitizeForLog($e->getMessage()),
                 'model' => self::sanitizeForLog($model),


### PR DESCRIPTION
### 🛡️ Sentinel Security Hardening

**Severity:** MEDIUM

**Vulnerability:** Information leakage via unredacted exception messages and unsanitized log entries.

**Impact:** Technical details (stack traces, raw API responses) and user-controlled data could be leaked to end-users or into log files, potentially exposing internal system structure or sensitive AI-generated metadata.

**Fixes:**
1.  **Transcript Services**: Added `SanitizesLogData` to `TranscriptStorageService` and `SermonTranscriptReader`. Sanitized all log context and switched to generic exception messages for callers.
2.  **Sermon Analysis**: Hardened `SermonAnalysisService` to throw generic "OpenAI API response malformed" messages instead of leaking raw AI response strings. Removed unsanitized AI-generated titles from "title too long" exceptions.
3.  **Audit**: Conducted a full audit of `Log::` calls in the affected files to ensure consistent application of sanitization.

**Verification:**
- Ran `php artisan test` (5118 passed).
- Verified specific tests for `SermonAnalysisServiceTest` and `JsonLdConsistencyTest`.
- Confirmed edits via `read_file` to ensure all `Log::` calls are sanitized and exceptions are redacted.
- Verified that `phpstan` and `pint` pass with 0 errors.

---
*PR created automatically by Jules for task [4901267934229490838](https://jules.google.com/task/4901267934229490838) started by @GarethClarridge*