### PR TITLE
🎨 Palette: [UX improvement] Tactile feedback for navigation and alerts

### DIFF
--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -48,7 +48,7 @@ $v = $variants[$type] ?? $variants['info'];
             <button
                 type="button"
                 @click="visible = false"
-                class="shrink-0 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-1"
+                class="shrink-0 rounded transition-all active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-1"
                 aria-label="Dismiss"
             >
                 <x-heroicon-o-x-mark class="h-4 w-4 opacity-60 hover:opacity-100" />

--- a/resources/views/components/layout/header.blade.php
+++ b/resources/views/components/layout/header.blade.php
@@ -9,12 +9,12 @@
 <div class="relative">
   <div class="w-100 grid grid-cols-7 justify-between bg-cbc-pattern bg-cover text-white lg:grid-cols-12">
 
-  <a class="p-2 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-white/90 focus-visible:ring-offset-2 focus-visible:ring-offset-cbc-teal-dark" href="/" wire:navigate>
+  <a class="p-2 rounded transition-all active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/90 focus-visible:ring-offset-2 focus-visible:ring-offset-cbc-teal-dark" href="/" wire:navigate>
     <img src="/svg/IconWhite.svg" class="inline-block max-h-8 align-top" alt="Crockenhill Baptist Church logo" width="30" height="32">
   </a>
 
   <a
-    class="col-span-5 flex text-center font-display text-xl min-[400px]:text-2xl lg:col-start-2 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-white/90 focus-visible:ring-offset-2 focus-visible:ring-offset-cbc-teal-dark"
+    class="col-span-5 flex text-center font-display text-xl min-[400px]:text-2xl lg:col-start-2 rounded transition-all active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/90 focus-visible:ring-offset-2 focus-visible:ring-offset-cbc-teal-dark"
     :class="expanded ? 'lg:pointer-events-none lg:opacity-0' : 'lg:pointer-events-auto lg:opacity-100'"
     href="/"
     wire:navigate
@@ -25,7 +25,7 @@
   </a>
 
   <a
-    class="absolute inset-y-0 left-16 right-16 z-10 hidden items-center justify-center text-center font-display text-xl opacity-0 transition-opacity duration-200 min-[400px]:text-2xl lg:flex rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-white/90 focus-visible:ring-offset-2 focus-visible:ring-offset-cbc-teal-dark"
+    class="absolute inset-y-0 left-16 right-16 z-10 hidden items-center justify-center text-center font-display text-xl opacity-0 transition-all duration-200 active:scale-95 min-[400px]:text-2xl lg:flex rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-white/90 focus-visible:ring-offset-2 focus-visible:ring-offset-cbc-teal-dark"
     :class="expanded ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'"
     :aria-hidden="!expanded"
     :inert="!expanded"

--- a/resources/views/components/session-message.blade.php
+++ b/resources/views/components/session-message.blade.php
@@ -48,7 +48,7 @@ $config = $types[$type] ?? $types['success'];
 
     <button type="button"
             @click="show = false"
-            class="absolute top-2 right-2 p-1.5 text-current opacity-50 hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded-md transition-all"
+            class="absolute top-2 right-2 p-1.5 text-current opacity-50 hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded-md transition-all active:scale-95"
             aria-label="Close notification">
         <x-heroicon-m-x-mark class="h-4 w-4" aria-hidden="true" />
     </button>

--- a/tests/Feature/ViewComposerTest.php
+++ b/tests/Feature/ViewComposerTest.php
@@ -130,7 +130,7 @@ class ViewComposerTest extends TestCase
         $this->assertStringContainsString('via-cbc-teal-dark/95', $content);
         $this->assertStringContainsString('to-cbc-teal/92', $content);
         $this->assertStringContainsString(":class=\"expanded ? 'lg:pointer-events-none lg:opacity-0' : 'lg:pointer-events-auto lg:opacity-100'\"", $content);
-        $this->assertStringContainsString('absolute inset-y-0 left-16 right-16 z-10 hidden items-center justify-center text-center font-display text-xl opacity-0 transition-opacity duration-200', $content);
+        $this->assertStringContainsString('absolute inset-y-0 left-16 right-16 z-10 hidden items-center justify-center text-center font-display text-xl opacity-0 transition-all duration-200 active:scale-95', $content);
         $this->assertStringContainsString(":class=\"expanded ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'\"", $content);
         $this->assertStringContainsString(':aria-hidden="!expanded"', $content);
         $this->assertStringContainsString(':inert="!expanded"', $content);


### PR DESCRIPTION
Standardized tactile feedback across prominent navigation and dismissable components by adding `active:scale-95` and `transition-all`. This ensures a more responsive and "pleasant" user experience when interacting with core site elements. Updated the `ViewComposerTest` to reflect these changes.

---
*PR created automatically by Jules for task [6374074677249862843](https://jules.google.com/task/6374074677249862843) started by @GarethClarridge*