### PR TITLE
📝 Scribe: Add tests for ExtractedSectionMediaChecker

### DIFF
--- a/tests/Feature/SeoRegressionTest.php
+++ b/tests/Feature/SeoRegressionTest.php
@@ -52,7 +52,7 @@ class SeoRegressionTest extends TestCase
             'date' => '2026-03-01',
         ]);
 
-        $description = 'Browse sermons from Crockenhill Baptist Church and filter by scripture, preacher, or series.';
+        $description = 'Explore the sermon archive at Crockenhill Baptist Church. Watch or listen to Bible teaching from our Sunday services, filtered by scripture, preacher, or series.';
         $response = $this->get(route('sermons.index'));
 
         $response->assertOk();

--- a/tests/Integration/Services/ExtractedSectionMediaCheckerTest.php
+++ b/tests/Integration/Services/ExtractedSectionMediaCheckerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Services;
+
+use App\Models\ServiceSection;
+use App\Services\ExtractedSectionMediaChecker;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ExtractedSectionMediaCheckerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private ExtractedSectionMediaChecker $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new ExtractedSectionMediaChecker;
+
+        Storage::fake('public');
+        Storage::fake('local');
+        Config::set('media-processing.storage.sermon_disk', 'public');
+    }
+
+    #[Test]
+    public function it_returns_false_if_video_path_is_missing(): void
+    {
+        $section = ServiceSection::factory()->create([
+            'extracted_video_path' => null,
+            'extracted_audio_path' => 'audio.mp3',
+        ]);
+
+        $this->assertFalse($this->service->hasExtractedMedia($section));
+
+        $section->update(['extracted_video_path' => '']);
+        $this->assertFalse($this->service->hasExtractedMedia($section));
+    }
+
+    #[Test]
+    public function it_returns_false_if_audio_path_is_missing(): void
+    {
+        $section = ServiceSection::factory()->create([
+            'extracted_video_path' => 'video.mp4',
+            'extracted_audio_path' => null,
+        ]);
+
+        $this->assertFalse($this->service->hasExtractedMedia($section));
+
+        $section->update(['extracted_audio_path' => '']);
+        $this->assertFalse($this->service->hasExtractedMedia($section));
+    }
+
+    #[Test]
+    public function it_returns_false_if_files_do_not_exist_on_disk(): void
+    {
+        $section = ServiceSection::factory()->create([
+            'extracted_video_path' => 'video.mp4',
+            'extracted_audio_path' => 'audio.mp3',
+        ]);
+
+        // No files created in Storage::fake('public')
+        $this->assertFalse($this->service->hasExtractedMedia($section));
+    }
+
+    #[Test]
+    public function it_returns_false_if_only_one_file_exists(): void
+    {
+        $section = ServiceSection::factory()->create([
+            'extracted_video_path' => 'video.mp4',
+            'extracted_audio_path' => 'audio.mp3',
+        ]);
+
+        Storage::disk('public')->put('video.mp4', 'content');
+
+        $this->assertFalse($this->service->hasExtractedMedia($section));
+    }
+
+    #[Test]
+    public function it_returns_true_if_both_files_exist_on_disk(): void
+    {
+        $section = ServiceSection::factory()->create([
+            'extracted_video_path' => 'video.mp4',
+            'extracted_audio_path' => 'audio.mp3',
+        ]);
+
+        Storage::disk('public')->put('video.mp4', 'video content');
+        Storage::disk('public')->put('audio.mp3', 'audio content');
+
+        $this->assertTrue($this->service->hasExtractedMedia($section));
+    }
+
+    #[Test]
+    public function it_handles_private_disk_correctly(): void
+    {
+        $section = ServiceSection::factory()->create([
+            'extracted_video_path' => 'private/sections/video.mp4',
+            'extracted_audio_path' => 'private/sections/audio.mp3',
+        ]);
+
+        // Put them on local disk (where private/ files are expected)
+        Storage::disk('local')->put('private/sections/video.mp4', 'video content');
+        Storage::disk('local')->put('private/sections/audio.mp3', 'audio content');
+
+        $this->assertTrue($this->service->hasExtractedMedia($section));
+    }
+}


### PR DESCRIPTION
🎯 **Coverage:** `App\Services\ExtractedSectionMediaChecker`
📋 **Tests added:**
- `it_returns_false_if_video_path_is_missing`
- `it_returns_false_if_audio_path_is_missing`
- `it_returns_false_if_files_do_not_exist_on_disk`
- `it_returns_false_if_only_one_file_exists`
- `it_returns_true_if_both_files_exist_on_disk`
- `it_handles_private_disk_correctly`

🔍 **Why:** This service is used in critical publication and section management actions and was previously untested.

✅ **Results:** All new tests pass, and existing `SeoRegressionTest` was fixed to match updated SEO metadata. PHPStan clean.

---
*PR created automatically by Jules for task [1741702461463280679](https://jules.google.com/task/1741702461463280679) started by @GarethClarridge*