### PR TITLE
🧹 Tidy: refactor ServiceSectionPublicationStatus enum to use TitleCase keys

### DIFF
--- a/app/Actions/Publication/ApproveSectionForPublication.php
+++ b/app/Actions/Publication/ApproveSectionForPublication.php
@@ -35,7 +35,7 @@ class ApproveSectionForPublication
             return $error;
         }
 
-        if (! $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::APPROVED)) {
+        if (! $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::Approved)) {
             return 'This section cannot be approved in its current state.';
         }
 

--- a/app/Actions/Publication/ExpireSectionPublicationAssets.php
+++ b/app/Actions/Publication/ExpireSectionPublicationAssets.php
@@ -29,7 +29,7 @@ class ExpireSectionPublicationAssets
     {
         $previousStatus = $section->publication_status->value;
 
-        if (! $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::NOT_APPLICABLE)) {
+        if (! $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::NotApplicable)) {
             throw new \RuntimeException(
                 "Failed to transition section #{$section->id} from {$previousStatus} to not_applicable."
             );

--- a/app/Actions/Publication/RejectSectionPublication.php
+++ b/app/Actions/Publication/RejectSectionPublication.php
@@ -21,7 +21,7 @@ class RejectSectionPublication
      */
     public function execute(ServiceSection $section): bool
     {
-        if (! $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::REJECTED)) {
+        if (! $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::Rejected)) {
             return false;
         }
 

--- a/app/Actions/Publication/RequeueSectionPublication.php
+++ b/app/Actions/Publication/RequeueSectionPublication.php
@@ -21,7 +21,7 @@ class RequeueSectionPublication
      */
     public function execute(ServiceSection $section): bool
     {
-        if (! $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::PENDING_APPROVAL)) {
+        if (! $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::PendingApproval)) {
             return false;
         }
 

--- a/app/Actions/ServiceReview/MergeAdjacentServiceSections.php
+++ b/app/Actions/ServiceReview/MergeAdjacentServiceSections.php
@@ -63,7 +63,7 @@ class MergeAdjacentServiceSections
             $primary->extracted_video_path = null;
             $primary->extracted_audio_path = null;
             $primary->extracted_at = null;
-            $primary->publication_status = ServiceSectionPublicationStatus::NOT_APPLICABLE;
+            $primary->publication_status = ServiceSectionPublicationStatus::NotApplicable;
         }
 
         $primary->metadata = ServiceSectionMetadata::fromArray($metadata);
@@ -93,7 +93,7 @@ class MergeAdjacentServiceSections
             return 'Both sections must have the same section type.';
         }
 
-        $publishedStatuses = [ServiceSectionPublicationStatus::PUBLISHED];
+        $publishedStatuses = [ServiceSectionPublicationStatus::Published];
         if (in_array($primary->publication_status, $publishedStatuses, true)
             || in_array($secondary->publication_status, $publishedStatuses, true)) {
             return 'Published sections cannot be merged.';

--- a/app/Actions/ServiceReview/SaveServiceSection.php
+++ b/app/Actions/ServiceReview/SaveServiceSection.php
@@ -114,13 +114,13 @@ class SaveServiceSection
 
         if (
             ! $this->publicationTransitions->isPublishableType($section)
-            && $section->publication_status !== ServiceSectionPublicationStatus::NOT_APPLICABLE
+            && $section->publication_status !== ServiceSectionPublicationStatus::NotApplicable
         ) {
-            $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::NOT_APPLICABLE);
+            $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::NotApplicable);
         } elseif (
             $this->publicationTransitions->isPublishableType($section)
             && ! $section->needs_manual_review
-            && $section->publication_status === ServiceSectionPublicationStatus::NOT_APPLICABLE
+            && $section->publication_status === ServiceSectionPublicationStatus::NotApplicable
         ) {
             $section->save();
 
@@ -134,7 +134,7 @@ class SaveServiceSection
                     $section->unpublished_expires_at = now()->addHours(max(1, $retainHours));
                 }
 
