### PR TITLE
🏛️ Warden: Fortify SongVideo data integrity

### DIFF
--- a/app/Models/SongVideo.php
+++ b/app/Models/SongVideo.php
@@ -6,10 +6,12 @@ namespace App\Models;
 
 use Database\Factories\SongVideoFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use Illuminate\Validation\Rule;
 
 /**
  * @property int $id
@@ -113,12 +115,34 @@ class SongVideo extends Model
     }
 
     /**
-     * @return array<string, list<string>>
+     * @return Attribute<string, string>
      */
-    public static function validationRules(): array
+    protected function videoFilePath(): Attribute
     {
+        return Attribute::make(
+            set: fn (string $value): string => trim($value),
+        );
+    }
+
+    /**
+     * @return array<string, list<string|mixed>>
+     */
+    public static function validationRules(?self $songVideo = null): array
+    {
+        $uniqueServiceSection = Rule::unique('song_videos', 'service_section_id');
+
+        if ($songVideo) {
+            $uniqueServiceSection->ignore($songVideo->id);
+        }
+
         return [
+            'song_id' => ['required', 'integer', 'exists:songs,id'],
+            'service_section_id' => ['nullable', 'integer', 'exists:service_sections,id', $uniqueServiceSection],
+            'church_service_id' => ['nullable', 'integer', 'exists:church_services,id'],
+            'video_file_path' => ['required', 'string', 'max:500'],
             'duration' => ['nullable', 'numeric', 'min:0'],
+            'recorded_date' => ['nullable', 'date'],
+            'is_featured' => ['required', 'boolean'],
         ];
     }
 }

--- a/database/migrations/2026_05_20_054000_add_integrity_check_to_song_videos_table.php
+++ b/database/migrations/2026_05_20_054000_add_integrity_check_to_song_videos_table.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const CONSTRAINT_NAME = 'song_videos_video_file_path_format_check';
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasTable('song_videos')) {
+            return;
+        }
+
+        /**
+         * Warden Constraint Principle: Integrity migrations must not modify existing data.
+         * If existing data violates a proposed constraint, the migration must fail
+         * to surface the issue for manual intervention or a separate backfill.
+         */
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement('ALTER TABLE song_videos ADD CONSTRAINT '.self::CONSTRAINT_NAME." CHECK (video_file_path != '' AND BINARY video_file_path = TRIM(video_file_path))");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'mysql' && Schema::hasTable('song_videos')) {
+            DB::statement('ALTER TABLE song_videos DROP CHECK '.self::CONSTRAINT_NAME);
+        }
+    }
+};

--- a/database/migrations/2026_05_20_054000_add_integrity_check_to_song_videos_table.php
+++ b/database/migrations/2026_05_20_054000_add_integrity_check_to_song_videos_table.php
@@ -15,7 +15,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (! Schema::hasTable('song_videos')) {
+        if (DB::getDriverName() !== 'mysql' || ! Schema::hasTable('song_videos')) {
+            return;
+        }
+
+        if ($this->constraintExists('song_videos', self::CONSTRAINT_NAME)) {
             return;
         }
 
@@ -24,9 +28,7 @@ return new class extends Migration
          * If existing data violates a proposed constraint, the migration must fail
          * to surface the issue for manual intervention or a separate backfill.
          */
-        if (DB::getDriverName() === 'mysql') {
-            DB::statement('ALTER TABLE song_videos ADD CONSTRAINT '.self::CONSTRAINT_NAME." CHECK (video_file_path != '' AND BINARY video_file_path = TRIM(video_file_path))");
-        }
+        DB::statement('ALTER TABLE song_videos ADD CONSTRAINT '.self::CONSTRAINT_NAME." CHECK (video_file_path != '' AND BINARY video_file_path = TRIM(video_file_path))");
     }
 
     /**
@@ -34,8 +36,23 @@ return new class extends Migration
      */
     public function down(): void
     {
-        if (DB::getDriverName() === 'mysql' && Schema::hasTable('song_videos')) {
-            DB::statement('ALTER TABLE song_videos DROP CHECK '.self::CONSTRAINT_NAME);
+        if (DB::getDriverName() !== 'mysql' || ! Schema::hasTable('song_videos')) {
+            return;
         }
+
+        if (! $this->constraintExists('song_videos', self::CONSTRAINT_NAME)) {
+            return;
+        }
+
+        DB::statement('ALTER TABLE song_videos DROP CHECK '.self::CONSTRAINT_NAME);
+    }
+
+    private function constraintExists(string $table, string $constraint): bool
+    {
+        return DB::table('information_schema.table_constraints')
+            ->where('table_schema', DB::getDatabaseName())
+            ->where('table_name', $table)
+            ->where('constraint_name', $constraint)
+            ->exists();
     }
 };

