### PR TITLE
🔦 Lighthouse: Improve SEO with Linked Data structured data graph

### DIFF
--- a/resources/views/church/songs/show.blade.php
+++ b/resources/views/church/songs/show.blade.php
@@ -10,6 +10,7 @@
 <x-schema.webpage
     :heading="$heading"
     :description="$description"
+    :main-entity="route('church.songs.show', $song->slug) . '#song'"
 />
 <x-schema.music-composition :$song />
 @stop

--- a/resources/views/components/schema/music-composition.blade.php
+++ b/resources/views/components/schema/music-composition.blade.php
@@ -13,6 +13,7 @@
     $schema = [
         '@' . 'context' => 'https://schema.org',
         '@type' => 'MusicComposition',
+        '@id' => route('church.songs.show', $song->slug) . '#song',
         'name' => $song->title,
         'url' => route('church.songs.show', $song->slug),
         'author' => $authors,

--- a/resources/views/components/schema/person.blade.php
+++ b/resources/views/components/schema/person.blade.php
@@ -6,6 +6,7 @@
     $schema = [
         '@' . 'context' => 'https://schema.org',
         '@type' => 'Person',
+        '@id' => url("/christ/sermons/preachers/{$preacher->slug}").'#person',
         'name' => $preacher->name,
         'url' => url("/christ/sermons/preachers/{$preacher->slug}"),
         'worksFor' => [

--- a/resources/views/components/schema/sermon.blade.php
+++ b/resources/views/components/schema/sermon.blade.php
@@ -32,6 +32,7 @@
     $schema = [
         '@' . 'context' => 'https://schema.org',
         '@type' => 'Article',
+        '@id' => $sermonView['canonical_url'] . '#sermon',
         'headline' => $sermon->title,
         'description' => $metaDescription,
         'image' => $thumbnailUrl,
@@ -53,7 +54,7 @@
         ],
         'mainEntityOfPage' => [
             '@type' => 'WebPage',
-            '@id' => $sermonView['canonical_url'],
+            '@id' => $sermonView['canonical_url'] . '#webpage',
         ],
     ];
 

--- a/resources/views/components/schema/webpage.blade.php
+++ b/resources/views/components/schema/webpage.blade.php
@@ -4,6 +4,7 @@
     'description' => null,
     'image' => null,
     'canonical' => null,
+    'mainEntity' => null,
 ])
 
 @php
@@ -36,6 +37,12 @@
 
     if ($image) {
         $schema['image'] = $image;
+    }
+
+    if ($mainEntity) {
+        $schema['mainEntity'] = [
+            '@id' => $mainEntity,
+        ];
     }
 @endphp
 

--- a/resources/views/sermons/preacher.blade.php
+++ b/resources/views/sermons/preacher.blade.php
@@ -26,6 +26,7 @@
             :heading="$heading"
             :description="$description"
             :image="$share_image"
+            :main-entity="url('/christ/sermons/preachers/' . $preacher->slug) . '#person'"
         />
         <x-schema.person :$preacher />
 

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -48,6 +48,7 @@
             :heading="$fullTitle"
             :description="$description ?? $metaDescription"
             :image="$sermonView['thumbnail_url']"
+            :main-entity="$sermonView['canonical_url'] . '#sermon'"
         />
     @endpush
 

--- a/tests/Feature/Seo/LinkedDataTest.php
+++ b/tests/Feature/Seo/LinkedDataTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Seo;
+
+use App\Models\Preacher;
+use App\Models\Sermon;
+use App\Models\Song;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class LinkedDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function sermon_page_links_webpage_to_sermon_article(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'title' => 'Test Sermon Title',
+            'date' => '2023-10-22',
+        ]);
+
+        $year = $sermon->date->format('Y');
+        $month = $sermon->date->format('m');
+        $url = "/christ/sermons/{$year}/{$month}/{$sermon->slug}";
+
+        $response = $this->get($url);
+
+        $response->assertStatus(200);
+
+        // Verify Sermon Article has an @id ending in #sermon
+        $response->assertSee('"@id": "'.url($url).'#sermon"', false);
+
+        // Verify WebPage has a mainEntity pointing to #sermon
+        // It's tricky to assert the exact structure with assertSee, but we can check for the key/value pair
+        $response->assertSee('"mainEntity": {', false);
+        $response->assertSee('"@id": "'.url($url).'#sermon"', false);
+
+        // Verify Sermon Article points to #webpage for mainEntityOfPage
+        $response->assertSee('"mainEntityOfPage": {', false);
+        $response->assertSee('"@id": "'.url($url).'#webpage"', false);
+    }
+
+    #[Test]
+    public function preacher_page_links_webpage_to_person(): void
+    {
+        $preacher = Preacher::factory()->create([
+            'name' => 'John Doe',
+            'slug' => 'john-doe',
+        ]);
+
+        $url = "/christ/sermons/preachers/{$preacher->slug}";
+
+        $response = $this->get($url);
+
+        $response->assertStatus(200);
+
+        // Verify Person has an @id ending in #person
+        $response->assertSee('"@id": "'.url($url).'#person"', false);
+
+        // Verify WebPage has a mainEntity pointing to #person
+        $response->assertSee('"mainEntity": {', false);
+        $response->assertSee('"@id": "'.url($url).'#person"', false);
+    }
+
+    #[Test]
+    public function song_page_links_webpage_to_music_composition(): void
+    {
+        // Authenticate as a user to access song pages
+        $this->actingAs(User::factory()->create());
+
+        $song = Song::factory()->create([
+            'title' => 'Amazing Grace',
+            'slug' => 'amazing-grace',
+        ]);
+
+        $url = "/church/songs/{$song->slug}";
+
+        $response = $this->get($url);
+
+        $response->assertStatus(200);
+
+        // Verify MusicComposition has an @id ending in #song
+        $response->assertSee('"@id": "'.url($url).'#song"', false);
+
+        // Verify WebPage has a mainEntity pointing to #song
+        $response->assertSee('"mainEntity": {', false);
+        $response->assertSee('"@id": "'.url($url).'#song"', false);
+    }
+}


### PR DESCRIPTION
🔦 **What:** Improved SEO by establishing a connected graph of structured data using Schema.org fragment IDs.
🎯 **Why:** Explicitly linking the `WebPage` to its `mainEntity` (and vice-versa) helps search engines understand the primary focus of a page and the relationship between different objects in the JSON-LD.
📊 **Impact:** Sermon, Preacher, and Song pages now have a coherent structured data graph. This can improve how search engines represent these pages in search results (e.g., enhanced snippets).
🔍 **Verification:** Verified via a new feature test `tests/Feature/Seo/LinkedDataTest.php` and manual inspection of the rendered JSON-LD.

---
*PR created automatically by Jules for task [1612975101537200137](https://jules.google.com/task/1612975101537200137) started by @GarethClarridge*