-                $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::PENDING_APPROVAL);
+                $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::PendingApproval);
                 $section->save();
             } else {
                 $section->loadMissing('processingLog');

--- a/app/Console/Commands/CleanupUnpublishedSectionAssetsCommand.php
+++ b/app/Console/Commands/CleanupUnpublishedSectionAssetsCommand.php
@@ -27,9 +27,9 @@ class CleanupUnpublishedSectionAssetsCommand extends Command
         $cutoff = now()->subHours($hours);
 
         $targetStatuses = [
-            ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
-            ServiceSectionPublicationStatus::REJECTED->value,
-            ServiceSectionPublicationStatus::APPROVED->value,
+            ServiceSectionPublicationStatus::PendingApproval->value,
+            ServiceSectionPublicationStatus::Rejected->value,
+            ServiceSectionPublicationStatus::Approved->value,
         ];
 
         $sections = ServiceSection::query()

--- a/app/Enums/ServiceSectionPublicationStatus.php
+++ b/app/Enums/ServiceSectionPublicationStatus.php
@@ -10,20 +10,20 @@ enum ServiceSectionPublicationStatus: string
 {
     use HasValues;
 
-    case NOT_APPLICABLE = 'not_applicable';
-    case PENDING_APPROVAL = 'pending_approval';
-    case APPROVED = 'approved';
-    case REJECTED = 'rejected';
-    case PUBLISHED = 'published';
+    case NotApplicable = 'not_applicable';
+    case PendingApproval = 'pending_approval';
+    case Approved = 'approved';
+    case Rejected = 'rejected';
+    case Published = 'published';
 
     public function label(): string
     {
         return match ($this) {
-            self::NOT_APPLICABLE => 'Not Applicable',
-            self::PENDING_APPROVAL => 'Pending Approval',
-            self::APPROVED => 'Approved',
-            self::REJECTED => 'Rejected',
-            self::PUBLISHED => 'Published',
+            self::NotApplicable => 'Not Applicable',
+            self::PendingApproval => 'Pending Approval',
+            self::Approved => 'Approved',
+            self::Rejected => 'Rejected',
+            self::Published => 'Published',
         };
     }
 }

--- a/app/Http/Controllers/Admin/ServiceSectionCandidateMediaController.php
+++ b/app/Http/Controllers/Admin/ServiceSectionCandidateMediaController.php
@@ -40,7 +40,7 @@ class ServiceSectionCandidateMediaController extends Controller
         string $contentType,
     ): BinaryFileResponse {
         abort_if(
-            $serviceSection->publication_status === ServiceSectionPublicationStatus::PUBLISHED
+            $serviceSection->publication_status === ServiceSectionPublicationStatus::Published
                 || $serviceSection->published_sermon_id !== null,
             404,
             'Candidate media is no longer available.',

--- a/app/Jobs/AutoPublishServiceSection.php
+++ b/app/Jobs/AutoPublishServiceSection.php
@@ -58,7 +58,7 @@ class AutoPublishServiceSection implements ShouldQueue
                 return;
             }
 
-            if ($section->publication_status === ServiceSectionPublicationStatus::PUBLISHED) {
+            if ($section->publication_status === ServiceSectionPublicationStatus::Published) {
                 return;
             }
 

--- a/app/Jobs/PrepareSectionPublicationCandidates.php
+++ b/app/Jobs/PrepareSectionPublicationCandidates.php
@@ -115,9 +115,9 @@ class PrepareSectionPublicationCandidates extends ProcessingJob implements Shoul
 
             if (! $handler instanceof SectionPublicationHandler || ! $handler->isEligible($section)) {
                 if (
-                    $section->publication_status === ServiceSectionPublicationStatus::PUBLISHED
-                    || $section->publication_status === ServiceSectionPublicationStatus::APPROVED
-                    || $section->publication_status === ServiceSectionPublicationStatus::REJECTED
+                    $section->publication_status === ServiceSectionPublicationStatus::Published
+                    || $section->publication_status === ServiceSectionPublicationStatus::Approved
+                    || $section->publication_status === ServiceSectionPublicationStatus::Rejected
                 ) {
                     continue;
                 }
@@ -137,9 +137,9 @@ class PrepareSectionPublicationCandidates extends ProcessingJob implements Shoul
 
             if (! $eligibleByStatus) {
                 if (
-                    $section->publication_status === ServiceSectionPublicationStatus::PUBLISHED
-                    || $section->publication_status === ServiceSectionPublicationStatus::APPROVED
-                    || $section->publication_status === ServiceSectionPublicationStatus::REJECTED
+                    $section->publication_status === ServiceSectionPublicationStatus::Published
+                    || $section->publication_status === ServiceSectionPublicationStatus::Approved
+                    || $section->publication_status === ServiceSectionPublicationStatus::Rejected
                 ) {
                     $section->save();
 
@@ -151,7 +151,7 @@ class PrepareSectionPublicationCandidates extends ProcessingJob implements Shoul
                 continue;
             }
 
-            if ($section->publication_status === ServiceSectionPublicationStatus::PUBLISHED) {
+            if ($section->publication_status === ServiceSectionPublicationStatus::Published) {
                 $section->save();
 
                 continue;
@@ -166,8 +166,8 @@ class PrepareSectionPublicationCandidates extends ProcessingJob implements Shoul
             }
 
             if (
-                $section->publication_status !== ServiceSectionPublicationStatus::PENDING_APPROVAL
-                && ! $publicationTransitions->transition($section, ServiceSectionPublicationStatus::PENDING_APPROVAL)
+                $section->publication_status !== ServiceSectionPublicationStatus::PendingApproval
+                && ! $publicationTransitions->transition($section, ServiceSectionPublicationStatus::PendingApproval)
             ) {
                 continue;
             }
@@ -187,11 +187,11 @@ class PrepareSectionPublicationCandidates extends ProcessingJob implements Shoul
         ServiceSection $section,
         ServiceSectionPublicationTransitionService $publicationTransitions
     ): void {
-        if ($section->publication_status === ServiceSectionPublicationStatus::PUBLISHED) {
+        if ($section->publication_status === ServiceSectionPublicationStatus::Published) {
             return;
         }
 
-        if (! $publicationTransitions->transition($section, ServiceSectionPublicationStatus::NOT_APPLICABLE)) {
+        if (! $publicationTransitions->transition($section, ServiceSectionPublicationStatus::NotApplicable)) {
             return;
         }
 

--- a/app/Jobs/PublishApprovedServiceSection.php
+++ b/app/Jobs/PublishApprovedServiceSection.php
@@ -60,14 +60,14 @@ class PublishApprovedServiceSection implements ShouldQueue
             }
 
             if (
-                $section->publication_status === ServiceSectionPublicationStatus::PUBLISHED
+                $section->publication_status === ServiceSectionPublicationStatus::Published
                 && $section->published_sermon_id !== null
             ) {
                 return;
             }
 
             if (
-                $section->publication_status !== ServiceSectionPublicationStatus::APPROVED
+                $section->publication_status !== ServiceSectionPublicationStatus::Approved
                 || $section->published_sermon_id !== null
             ) {
                 return;

--- a/app/Livewire/Admin/ChurchServices/ListSectionPublications.php
+++ b/app/Livewire/Admin/ChurchServices/ListSectionPublications.php
@@ -27,7 +27,7 @@ class ListSectionPublications extends Component
     public string $search = '';
 
     #[Url(except: 'pending_approval')]
-    public string $publicationStatus = ServiceSectionPublicationStatus::PENDING_APPROVAL->value;
+    public string $publicationStatus = ServiceSectionPublicationStatus::PendingApproval->value;
 
     public bool $hasFilters = false;
 
@@ -49,7 +49,7 @@ class ListSectionPublications extends Component
     public function resetFilters(): void
     {
         $this->reset(['search']);
-        $this->publicationStatus = ServiceSectionPublicationStatus::PENDING_APPROVAL->value;
+        $this->publicationStatus = ServiceSectionPublicationStatus::PendingApproval->value;
         $this->resetPage();
     }
 
@@ -59,7 +59,7 @@ class ListSectionPublications extends Component
         $escapedSearch = $this->escapeLike($search);
         $searchPattern = '%'.$escapedSearch.'%';
         $this->hasFilters = $search !== ''
-            || $this->publicationStatus !== ServiceSectionPublicationStatus::PENDING_APPROVAL->value;
+            || $this->publicationStatus !== ServiceSectionPublicationStatus::PendingApproval->value;
 
         $sections = ServiceSection::query()
             ->with([

--- a/app/Presenters/ChurchServiceShowPresenter.php
+++ b/app/Presenters/ChurchServiceShowPresenter.php
@@ -84,8 +84,8 @@ class ChurchServiceShowPresenter
                 needsSectionReview: $run->serviceSections->contains('needs_manual_review', true),
                 hasPendingPublications: $run->serviceSections->contains(
                     fn ($section): bool => in_array($section->publication_status, [
-                        ServiceSectionPublicationStatus::PENDING_APPROVAL,
-                        ServiceSectionPublicationStatus::APPROVED,
+                        ServiceSectionPublicationStatus::PendingApproval,
+                        ServiceSectionPublicationStatus::Approved,
                     ], true)
                 ),
             ))

--- a/app/Queries/ServiceReviewDashboardQuery.php
+++ b/app/Queries/ServiceReviewDashboardQuery.php
@@ -123,13 +123,13 @@ class ServiceReviewDashboardQuery
             });
 
             $group['pending_approval_count'] = collect($group['sections'])
-                ->filter(fn (array $entry): bool => $entry['section']->publication_status === ServiceSectionPublicationStatus::PENDING_APPROVAL)
+                ->filter(fn (array $entry): bool => $entry['section']->publication_status === ServiceSectionPublicationStatus::PendingApproval)
                 ->count();
             $group['batch_ready_count'] = collect($group['sections'])
                 ->filter(function (array $entry): bool {
                     $section = $entry['section'];
 
-                    return $section->publication_status === ServiceSectionPublicationStatus::PENDING_APPROVAL
+                    return $section->publication_status === ServiceSectionPublicationStatus::PendingApproval
                         && $this->batchApprovalSkipReason($section) === null;
                 })
                 ->count();
@@ -200,7 +200,7 @@ class ServiceReviewDashboardQuery
                 'churchServiceItem:id,church_service_id,title,song_id,type',
                 'churchServiceItem.churchService:id,date,service,needs_review',
             ])
-            ->where('publication_status', ServiceSectionPublicationStatus::PENDING_APPROVAL->value)
+            ->where('publication_status', ServiceSectionPublicationStatus::PendingApproval->value)
             ->where(function (Builder $query) use ($service): void {
                 $query->whereHas('processingLog', function (Builder $query) use ($service): void {
                     $query->where('church_service_id', $service->id)
@@ -242,7 +242,7 @@ class ServiceReviewDashboardQuery
             ];
         }
 
-        if ($section->publication_status === ServiceSectionPublicationStatus::PENDING_APPROVAL) {
+        if ($section->publication_status === ServiceSectionPublicationStatus::PendingApproval) {
             $reasons[] = [
                 'key' => 'pending_approval',
                 'label' => 'Pending approval',
@@ -321,7 +321,7 @@ class ServiceReviewDashboardQuery
             ])
             ->where(function (Builder $query): void {
                 $query->where('needs_manual_review', true)
-                    ->orWhere('publication_status', ServiceSectionPublicationStatus::PENDING_APPROVAL->value)
+                    ->orWhere('publication_status', ServiceSectionPublicationStatus::PendingApproval->value)
                     ->orWhere('confidence', '<', ServiceSectionConfidence::HIGH_THRESHOLD)
                     ->orWhere(function (Builder $query): void {
                         $query->where('section_type', ServiceSectionType::SONG->value)
@@ -473,7 +473,7 @@ class ServiceReviewDashboardQuery
         }
 
         if (
-            $section->publication_status === ServiceSectionPublicationStatus::PUBLISHED
+            $section->publication_status === ServiceSectionPublicationStatus::Published
             || $section->published_sermon_id !== null
         ) {
             return null;

--- a/app/Services/SectionPublication/SermonPublicationHandler.php
+++ b/app/Services/SectionPublication/SermonPublicationHandler.php
@@ -112,7 +112,7 @@ class SermonPublicationHandler implements SectionPublicationHandler
             'sermons/audio/'.basename($audioPath),
         );
 
-        if (! $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::PUBLISHED)) {
+        if (! $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::Published)) {
             throw new \RuntimeException('Invalid state transition when publishing approved section');
         }
 

--- a/app/Services/SectionPublication/SongPublicationHandler.php
+++ b/app/Services/SectionPublication/SongPublicationHandler.php
@@ -124,7 +124,7 @@ class SongPublicationHandler implements SectionPublicationHandler
 
         $this->songVideoService->createFromExtraction($section, $promotedPath);
 
-        if (! $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::PUBLISHED)) {
+        if (! $this->publicationTransitions->transition($section, ServiceSectionPublicationStatus::Published)) {
             throw new \RuntimeException('Invalid state transition when publishing song section');
         }
 

--- a/app/Services/ServiceSectionPublicationTransitionService.php
+++ b/app/Services/ServiceSectionPublicationTransitionService.php
@@ -22,26 +22,26 @@ class ServiceSectionPublicationTransitionService
     {
         $current = $section->publication_status;
         $allowed = match ($current) {
-            ServiceSectionPublicationStatus::NOT_APPLICABLE => [
-                ServiceSectionPublicationStatus::PENDING_APPROVAL,
-                ServiceSectionPublicationStatus::PUBLISHED,
+            ServiceSectionPublicationStatus::NotApplicable => [
+                ServiceSectionPublicationStatus::PendingApproval,
+                ServiceSectionPublicationStatus::Published,
             ],
-            ServiceSectionPublicationStatus::PENDING_APPROVAL => [
-                ServiceSectionPublicationStatus::APPROVED,
-                ServiceSectionPublicationStatus::REJECTED,
-                ServiceSectionPublicationStatus::NOT_APPLICABLE,
+            ServiceSectionPublicationStatus::PendingApproval => [
+                ServiceSectionPublicationStatus::Approved,
+                ServiceSectionPublicationStatus::Rejected,
+                ServiceSectionPublicationStatus::NotApplicable,
             ],
-            ServiceSectionPublicationStatus::APPROVED => [
-                ServiceSectionPublicationStatus::PUBLISHED,
-                ServiceSectionPublicationStatus::REJECTED,
-                ServiceSectionPublicationStatus::NOT_APPLICABLE,
+            ServiceSectionPublicationStatus::Approved => [
+                ServiceSectionPublicationStatus::Published,
+                ServiceSectionPublicationStatus::Rejected,
+                ServiceSectionPublicationStatus::NotApplicable,
             ],
-            ServiceSectionPublicationStatus::REJECTED => [
-                ServiceSectionPublicationStatus::PENDING_APPROVAL,
-                ServiceSectionPublicationStatus::NOT_APPLICABLE,
+            ServiceSectionPublicationStatus::Rejected => [
+                ServiceSectionPublicationStatus::PendingApproval,
+                ServiceSectionPublicationStatus::NotApplicable,
             ],
-            ServiceSectionPublicationStatus::PUBLISHED => [
-                ServiceSectionPublicationStatus::NOT_APPLICABLE,
+            ServiceSectionPublicationStatus::Published => [
+                ServiceSectionPublicationStatus::NotApplicable,
             ],
         };
 

--- a/app/Services/ServiceSectionSyncService.php
+++ b/app/Services/ServiceSectionSyncService.php
@@ -50,7 +50,7 @@ class ServiceSectionSyncService
      */
     public function sync(MediaProcessingLog $processingLog, array $classifiedSections): void
     {
-        $defaultPublicationStatus = ServiceSectionPublicationStatus::NOT_APPLICABLE->value;
+        $defaultPublicationStatus = ServiceSectionPublicationStatus::NotApplicable->value;
 
         DB::transaction(function () use ($processingLog, $classifiedSections, $defaultPublicationStatus): void {
             $existingByOrder = ServiceSection::query()
@@ -114,7 +114,7 @@ class ServiceSectionSyncService
                 ServiceSection::query()->create(array_merge(
                     $payload,
                     [
-                        'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+                        'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
                         'song_match_type' => null,
                         'published_sermon_id' => null,
                         'published_at' => null,
@@ -195,7 +195,7 @@ class ServiceSectionSyncService
         }
 
         return [
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'published_sermon_id' => null,
             'published_at' => null,
             'extracted_video_path' => null,

--- a/app/Services/SongVideoService.php
+++ b/app/Services/SongVideoService.php
@@ -107,11 +107,11 @@ class SongVideoService
             return;
         }
 
-        if ($section->publication_status !== ServiceSectionPublicationStatus::PUBLISHED) {
+        if ($section->publication_status !== ServiceSectionPublicationStatus::Published) {
             return;
         }
 
-        $section->publication_status = ServiceSectionPublicationStatus::NOT_APPLICABLE;
+        $section->publication_status = ServiceSectionPublicationStatus::NotApplicable;
         $section->published_at = null;
         $section->published_sermon_id = null;
         $section->save();

--- a/app/Support/SchemaGuardrailAudit.php
+++ b/app/Support/SchemaGuardrailAudit.php
@@ -209,21 +209,21 @@ class SchemaGuardrailAudit
         return ServiceSection::query()
             ->where(function ($query): void {
                 $query->where(function ($query): void {
-                    $query->where('publication_status', ServiceSectionPublicationStatus::PUBLISHED->value)
+                    $query->where('publication_status', ServiceSectionPublicationStatus::Published->value)
                         ->where(function ($query): void {
                             $query->whereNull('published_sermon_id')
                                 ->orWhereNull('published_at');
                         });
                 })->orWhere(function ($query): void {
-                    $query->where('publication_status', '!=', ServiceSectionPublicationStatus::PUBLISHED->value)
+                    $query->where('publication_status', '!=', ServiceSectionPublicationStatus::Published->value)
                         ->where(function ($query): void {
                             $query->whereNotNull('published_sermon_id')
                                 ->orWhereNotNull('published_at');
                         });
                 })->orWhere(function ($query): void {
                     $query->whereIn('publication_status', [
-                        ServiceSectionPublicationStatus::APPROVED->value,
-                        ServiceSectionPublicationStatus::PUBLISHED->value,
+                        ServiceSectionPublicationStatus::Approved->value,
+                        ServiceSectionPublicationStatus::Published->value,
                     ])->where(function ($query): void {
                         $query->whereNull('extracted_video_path')
                             ->orWhereNull('extracted_audio_path')
@@ -231,7 +231,7 @@ class SchemaGuardrailAudit
                     });
                 })->orWhere(function ($query): void {
                     $query->where('status', ServiceSectionStatus::Skipped->value)
-                        ->where('publication_status', '!=', ServiceSectionPublicationStatus::NOT_APPLICABLE->value);
+                        ->where('publication_status', '!=', ServiceSectionPublicationStatus::NotApplicable->value);
                 });
             })
             ->count();

--- a/database/factories/ServiceSectionFactory.php
+++ b/database/factories/ServiceSectionFactory.php
@@ -66,13 +66,13 @@ class ServiceSectionFactory extends Factory
             }
 
             if ($section->published_sermon_id !== null || $section->published_at !== null) {
-                $section->publication_status = ServiceSectionPublicationStatus::PUBLISHED;
+                $section->publication_status = ServiceSectionPublicationStatus::Published;
             }
 
             if (
                 in_array($section->publication_status, [
-                    ServiceSectionPublicationStatus::APPROVED,
-                    ServiceSectionPublicationStatus::PUBLISHED,
+                    ServiceSectionPublicationStatus::Approved,
+                    ServiceSectionPublicationStatus::Published,
                 ], true)
             ) {
                 $section->extracted_video_path ??= 'sermons/sections/'.($section->id ?? 'pending').'/video.mp4';
@@ -80,7 +80,7 @@ class ServiceSectionFactory extends Factory
                 $section->extracted_at ??= now();
             }
 
-            if ($section->publication_status === ServiceSectionPublicationStatus::PUBLISHED) {
+            if ($section->publication_status === ServiceSectionPublicationStatus::Published) {
                 $section->published_sermon_id ??= Sermon::factory()->create()->id;
                 $section->published_at ??= now();
             }
@@ -116,7 +116,7 @@ class ServiceSectionFactory extends Factory
             'song_match_type' => null,
             'matched_item_id' => null,
             'expected_item_id' => null,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable,
             'published_sermon_id' => null,
             'published_at' => null,
             'extracted_video_path' => null,

--- a/database/migrations/2026_03_19_050000_add_additive_schema_guardrails_for_processing_tables.php
+++ b/database/migrations/2026_03_19_050000_add_additive_schema_guardrails_for_processing_tables.php
@@ -70,7 +70,7 @@ return new class extends Migration
                 static fn (ServiceSectionPublicationStatus $status): string => $status->value,
                 ServiceSectionPublicationStatus::cases()
             )),
-            $this->quote(ServiceSectionPublicationStatus::NOT_APPLICABLE->value)
+            $this->quote(ServiceSectionPublicationStatus::NotApplicable->value)
         ));
     }
 
@@ -82,7 +82,7 @@ return new class extends Migration
         DB::statement('ALTER TABLE service_sections MODIFY status VARCHAR(255) NOT NULL');
         DB::statement(
             'ALTER TABLE service_sections MODIFY publication_status VARCHAR(255) NOT NULL DEFAULT '
-            .$this->quote(ServiceSectionPublicationStatus::NOT_APPLICABLE->value)
+            .$this->quote(ServiceSectionPublicationStatus::NotApplicable->value)
         );
 
         Schema::table('service_sections', function (Blueprint $table): void {

--- a/database/migrations/2026_03_22_120000_formalize_review_publication_state_and_ordering_invariants.php
+++ b/database/migrations/2026_03_22_120000_formalize_review_publication_state_and_ordering_invariants.php
@@ -251,12 +251,12 @@ return new class extends Migration
 
                     $updates = [];
 
-                    if ($status === ServiceSectionStatus::Skipped->value && $publicationStatus !== ServiceSectionPublicationStatus::NOT_APPLICABLE->value) {
-                        $publicationStatus = ServiceSectionPublicationStatus::NOT_APPLICABLE->value;
+                    if ($status === ServiceSectionStatus::Skipped->value && $publicationStatus !== ServiceSectionPublicationStatus::NotApplicable->value) {
+                        $publicationStatus = ServiceSectionPublicationStatus::NotApplicable->value;
                         $updates['publication_status'] = $publicationStatus;
                     }
 
-                    if ($publicationStatus !== ServiceSectionPublicationStatus::PUBLISHED->value) {
+                    if ($publicationStatus !== ServiceSectionPublicationStatus::Published->value) {
                         if ($publishedSermonId !== null) {
                             $updates['published_sermon_id'] = null;
                         }
@@ -270,10 +270,10 @@ return new class extends Migration
 
                     if (
                         in_array($publicationStatus, [
-                            ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
-                            ServiceSectionPublicationStatus::APPROVED->value,
-                            ServiceSectionPublicationStatus::REJECTED->value,
-                            ServiceSectionPublicationStatus::PUBLISHED->value,
+                            ServiceSectionPublicationStatus::PendingApproval->value,
+                            ServiceSectionPublicationStatus::Approved->value,
+                            ServiceSectionPublicationStatus::Rejected->value,
+                            ServiceSectionPublicationStatus::Published->value,
                         ], true)
                         && $extractedAt === null
                         && is_string($section->extracted_video_path)

--- a/resources/views/livewire/admin/church-services/list-section-publications.blade.php
+++ b/resources/views/livewire/admin/church-services/list-section-publications.blade.php
@@ -80,10 +80,10 @@
                             <td class="px-4 py-3 text-sm">{{ ucfirst((string) $confidence) }}</td>
                             <td class="px-4 py-3 text-sm">
                                 <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ match($section->publication_status) {
-                                    \App\Enums\ServiceSectionPublicationStatus::PENDING_APPROVAL => 'bg-amber-100 text-amber-800',
-                                    \App\Enums\ServiceSectionPublicationStatus::APPROVED => 'bg-sky-100 text-sky-800',
-                                    \App\Enums\ServiceSectionPublicationStatus::REJECTED => 'bg-rose-100 text-rose-800',
-                                    \App\Enums\ServiceSectionPublicationStatus::PUBLISHED => 'bg-cbc-teal-light/15 text-cbc-teal-dark',
+                                    \App\Enums\ServiceSectionPublicationStatus::PendingApproval => 'bg-amber-100 text-amber-800',
+                                    \App\Enums\ServiceSectionPublicationStatus::Approved => 'bg-sky-100 text-sky-800',
+                                    \App\Enums\ServiceSectionPublicationStatus::Rejected => 'bg-rose-100 text-rose-800',
+                                    \App\Enums\ServiceSectionPublicationStatus::Published => 'bg-cbc-teal-light/15 text-cbc-teal-dark',
                                     default => 'bg-gray-100 text-gray-700',
                                 } }}">
                                     {{ $section->publication_status->label() }}
@@ -91,7 +91,7 @@
                             </td>
                             <td class="px-4 py-3 text-right">
                                 <div class="flex items-center justify-end gap-2">
-                                    @if($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::PENDING_APPROVAL)
+                                    @if($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::PendingApproval)
                                         <x-form-button
                                             type="button"
                                             size="xs"
@@ -110,7 +110,7 @@
                                         >
                                             Reject
                                         </x-form-button>
-                                    @elseif($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::APPROVED)
+                                    @elseif($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::Approved)
                                         <x-form-button
                                             type="button"
                                             size="xs"
@@ -120,7 +120,7 @@
                                         >
                                             Reject
                                         </x-form-button>
-                                    @elseif($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::REJECTED)
+                                    @elseif($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::Rejected)
                                         <x-form-button
                                             type="button"
                                             size="xs"
@@ -130,7 +130,7 @@
                                         >
                                             Requeue
                                         </x-form-button>
-                                    @elseif($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::PUBLISHED && $section->publishedSermon)
+                                    @elseif($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::Published && $section->publishedSermon)
                                         @php
                                             $publishedSermonUrl = $section->publishedSermon->content_type === \App\Enums\SermonContentType::ChildrensTalk
                                                 ? route('childrens-corner.show', ['sermon' => $section->publishedSermon->slug])

--- a/resources/views/livewire/admin/church-services/partials/service-flow-row.blade.php
+++ b/resources/views/livewire/admin/church-services/partials/service-flow-row.blade.php
@@ -98,16 +98,16 @@
                     <span class="inline-block h-2 w-2 rounded-full bg-rose-400" title="No confidence"></span>
                 @endif
 
-                @if($item['publication_status'] instanceof ServiceSectionPublicationStatus && $item['publication_status'] !== ServiceSectionPublicationStatus::PENDING_APPROVAL)
+                @if($item['publication_status'] instanceof ServiceSectionPublicationStatus && $item['publication_status'] !== ServiceSectionPublicationStatus::PendingApproval)
                     <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {{ match($item['publication_status']) {
-                        ServiceSectionPublicationStatus::APPROVED => 'bg-sky-100 text-sky-800',
-                        ServiceSectionPublicationStatus::REJECTED => 'bg-rose-100 text-rose-800',
-                        ServiceSectionPublicationStatus::PUBLISHED => 'bg-cbc-teal-light/15 text-cbc-teal-dark',
+                        ServiceSectionPublicationStatus::Approved => 'bg-sky-100 text-sky-800',
+                        ServiceSectionPublicationStatus::Rejected => 'bg-rose-100 text-rose-800',
+                        ServiceSectionPublicationStatus::Published => 'bg-cbc-teal-light/15 text-cbc-teal-dark',
                         default => 'bg-gray-100 text-gray-700',
                     } }}">
                         {{ $item['publication_status']->label() }}
                     </span>
-                @elseif($item['publication_status'] === ServiceSectionPublicationStatus::PENDING_APPROVAL)
+                @elseif($item['publication_status'] === ServiceSectionPublicationStatus::PendingApproval)
                     <span class="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
                         Pending approval
                     </span>
@@ -130,7 +130,7 @@
                 </p>
             @endif
 
-            @if($item['publication_status'] === ServiceSectionPublicationStatus::PUBLISHED && $item['published_sermon'])
+            @if($item['publication_status'] === ServiceSectionPublicationStatus::Published && $item['published_sermon'])
                 @php
                     $publishedSermonUrl = $item['published_sermon']->content_type === SermonContentType::ChildrensTalk
                         ? route('childrens-corner.show', ['sermon' => $item['published_sermon']->slug])

--- a/resources/views/livewire/admin/church-services/partials/timeline-alignment-table-row.blade.php
+++ b/resources/views/livewire/admin/church-services/partials/timeline-alignment-table-row.blade.php
@@ -142,15 +142,15 @@
     <td class="px-3 py-2 text-sm">
         @if($row['publication_status'] instanceof ServiceSectionPublicationStatus)
             <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ match($row['publication_status']) {
-                ServiceSectionPublicationStatus::PENDING_APPROVAL => 'bg-amber-100 text-amber-800',
-                ServiceSectionPublicationStatus::APPROVED => 'bg-sky-100 text-sky-800',
-                ServiceSectionPublicationStatus::REJECTED => 'bg-rose-100 text-rose-800',
-                ServiceSectionPublicationStatus::PUBLISHED => 'bg-cbc-teal-light/15 text-cbc-teal-dark',
+                ServiceSectionPublicationStatus::PendingApproval => 'bg-amber-100 text-amber-800',
+                ServiceSectionPublicationStatus::Approved => 'bg-sky-100 text-sky-800',
+                ServiceSectionPublicationStatus::Rejected => 'bg-rose-100 text-rose-800',
+                ServiceSectionPublicationStatus::Published => 'bg-cbc-teal-light/15 text-cbc-teal-dark',
                 default => 'bg-gray-100 text-gray-700',
             } }}">
                 {{ $row['publication_status']->label() }}
             </span>
-            @if($row['publication_status'] === ServiceSectionPublicationStatus::PUBLISHED && $row['published_sermon'])
+            @if($row['publication_status'] === ServiceSectionPublicationStatus::Published && $row['published_sermon'])
                 @php
                     $publishedSermonUrl = $row['published_sermon']->content_type === SermonContentType::ChildrensTalk
                         ? route('childrens-corner.show', ['sermon' => $row['published_sermon']->slug])

--- a/resources/views/livewire/admin/church-services/service-review-dashboard.blade.php
+++ b/resources/views/livewire/admin/church-services/service-review-dashboard.blade.php
@@ -133,8 +133,8 @@
                                 $isMergeCandidate = $nextSection !== null
                                     && $nextSection->section_type === $section->section_type
                                     && abs($nextSection->start_time - $section->end_time) <= 2
-                                    && $section->publication_status !== \App\Enums\ServiceSectionPublicationStatus::PUBLISHED
-                                    && $nextSection->publication_status !== \App\Enums\ServiceSectionPublicationStatus::PUBLISHED;
+                                    && $section->publication_status !== \App\Enums\ServiceSectionPublicationStatus::Published
+                                    && $nextSection->publication_status !== \App\Enums\ServiceSectionPublicationStatus::Published;
                             @endphp
                             <div wire:key="service-review-section-{{ $section->id }}" class="rounded-lg border border-gray-200 bg-gray-50 p-4">
                                 <div class="flex flex-wrap items-start justify-between gap-4">
@@ -213,7 +213,7 @@
                                     </div>
 
                                     <div class="flex flex-wrap gap-2">
-                                        @if($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::PENDING_APPROVAL)
+                                        @if($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::PendingApproval)
                                             <x-form-button
                                                 type="button"
                                                 size="xs"
@@ -226,8 +226,8 @@
                                         @endif
 
                                         @if(in_array($section->publication_status, [
-                                            \App\Enums\ServiceSectionPublicationStatus::PENDING_APPROVAL,
-                                            \App\Enums\ServiceSectionPublicationStatus::APPROVED,
+                                            \App\Enums\ServiceSectionPublicationStatus::PendingApproval,
+                                            \App\Enums\ServiceSectionPublicationStatus::Approved,
                                         ], true))
                                             <x-form-button
                                                 type="button"
@@ -240,7 +240,7 @@
                                             </x-form-button>
                                         @endif
 
-                                        @if($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::REJECTED)
+                                        @if($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::Rejected)
                                             <x-form-button
                                                 type="button"
                                                 size="xs"

--- a/tests/Feature/Actions/ServiceReview/BatchApproveServicePublicationsTest.php
+++ b/tests/Feature/Actions/ServiceReview/BatchApproveServicePublicationsTest.php
@@ -57,7 +57,7 @@ class BatchApproveServicePublicationsTest extends TestCase
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sections/video.mp4',
             'extracted_audio_path' => 'sections/audio.mp3',
         ]);
@@ -69,7 +69,7 @@ class BatchApproveServicePublicationsTest extends TestCase
 
         $this->assertSame(1, $result['approved_count']);
         $this->assertSame([], $result['skipped_reasons']);
-        $this->assertSame(ServiceSectionPublicationStatus::APPROVED, $section->fresh()->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Approved, $section->fresh()->publication_status);
 
         Queue::assertPushed(PublishApprovedServiceSection::class);
     }
@@ -95,7 +95,7 @@ class BatchApproveServicePublicationsTest extends TestCase
         ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'needs_manual_review' => true,
             'extracted_video_path' => 'sections/review/video.mp4',
             'extracted_audio_path' => 'sections/review/audio.mp3',
@@ -132,7 +132,7 @@ class BatchApproveServicePublicationsTest extends TestCase
         ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'needs_manual_review' => false,
             'extracted_video_path' => 'sections/missing/video.mp4',
             'extracted_audio_path' => 'sections/missing/audio.mp3',
@@ -176,7 +176,7 @@ class BatchApproveServicePublicationsTest extends TestCase
         $selectedSection = ServiceSection::factory()->create([
             'media_processing_log_id' => $selectedRun->id,
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sections/selected/video.mp4',
             'extracted_audio_path' => 'sections/selected/audio.mp3',
         ]);
@@ -184,7 +184,7 @@ class BatchApproveServicePublicationsTest extends TestCase
         $otherSection = ServiceSection::factory()->create([
             'media_processing_log_id' => $otherRun->id,
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sections/other/video.mp4',
             'extracted_audio_path' => 'sections/other/audio.mp3',
         ]);
@@ -197,8 +197,8 @@ class BatchApproveServicePublicationsTest extends TestCase
         $result = $this->action->execute($selectedService, $this->admin->id);
 
         $this->assertSame(1, $result['approved_count']);
-        $this->assertSame(ServiceSectionPublicationStatus::APPROVED, $selectedSection->fresh()->publication_status);
-        $this->assertSame(ServiceSectionPublicationStatus::PENDING_APPROVAL, $otherSection->fresh()->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Approved, $selectedSection->fresh()->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::PendingApproval, $otherSection->fresh()->publication_status);
     }
 
     #[Test]
@@ -223,7 +223,7 @@ class BatchApproveServicePublicationsTest extends TestCase
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
             'section_order' => 1,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sections/audit/first/video.mp4',
             'extracted_audio_path' => 'sections/audit/first/audio.mp3',
         ]);
@@ -232,7 +232,7 @@ class BatchApproveServicePublicationsTest extends TestCase
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
             'section_order' => 2,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sections/audit/second/video.mp4',
             'extracted_audio_path' => 'sections/audit/second/audio.mp3',
         ]);
@@ -295,7 +295,7 @@ class BatchApproveServicePublicationsTest extends TestCase
         ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'needs_manual_review' => false,
             'extracted_video_path' => 'sections/default-error/video.mp4',
             'extracted_audio_path' => 'sections/default-error/audio.mp3',

--- a/tests/Feature/Actions/ServiceReview/MergeAdjacentServiceSectionsTest.php
+++ b/tests/Feature/Actions/ServiceReview/MergeAdjacentServiceSectionsTest.php
@@ -106,7 +106,7 @@ class MergeAdjacentServiceSectionsTest extends TestCase
         $section1 = ServiceSection::factory()->create([
             'media_processing_log_id' => $log->id,
             'section_type' => ServiceSectionType::SONG,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED,
+            'publication_status' => ServiceSectionPublicationStatus::Published,
         ]);
         $section2 = ServiceSection::factory()->create([
             'media_processing_log_id' => $log->id,
@@ -292,7 +292,7 @@ class MergeAdjacentServiceSectionsTest extends TestCase
             'extracted_video_path' => 'path/to/video.mp4',
             'extracted_audio_path' => 'path/to/audio.mp3',
             'extracted_at' => now(),
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED,
+            'publication_status' => ServiceSectionPublicationStatus::Approved,
         ]);
 
         // Mock hasExtractedMedia to return true by making files exist
@@ -314,6 +314,6 @@ class MergeAdjacentServiceSectionsTest extends TestCase
         $this->assertNull($section1->extracted_video_path);
         $this->assertNull($section1->extracted_audio_path);
         $this->assertNull($section1->extracted_at);
-        $this->assertEquals(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section1->publication_status);
+        $this->assertEquals(ServiceSectionPublicationStatus::NotApplicable, $section1->publication_status);
     }
 }

--- a/tests/Feature/Actions/ServiceReview/SaveServiceSectionTest.php
+++ b/tests/Feature/Actions/ServiceReview/SaveServiceSectionTest.php
@@ -119,7 +119,7 @@ class SaveServiceSectionTest extends TestCase
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::SONG->value,
             'needs_manual_review' => true,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         $this->action->execute(
@@ -131,7 +131,7 @@ class SaveServiceSectionTest extends TestCase
 
         $section->refresh();
 
-        $this->assertSame(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
     }
 
     #[Test]
@@ -147,7 +147,7 @@ class SaveServiceSectionTest extends TestCase
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
             'title' => "Children's Talk",
             'needs_manual_review' => true,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'extracted_video_path' => 'sections/video.mp4',
             'extracted_audio_path' => 'sections/audio.mp3',
             'metadata' => [
@@ -173,7 +173,7 @@ class SaveServiceSectionTest extends TestCase
         $section->refresh();
 
         $this->assertFalse($section->needs_manual_review);
-        $this->assertSame(ServiceSectionPublicationStatus::PENDING_APPROVAL, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::PendingApproval, $section->publication_status);
     }
 
     #[Test]
@@ -190,7 +190,7 @@ class SaveServiceSectionTest extends TestCase
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
             'title' => "Children's Talk",
             'needs_manual_review' => true,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'extracted_video_path' => null,
             'extracted_audio_path' => null,
             'metadata' => [
@@ -210,7 +210,7 @@ class SaveServiceSectionTest extends TestCase
         $section->refresh();
 
         $this->assertFalse($section->needs_manual_review);
-        $this->assertSame(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
         Bus::assertDispatched(PrepareSectionPublicationCandidates::class);
     }
 
@@ -274,7 +274,7 @@ class SaveServiceSectionTest extends TestCase
             'title' => 'Old Title',
             'needs_manual_review' => false,
             'confidence' => 0.99,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->action->execute(

--- a/tests/Feature/Admin/ServiceSectionCandidateMediaControllerTest.php
+++ b/tests/Feature/Admin/ServiceSectionCandidateMediaControllerTest.php
@@ -22,7 +22,7 @@ class ServiceSectionCandidateMediaControllerTest extends TestCase
     public function audio_preview_redirects_guests_to_login(): void
     {
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED,
+            'publication_status' => ServiceSectionPublicationStatus::Approved,
             'extracted_audio_path' => 'private/section-publications/1/audio.mp3',
         ]);
 
@@ -35,7 +35,7 @@ class ServiceSectionCandidateMediaControllerTest extends TestCase
     {
         $user = User::factory()->create(['is_admin' => false]);
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED,
+            'publication_status' => ServiceSectionPublicationStatus::Approved,
         ]);
 
         $response = $this->actingAs($user)->get(route('admin.services.section-publications.preview-audio', $section));
@@ -51,7 +51,7 @@ class ServiceSectionCandidateMediaControllerTest extends TestCase
         $admin = User::factory()->crockenhillAdmin()->create();
 
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED,
+            'publication_status' => ServiceSectionPublicationStatus::Published,
             'extracted_audio_path' => 'private/section-publications/99/audio.mp3',
         ]);
 
@@ -68,7 +68,7 @@ class ServiceSectionCandidateMediaControllerTest extends TestCase
         $admin = User::factory()->crockenhillAdmin()->create();
 
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED,
+            'publication_status' => ServiceSectionPublicationStatus::Published,
             'extracted_video_path' => 'private/section-publications/99/video.mp4',
         ]);
 
@@ -86,7 +86,7 @@ class ServiceSectionCandidateMediaControllerTest extends TestCase
         $admin = User::factory()->crockenhillAdmin()->create();
 
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED,
+            'publication_status' => ServiceSectionPublicationStatus::Approved,
             'extracted_audio_path' => '../../etc/passwd',
         ]);
 
@@ -103,7 +103,7 @@ class ServiceSectionCandidateMediaControllerTest extends TestCase
         $admin = User::factory()->crockenhillAdmin()->create();
 
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED,
+            'publication_status' => ServiceSectionPublicationStatus::Approved,
             'extracted_audio_path' => 'private/section-publications/1/missing.mp3',
         ]);
 

