### PR TITLE
⚡ Bolt: eliminate N+1 lazy-loading in sermon listings and sitemaps

### DIFF
--- a/app/Livewire/Admin/Sermons/ListSermons.php
+++ b/app/Livewire/Admin/Sermons/ListSermons.php
@@ -130,7 +130,7 @@ class ListSermons extends Component
         $escapedSearch = $this->escapeLike(trim($this->search));
 
         $query = Sermon::query()
-            ->select(['id', 'title', 'date', 'service', 'preacher', 'preacher_id', 'series', 'reference', 'scripture_passage_id', 'needs_preacher_review', 'audio_file_path', 'video_file_path', 'slug', 'transcript_file_path', 'content_type'])
+            ->select(['id', 'title', 'date', 'service', 'preacher', 'preacher_id', 'series', 'reference', 'scripture_passage_id', 'needs_preacher_review', 'audio_file_path', 'video_file_path', 'slug', 'transcript_file_path', 'content_type', 'updated_at'])
             ->with([
                 'preacherProfile:id,name,slug',
                 'scripturePassage:id,display_reference,normalized_reference',
@@ -171,7 +171,7 @@ class ListSermons extends Component
          * container lookups and logic when rendering preacher names and scripture
          * references for each row.
          */
-        $this->sermonViewPresenter->presentCollection($sermons->getCollection());
+        $this->sermonViewPresenter->preWarmForAdminList($sermons->getCollection());
 
         $headers = [
             ['key' => 'title', 'label' => 'Title', 'sortable' => true],

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -546,6 +546,27 @@ class SermonViewPresenter
     }
 
     /**
+     * Pre-warm the internal memoization caches for fields used in admin listings.
+     *
+     * Performance Optimization: Only computes preacher names and scripture references
+     * to avoid triggering lazy-loading of media-related columns that are typically
+     * excluded from admin list queries.
+     *
+     * @param  Collection<int, Sermon>  $sermons
+     */
+    public function preWarmForAdminList(Collection $sermons): void
+    {
+        if ($sermons->isEmpty()) {
+            return;
+        }
+
+        foreach ($sermons as $sermon) {
+            $this->displayPreacherName($sermon);
+            $this->displayReference($sermon);
+        }
+    }
+
+    /**
      * @return array{
      *     audio_url: ?string,
      *     canonical_url: string,

--- a/app/Services/PodcastFeedService.php
+++ b/app/Services/PodcastFeedService.php
@@ -59,7 +59,7 @@ class PodcastFeedService
         return Sermon::query()
             ->whereSermon()
             ->forPodcast()
-            ->select(['id', 'title', 'audio_file_path', 'filetype', 'date', 'service', 'series', 'reference', 'preacher', 'preacher_id', 'duration', 'summary', 'slug', 'thumbnail_file_path', 'thumbnail_generated_at', 'transcript_file_path', 'updated_at', 'scripture_passage_id'])
+            ->select(['id', 'title', 'audio_file_path', 'filetype', 'date', 'service', 'series', 'reference', 'preacher', 'preacher_id', 'duration', 'summary', 'slug', 'thumbnail_file_path', 'thumbnail_generated_at', 'transcript_file_path', 'updated_at', 'scripture_passage_id', 'content_type'])
             ->with([
                 'preacherProfile:id,name,slug,image_path',
                 'scripturePassage:id,display_reference,normalized_reference',

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -176,6 +176,11 @@ class SitemapService
                 'sermons.thumbnail_file_path',
                 'sermons.thumbnail_generated_at',
                 'sermons.thumbnail_metadata',
+                'sermons.video_file_path',
+                'sermons.video_visibility_override',
+                'sermons.video_quality_status',
+                'sermons.content_type',
+                'sermons.updated_at',
                 'sermon_scripture_filters.bible_book as book_group',
             ])
             ->selectRaw('ROW_NUMBER() OVER (PARTITION BY sermon_scripture_filters.bible_book ORDER BY sermons.date DESC, sermons.id DESC) as row_num');
@@ -245,7 +250,10 @@ class SitemapService
         $preachers = Preacher::query()->active()
             ->select(['id', 'name', 'slug', 'image_path', 'updated_at'])
             ->with([
-                'sermons' => fn ($query) => $query->whereSermon()->orderBy('date', 'desc')->limit(1),
+                'sermons' => fn ($query) => $query->whereSermon()
+                    ->select(['id', 'preacher_id', 'title', 'date', 'slug', 'thumbnail_file_path', 'thumbnail_generated_at', 'thumbnail_metadata', 'video_file_path', 'video_visibility_override', 'video_quality_status', 'content_type', 'updated_at'])
+                    ->orderBy('date', 'desc')
+                    ->limit(1),
             ])
             ->lazy();
 
@@ -281,6 +289,11 @@ class SitemapService
                 'thumbnail_file_path',
                 'thumbnail_generated_at',
                 'thumbnail_metadata',
+                'video_file_path',
+                'video_visibility_override',
+                'video_quality_status',
+                'content_type',
+                'updated_at',
             ])
             ->selectRaw('ROW_NUMBER() OVER (PARTITION BY series ORDER BY date DESC, id DESC) as row_num');
 


### PR DESCRIPTION
⚡ Bolt: eliminate N+1 lazy-loading in sermon listings and sitemaps

Implemented several performance optimizations targeting N+1 query bottlenecks:

- Added `SermonViewPresenter::preWarmForAdminList()` to efficiently pre-cache preacher names and scripture references for admin listings, avoiding triggers for media URL and duration lazy-loading.
- Updated `ListSermons` admin component to include `updated_at` in the query, which is essential for presenter memoization cache keys.
- Added `content_type` and `updated_at` to `PodcastFeedService` and `SitemapService` queries. These columns are required for visibility checks and URL versioning; omitting them was causing N+1 lazy-loading for every item in these large collections.
- Refined `SitemapService` representative sermon subqueries to select all columns needed by the presenter.
- Added a performance guideline memory regarding the necessity of `updated_at` and `content_type` when using `SermonViewPresenter`.

These changes significantly reduce the total database query count on high-traffic and background processing routes. Verified with unit and feature tests.

---
*PR created automatically by Jules for task [2801496151380986006](https://jules.google.com/task/2801496151380986006) started by @GarethClarridge*