### PR TITLE
🔦 Lighthouse: Enhance Structured Data and Breadcrumb Schema

### DIFF
--- a/app/Livewire/Sermons/BrowseSermons.php
+++ b/app/Livewire/Sermons/BrowseSermons.php
@@ -162,7 +162,7 @@ class BrowseSermons extends Component
     {
         $presenter = app(\App\Presenters\BreadcrumbPresenter::class);
 
-        return $presenter->jsonLd($presenter->items('christ', $this->seoTitle));
+        return $presenter->jsonLd($presenter->items('christ', $this->seoTitle), $this->seoCanonical);
     }
 
     /**

--- a/app/Livewire/Sermons/BrowseSermons.php
+++ b/app/Livewire/Sermons/BrowseSermons.php
@@ -122,6 +122,7 @@ class BrowseSermons extends Component
             'title' => $this->seoTitle,
             'description' => $this->seoDescription,
             'canonical' => $this->seoCanonical,
+            'breadcrumb' => $this->seoBreadcrumb,
         ]);
     }
 
@@ -151,6 +152,17 @@ class BrowseSermons extends Component
             || $this->chapterFilter !== null
             || $this->preacherFilter !== null
             || $this->seriesFilter !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[Computed]
+    public function seoBreadcrumb(): array
+    {
+        $presenter = app(\App\Presenters\BreadcrumbPresenter::class);
+
+        return $presenter->jsonLd($presenter->items('christ', $this->seoTitle));
     }
 
     /**

--- a/app/Livewire/Sermons/BrowseSermons.php
+++ b/app/Livewire/Sermons/BrowseSermons.php
@@ -162,7 +162,7 @@ class BrowseSermons extends Component
     {
         $presenter = app(\App\Presenters\BreadcrumbPresenter::class);
 
-        return $presenter->jsonLd($presenter->items('christ', $this->seoTitle), $this->seoCanonical);
+        return $presenter->jsonLd($presenter->items('christ', $this->seoTitle, $this->seoCanonical), $this->seoCanonical);
     }
 
     /**

--- a/app/Presenters/BreadcrumbPresenter.php
+++ b/app/Presenters/BreadcrumbPresenter.php
@@ -127,12 +127,14 @@ class BreadcrumbPresenter
      * @param  list<array{name: string, item: string}>  $items
      * @return array<string, mixed>
      */