--- a/tests/Feature/AdminSectionPublicationCandidateMediaTest.php
+++ b/tests/Feature/AdminSectionPublicationCandidateMediaTest.php
@@ -38,7 +38,7 @@ class AdminSectionPublicationCandidateMediaTest extends TestCase
         $run = MediaProcessingLog::factory()->livestream()->create();
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_audio_path' => 'private/section-publications/700/audio.mp3',
         ]);
 
@@ -58,7 +58,7 @@ class AdminSectionPublicationCandidateMediaTest extends TestCase
         $run = MediaProcessingLog::factory()->livestream()->create();
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_audio_path' => 'private/section-publications/701/audio.mp3',
             'extracted_video_path' => 'private/section-publications/701/video.mp4',
         ]);

--- a/tests/Feature/Console/CleanupUnpublishedSectionAssetsCommandTest.php
+++ b/tests/Feature/Console/CleanupUnpublishedSectionAssetsCommandTest.php
@@ -27,7 +27,7 @@ class CleanupUnpublishedSectionAssetsCommandTest extends TestCase
         ]);
 
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'published_sermon_id' => null,
             'extracted_video_path' => 'sermons/sections/70/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-70.mp3',
@@ -61,7 +61,7 @@ class CleanupUnpublishedSectionAssetsCommandTest extends TestCase
         ]);
 
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Approved->value,
             'published_sermon_id' => null,
             'extracted_video_path' => 'sermons/sections/71/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-71.mp3',
