### PR TITLE
⚡ Bolt: Optimize sitemap generation and admin sermon listing

### DIFF
--- a/app/Livewire/Admin/Sermons/ListSermons.php
+++ b/app/Livewire/Admin/Sermons/ListSermons.php
@@ -198,6 +198,14 @@ class ListSermons extends Component
 
         $sermons = $query->paginate(20);
 
+        /**
+         * Performance Optimization: Pre-warm the internal memoization caches of the
+         * presenter before Blade iterates over the collection. This avoids redundant
+         * container lookups and logic when rendering preacher names and scripture
+         * references for each row.
+         */
+        $this->sermonViewPresenter->presentCollection($sermons->getCollection());
+
         $headers = [
             ['key' => 'title', 'label' => 'Title', 'sortable' => true],
             ['key' => 'date', 'label' => 'Date', 'sortable' => true],

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -10,10 +10,10 @@ use App\Models\Page;
 use App\Models\Preacher;
 use App\Models\Sermon;
 use App\Presenters\MeetingSitemapPresenter;
-use App\Presenters\SermonViewPresenter;
 use App\Presenters\PageSitemapPresenter;
 use App\Presenters\PreacherSitemapPresenter;
 use App\Presenters\SermonSitemapPresenter;
+use App\Presenters\SermonViewPresenter;
 use App\Repositories\SermonRepository;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -149,23 +149,43 @@ class SitemapService
 
     /**
      * Add Bible book filtered sermon archive URLs to the sitemap.
+     *
+     * Performance Optimization: Fetches latest representative sermons for all books
+     * in a single bulk query using a window function to eliminate N+1 bottlenecks
+     * during sitemap generation.
      */
     private function addBooks(Sitemap $sitemap): void
     {
         $books = $this->sermonRepository->getScriptureBooks();
         $sermonsImage = asset('/images/headings/large/sermons.webp');
 
+        if ($books->isEmpty()) {
+            return;
+        }
+
+        $subquery = Sermon::query()
+            ->select('sermons.id')
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY sermon_scripture_filters.bible_book ORDER BY sermons.date DESC, sermons.id DESC) as row_num')
+            ->join('sermon_scripture_filters', 'sermons.id', '=', 'sermon_scripture_filters.sermon_id')
+            ->whereSermon();
+
+        $representativeSermons = Sermon::query()
+            ->select(['sermons.id', 'sermons.title', 'sermons.date', 'sermons.slug', 'sermons.thumbnail_file_path', 'sermons.thumbnail_generated_at', 'sermons.thumbnail_metadata', 'f.bible_book as book_group'])
+            ->join('sermon_scripture_filters as f', 'sermons.id', '=', 'f.sermon_id')
+            ->whereIn('sermons.id', function ($query) use ($subquery): void {
+                $query->select('id')
+                    ->fromSub($subquery, 'ranked')
+                    ->where('row_num', 1);
+            })
+            ->get()
+            ->keyBy('book_group');
+
         foreach ($books as $book) {
             $url = Url::create(route('sermons.index', ['book' => $book]))
                 ->setPriority(0.7)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY);
 
-            $latestSermon = Sermon::query()
-                ->whereHas('scriptureFilters', fn ($q) => $q->where('bible_book', $book))
-                ->whereSermon()
-                ->orderBy('date', 'desc')
-                ->first();
-
+            $latestSermon = $representativeSermons->get($book);
             $image = $latestSermon ? $this->sermonViewPresenter->thumbnailUrl($latestSermon) : null;
 
             $url->addImage($image ?: $sermonsImage, "Sermons on {$book}");
@@ -228,22 +248,43 @@ class SitemapService
 
     /**
      * Add sermon series URLs to the sitemap.
+     *
+     * Performance Optimization: Fetches latest representative sermons for all series
+     * in a single bulk query using a window function to eliminate N+1 bottlenecks
+     * during sitemap generation.
      */
     private function addSeries(Sitemap $sitemap): void
     {
+        $seriesList = $this->sermonRepository->getSeriesForDisplay();
         $sermonsImage = asset('/images/headings/large/sermons.webp');
 
-        foreach ($this->sermonRepository->getSeriesForDisplay() as $series) {
+        if ($seriesList === []) {
+            return;
+        }
+
+        $subquery = Sermon::query()
+            ->select('id')
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY series ORDER BY date DESC, id DESC) as row_num')
+            ->whereSermon()
+            ->whereNotNull('series')
+            ->where('series', '!=', '');
+
+        $representativeSermons = Sermon::query()
+            ->select(['id', 'title', 'date', 'slug', 'series', 'thumbnail_file_path', 'thumbnail_generated_at', 'thumbnail_metadata'])
+            ->whereIn('id', function ($query) use ($subquery): void {
+                $query->select('id')
+                    ->fromSub($subquery, 'ranked')
+                    ->where('row_num', 1);
+            })
+            ->get()
+            ->keyBy('series');
+
+        foreach ($seriesList as $series) {
             $url = Url::create(route('sermons.series.show', ['series' => Str::slug($series)]))
                 ->setPriority(0.6)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_MONTHLY);
 
-            $latestSermon = Sermon::query()
-                ->where('series', $series)
-                ->whereSermon()
-                ->orderBy('date', 'desc')
-                ->first();
-
+            $latestSermon = $representativeSermons->get($series);
             $image = $latestSermon ? $this->sermonViewPresenter->thumbnailUrl($latestSermon) : null;
 
             $url->addImage($image ?: $sermonsImage, "Sermon Series: {$series}");

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Enums\PageArea;
+use App\Enums\SermonContentType;
 use App\Models\Meeting;
 use App\Models\Page;
 use App\Models\Preacher;
@@ -16,6 +17,7 @@ use App\Presenters\SermonSitemapPresenter;
 use App\Presenters\SermonViewPresenter;
 use App\Repositories\SermonRepository;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Spatie\Sitemap\Sitemap;
 use Spatie\Sitemap\Tags\Url;
@@ -163,12 +165,20 @@ class SitemapService
             return;
         }
 
-        $subquery = Sermon::query()
-            ->select(['sermons.id', 'sermons.title', 'sermons.date', 'sermons.slug', 'sermons.thumbnail_file_path', 'sermons.thumbnail_generated_at', 'sermons.thumbnail_metadata'])
-            ->selectRaw('sermon_scripture_filters.bible_book as book_group')
-            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY sermon_scripture_filters.bible_book ORDER BY sermons.date DESC, sermons.id DESC) as row_num')
+        $subquery = DB::table('sermons')
             ->join('sermon_scripture_filters', 'sermons.id', '=', 'sermon_scripture_filters.sermon_id')