--- a/tests/Feature/Warden/SongVideoIntegrityTest.php
+++ b/tests/Feature/Warden/SongVideoIntegrityTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Warden;
+
+use App\Models\Song;
+use App\Models\SongVideo;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SongVideoIntegrityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_validates_required_fields(): void
+    {
+        $rules = SongVideo::validationRules();
+
+        $validator = Validator::make([], $rules);
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('song_id', $validator->errors()->toArray());
+        $this->assertArrayHasKey('video_file_path', $validator->errors()->toArray());
+        $this->assertArrayHasKey('is_featured', $validator->errors()->toArray());
+    }
+
+    #[Test]
+    public function it_validates_video_file_path_length(): void
+    {
+        $rules = SongVideo::validationRules();
+
+        $validator = Validator::make([
+            'video_file_path' => str_repeat('a', 501),
+        ], $rules);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('video_file_path', $validator->errors()->toArray());
+    }
+
+    #[Test]
+    public function it_trims_video_file_path_via_attribute_setter(): void
+    {
+        $song = Song::factory()->create();
+        $songVideo = new SongVideo([
+            'song_id' => $song->id,
+            'video_file_path' => '  path/to/video.mp4  ',
+            'is_featured' => false,
+        ]);
+
+        $this->assertEquals('path/to/video.mp4', $songVideo->video_file_path);
+    }
+
+    #[Test]
+    public function database_constraint_prevents_empty_video_file_path(): void
+    {
+        $song = Song::factory()->create();
+
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('song_videos_video_file_path_format_check');
+
+        // Use raw DB insert to bypass model attribute setters
+        DB::table('song_videos')->insert([
+            'song_id' => $song->id,
+            'video_file_path' => '',
+            'is_featured' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function database_constraint_prevents_untrimmed_video_file_path(): void
+    {
+        $song = Song::factory()->create();
+
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('song_videos_video_file_path_format_check');
+
+        // Use raw DB insert to bypass model attribute setters
+        DB::table('song_videos')->insert([
+            'song_id' => $song->id,
+            'video_file_path' => ' untrimmed/path.mp4 ',
+            'is_featured' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_allows_valid_video_file_path(): void
+    {
+        $song = Song::factory()->create();
+
+        $songVideo = SongVideo::query()->create([
+            'song_id' => $song->id,
+            'video_file_path' => 'valid/path.mp4',
+            'is_featured' => true,
+        ]);
+
+        $this->assertDatabaseHas('song_videos', [
+            'id' => $songVideo->id,
+            'video_file_path' => 'valid/path.mp4',
+        ]);
+    }
+}


### PR DESCRIPTION
This PR enhances the data integrity of the `SongVideo` model following the Warden "Three-Layer Pattern".

### 💡 What
- **Model Layer**: Expanded `validationRules()` to cover `song_id`, `video_file_path`, `is_featured`, and optional foreign keys. Added an attribute setter to `SongVideo` to automatically trim `video_file_path` on save.
- **Database Layer**: Added a `CHECK` constraint to the `song_videos` table to ensure `video_file_path` is never empty and matches its trimmed binary representation.
- **Validation Layer**: Verified `video_file_path` validation matches the `VARCHAR(500)` database column length.

### 🎯 Why
Prevents broken video links caused by accidental whitespace or empty strings in the database, ensuring a robust foundation for song video archives.

### 🗄️ Migration
`database/migrations/2026_05_20_054000_add_integrity_check_to_song_videos_table.php`

### ✅ Verification
Ran `php artisan test tests/Feature/Warden/SongVideoIntegrityTest.php`:
- `it_validates_required_fields` (PASS)
- `it_validates_video_file_path_length` (PASS)
- `it_trims_video_file_path_via_attribute_setter` (PASS)
- `database_constraint_prevents_empty_video_file_path` (PASS)
- `database_constraint_prevents_untrimmed_video_file_path` (PASS)
- `it_allows_valid_video_file_path` (PASS)

### ⚠️ Rollback
`php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [3303372063869709439](https://jules.google.com/task/3303372063869709439) started by @GarethClarridge*