@@ -95,7 +95,7 @@ class CleanupUnpublishedSectionAssetsCommandTest extends TestCase
         ]);
 
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Approved->value,
             'published_sermon_id' => null,
             'extracted_video_path' => 'sermons/sections/72/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-72.mp3',
@@ -109,7 +109,7 @@ class CleanupUnpublishedSectionAssetsCommandTest extends TestCase
         $this->artisan('media:cleanup-unpublished-section-assets')->assertSuccessful();
 
         $section->refresh();
-        $this->assertEquals(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertEquals(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
     }
 
     #[Test]
@@ -124,7 +124,7 @@ class CleanupUnpublishedSectionAssetsCommandTest extends TestCase
         ]);
 
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'published_sermon_id' => null,
             'extracted_video_path' => 'sermons/sections/73/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-73.mp3',
@@ -136,7 +136,7 @@ class CleanupUnpublishedSectionAssetsCommandTest extends TestCase
 
         $section->refresh();
         $metadata = $section->metadata?->toArray() ?? [];
-        $this->assertEquals(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertEquals(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
         $this->assertArrayHasKey('cleanup', $metadata);
         $this->assertEquals('asset_expiry', $metadata['cleanup']['reason']);
         $this->assertEquals('scheduler', $metadata['cleanup']['cleaned_by']);

--- a/tests/Feature/Database/ServiceSectionSchemaTest.php
+++ b/tests/Feature/Database/ServiceSectionSchemaTest.php
@@ -170,7 +170,7 @@ class ServiceSectionSchemaTest extends TestCase
         $sermon = Sermon::factory()->create();
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $processingLog->id,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
             'published_sermon_id' => $sermon->id,
             'published_at' => now(),
             'extracted_video_path' => 'sermons/sections/10/video.mp4',
@@ -195,7 +195,7 @@ class ServiceSectionSchemaTest extends TestCase
         $sermon = Sermon::factory()->create();
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $processingLog->id,
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Approved->value,
             'published_sermon_id' => null,
             'published_at' => null,
             'extracted_video_path' => 'sermons/sections/11/video.mp4',
@@ -219,7 +219,7 @@ class ServiceSectionSchemaTest extends TestCase
         $processingLog = MediaProcessingLog::factory()->livestream()->create();
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $processingLog->id,
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Approved->value,
             'extracted_video_path' => 'sermons/sections/12/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-12.mp3',
             'extracted_at' => now(),
@@ -246,7 +246,7 @@ class ServiceSectionSchemaTest extends TestCase
         ServiceSection::factory()->create([
             'media_processing_log_id' => $processingLog->id,
             'status' => ServiceSectionStatus::Skipped->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sermons/sections/12/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-12.mp3',
             'extracted_at' => now(),
@@ -260,7 +260,7 @@ class ServiceSectionSchemaTest extends TestCase
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $processingLog->id,
             'section_type' => ServiceSectionType::SERMON->value,
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Approved->value,
             'extracted_video_path' => 'sermons/sections/13/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-13.mp3',
             'extracted_at' => now(),

--- a/tests/Feature/Jobs/AutoPublishServiceSectionTest.php
+++ b/tests/Feature/Jobs/AutoPublishServiceSectionTest.php
@@ -49,7 +49,7 @@ class AutoPublishServiceSectionTest extends TestCase
             'church_service_item_id' => $item->id,
             'section_type' => ServiceSectionType::SONG->value,
             'song_match_type' => ServiceSectionSongMatchType::CONFIRMED->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'extracted_video_path' => $videoPath,
             'extracted_audio_path' => null,
             'extracted_at' => now(),
@@ -61,7 +61,7 @@ class AutoPublishServiceSectionTest extends TestCase
         );
 
         $section->refresh();
-        $this->assertEquals(ServiceSectionPublicationStatus::PUBLISHED, $section->publication_status);
+        $this->assertEquals(ServiceSectionPublicationStatus::Published, $section->publication_status);
         $this->assertNotNull($section->published_at);
 
         $songVideo = SongVideo::query()->where('service_section_id', $section->id)->first();
@@ -74,7 +74,7 @@ class AutoPublishServiceSectionTest extends TestCase
     {
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::SONG->value,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
         ]);
 
         $initialCount = SongVideo::count();
@@ -93,7 +93,7 @@ class AutoPublishServiceSectionTest extends TestCase
 
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::SONG->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         (new AutoPublishServiceSection($section->id))->handle(
@@ -101,7 +101,7 @@ class AutoPublishServiceSectionTest extends TestCase
         );
 
         $section->refresh();
-        $this->assertEquals(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertEquals(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
     }
 
     #[Test]
@@ -111,7 +111,7 @@ class AutoPublishServiceSectionTest extends TestCase
 
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::SONG->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->expectException(\RuntimeException::class);

--- a/tests/Feature/Livewire/Admin/AdminUrlStateTest.php
+++ b/tests/Feature/Livewire/Admin/AdminUrlStateTest.php
@@ -389,22 +389,22 @@ class AdminUrlStateTest extends TestCase
             'media_processing_log_id' => $run->id,
             'title' => 'Rejected Section',
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::REJECTED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Rejected->value,
         ]);
 
         ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
             'title' => 'Pending Section',
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         Livewire::withQueryParams([
             'search' => 'Rejected',
-            'publicationStatus' => ServiceSectionPublicationStatus::REJECTED->value,
+            'publicationStatus' => ServiceSectionPublicationStatus::Rejected->value,
         ])->test(ListSectionPublications::class)
             ->assertSet('search', 'Rejected')
-            ->assertSet('publicationStatus', ServiceSectionPublicationStatus::REJECTED->value)
+            ->assertSet('publicationStatus', ServiceSectionPublicationStatus::Rejected->value)
             ->assertSee('Rejected Section')
             ->assertDontSee('Pending Section');
     }

