### PR TITLE
🔦 Lighthouse: Enhanced Sermon Archive SEO & Metadata

### DIFF
--- a/app/Livewire/Sermons/BrowseSermons.php
+++ b/app/Livewire/Sermons/BrowseSermons.php
@@ -67,21 +67,25 @@ class BrowseSermons extends Component
     {
         $this->chapterFilter = null;
         $this->resetPage();
+        $this->dispatchMetadataUpdate();
     }
 
     public function updatedChapterFilter(): void
     {
         $this->resetPage();
+        $this->dispatchMetadataUpdate();
     }
 
     public function updatedPreacherFilter(): void
     {
         $this->resetPage();
+        $this->dispatchMetadataUpdate();
     }
 
     public function updatedSeriesFilter(): void
     {
         $this->resetPage();
+        $this->dispatchMetadataUpdate();
     }
 
     public function clearFilters(): void
@@ -94,6 +98,7 @@ class BrowseSermons extends Component
         ]);
 
         $this->resetPage();
+        $this->dispatchMetadataUpdate();
     }
 
     public function removeFilter(string $filter): void
@@ -108,6 +113,16 @@ class BrowseSermons extends Component
         }
 
         $this->resetPage();
+        $this->dispatchMetadataUpdate();
+    }
+
+    private function dispatchMetadataUpdate(): void
+    {
+        $this->dispatch('sermon-filters-updated', [
+            'title' => $this->seoTitle,
+            'description' => $this->seoDescription,
+            'canonical' => $this->seoCanonical,
+        ]);
     }
 
     public function render(BibleCanon $bibleCanon): View