-            ->whereSermon();
+            ->where('sermons.content_type', SermonContentType::Sermon->value)
+            ->select([
+                'sermons.id',
+                'sermons.title',
+                'sermons.date',
+                'sermons.slug',
+                'sermons.thumbnail_file_path',
+                'sermons.thumbnail_generated_at',
+                'sermons.thumbnail_metadata',
+                'sermon_scripture_filters.bible_book as book_group',
+            ])
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY sermon_scripture_filters.bible_book ORDER BY sermons.date DESC, sermons.id DESC) as row_num');
 
         $representativeSermons = Sermon::query()
             ->fromSub($subquery, 'ranked')
@@ -258,12 +268,21 @@ class SitemapService
             return;
         }
 
-        $subquery = Sermon::query()
-            ->select(['id', 'title', 'date', 'slug', 'series', 'thumbnail_file_path', 'thumbnail_generated_at', 'thumbnail_metadata'])
-            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY series ORDER BY date DESC, id DESC) as row_num')
-            ->whereSermon()
+        $subquery = DB::table('sermons')
+            ->where('content_type', SermonContentType::Sermon->value)
             ->whereNotNull('series')
-            ->where('series', '!=', '');
+            ->where('series', '!=', '')
+            ->select([
+                'id',
+                'title',
+                'date',
+                'slug',
+                'series',
+                'thumbnail_file_path',
+                'thumbnail_generated_at',
+                'thumbnail_metadata',
+            ])
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY series ORDER BY date DESC, id DESC) as row_num');
 
         $representativeSermons = Sermon::query()
             ->fromSub($subquery, 'ranked')

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -164,19 +164,15 @@ class SitemapService
         }
 
         $subquery = Sermon::query()
-            ->select('sermons.id')
+            ->select(['sermons.id', 'sermons.title', 'sermons.date', 'sermons.slug', 'sermons.thumbnail_file_path', 'sermons.thumbnail_generated_at', 'sermons.thumbnail_metadata'])
+            ->selectRaw('sermon_scripture_filters.bible_book as book_group')
             ->selectRaw('ROW_NUMBER() OVER (PARTITION BY sermon_scripture_filters.bible_book ORDER BY sermons.date DESC, sermons.id DESC) as row_num')
             ->join('sermon_scripture_filters', 'sermons.id', '=', 'sermon_scripture_filters.sermon_id')
             ->whereSermon();
 
         $representativeSermons = Sermon::query()