--- a/tests/Feature/Livewire/AdminChurchServiceTest.php
+++ b/tests/Feature/Livewire/AdminChurchServiceTest.php
@@ -606,7 +606,7 @@ class AdminChurchServiceTest extends TestCase
                     'confidence_level' => 'low',
                     'review_reason' => 'expected_type_mismatch',
                 ],
-                'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL,
+                'publication_status' => ServiceSectionPublicationStatus::PendingApproval,
             ])
             ->create();
 
@@ -625,7 +625,7 @@ class AdminChurchServiceTest extends TestCase
                 'metadata' => [
                     'confidence_level' => 'high',
                 ],
-                'publication_status' => ServiceSectionPublicationStatus::PUBLISHED,
+                'publication_status' => ServiceSectionPublicationStatus::Published,
             ])
             ->create();
 

--- a/tests/Feature/Livewire/AdminSectionPublicationQueueTest.php
+++ b/tests/Feature/Livewire/AdminSectionPublicationQueueTest.php
@@ -49,7 +49,7 @@ class AdminSectionPublicationQueueTest extends TestCase
             'title' => "Children's Talk",
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
             'section_order' => 1,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -57,13 +57,13 @@ class AdminSectionPublicationQueueTest extends TestCase
             'title' => 'Rejected Section',
             'section_type' => ServiceSectionType::WELCOME->value,
             'section_order' => 2,
-            'publication_status' => ServiceSectionPublicationStatus::REJECTED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Rejected->value,
         ]);
 
         Livewire::test(ListSectionPublications::class)
             ->assertSee("Children's Talk")
             ->assertDontSee('Rejected Section')
-            ->set('publicationStatus', ServiceSectionPublicationStatus::REJECTED->value)
+            ->set('publicationStatus', ServiceSectionPublicationStatus::Rejected->value)
             ->assertSee('Rejected Section')
             ->assertDontSee("Children's Talk");
     }
@@ -85,7 +85,7 @@ class AdminSectionPublicationQueueTest extends TestCase
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sermons/sections/'.$run->id.'/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-'.$run->id.'.mp3',
         ]);
@@ -98,7 +98,7 @@ class AdminSectionPublicationQueueTest extends TestCase
             ->assertDispatched('notify', type: 'success', message: 'Section approved and publish job queued.');
 
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::APPROVED, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Approved, $section->publication_status);
         Queue::assertPushed(PublishApprovedServiceSection::class);
     }
 
@@ -119,7 +119,7 @@ class AdminSectionPublicationQueueTest extends TestCase
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sermons/sections/'.$run->id.'/missing-video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-'.$run->id.'-missing.mp3',
         ]);
@@ -133,7 +133,7 @@ class AdminSectionPublicationQueueTest extends TestCase
             );
 
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::PENDING_APPROVAL, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::PendingApproval, $section->publication_status);
         Queue::assertNothingPushed();
     }
 
@@ -154,7 +154,7 @@ class AdminSectionPublicationQueueTest extends TestCase
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sermons/sections/'.$run->id.'/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-'.$run->id.'.mp3',
             'metadata' => [
@@ -180,7 +180,7 @@ class AdminSectionPublicationQueueTest extends TestCase
             );
 
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::PENDING_APPROVAL, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::PendingApproval, $section->publication_status);
         Queue::assertNothingPushed();
     }
 
@@ -192,7 +192,7 @@ class AdminSectionPublicationQueueTest extends TestCase
         $run = MediaProcessingLog::factory()->livestream()->create();
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         Livewire::test(ListSectionPublications::class)
@@ -202,6 +202,6 @@ class AdminSectionPublicationQueueTest extends TestCase
             ->assertDispatched('notify', type: 'success', message: 'Section moved back to pending approval.');
 
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::PENDING_APPROVAL, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::PendingApproval, $section->publication_status);
     }
 }

--- a/tests/Feature/Livewire/AdminServiceReviewDashboardTest.php
+++ b/tests/Feature/Livewire/AdminServiceReviewDashboardTest.php
@@ -76,7 +76,7 @@ class AdminServiceReviewDashboardTest extends TestCase
                     'song_match_type' => 'unmatched',
                 ],
             ],
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         $this->get(route('admin.services.review'))
@@ -220,7 +220,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
             'section_order' => 1,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sermons/sections/'.$run->id.'/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-'.$run->id.'.mp3',
         ]);
@@ -229,7 +229,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
             'section_order' => 2,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         Storage::disk('public')->put('sermons/sections/'.$run->id.'/video.mp4', 'video');
@@ -244,8 +244,8 @@ class AdminServiceReviewDashboardTest extends TestCase
         $approveSection->refresh();
         $rejectSection->refresh();
 
-        $this->assertSame(ServiceSectionPublicationStatus::APPROVED, $approveSection->publication_status);
-        $this->assertSame(ServiceSectionPublicationStatus::REJECTED, $rejectSection->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Approved, $approveSection->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Rejected, $rejectSection->publication_status);
         Queue::assertPushed(PublishApprovedServiceSection::class);
     }
 
@@ -261,14 +261,14 @@ class AdminServiceReviewDashboardTest extends TestCase
 
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::REJECTED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Rejected->value,
         ]);
 
         Livewire::test(ServiceReviewDashboard::class)
             ->call('requeue', $section->id)
             ->assertDispatched('notify', type: 'success', message: 'Section moved back to pending approval.');
 
-        $this->assertSame(ServiceSectionPublicationStatus::PENDING_APPROVAL, $section->fresh()->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::PendingApproval, $section->fresh()->publication_status);
     }
 
     #[Test]
@@ -310,7 +310,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'media_processing_log_id' => $run->id,
             'needs_manual_review' => false,
             'confidence' => 0.98,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'section_type' => ServiceSectionType::WELCOME->value,
         ]);
 
@@ -372,7 +372,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'needs_manual_review' => true,
             'start_time' => 100.0,
             'end_time' => 107.0,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -383,7 +383,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'needs_manual_review' => true,
             'start_time' => 107.0,
             'end_time' => 231.0,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         Livewire::test(ServiceReviewDashboard::class)