-    public function jsonLd(array $items): array
+    public function jsonLd(array $items, ?string $url = null): array
     {
+        $pageUrl = $url ?? url()->current();
+
         return [
             '@context' => 'https://schema.org',
             '@type' => 'BreadcrumbList',
-            '@id' => url()->current().'#breadcrumb',
+            '@id' => $pageUrl.'#breadcrumb',
             'itemListElement' => array_map(
                 static fn (array $item, int $index): array => [
                     '@type' => 'ListItem',

--- a/app/Presenters/BreadcrumbPresenter.php
+++ b/app/Presenters/BreadcrumbPresenter.php
@@ -16,7 +16,7 @@ class BreadcrumbPresenter
      *
      * @return list<array{name: string, item: string}>
      */
-    public function items(string $area, string $heading): array
+    public function items(string $area, string $heading, ?string $url = null): array
     {
         $items = [['name' => 'Home', 'item' => url('/')]];
 
@@ -26,8 +26,8 @@ class BreadcrumbPresenter
             $items = array_merge($items, $this->buildPublicItems($area));
         }
 
-        if (end($items)['item'] !== url()->current()) {
-            $items[] = ['name' => $heading, 'item' => url()->current()];
+        if (end($items)['item'] !== ($url ?? url()->current())) {
+            $items[] = ['name' => $heading, 'item' => $url ?? url()->current()];
         }
 
         return $items;

--- a/app/View/Components/Breadcrumbs.php
+++ b/app/View/Components/Breadcrumbs.php
@@ -22,9 +22,10 @@ class Breadcrumbs extends Component
         public string $area,
         public string $heading,
         public bool $jsonOnly = false,
+        public ?string $url = null,
     ) {
         $this->breadcrumbItems = $presenter->items($area, $heading);
-        $this->breadcrumbList = $presenter->jsonLd($this->breadcrumbItems);
+        $this->breadcrumbList = $presenter->jsonLd($this->breadcrumbItems, $this->url);
     }
 
     public function render(): View|Closure|string

--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -25,6 +25,7 @@
             description="Upcoming events at Crockenhill Baptist Church."
             :image="asset('/images/homepage/may2024wide.webp')"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
 
         @if($allEvents->isNotEmpty())
             {{--

--- a/resources/views/church/songs/index.blade.php
+++ b/resources/views/church/songs/index.blade.php
@@ -19,12 +19,15 @@
             :title="$heading"
             :description="$description"
             :canonical="$canonical_url ?? null"
+            :image="asset('/images/homepage/may2024wide.webp')"
+            image-alt="Worship songs at Crockenhill Baptist Church"
         />
         <x-schema.webpage
             :heading="$heading"
             :description="$description"
             :canonical="$canonical_url ?? null"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
     @endpush
 
     <livewire:church.songs.browse-songs />

--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -1,4 +1,4 @@
-<script type="application/ld+json">
+<script type="application/ld+json" id="breadcrumb-jsonld">
   {!! json_encode($breadcrumbList, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}
 </script>
 

--- a/resources/views/components/schema/sermon.blade.php
+++ b/resources/views/components/schema/sermon.blade.php
@@ -37,6 +37,7 @@
         'headline' => $sermon->title,
         'description' => $metaDescription,
         'image' => $thumbnailUrl,
+        'dateCreated' => $datePublished,
         'datePublished' => $datePublished,
         'dateModified' => ($sermon->updated_at instanceof \Carbon\CarbonInterface && $sermon->updated_at->year > 0)
             ? $sermon->updated_at->toIso8601String()

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -12,6 +12,15 @@
                     const linkCanonical = document.querySelector('link[rel=\'canonical\']');
                     if (linkCanonical) linkCanonical.setAttribute('href', data.canonical);
                 }
+                if (data.breadcrumb) {
+                    // Find specifically the breadcrumb script if possible, otherwise we might overwrite another one
+                    const scripts = document.querySelectorAll('script[type=\'application/ld+json\']');
+                    scripts.forEach(script => {
+                        if (script.textContent.includes('#breadcrumb')) {
+                            script.textContent = JSON.stringify(data.breadcrumb, null, 2);
+                        }
+                    });
+                }
             };
             if (Array.isArray(data) && data.length > 0) {
                 update(data[0]);

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -13,13 +13,10 @@
                     if (linkCanonical) linkCanonical.setAttribute('href', data.canonical);
                 }
                 if (data.breadcrumb) {
-                    // Find specifically the breadcrumb script if possible, otherwise we might overwrite another one
-                    const scripts = document.querySelectorAll('script[type=\'application/ld+json\']');
-                    scripts.forEach(script => {
-                        if (script.textContent.includes('#breadcrumb')) {
-                            script.textContent = JSON.stringify(data.breadcrumb, null, 2);
-                        }
-                    });
+                    const breadcrumbScript = document.getElementById('breadcrumb-jsonld');
+                    if (breadcrumbScript) {
+                        breadcrumbScript.textContent = JSON.stringify(data.breadcrumb, null, 2);
+                    }
                 }
             };
             if (Array.isArray(data) && data.length > 0) {

--- a/resources/views/sermons/index.blade.php
+++ b/resources/views/sermons/index.blade.php
@@ -28,6 +28,7 @@
             :image="asset('/images/headings/large/sermons.webp')"
             :canonical="$canonical_url"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
     @endpush
 
     @if (isset($content))

--- a/resources/views/sermons/preachers.blade.php
+++ b/resources/views/sermons/preachers.blade.php
@@ -25,6 +25,7 @@
             :description="$description"
             :image="asset('/images/headings/large/sermons.webp')"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
 
         @if(isset($json_ld_data))
             <script type="application/ld+json">

--- a/resources/views/sermons/serieses.blade.php
+++ b/resources/views/sermons/serieses.blade.php
@@ -25,6 +25,7 @@
             :description="$description"
             :image="asset('/images/headings/large/sermons.webp')"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
 
         @if(isset($json_ld_data))
             <script type="application/ld+json">

--- a/resources/views/sermons/service.blade.php
+++ b/resources/views/sermons/service.blade.php
@@ -25,6 +25,7 @@
             :description="$description"
             :image="asset('/images/headings/large/sermons.webp')"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
 
         <script type="application/ld+json">
             {!! json_encode($json_ld_data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}


### PR DESCRIPTION
This PR implements several SEO and metadata improvements to enhance site discoverability and rich results:

1.  **Enhanced Sermon Schema**: Updated `x-schema.sermon` (Article type) to include `dateCreated` and ensured `author` and `publisher` properties correctly reference the church's canonical organization ID.
2.  **Breadcrumb Structured Data**: Added `BreadcrumbList` schema to all high-level listing and landing pages where it was previously missing. This is achieved using the `<x-breadcrumbs />` component with a `jsonOnly` flag, pushing the JSON-LD to the head without altering the visual UI.
3.  **Dynamic Archive SEO**: The `BrowseSermons` Livewire component now dynamically updates the `BreadcrumbList` JSON-LD in the browser when filters are applied. This ensures search engines and social platforms receive accurate hierarchy data even when browsing filtered results.
4.  **Social Sharing Improvements**: Added a representative Open Graph image to the songs listing page.

Verification:
- Ran `SeoRegressionTest`, `SermonBrowseSeoTest`, and `SongSeoTest`.
- Validated JSON-LD structure manually in component views.
- Verified dynamic metadata update logic in `BrowseSermons`.
- Ran `composer phpstan` and `bin pint`.

---
*PR created automatically by Jules for task [10003333724111708018](https://jules.google.com/task/10003333724111708018) started by @GarethClarridge*