### PR TITLE
🛡️ Sentinel: [MEDIUM] implement log sanitization in key services

### DIFF
--- a/app/Services/ApiBibleClient.php
+++ b/app/Services/ApiBibleClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Data\ApiBiblePassageResult;
+use App\Traits\SanitizesLogData;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
@@ -15,6 +16,8 @@ use Illuminate\Support\Facades\Log;
 
 class ApiBibleClient
 {
+    use SanitizesLogData;
+
     private string $baseUrl;
 
     private string $apiKey;
@@ -70,7 +73,7 @@ class ApiBibleClient
     private function assertDailyBudget(string $context): void
     {
         if (! $this->hasDailyBudget()) {
-            Log::warning("api.bible daily budget exhausted — skipping {$context}", [
+            Log::warning('api.bible daily budget exhausted — skipping '.self::sanitizeForLog($context), [
                 'budget' => $this->dailyBudget,
             ]);
 
@@ -105,7 +108,7 @@ class ApiBibleClient
 
                 if ($status === 429 || $status >= 500) {
                     Log::warning('api.bible search rate-limited or server error', [
-                        'reference' => $normalizedReference,
+                        'reference' => self::sanitizeForLog($normalizedReference),
                         'status' => $status,
                     ]);
 
@@ -113,7 +116,7 @@ class ApiBibleClient
                 }
 
                 Log::info('api.bible search returned non-2xx (terminal)', [
-                    'reference' => $normalizedReference,
+                    'reference' => self::sanitizeForLog($normalizedReference),
                     'status' => $status,
                 ]);
 
@@ -127,7 +130,7 @@ class ApiBibleClient
             $passages = is_array($data['passages'] ?? null) ? $data['passages'] : [];
 
             if (empty($passages)) {
-                Log::info('api.bible search returned no passages', ['reference' => $normalizedReference]);
+                Log::info('api.bible search returned no passages', ['reference' => self::sanitizeForLog($normalizedReference)]);
 
                 return null;
             }
@@ -160,16 +163,16 @@ class ApiBibleClient
             );
         } catch (ConnectionException $e) {
             Log::error('api.bible connection error during search', [
-                'reference' => $normalizedReference,
-                'error' => $e->getMessage(),
+                'reference' => self::sanitizeForLog($normalizedReference),
+                'error' => self::sanitizeForLog($e->getMessage()),
             ]);
 
             throw $e;
         } catch (RequestException $e) {
             Log::error('api.bible request error during search', [
-                'reference' => $normalizedReference,
+                'reference' => self::sanitizeForLog($normalizedReference),
                 'status' => $e->response->status(),
-                'error' => $e->getMessage(),
+                'error' => self::sanitizeForLog($e->getMessage()),
             ]);
 
             return null;
@@ -197,7 +200,7 @@ class ApiBibleClient
 
                 if ($status === 429 || $status >= 500) {
                     Log::warning('api.bible passage fetch rate-limited or server error', [
-                        'passage_id' => $passageId,
+                        'passage_id' => self::sanitizeForLog($passageId),
                         'status' => $status,
                     ]);
 
@@ -205,7 +208,7 @@ class ApiBibleClient
                 }
 
                 Log::info('api.bible passage fetch returned non-2xx (terminal)', [
-                    'passage_id' => $passageId,
+                    'passage_id' => self::sanitizeForLog($passageId),
                     'status' => $status,
                 ]);
 
@@ -239,14 +242,14 @@ class ApiBibleClient
             );
         } catch (ConnectionException $e) {
             Log::error('api.bible connection error during passage fetch', [
-                'passage_id' => $passageId,
-                'error' => $e->getMessage(),
+                'passage_id' => self::sanitizeForLog($passageId),
+                'error' => self::sanitizeForLog($e->getMessage()),
             ]);
 
             throw $e;
         } catch (RequestException $e) {
             Log::error('api.bible request error during passage fetch', [
-                'passage_id' => $passageId,
+                'passage_id' => self::sanitizeForLog($passageId),
                 'status' => $e->response->status(),
             ]);
 

--- a/app/Services/SermonVideoQualityAssessmentService.php
+++ b/app/Services/SermonVideoQualityAssessmentService.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use App\Data\SermonVideoQualityAssessmentResult;
 use App\Enums\SermonVideoQualityStatus;
 use App\Models\Sermon;
+use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
@@ -18,6 +19,8 @@ use Illuminate\Support\Facades\Storage;
  */
 class SermonVideoQualityAssessmentService
 {
+    use SanitizesLogData;
+
     private string $tempDisk;
 
     public function __construct(
@@ -53,9 +56,9 @@ class SermonVideoQualityAssessmentService
         } catch (\Throwable $e) {
             Log::warning('Sermon video quality assessment failed', [
                 'sermon_id' => $sermon->id,
-                'video_path' => $videoPath,
+                'video_path' => self::sanitizeForLog($videoPath),
                 'disk' => $disk,
-                'error' => $e->getMessage(),
+                'error' => self::sanitizeForLog($e->getMessage()),
             ]);
 
             return SermonVideoQualityAssessmentResult::failed();
@@ -99,9 +102,9 @@ class SermonVideoQualityAssessmentService
         } catch (\Throwable $e) {
             Log::warning('Sermon video quality assessment failed', [
                 'sermon_id' => $sermon->id,
-                'video_path' => $videoPath,
+                'video_path' => self::sanitizeForLog($videoPath),
                 'disk' => $disk,
-                'error' => $e->getMessage(),
+                'error' => self::sanitizeForLog($e->getMessage()),
             ]);
 
             return ['result' => SermonVideoQualityAssessmentResult::failed(), 'localVideoPath' => null];
@@ -504,8 +507,8 @@ class SermonVideoQualityAssessmentService
             }
         } catch (\Throwable $e) {
             Log::warning('Failed to cleanup video-quality frame', [
-                'frame_path' => $framePath,
-                'error' => $e->getMessage(),
+                'frame_path' => self::sanitizeForLog($framePath),
+                'error' => self::sanitizeForLog($e->getMessage()),
             ]);
         }
     }

--- a/app/Services/SongLyricOcrService.php
+++ b/app/Services/SongLyricOcrService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -12,6 +13,8 @@ use Symfony\Component\Process\Process;
 
 class SongLyricOcrService
 {
+    use SanitizesLogData;
+
     /**
      * Fraction into the song segment at which to extract the frame.
      * 10% past the start avoids instrumental intros while still showing opening lyrics.
@@ -40,7 +43,7 @@ class SongLyricOcrService
             return $this->parseOcrResponse($ocrText);
         } catch (\Throwable $throwable) {
             Log::warning('SongLyricOcrService: OCR failed', [
-                'error' => $throwable->getMessage(),
+                'error' => self::sanitizeForLog($throwable->getMessage()),
             ]);
 
             return null;
@@ -88,9 +91,9 @@ class SongLyricOcrService
 
         if (! $process->isSuccessful() || ! file_exists($fullFramePath) || filesize($fullFramePath) === 0) {
             Log::warning('SongLyricOcrService: frame extraction failed', [
-                'video_path' => $localVideoPath,
+                'video_path' => self::sanitizeForLog($localVideoPath),
                 'timestamp' => $timestamp,
-                'error' => $process->getErrorOutput(),
+                'error' => self::sanitizeForLog($process->getErrorOutput()),
             ]);
 
             return [null, null];
@@ -158,8 +161,8 @@ class SongLyricOcrService
             }
         } catch (\Throwable $throwable) {
             Log::warning('SongLyricOcrService: failed to clean up frame', [
-                'frame_path' => $framePath,
-                'error' => $throwable->getMessage(),
+                'frame_path' => self::sanitizeForLog((string) $framePath),
+                'error' => self::sanitizeForLog($throwable->getMessage()),
             ]);
         }
     }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM (Security Enhancement)
💡 **Vulnerability:** Potentially unsanitized user-controlled data or internal details leaking into system logs.
🎯 **Impact:** Risk of log injection if user input contains control characters, and information leakage (e.g., server paths, external provider details) if raw exception messages are logged.
🔧 **Fix:** Applied the `SanitizesLogData` trait to three key services (`ApiBibleClient`, `SermonVideoQualityAssessmentService`, `SongLyricOcrService`) and audited/updated every `Log::` call to use `sanitizeForLog()`.
✅ **Verification:** Verified by running `composer phpstan` (passed with 0 errors) and the specific test suites for the modified services:
- `Tests\Integration\Services\ApiBibleClientTest`
- `Tests\Integration\Services\SermonVideoQualityAssessmentServiceTest`
- `Tests\Unit\Services\SongLyricOcrServiceTest`
All relevant tests passed.

---
*PR created automatically by Jules for task [14310196484608637757](https://jules.google.com/task/14310196484608637757) started by @GarethClarridge*