@@ -408,7 +408,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'needs_manual_review' => true,
             'start_time' => 0.0,
             'end_time' => 15.0,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         ServiceSection::factory()->create([
@@ -419,7 +419,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'needs_manual_review' => true,
             'start_time' => 15.0,
             'end_time' => 195.0,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         Livewire::test(ServiceReviewDashboard::class)
@@ -444,7 +444,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'needs_manual_review' => true,
             'start_time' => 100.0,
             'end_time' => 107.0,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $second = ServiceSection::factory()->create([
@@ -455,7 +455,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'needs_manual_review' => true,
             'start_time' => 107.0,
             'end_time' => 231.0,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         Livewire::test(ServiceReviewDashboard::class)
@@ -482,7 +482,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'needs_manual_review' => true,
             'start_time' => 100.0,
             'end_time' => 107.0,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $second = ServiceSection::factory()->create([
@@ -493,7 +493,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'needs_manual_review' => true,
             'start_time' => 107.0,
             'end_time' => 231.0,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         Livewire::test(ServiceReviewDashboard::class)
@@ -599,7 +599,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'needs_manual_review' => true,
             'start_time' => 100.0,
             'end_time' => 107.0,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
         ]);
 
         $second = ServiceSection::factory()->create([
@@ -609,7 +609,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'needs_manual_review' => true,
             'start_time' => 107.0,
             'end_time' => 231.0,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         Livewire::test(ServiceReviewDashboard::class)
@@ -718,7 +718,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
             'title' => "Children's Talk",
             'needs_manual_review' => true,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'extracted_video_path' => 'sermons/sections/speaker-test/video.mp4',
             'extracted_audio_path' => 'sermons/audio/speaker-test.mp3',
             'metadata' => [
@@ -741,7 +741,7 @@ class AdminServiceReviewDashboardTest extends TestCase
         $section->refresh();
 
         $this->assertFalse($section->needs_manual_review);
-        $this->assertSame(ServiceSectionPublicationStatus::PENDING_APPROVAL, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::PendingApproval, $section->publication_status);
         $this->assertSame('Rev Override', $section->metadata['childrens_talk_speaker']['reviewed']['preacher_name'] ?? null);
     }
 
@@ -769,7 +769,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
             'section_order' => 1,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sermons/sections/batch-journey/video.mp4',
             'extracted_audio_path' => 'sermons/audio/batch-journey.mp3',
         ]);
@@ -781,7 +781,7 @@ class AdminServiceReviewDashboardTest extends TestCase
             ->call('approvePendingPublications', $service->id)
             ->assertDispatched('notify', type: 'success', message: 'Approved all 1 pending publication for this service.');
 
-        $this->assertSame(ServiceSectionPublicationStatus::APPROVED, $section->fresh()->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Approved, $section->fresh()->publication_status);
         Queue::assertPushed(PublishApprovedServiceSection::class);
     }
 }

--- a/tests/Feature/Queries/ServiceReviewDashboardQueryTest.php
+++ b/tests/Feature/Queries/ServiceReviewDashboardQueryTest.php
@@ -93,7 +93,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
             'title' => 'Clean Section',
             'needs_manual_review' => false,
             'confidence' => 0.99,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $groups = $this->query->reviewGroups();
@@ -164,7 +164,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
             'section_order' => 1,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'needs_manual_review' => false,
         ]);
 
@@ -172,7 +172,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
             'section_order' => 2,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'needs_manual_review' => true,
         ]);
 
@@ -196,7 +196,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
 
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_audio_path' => 'private/section-publications/501/audio.mp3',
             'extracted_video_path' => 'private/section-publications/501/video.mp4',
         ]);
@@ -224,7 +224,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
 
         ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
             'published_sermon_id' => $sermon->id,
             'needs_manual_review' => true,
             'extracted_audio_path' => 'private/section-publications/502/audio.mp3',
@@ -255,7 +255,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
         ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
             'needs_manual_review' => true,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         $groups = $this->query->reviewGroups();
@@ -303,7 +303,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
             'media_processing_log_id' => $run->id,
             'needs_manual_review' => false,
             'confidence' => 0.99,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         $reasons = $this->query->reviewReasons($section);
@@ -321,7 +321,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
             'media_processing_log_id' => $run->id,
             'needs_manual_review' => false,
             'confidence' => ServiceSectionConfidence::HIGH_THRESHOLD - 0.01,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $reasons = $this->query->reviewReasons($section);
@@ -347,7 +347,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
             'needs_manual_review' => true,
             'confidence' => 0.99,
             'song_match_type' => 'inferred',
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'metadata' => ['oos_alignment' => ['song_match_type' => 'inferred']],
         ]);
 
@@ -371,7 +371,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
             'needs_manual_review' => true,
             'confidence' => 0.99,
             'song_match_type' => 'unmatched',
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'metadata' => ['oos_alignment' => ['song_match_type' => 'unmatched']],
         ]);
 
@@ -390,7 +390,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
             'media_processing_log_id' => $run->id,
             'needs_manual_review' => false,
             'confidence' => 0.99,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertFalse($this->query->isReviewCandidate($section));
@@ -418,7 +418,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
             'media_processing_log_id' => $run->id,
             'needs_manual_review' => false,
             'confidence' => 0.99,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         $this->assertNull($this->query->batchApprovalSkipReason($section));
@@ -432,7 +432,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
             'needs_manual_review' => true,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         $this->assertSame('blocked by other review flags', $this->query->batchApprovalSkipReason($section));
@@ -447,7 +447,7 @@ class ServiceReviewDashboardQueryTest extends TestCase
             'media_processing_log_id' => $run->id,
             'needs_manual_review' => false,
             'confidence' => 0.99,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'metadata' => [
                 'confidence_level' => 'high',
                 'review_flags' => ['heuristic_demotion'],
@@ -484,12 +484,12 @@ class ServiceReviewDashboardQueryTest extends TestCase
 
         $matchedSection = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         ServiceSection::factory()->create([
             'media_processing_log_id' => $otherRun->id,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         $result = $this->query->pendingPublicationSectionsForService($service);

--- a/tests/Integration/Actions/Publication/ApproveSectionForPublicationTest.php
+++ b/tests/Integration/Actions/Publication/ApproveSectionForPublicationTest.php
@@ -39,7 +39,7 @@ class ApproveSectionForPublicationTest extends TestCase
         return ServiceSection::factory()->create(array_merge([
             'media_processing_log_id' => $run->id,
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sermons/sections/1/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-1.mp3',
         ], $attributes));
@@ -137,7 +137,7 @@ class ApproveSectionForPublicationTest extends TestCase
 
         $section->refresh();
         $metadata = $section->metadata?->toArray() ?? [];
-        $this->assertSame(ServiceSectionPublicationStatus::APPROVED, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Approved, $section->publication_status);
         $this->assertArrayHasKey('publication', $metadata);
         $this->assertArrayHasKey('approved_signature', $metadata['publication']);
         $this->assertArrayHasKey('approved_at', $metadata['publication']);
@@ -182,7 +182,7 @@ class ApproveSectionForPublicationTest extends TestCase
 
         // PUBLISHED → APPROVED is not an allowed transition
         $section = $this->makePendingSection([
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
             'extracted_video_path' => 'sermons/sections/12/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-12.mp3',
         ]);

--- a/tests/Integration/Actions/Publication/ExpireSectionPublicationAssetsTest.php
+++ b/tests/Integration/Actions/Publication/ExpireSectionPublicationAssetsTest.php
@@ -32,7 +32,7 @@ class ExpireSectionPublicationAssetsTest extends TestCase
         $run = MediaProcessingLog::factory()->livestream()->create();
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sermons/sections/40/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-40.mp3',
             'extracted_at' => now()->subHours(72),
@@ -42,7 +42,7 @@ class ExpireSectionPublicationAssetsTest extends TestCase
         $this->action->execute($section, ['reason' => 'asset_expiry', 'cleaned_by' => 'scheduler']);
 
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
         $this->assertNull($section->extracted_video_path);
         $this->assertNull($section->extracted_audio_path);
         $this->assertNull($section->extracted_at);
@@ -55,7 +55,7 @@ class ExpireSectionPublicationAssetsTest extends TestCase
         $run = MediaProcessingLog::factory()->livestream()->create();
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Approved->value,
             'extracted_at' => now()->subHours(24),
             'unpublished_expires_at' => now()->subHour(),
         ]);
@@ -68,7 +68,7 @@ class ExpireSectionPublicationAssetsTest extends TestCase
         $this->assertIsArray($cleanup);
         $this->assertSame('asset_expiry', $cleanup['reason']);
         $this->assertSame('scheduler', $cleanup['cleaned_by']);
-        $this->assertSame(ServiceSectionPublicationStatus::APPROVED->value, $cleanup['previous_status']);
+        $this->assertSame(ServiceSectionPublicationStatus::Approved->value, $cleanup['previous_status']);
         $this->assertArrayHasKey('cleaned_at', $cleanup);
     }
 
@@ -80,7 +80,7 @@ class ExpireSectionPublicationAssetsTest extends TestCase
         $run = MediaProcessingLog::factory()->livestream()->create();
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sermons/sections/41/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-41.mp3',
         ]);
@@ -90,7 +90,7 @@ class ExpireSectionPublicationAssetsTest extends TestCase
         Storage::shouldNotHaveReceived('delete');
 
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
     }
 
     #[Test]
@@ -101,13 +101,13 @@ class ExpireSectionPublicationAssetsTest extends TestCase
         $run = MediaProcessingLog::factory()->livestream()->create();
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->action->execute($section, ['reason' => 'idempotent_retry', 'cleaned_by' => 'scheduler']);
 
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
         $this->assertSame('idempotent_retry', $section->metadata['cleanup']['reason'] ?? null);
     }
 }

--- a/tests/Integration/Actions/Publication/RejectSectionPublicationTest.php
+++ b/tests/Integration/Actions/Publication/RejectSectionPublicationTest.php
@@ -31,14 +31,14 @@ class RejectSectionPublicationTest extends TestCase
         $run = MediaProcessingLog::factory()->livestream()->create();
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         $result = $this->action->execute($section);
 
         $this->assertTrue($result);
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::REJECTED, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Rejected, $section->publication_status);
     }
 
     #[Test]
@@ -49,13 +49,13 @@ class RejectSectionPublicationTest extends TestCase
         // PUBLISHED → REJECTED is not an allowed transition
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
         ]);
 
         $result = $this->action->execute($section);
 
         $this->assertFalse($result);
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::PUBLISHED, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Published, $section->publication_status);
     }
 }

--- a/tests/Integration/Actions/Publication/RequeueSectionPublicationTest.php
+++ b/tests/Integration/Actions/Publication/RequeueSectionPublicationTest.php
@@ -31,14 +31,14 @@ class RequeueSectionPublicationTest extends TestCase
         $run = MediaProcessingLog::factory()->livestream()->create();
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::REJECTED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Rejected->value,
         ]);
 
         $result = $this->action->execute($section);
 
         $this->assertTrue($result);
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::PENDING_APPROVAL, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::PendingApproval, $section->publication_status);
     }
 
     #[Test]
@@ -49,13 +49,13 @@ class RequeueSectionPublicationTest extends TestCase
         // APPROVED → PENDING_APPROVAL is not an allowed transition
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $run->id,
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Approved->value,
         ]);
 
         $result = $this->action->execute($section);
 
         $this->assertFalse($result);
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::APPROVED, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Approved, $section->publication_status);
     }
 }

--- a/tests/Integration/Jobs/PrepareSectionPublicationCandidatesTest.php
+++ b/tests/Integration/Jobs/PrepareSectionPublicationCandidatesTest.php
@@ -79,7 +79,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
             'status' => ServiceSectionStatus::Identified->value,
             'needs_manual_review' => false,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'metadata' => ['confidence_level' => 'high'],
             'start_time' => 120.0,
             'end_time' => 420.0,
@@ -112,7 +112,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
 
         $section->refresh();
 
-        $this->assertSame(ServiceSectionPublicationStatus::PENDING_APPROVAL, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::PendingApproval, $section->publication_status);
         $this->assertFalse($section->needs_manual_review);
         $this->assertSame($expectedAudioPath, $section->extracted_audio_path);
         $this->assertSame('private/section-publications/'.$section->id.'/video.mp4', $section->extracted_video_path);
@@ -142,7 +142,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
             'media_processing_log_id' => $processingLog->id,
             'section_type' => ServiceSectionType::SONG->value,
             'status' => ServiceSectionStatus::Identified->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         $videoExtractor = $this->createMock(VideoExtractionService::class);
@@ -157,7 +157,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
         );
 
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
         $this->assertNotNull($section->unpublished_expires_at);
     }
 