--- a/app/Presenters/BreadcrumbPresenter.php
+++ b/app/Presenters/BreadcrumbPresenter.php
@@ -132,6 +132,7 @@ class BreadcrumbPresenter
         return [
             '@context' => 'https://schema.org',
             '@type' => 'BreadcrumbList',
+            '@id' => url()->current().'#breadcrumb',
             'itemListElement' => array_map(
                 static fn (array $item, int $index): array => [
                     '@type' => 'ListItem',

--- a/app/Presenters/SermonArchiveSeoPresenter.php
+++ b/app/Presenters/SermonArchiveSeoPresenter.php
@@ -53,7 +53,7 @@ class SermonArchiveSeoPresenter
     public function description(array $filters): string
     {
         if (! array_filter($filters)) {
-            return 'Browse sermons from Crockenhill Baptist Church and filter by scripture, preacher, or series.';
+            return 'Explore the sermon archive at Crockenhill Baptist Church. Watch or listen to Bible teaching from our Sunday services, filtered by scripture, preacher, or series.';
         }
 
         $parts = [];
@@ -71,10 +71,10 @@ class SermonArchiveSeoPresenter
         }
 
         if ($filters['series']) {
-            $parts[] = "in the {$filters['series']} series";
+            $parts[] = "in the '{$filters['series']}' series";
         }
 
-        return 'Browse sermons from Crockenhill Baptist Church '.implode(' ', $parts).'.';
+        return 'Watch or listen to Bible-based sermons '.implode(' ', $parts).' from Crockenhill Baptist Church. Explore recent teaching from our morning and evening services.';
     }
 
     /**

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -147,9 +147,6 @@ class SitemapService
 
     /**
      * Add Bible book filtered sermon archive URLs to the sitemap.
-     *
-     * Performance Optimization: Resolves the sermons heading asset URL once before
-     * the loop to avoid redundant asset() calls for every Bible book.
      */
     private function addBooks(Sitemap $sitemap): void
     {
@@ -157,12 +154,21 @@ class SitemapService
         $sermonsImage = asset('/images/headings/large/sermons.webp');
 
         foreach ($books as $book) {
-            $sitemap->add(
-                Url::create(route('sermons.index', ['book' => $book]))
-                    ->setPriority(0.7)
-                    ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
-                    ->addImage($sermonsImage, "Sermons on {$book}")
-            );
+            $url = Url::create(route('sermons.index', ['book' => $book]))
+                ->setPriority(0.7)
+                ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY);
+
+            $latestSermon = Sermon::query()
+                ->whereHas('scriptureFilters', fn ($q) => $q->where('bible_book', $book))
+                ->whereSermon()
+                ->orderBy('date', 'desc')
+                ->first();
+
+            $image = $latestSermon ? $this->sermonViewPresenter->thumbnailUrl($latestSermon) : null;
+
+            $url->addImage($image ?: $sermonsImage, "Sermons on {$book}");
+
+            $sitemap->add($url);
         }
     }
 
@@ -223,12 +229,24 @@ class SitemapService
      */
     private function addSeries(Sitemap $sitemap): void
     {
+        $sermonsImage = asset('/images/headings/large/sermons.webp');
+
         foreach ($this->sermonRepository->getSeriesForDisplay() as $series) {
-            $sitemap->add(
-                Url::create(route('sermons.series.show', ['series' => Str::slug($series)]))
-                    ->setPriority(0.6)
-                    ->setChangeFrequency(Url::CHANGE_FREQUENCY_MONTHLY)
-            );
+            $url = Url::create(route('sermons.series.show', ['series' => Str::slug($series)]))
+                ->setPriority(0.6)
+                ->setChangeFrequency(Url::CHANGE_FREQUENCY_MONTHLY);
+
+            $latestSermon = Sermon::query()
+                ->where('series', $series)
+                ->whereSermon()
+                ->orderBy('date', 'desc')
+                ->first();
+
+            $image = $latestSermon ? $this->sermonViewPresenter->thumbnailUrl($latestSermon) : null;
+
+            $url->addImage($image ?: $sermonsImage, "Sermon Series: {$series}");
+
+            $sitemap->add($url);
         }
     }
 

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -10,6 +10,7 @@ use App\Models\Page;
 use App\Models\Preacher;
 use App\Models\Sermon;
 use App\Presenters\MeetingSitemapPresenter;
+use App\Presenters\SermonViewPresenter;
 use App\Presenters\PageSitemapPresenter;
 use App\Presenters\PreacherSitemapPresenter;
 use App\Presenters\SermonSitemapPresenter;
@@ -28,6 +29,7 @@ class SitemapService
         private readonly SermonSitemapPresenter $sermonSitemapPresenter,
         private readonly MeetingSitemapPresenter $meetingSitemapPresenter,
         private readonly PreacherSitemapPresenter $preacherSitemapPresenter,
+        private readonly SermonViewPresenter $sermonViewPresenter,
     ) {}
 
     /**

--- a/resources/views/components/schema/organization.blade.php
+++ b/resources/views/components/schema/organization.blade.php
@@ -19,7 +19,12 @@
         'name' => config('organization.name'),
         '@id' => config('app.url').'/',
         'url' => config('app.url'),
-        'logo' => asset('images/Primary.png'),
+        'logo' => [
+            '@type' => 'ImageObject',
+            'url' => asset('images/Primary.png'),
+            'width' => '512',
+            'height' => '512',
+        ],
         'description' => config('organization.description'),
         'address' => [
             '@type' => 'PostalAddress',

--- a/resources/views/components/schema/webpage.blade.php
+++ b/resources/views/components/schema/webpage.blade.php
@@ -28,6 +28,10 @@
                 'url' => asset('images/Primary.png'),
             ],
         ],
+        'breadcrumb' => [
+            '@type' => 'BreadcrumbList',
+            '@id' => $pageUrl.'#breadcrumb',
+        ],
     ];
 
     if ($image) {

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -1,4 +1,28 @@
-<div class="pb-12" x-init="document.title = @js($this->seoTitle . ' | Crockenhill Baptist Church')">
+<div
+    class="pb-12"
+    x-init="
+        Livewire.on('sermon-filters-updated', (data) => {
+            const update = (data) => {
+                if (data.title) document.title = data.title + ' | Crockenhill Baptist Church';
+                if (data.description) {
+                    const metaDesc = document.querySelector('meta[name=\'description\']');
+                    if (metaDesc) metaDesc.setAttribute('content', data.description);
+                }
+                if (data.canonical) {
+                    const linkCanonical = document.querySelector('link[rel=\'canonical\']');
+                    if (linkCanonical) linkCanonical.setAttribute('href', data.canonical);
+                }
+            };
+            if (Array.isArray(data) && data.length > 0) {
+                update(data[0]);
+            } else {
+                update(data);
+            }
+        });
+
+        document.title = @js($this->seoTitle) + ' | Crockenhill Baptist Church';
+    "
+>
 
     <a href="#sermon-results" @click.prevent="document.getElementById('sermon-results').focus()" class="sr-only focus:not-sr-only focus:absolute focus:z-30 focus:m-4 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-cbc-teal-dark focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-cbc-teal">
         Skip to results

--- a/tests/Feature/SermonBrowseSeoTest.php
+++ b/tests/Feature/SermonBrowseSeoTest.php
@@ -19,7 +19,7 @@ class SermonBrowseSeoTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSee('<title>Sermons | Crockenhill Baptist Church</title>', false);
-        $response->assertSee('<meta name="description" content="Browse sermons from Crockenhill Baptist Church and filter by scripture, preacher, or series.">', false);
+        $response->assertSee('<meta name="description" content="Explore the sermon archive at Crockenhill Baptist Church. Watch or listen to Bible teaching from our Sunday services, filtered by scripture, preacher, or series.">', false);
         $response->assertSee('<link rel="canonical" href="http://localhost/christ/sermons">', false);
     }
 
@@ -29,7 +29,7 @@ class SermonBrowseSeoTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSee('<title>John 3 | Sermons | Crockenhill Baptist Church</title>', false);
-        $response->assertSee('<meta name="description" content="Browse sermons from Crockenhill Baptist Church on John 3.">', false);
+        $response->assertSee('<meta name="description" content="Watch or listen to Bible-based sermons on John 3 from Crockenhill Baptist Church. Explore recent teaching from our morning and evening services.">', false);
         $response->assertSee('<link rel="canonical" href="http://localhost/christ/sermons?book=John&amp;chapter=3">', false);
     }
 


### PR DESCRIPTION
💡 **What:** A suite of SEO and metadata enhancements focused on the sermon archive and structured data.
🎯 **Why:** To improve search engine visibility for filtered archive views and provide richer social media snippets.
📊 **Impact:** Sermon archive pages now have unique, descriptive metadata that updates dynamically in the browser without a full page reload. Sitemap entries for series and Bible books now include relevant images, making them more attractive in search results.
🔍 **Verification:** Verified through updated PHPUnit tests (`SermonBrowseSeoTest`) and manual visual inspection using Playwright scripts to confirm browser metadata updates when applying filters.

---
*PR created automatically by Jules for task [15701869117251246004](https://jules.google.com/task/15701869117251246004) started by @GarethClarridge*