-            ->select(['sermons.id', 'sermons.title', 'sermons.date', 'sermons.slug', 'sermons.thumbnail_file_path', 'sermons.thumbnail_generated_at', 'sermons.thumbnail_metadata', 'f.bible_book as book_group'])
-            ->join('sermon_scripture_filters as f', 'sermons.id', '=', 'f.sermon_id')
-            ->whereIn('sermons.id', function ($query) use ($subquery): void {
-                $query->select('id')
-                    ->fromSub($subquery, 'ranked')
-                    ->where('row_num', 1);
-            })
+            ->fromSub($subquery, 'ranked')
+            ->where('row_num', 1)
             ->get()
             ->keyBy('book_group');
 
@@ -263,19 +259,15 @@ class SitemapService
         }
 
         $subquery = Sermon::query()
-            ->select('id')
+            ->select(['id', 'title', 'date', 'slug', 'series', 'thumbnail_file_path', 'thumbnail_generated_at', 'thumbnail_metadata'])
             ->selectRaw('ROW_NUMBER() OVER (PARTITION BY series ORDER BY date DESC, id DESC) as row_num')
             ->whereSermon()
             ->whereNotNull('series')
             ->where('series', '!=', '');
 
         $representativeSermons = Sermon::query()
-            ->select(['id', 'title', 'date', 'slug', 'series', 'thumbnail_file_path', 'thumbnail_generated_at', 'thumbnail_metadata'])
-            ->whereIn('id', function ($query) use ($subquery): void {
-                $query->select('id')
-                    ->fromSub($subquery, 'ranked')
-                    ->where('row_num', 1);
-            })
+            ->fromSub($subquery, 'ranked')
+            ->where('row_num', 1)
             ->get()
             ->keyBy('series');
 

--- a/tests/Feature/ViewComposerTest.php
+++ b/tests/Feature/ViewComposerTest.php
@@ -251,7 +251,7 @@ class ViewComposerTest extends TestCase
         ])->render();
 
         $this->assertStringContainsString('Learn about Sunday Evenings', $view);
-        $this->assertStringContainsString('bg-[linear-gradient(120deg,theme(colors.cbc-teal.DEFAULT)_0%,theme(colors.cbc-teal.dark)_55%,#0e3a3c_100%)]', $view);
+        $this->assertStringContainsString('bg-[linear-gradient(120deg,var(--color-cbc-teal)_0%,var(--color-cbc-teal-dark)_55%,#0e3a3c_100%)]', $view);
         $this->assertStringContainsString('justify-between', $view);
     }
 
@@ -271,7 +271,7 @@ class ViewComposerTest extends TestCase
         ])->render();
 
         $this->assertStringContainsString('[grid-template-columns:repeat(auto-fit,minmax(min(100%,19rem),19rem))]', $view);
-        $this->assertStringContainsString('bg-[linear-gradient(120deg,theme(colors.cbc-teal.DEFAULT)_0%,theme(colors.cbc-teal.dark)_55%,#0e3a3c_100%)]', $view);
+        $this->assertStringContainsString('bg-[linear-gradient(120deg,var(--color-cbc-teal)_0%,var(--color-cbc-teal-dark)_55%,#0e3a3c_100%)]', $view);
         $this->assertStringContainsString('View Sermon', $view);
     }
 


### PR DESCRIPTION
This PR implements two performance optimizations:

1. **Sitemap N+1 Fix**: Refactors `SitemapService::addBooks()` and `SitemapService::addSeries()` to fetch the latest representative sermons for all groups in a single bulk query using MySQL window functions (`ROW_NUMBER() OVER`). This eliminates the previous N+1 bottleneck where a separate query was executed for every Bible book and sermon series to find a representative image.

2. **Admin Listing Pre-warming**: Updates the `ListSermons` Livewire component to call `presentCollection()` on the `SermonViewPresenter` before the Blade template iterates over the paginated collection. This pre-warms the presenter's internal memoization caches (for preacher names, scripture references, and dates), reducing the overhead of redundant container lookups and logic during the rendering phase.

Additionally, this PR fixes a regression in `ViewComposerTest` where assertions were using legacy Tailwind `theme()` syntax instead of the modern `var(--color-*)` syntax used in the components.

---
*PR created automatically by Jules for task [6006112220858943900](https://jules.google.com/task/6006112220858943900) started by @GarethClarridge*