@@ -177,7 +177,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
             'status' => ServiceSectionStatus::Identified->value,
             'needs_manual_review' => false,
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Approved->value,
             'confidence' => 0.72,
             'metadata' => ['confidence_level' => 'low'],
         ]);
@@ -194,7 +194,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
         );
 
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::APPROVED, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Approved, $section->publication_status);
     }
 
     #[Test]
@@ -238,7 +238,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
             'status' => ServiceSectionStatus::Identified->value,
             'needs_manual_review' => false,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'metadata' => ['confidence_level' => 'high'],
             'start_time' => 120.0,
             'end_time' => 420.0,
@@ -271,7 +271,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
 
         $section->refresh();
 
-        $this->assertSame(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
         $this->assertTrue($section->needs_manual_review);
         $this->assertSame('ambiguous', $section->metadata['childrens_talk_speaker']['predicted']['outcome'] ?? null);
         $this->assertArrayNotHasKey('reviewed', $section->metadata['childrens_talk_speaker'] ?? []);
@@ -319,7 +319,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
             'status' => ServiceSectionStatus::Identified->value,
             'needs_manual_review' => false,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'metadata' => [
                 'confidence_level' => 'high',
                 'review_reason' => 'demoted_secondary_sermon_to_childrens_talk',
@@ -357,7 +357,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
 
         $section->refresh();
 
-        $this->assertSame(ServiceSectionPublicationStatus::PENDING_APPROVAL, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::PendingApproval, $section->publication_status);
         $this->assertFalse($section->needs_manual_review);
         $this->assertSame($expectedAudioPath, $section->extracted_audio_path);
         $this->assertNotNull($section->extracted_video_path);
@@ -419,7 +419,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
             'status' => ServiceSectionStatus::Identified->value,
             'needs_manual_review' => false,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'metadata' => [
                 'confidence_level' => 'high',
                 'publication_candidate_extraction' => [
@@ -508,7 +508,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
             'section_type' => ServiceSectionType::SONG->value,
             'status' => ServiceSectionStatus::Identified->value,
             'needs_manual_review' => false,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'song_match_type' => ServiceSectionSongMatchType::CONFIRMED->value,
             'metadata' => ['confidence_level' => 'high'],
             'start_time' => 60.0,
@@ -533,7 +533,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
         $section->refresh();
 
         // Song sections do NOT go to PENDING_APPROVAL — they dispatch auto-publish instead.
-        $this->assertNotSame(ServiceSectionPublicationStatus::PENDING_APPROVAL, $section->publication_status);
+        $this->assertNotSame(ServiceSectionPublicationStatus::PendingApproval, $section->publication_status);
         $this->assertNotNull($section->extracted_video_path);
         $this->assertNull($section->extracted_audio_path);
         $this->assertNotNull($section->extracted_at);
@@ -570,7 +570,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
             'section_type' => ServiceSectionType::SONG->value,
             'status' => ServiceSectionStatus::Identified->value,
             'needs_manual_review' => false,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'song_match_type' => ServiceSectionSongMatchType::UNMATCHED->value,
         ]);
 
@@ -586,7 +586,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
         );
 
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
 
         Bus::assertNotDispatched(AutoPublishServiceSection::class);
     }
@@ -623,7 +623,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
             'section_type' => ServiceSectionType::SONG->value,
             'status' => ServiceSectionStatus::Identified->value,
             'needs_manual_review' => false,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'song_match_type' => ServiceSectionSongMatchType::CONFIRMED->value,
             'metadata' => ['confidence_level' => 'high'],
             'start_time' => 60.0,

--- a/tests/Integration/Jobs/PublishApprovedServiceSectionTest.php
+++ b/tests/Integration/Jobs/PublishApprovedServiceSectionTest.php
@@ -48,7 +48,7 @@ class PublishApprovedServiceSectionTest extends TestCase
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $processingLog->id,
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Approved->value,
             'extracted_video_path' => 'private/section-publications/10/video.mp4',
             'extracted_audio_path' => 'private/section-publications/10/section-10.mp3',
             'start_time' => 500.0,
@@ -82,7 +82,7 @@ class PublishApprovedServiceSectionTest extends TestCase
 
         $section->refresh();
 
-        $this->assertSame(ServiceSectionPublicationStatus::PUBLISHED, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Published, $section->publication_status);
         $this->assertSame($createdSermon->id, $section->published_sermon_id);
         $this->assertNotNull($section->published_at);
         $this->assertNull($section->unpublished_expires_at);
@@ -115,7 +115,7 @@ class PublishApprovedServiceSectionTest extends TestCase
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $processingLog->id,
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
             'extracted_video_path' => 'sermons/sections/11/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-11.mp3',
         ]);
@@ -133,7 +133,7 @@ class PublishApprovedServiceSectionTest extends TestCase
         );
 
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::PENDING_APPROVAL, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::PendingApproval, $section->publication_status);
         $this->assertNull($section->published_sermon_id);
     }
 
@@ -158,7 +158,7 @@ class PublishApprovedServiceSectionTest extends TestCase
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $processingLog->id,
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Approved->value,
             'extracted_video_path' => 'sermons/sections/12/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-12.mp3',
             'metadata' => [
@@ -203,7 +203,7 @@ class PublishApprovedServiceSectionTest extends TestCase
 
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $processingLog->id,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
             'published_sermon_id' => $sermon->id,
         ]);
 
@@ -217,7 +217,7 @@ class PublishApprovedServiceSectionTest extends TestCase
         );
 
         $section->refresh();
-        $this->assertSame(ServiceSectionPublicationStatus::PUBLISHED, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Published, $section->publication_status);
         $this->assertSame($sermon->id, $section->published_sermon_id);
     }
 
@@ -244,7 +244,7 @@ class PublishApprovedServiceSectionTest extends TestCase
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $processingLog->id,
             'section_type' => ServiceSectionType::CHILDRENS_TALK,
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Approved->value,
             'extracted_video_path' => 'sermons/sections/13/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-13.mp3',
             'start_time' => 300.0,
@@ -281,7 +281,7 @@ class PublishApprovedServiceSectionTest extends TestCase
         $section->refresh();
         $sermon = Sermon::query()->findOrFail($section->published_sermon_id);
 
-        $this->assertSame(ServiceSectionPublicationStatus::PUBLISHED, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Published, $section->publication_status);
         $this->assertSame(SermonContentType::ChildrensTalk, $sermon->content_type);
         $this->assertSame($preacher->id, $sermon->preacher_id);
         $this->assertSame($preacher->name, $sermon->preacher);
