### PR TITLE
🎨 Palette: UX & Accessibility polish for base components

### DIFF
--- a/resources/views/components/admin/sortable-header.blade.php
+++ b/resources/views/components/admin/sortable-header.blade.php
@@ -12,7 +12,7 @@
         <button wire:click="sort('{{ $column }}')"
                 wire:loading.attr="disabled"
                 wire:target="sort('{{ $column }}')"
-                class="group inline-flex items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded px-1 -mx-1 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                class="group inline-flex items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded px-1 -mx-1 transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
                 @if($sortBy === $column) aria-label="{{ $label }}: sorted {{ $sortDirection === 'asc' ? 'ascending' : 'descending' }}" @else aria-label="{{ $label }}: click to sort" @endif>
             <span>{{ $label }}</span>
             <span class="flex-none rounded bg-gray-100 text-gray-900 group-hover:bg-gray-200 transition-colors">

--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -11,7 +11,7 @@
 ])
 
 @php
-$baseClasses = 'no-underline rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 transition-all inline-flex items-center justify-center gap-2';
+$baseClasses = 'no-underline rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 transition-all active:scale-95 inline-flex items-center justify-center gap-2';
 
 $sizeClasses = [
     'xs' => 'px-2 py-1 text-xs',
@@ -23,7 +23,7 @@ $sizeClasses = [
 ];
 
 $variantClasses = [
-    'primary'   => 'bg-cbc-pattern bg-cover text-white',
+    'primary'   => 'bg-cbc-pattern bg-cover text-white hover:brightness-110',
     'secondary' => 'border border-transparent bg-slate-100/90 text-[#145557] hover:bg-white shadow-none focus:ring-cbc-teal',
     'feature'   => 'bg-[linear-gradient(120deg,var(--color-cbc-teal)_0%,var(--color-cbc-teal-dark)_55%,#0e3a3c_100%)] text-white hover:brightness-110',
     'featureOutline' => 'border border-transparent bg-slate-100/90 text-[#145557] hover:bg-white shadow-none focus:ring-cbc-teal',

--- a/resources/views/components/clipboard-button.blade.php
+++ b/resources/views/components/clipboard-button.blade.php
@@ -12,7 +12,7 @@
 
 @php
 $copyContent = $content ?? $url;
-$baseClasses = 'inline-flex items-center transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2';
+$baseClasses = 'inline-flex items-center transition-all active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2';
 
 $sizeClasses = [
     'xs' => 'p-1 text-xs',

--- a/resources/views/components/form-button.blade.php
+++ b/resources/views/components/form-button.blade.php
@@ -1,7 +1,7 @@
 @props(['variant' => 'primary', 'size' => 'md', 'type' => 'submit', 'icon' => null])
 
 @php
-$baseClasses = 'inline-flex items-center justify-center font-medium rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 transition-colors duration-200';
+$baseClasses = 'inline-flex items-center justify-center font-medium rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 transition-all active:scale-95 duration-200';
 
 $sizeClasses = [
     'xs' => 'px-2 py-1 text-xs',
@@ -12,7 +12,7 @@ $sizeClasses = [
 ];
 
 $variantClasses = [
-    'primary'   => 'bg-cbc-pattern bg-cover text-white',
+    'primary'   => 'bg-cbc-pattern bg-cover text-white hover:brightness-110',
     'secondary' => 'border border-transparent bg-slate-100/90 text-[#145557] hover:bg-white shadow-none',
     'outline'   => 'border border-gray-300 bg-white hover:bg-gray-50 text-gray-700',
     'danger'    => 'bg-cbc-crimson hover:bg-[#590d16] text-white',

--- a/resources/views/components/icon-button.blade.php
+++ b/resources/views/components/icon-button.blade.php
@@ -30,7 +30,7 @@ $iconSizes = [
 ];
 
 $iconComponent = 'heroicon-' . ($iconStyle === 'solid' ? 's' : 'o') . '-' . $icon;
-$classes = 'inline-flex items-center justify-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-1 transition-colors '
+$classes = 'inline-flex items-center justify-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-1 transition-all active:scale-95 '
     . ($sizeClasses[$size] ?? $sizeClasses['sm']) . ' '
     . ($variantClasses[$variant] ?? $variantClasses['ghost']);
 @endphp

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -11,7 +11,7 @@ $isPassword = $type === 'password';
 $inputClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2 disabled:opacity-50 disabled:bg-gray-50 disabled:cursor-not-allowed'
     . ($icon ? ' pl-10' : '')
     . ($hasError ? ' border-red-300' : ' border-gray-300')
-    . ($clearable || $isPassword ? ' pr-10' : '');
+    . ($clearable || $isPassword || $modelName ? ' pr-10' : '');
 
 $describedBy = [];
 if ($hint) $describedBy[] = $id . '-hint';
@@ -64,10 +64,11 @@ $clearLabel = 'Clear ' . ($label ?: ($attributes->get('placeholder') ?: 'input')
 
         @if($modelName)
             <div wire:loading wire:target="{{ $modelName }}" class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                <svg class="animate-spin h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <svg class="animate-spin h-4 w-4 text-cbc-teal" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>
+                <span class="sr-only">Loading...</span>
             </div>
         @endif
 
@@ -77,7 +78,7 @@ $clearLabel = 'Clear ' . ($label ?: ($attributes->get('placeholder') ?: 'input')
                 title="{{ $clearLabel }}"
                 wire:click="$set('{{ $modelName }}', '')"
                 @click="count = 0; $nextTick(() => $refs.input.focus())"
-                class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded"
+                class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 transition-all active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded"
                 x-show="$wire.{{ $modelName }}"
                 x-transition
                 wire:loading.remove wire:target="{{ $modelName }}">
@@ -88,7 +89,7 @@ $clearLabel = 'Clear ' . ($label ?: ($attributes->get('placeholder') ?: 'input')
         @if($isPassword)
             <button type="button"
                 @click="showPassword = !showPassword"
-                class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded"
+                class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 transition-all active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded"
                 :aria-label="showPassword ? 'Hide password' : 'Show password'"
                 :title="showPassword ? 'Hide password' : 'Show password'"
                 @if($modelName) wire:loading.remove wire:target="{{ $modelName }}" @endif

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -46,10 +46,11 @@ $describedBy = implode(' ', $describedBy);
 
         @if($modelName)
             <div wire:loading wire:target="{{ $modelName }}" class="absolute inset-y-0 right-0 pr-8 flex items-center pointer-events-none">
-                <svg class="animate-spin h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <svg class="animate-spin h-4 w-4 text-cbc-teal" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>
+                <span class="sr-only">Loading...</span>
             </div>
         @endif
     </div>

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -5,7 +5,8 @@ $modelName = $attributes->wire('model')->value();
 $id = $attributes->get('id', $modelName ? str_replace(['.', ' ', '[', ']'], '-', $modelName) : ($label ? \Illuminate\Support\Str::slug($label) : null));
 $hasError = $modelName && $errors->has($modelName);
 $textareaClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2 disabled:opacity-50 disabled:bg-gray-50 disabled:cursor-not-allowed'
-    . ($hasError ? ' border-red-300' : ' border-gray-300');
+    . ($hasError ? ' border-red-300' : ' border-gray-300')
+    . ($modelName ? ' pr-10' : '');
 
 $describedBy = [];
 if ($hint) $describedBy[] = $id . '-hint';
@@ -40,10 +41,11 @@ $describedBy = implode(' ', $describedBy);
 
         @if($modelName)
             <div wire:loading wire:target="{{ $modelName }}" class="absolute top-0 right-0 pt-2 pr-3 flex items-center pointer-events-none">
-                <svg class="animate-spin h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <svg class="animate-spin h-4 w-4 text-cbc-teal" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>
+                <span class="sr-only">Loading...</span>
             </div>
         @endif
     </div>

--- a/resources/views/components/toggle.blade.php
+++ b/resources/views/components/toggle.blade.php
@@ -37,6 +37,7 @@
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                     </svg>
+                    <span class="sr-only">Loading...</span>
                 </span>
             </button>
         @else

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -62,7 +62,8 @@
                                 <button
                                     type="button"
                                     wire:click="removeFilter('{{ $key }}')"
-                                    class="ml-1 -mr-1 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-cbc-teal hover:bg-cbc-teal/20 hover:text-cbc-teal-dark focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal"
+                                    wire:loading.attr="disabled"
+                                    class="ml-1 -mr-1 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-cbc-teal hover:bg-cbc-teal/20 hover:text-cbc-teal-dark focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal disabled:opacity-50 disabled:cursor-not-allowed"
                                     aria-label="Remove filter: {{ $label }}"
                                     title="Remove filter: {{ $label }}"
                                 >

--- a/tests/Feature/View/Components/FormAccessibilityTest.php
+++ b/tests/Feature/View/Components/FormAccessibilityTest.php
@@ -109,4 +109,13 @@ class FormAccessibilityTest extends TestCase
         $this->blade('<x-checkbox wire:model="field" />')->assertSeeHtml('role="alert"');
         $this->blade('<x-toggle wire:model="field" />')->assertSeeHtml('role="alert"');
     }
+
+    #[Test]
+    public function form_components_render_loading_screen_reader_text(): void
+    {
+        $this->blade('<x-input wire:model="field" />')->assertSee('<span class="sr-only">Loading...</span>', false);
+        $this->blade('<x-textarea wire:model="field" />')->assertSee('<span class="sr-only">Loading...</span>', false);
+        $this->blade('<x-select wire:model="field" :options="[]" />')->assertSee('<span class="sr-only">Loading...</span>', false);
+        $this->blade('<x-toggle wire:model="field" />')->assertSee('<span class="sr-only">Loading...</span>', false);
+    }
 }


### PR DESCRIPTION
💡 **What:** A cohesive set of micro-UX and accessibility improvements for base components.
🎯 **Why:** To unify the interaction language with branded tactile feedback and ensure loading states are accessible to screen reader users.
♿ **Accessibility:** Added `sr-only` text ("Loading...") to all form loading indicators and improved contrast by using `text-cbc-teal` for spinners.
📱 **Responsive:** No layout changes, but improved touch feedback with `active:scale-95`.

---
*PR created automatically by Jules for task [6168588082002112809](https://jules.google.com/task/6168588082002112809) started by @GarethClarridge*