@@ -309,7 +309,7 @@ class PublishApprovedServiceSectionTest extends TestCase
         $section = ServiceSection::factory()->create([
             'media_processing_log_id' => $processingLog->id,
             'section_type' => ServiceSectionType::CHILDRENS_TALK,
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Approved->value,
             'extracted_video_path' => 'sermons/sections/14/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-14.mp3',
             'metadata' => [

--- a/tests/Integration/Models/ServiceSectionTest.php
+++ b/tests/Integration/Models/ServiceSectionTest.php
@@ -25,7 +25,7 @@ class ServiceSectionTest extends TestCase
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::SERMON->value,
             'status' => ServiceSectionStatus::Identified->value,
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         $this->assertInstanceOf(ServiceSectionType::class, $section->section_type);
@@ -33,7 +33,7 @@ class ServiceSectionTest extends TestCase
         $this->assertInstanceOf(ServiceSectionStatus::class, $section->status);
         $this->assertSame(ServiceSectionStatus::Identified, $section->status);
         $this->assertInstanceOf(ServiceSectionPublicationStatus::class, $section->publication_status);
-        $this->assertSame(ServiceSectionPublicationStatus::PENDING_APPROVAL, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::PendingApproval, $section->publication_status);
     }
 
     #[Test]
@@ -69,7 +69,7 @@ class ServiceSectionTest extends TestCase
         $sermon = Sermon::factory()->create();
         $section = ServiceSection::factory()->create([
             'published_sermon_id' => $sermon->id,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
         ]);
 
         $this->assertSame($sermon->id, $section->publishedSermon?->id);

--- a/tests/Integration/Services/SectionPublication/SectionPublicationHandlerFactoryTest.php
+++ b/tests/Integration/Services/SectionPublication/SectionPublicationHandlerFactoryTest.php
@@ -35,7 +35,7 @@ class SectionPublicationHandlerFactoryTest extends TestCase
 
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $handler = $this->factory->forSection($section);
@@ -52,7 +52,7 @@ class SectionPublicationHandlerFactoryTest extends TestCase
 
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::WELCOME->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertNull($this->factory->forSection($section));
@@ -65,7 +65,7 @@ class SectionPublicationHandlerFactoryTest extends TestCase
 
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertNull($this->factory->forSection($section));

--- a/tests/Integration/Services/SectionPublication/SermonPublicationHandlerTest.php
+++ b/tests/Integration/Services/SectionPublication/SermonPublicationHandlerTest.php
@@ -71,7 +71,7 @@ class SermonPublicationHandlerTest extends TestCase
             'extracted_video_path' => null,
             'extracted_audio_path' => null,
             'extracted_at' => null,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertFalse($this->handler->hasReusableExtractedMedia($section));
@@ -91,7 +91,7 @@ class SermonPublicationHandlerTest extends TestCase
         $section = ServiceSection::factory()->create([
             'extracted_video_path' => $videoPath,
             'extracted_audio_path' => $audioPath,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertTrue($this->handler->hasReusableExtractedMedia($section));
@@ -104,12 +104,12 @@ class SermonPublicationHandlerTest extends TestCase
 
         $highConfidence = ServiceSection::factory()->create([
             'confidence' => 0.90,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $lowConfidence = ServiceSection::factory()->create([
             'confidence' => 0.50,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertTrue($this->handler->isEligible($highConfidence));
@@ -123,7 +123,7 @@ class SermonPublicationHandlerTest extends TestCase
 
         $lowConfidence = ServiceSection::factory()->create([
             'confidence' => 0.50,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertTrue($this->handler->isEligible($lowConfidence));
@@ -134,7 +134,7 @@ class SermonPublicationHandlerTest extends TestCase
     {
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->childrensTalkSpeakerService
@@ -150,7 +150,7 @@ class SermonPublicationHandlerTest extends TestCase
     {
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::SERMON->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->childrensTalkSpeakerService
@@ -166,7 +166,7 @@ class SermonPublicationHandlerTest extends TestCase
 
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
         ]);
 
         $this->handler->onSectionRemoved($section);
@@ -182,7 +182,7 @@ class SermonPublicationHandlerTest extends TestCase
         Log::spy();
 
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->handler->onSectionRemoved($section);

--- a/tests/Integration/Services/SectionPublication/SongPublicationHandlerTest.php
+++ b/tests/Integration/Services/SectionPublication/SongPublicationHandlerTest.php
@@ -67,7 +67,7 @@ class SongPublicationHandlerTest extends TestCase
             'church_service_item_id' => $item->id,
             'section_type' => ServiceSectionType::SONG->value,
             'song_match_type' => ServiceSectionSongMatchType::CONFIRMED->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'extracted_video_path' => $videoPath,
             'extracted_audio_path' => 'private/section-publications/audio.mp3',
             'extracted_at' => now(),
@@ -97,7 +97,7 @@ class SongPublicationHandlerTest extends TestCase
             'extracted_video_path' => null,
             'extracted_audio_path' => null,
             'extracted_at' => null,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertFalse($this->handler->hasReusableExtractedMedia($section));
@@ -114,7 +114,7 @@ class SongPublicationHandlerTest extends TestCase
         $section = ServiceSection::factory()->create([
             'extracted_video_path' => $videoPath,
             'extracted_audio_path' => null,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertTrue($this->handler->hasReusableExtractedMedia($section));
@@ -133,7 +133,7 @@ class SongPublicationHandlerTest extends TestCase
             'church_service_item_id' => $item->id,
             'section_type' => ServiceSectionType::SONG->value,
             'song_match_type' => ServiceSectionSongMatchType::CONFIRMED->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertTrue($this->handler->isEligible($section));
@@ -152,7 +152,7 @@ class SongPublicationHandlerTest extends TestCase
             'church_service_item_id' => $item->id,
             'section_type' => ServiceSectionType::SONG->value,
             'song_match_type' => ServiceSectionSongMatchType::INFERRED->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertTrue($this->handler->isEligible($section));
@@ -171,7 +171,7 @@ class SongPublicationHandlerTest extends TestCase
             'church_service_item_id' => $item->id,
             'section_type' => ServiceSectionType::SONG->value,
             'song_match_type' => ServiceSectionSongMatchType::UNMATCHED->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertFalse($this->handler->isEligible($section));
@@ -188,7 +188,7 @@ class SongPublicationHandlerTest extends TestCase
             'church_service_item_id' => $item->id,
             'section_type' => ServiceSectionType::SONG->value,
             'song_match_type' => ServiceSectionSongMatchType::CONFIRMED->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertFalse($this->handler->isEligible($section));
@@ -201,7 +201,7 @@ class SongPublicationHandlerTest extends TestCase
             'church_service_item_id' => null,
             'section_type' => ServiceSectionType::SONG->value,
             'song_match_type' => ServiceSectionSongMatchType::CONFIRMED->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertFalse($this->handler->isEligible($section));
@@ -226,7 +226,7 @@ class SongPublicationHandlerTest extends TestCase
         $this->handler->publish($section);
 
         $section->refresh();
-        $this->assertEquals(ServiceSectionPublicationStatus::PUBLISHED, $section->publication_status);
+        $this->assertEquals(ServiceSectionPublicationStatus::Published, $section->publication_status);
         $this->assertNotNull($section->published_at);
         $this->assertNull($section->unpublished_expires_at);
 
@@ -258,7 +258,7 @@ class SongPublicationHandlerTest extends TestCase
             'church_service_item_id' => $item->id,
             'section_type' => ServiceSectionType::SONG->value,
             'song_match_type' => ServiceSectionSongMatchType::CONFIRMED->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'extracted_video_path' => 'private/section-publications/99/video.mp4',
             'extracted_audio_path' => null,
             'extracted_at' => now(),
@@ -290,7 +290,7 @@ class SongPublicationHandlerTest extends TestCase
 
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::SONG->value,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
         ]);
 
         $songVideo = SongVideo::factory()->create([
@@ -315,7 +315,7 @@ class SongPublicationHandlerTest extends TestCase
 
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::SONG->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->handler->onSectionRemoved($section);
@@ -328,7 +328,7 @@ class SongPublicationHandlerTest extends TestCase
     {
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::SONG->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         // Should not throw or do anything.
@@ -442,7 +442,7 @@ class SongPublicationHandlerTest extends TestCase
         $this->handler->publish($section);
 
         $section->refresh();
-        $this->assertEquals(ServiceSectionPublicationStatus::PUBLISHED, $section->publication_status);
+        $this->assertEquals(ServiceSectionPublicationStatus::Published, $section->publication_status);
         $this->assertNotNull($section->published_at);
 
         $songVideo = SongVideo::query()->where('service_section_id', $section->id)->first();

--- a/tests/Integration/Services/ServiceSectionPublicationTransitionServiceTest.php
+++ b/tests/Integration/Services/ServiceSectionPublicationTransitionServiceTest.php
@@ -49,14 +49,14 @@ class ServiceSectionPublicationTransitionServiceTest extends TestCase
     public function it_allows_documented_publication_transitions(): void
     {
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
         $this->assertTrue(
-            $this->service->canTransition($section, ServiceSectionPublicationStatus::APPROVED)
+            $this->service->canTransition($section, ServiceSectionPublicationStatus::Approved)
         );
         $this->assertFalse(
-            $this->service->canTransition($section, ServiceSectionPublicationStatus::PUBLISHED)
+            $this->service->canTransition($section, ServiceSectionPublicationStatus::Published)
         );
     }
 
@@ -64,13 +64,13 @@ class ServiceSectionPublicationTransitionServiceTest extends TestCase
     public function it_mutates_the_section_when_a_transition_is_valid(): void
     {
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::PENDING_APPROVAL->value,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
         ]);
 
-        $result = $this->service->transition($section, ServiceSectionPublicationStatus::APPROVED);
+        $result = $this->service->transition($section, ServiceSectionPublicationStatus::Approved);
 
         $this->assertTrue($result);
-        $this->assertSame(ServiceSectionPublicationStatus::APPROVED, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Approved, $section->publication_status);
     }
 
     #[Test]
@@ -79,13 +79,13 @@ class ServiceSectionPublicationTransitionServiceTest extends TestCase
         Log::spy();
 
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
         ]);
 
-        $result = $this->service->transition($section, ServiceSectionPublicationStatus::APPROVED);
+        $result = $this->service->transition($section, ServiceSectionPublicationStatus::Approved);
 
         $this->assertFalse($result);
-        $this->assertSame(ServiceSectionPublicationStatus::PUBLISHED, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Published, $section->publication_status);
 
         Log::shouldHaveReceived('error')->once();
     }
@@ -94,11 +94,11 @@ class ServiceSectionPublicationTransitionServiceTest extends TestCase
     public function published_sections_cannot_be_requeued_without_explicit_unpublish_logic(): void
     {
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
         ]);
 
         $this->assertFalse(
-            $this->service->canTransition($section, ServiceSectionPublicationStatus::PENDING_APPROVAL)
+            $this->service->canTransition($section, ServiceSectionPublicationStatus::PendingApproval)
         );
     }
 
@@ -106,16 +106,16 @@ class ServiceSectionPublicationTransitionServiceTest extends TestCase
     public function not_applicable_sections_can_transition_directly_to_published(): void
     {
         $section = ServiceSection::factory()->create([
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $this->assertTrue(
-            $this->service->canTransition($section, ServiceSectionPublicationStatus::PUBLISHED)
+            $this->service->canTransition($section, ServiceSectionPublicationStatus::Published)
         );
 
-        $result = $this->service->transition($section, ServiceSectionPublicationStatus::PUBLISHED);
+        $result = $this->service->transition($section, ServiceSectionPublicationStatus::Published);
 
         $this->assertTrue($result);
-        $this->assertSame(ServiceSectionPublicationStatus::PUBLISHED, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::Published, $section->publication_status);
     }
 }

--- a/tests/Integration/Services/ServiceSectionSyncServiceTest.php
+++ b/tests/Integration/Services/ServiceSectionSyncServiceTest.php
@@ -163,7 +163,7 @@ class ServiceSectionSyncServiceTest extends TestCase
             'title' => 'Children Talk',
             'start_time' => 120.0,
             'end_time' => 360.0,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
             'published_sermon_id' => $publishedSermon->id,
             'published_at' => now(),
             'extracted_video_path' => 'sermons/sections/'.$churchServiceItem->id.'/video.mp4',
@@ -189,7 +189,7 @@ class ServiceSectionSyncServiceTest extends TestCase
         $section->refresh();
         $metadata = $section->metadata?->toArray() ?? [];
 
-        $this->assertSame(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertSame(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
         $this->assertNull($section->published_sermon_id);
         $this->assertNull($section->published_at);
         $this->assertNull($section->extracted_video_path);
@@ -223,7 +223,7 @@ class ServiceSectionSyncServiceTest extends TestCase
             'church_service_item_id' => $itemOne->id,
             'section_type' => ServiceSectionType::WELCOME->value,
             'section_order' => 1,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $stalePublished = ServiceSection::factory()->create([
@@ -231,7 +231,7 @@ class ServiceSectionSyncServiceTest extends TestCase
             'church_service_item_id' => $itemTwo->id,
             'section_type' => ServiceSectionType::CHILDRENS_TALK->value,
             'section_order' => 2,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
             'published_sermon_id' => $publishedSermon->id,
             'extracted_video_path' => 'sermons/sections/'.$itemTwo->id.'/video.mp4',
             'extracted_audio_path' => 'sermons/audio/section-'.$itemTwo->id.'.mp3',

--- a/tests/Integration/Services/SongVideoServiceTest.php
+++ b/tests/Integration/Services/SongVideoServiceTest.php
@@ -126,7 +126,7 @@ class SongVideoServiceTest extends TestCase
 
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::SONG->value,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
         ]);
 
         $video = SongVideo::factory()->create([
@@ -140,7 +140,7 @@ class SongVideoServiceTest extends TestCase
         Storage::disk('public')->assertMissing($videoPath);
 
         $section->refresh();
-        $this->assertEquals(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertEquals(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
         $this->assertNull($section->published_at);
     }
 
@@ -155,7 +155,7 @@ class SongVideoServiceTest extends TestCase
 
         $section = ServiceSection::factory()->create([
             'section_type' => ServiceSectionType::SONG->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
         ]);
 
         $video = SongVideo::factory()->create([
@@ -166,7 +166,7 @@ class SongVideoServiceTest extends TestCase
         $this->service->deleteVideo($video);
 
         $section->refresh();
-        $this->assertEquals(ServiceSectionPublicationStatus::NOT_APPLICABLE, $section->publication_status);
+        $this->assertEquals(ServiceSectionPublicationStatus::NotApplicable, $section->publication_status);
     }
 
     #[Test]
@@ -211,7 +211,7 @@ class SongVideoServiceTest extends TestCase
             'church_service_item_id' => $item->id,
             'section_type' => ServiceSectionType::SONG->value,
             'song_match_type' => ServiceSectionSongMatchType::CONFIRMED->value,
-            'publication_status' => ServiceSectionPublicationStatus::NOT_APPLICABLE->value,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
             'start_time' => 100.0,
             'end_time' => 340.5,
         ]);

--- a/tests/Integration/Support/ServiceFlowBuilderTest.php
+++ b/tests/Integration/Support/ServiceFlowBuilderTest.php
@@ -382,12 +382,12 @@ class ServiceFlowBuilderTest extends TestCase
 
         $row = $this->makeRow([
             'section_type' => ServiceSectionType::SERMON,
-            'publication_status' => ServiceSectionPublicationStatus::PUBLISHED,
+            'publication_status' => ServiceSectionPublicationStatus::Published,
         ]);
 
         $flow = ServiceFlowBuilder::build([$row], $run);
 
-        $this->assertSame(ServiceSectionPublicationStatus::PUBLISHED, $flow[0]['publication_status']);
+        $this->assertSame(ServiceSectionPublicationStatus::Published, $flow[0]['publication_status']);
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Integration/Support/ServiceRecordTimelineTest.php
+++ b/tests/Integration/Support/ServiceRecordTimelineTest.php
@@ -477,7 +477,7 @@ class ServiceRecordTimelineTest extends TestCase
             'media_processing_log_id' => $run->id,
             'church_service_item_id' => $item->id,
             'section_order' => 1,
-            'publication_status' => ServiceSectionPublicationStatus::APPROVED->value,
+            'publication_status' => ServiceSectionPublicationStatus::Approved->value,
             'metadata' => [],
         ]);
 
@@ -485,7 +485,7 @@ class ServiceRecordTimelineTest extends TestCase
 
         $rows = ServiceRecordTimeline::build($this->itemCollection([$item]), $run);
 
-        $this->assertSame(ServiceSectionPublicationStatus::APPROVED, $rows[0]['publication_status']);
+        $this->assertSame(ServiceSectionPublicationStatus::Approved, $rows[0]['publication_status']);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Standardized the `ServiceSectionPublicationStatus` enum keys to use `TitleCase` (e.g., `PendingApproval` instead of `PENDING_APPROVAL`) to align with project conventions. Backed string values were preserved to maintain data integrity. Updated all references across the application and test suite. No functional changes.

---
*PR created automatically by Jules for task [16675984336786886670](https://jules.google.com/task/16675984336786886670) started by @GarethClarridge*