### PR TITLE
🛡️ Sentinel: Harden log sanitization in media processing services

### DIFF
--- a/app/Services/AudioEnhancementService.php
+++ b/app/Services/AudioEnhancementService.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Process;
 
 class AudioEnhancementService
 {
+    use SanitizesLogData;
+
     /**
      * Enhance an audio file using FFmpeg filters (noise reduction, dynamic normalisation,
      * loudness normalisation) and write the result to a temp file.
@@ -24,8 +27,8 @@ class AudioEnhancementService
 
         if (! file_exists($inputPath)) {
             Log::warning('AudioEnhancementService: input file not found', [
-                'processing_id' => $processingId,
-                'input_path' => $inputPath,
+                'processing_id' => $this->sanitizeForLog($processingId),
+                'input_path' => $this->sanitizeForLog($inputPath),
             ]);
 
             return null;
@@ -46,15 +49,16 @@ class AudioEnhancementService
             $this->runEnhancement($ffmpegPath, $inputPath, $filterChain, $outputPath, $processingId);
 
             Log::info('AudioEnhancementService: enhancement complete', [
-                'processing_id' => $processingId,
-                'output_path' => $outputPath,
+                'processing_id' => $this->sanitizeForLog($processingId),
+                'output_path' => $this->sanitizeForLog($outputPath),
             ]);
 
             return $outputPath;
         } catch (\Throwable $e) {
             Log::warning('AudioEnhancementService: enhancement failed, continuing with original', [
-                'processing_id' => $processingId,
-                'error' => $e->getMessage(),
+                'processing_id' => $this->sanitizeForLog($processingId),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
             ]);
 
             return null;
@@ -96,7 +100,7 @@ class AudioEnhancementService
 
         if ($measuredStats !== null && $this->isAlreadyWithinTolerance($measuredStats['input_i'], $targetLufs)) {
             Log::info('AudioEnhancementService: measured loudness within tolerance, skipping encode pass', [
-                'processing_id' => $processingId,
+                'processing_id' => $this->sanitizeForLog($processingId),
                 'measured_lufs' => $measuredStats['input_i'],
                 'target_lufs' => $targetLufs,
                 'tolerance_lufs' => config('media-processing.audio_enhancement.skip_tolerance_lufs', 2.0),
@@ -175,7 +179,7 @@ class AudioEnhancementService
     {
         if (! preg_match('/\{[^}]+\}/s', $stderr, $matches)) {
             Log::warning('AudioEnhancementService: could not parse loudnorm JSON', [
-                'processing_id' => $processingId,
+                'processing_id' => $this->sanitizeForLog($processingId),
             ]);
 
             return null;
@@ -223,8 +227,8 @@ class AudioEnhancementService
         ];
 
         Log::info('AudioEnhancementService: running enhancement pass', [
-            'processing_id' => $processingId,
-            'filter_chain' => $filterChain,
+            'processing_id' => $this->sanitizeForLog($processingId),
+            'filter_chain' => $this->sanitizeForLog($filterChain),
         ]);
 
         $process = new Process($command);
@@ -256,8 +260,8 @@ class AudioEnhancementService
 
         if (! file_exists($inputPath)) {
             Log::warning('AudioEnhancementService: video input file not found', [
-                'processing_id' => $processingId,
-                'input_path' => $inputPath,
+                'processing_id' => $this->sanitizeForLog($processingId),
+                'input_path' => $this->sanitizeForLog($inputPath),
             ]);
 
             return null;
@@ -278,15 +282,16 @@ class AudioEnhancementService
             $this->runVideoEnhancement($ffmpegPath, $inputPath, $filterChain, $outputPath, $processingId);
 
             Log::info('AudioEnhancementService: video enhancement complete', [
-                'processing_id' => $processingId,
-                'output_path' => $outputPath,
+                'processing_id' => $this->sanitizeForLog($processingId),
+                'output_path' => $this->sanitizeForLog($outputPath),
             ]);
 
             return $outputPath;
         } catch (\Throwable $e) {
             Log::warning('AudioEnhancementService: video enhancement failed, continuing with original', [
-                'processing_id' => $processingId,
-                'error' => $e->getMessage(),
+                'processing_id' => $this->sanitizeForLog($processingId),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
             ]);
 
             return null;
@@ -312,8 +317,8 @@ class AudioEnhancementService
         ];
 
         Log::info('AudioEnhancementService: running video enhancement pass', [
-            'processing_id' => $processingId,
-            'filter_chain' => $filterChain,
+            'processing_id' => $this->sanitizeForLog($processingId),
+            'filter_chain' => $this->sanitizeForLog($filterChain),
         ]);
 
         $process = new Process($command);

--- a/app/Services/AudioExtractionService.php
+++ b/app/Services/AudioExtractionService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Enums\MediaType;
+use App\Traits\SanitizesLogData;
 use FFMpeg\FFMpeg;
 use FFMpeg\Format\Audio\Mp3;
 use Illuminate\Http\UploadedFile;
@@ -19,6 +20,8 @@ use Illuminate\Support\Str;
  */
 class AudioExtractionService
 {
+    use SanitizesLogData;
+
     public function __construct(private readonly MediaValidationService $mediaValidation) {}
 
     /**
@@ -59,8 +62,8 @@ class AudioExtractionService
             }
 
             Log::info('Audio extracted from video', [
-                'video_path' => $videoPath,
-                'audio_path' => $outputPath,
+                'video_path' => $this->sanitizeForLog($videoPath),
+                'audio_path' => $this->sanitizeForLog($outputPath),
                 'duration' => $duration,
                 'file_size' => $this->getLocalFileSize($outputPath),
             ]);
@@ -69,8 +72,9 @@ class AudioExtractionService
 
         } catch (\Exception $e) {
             Log::error('Failed to extract audio from video', [
-                'video_path' => $videoPath,
-                'error' => $e->getMessage(),
+                'video_path' => $this->sanitizeForLog($videoPath),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
             ]);
 
             throw $e;
@@ -108,8 +112,9 @@ class AudioExtractionService
 
         } catch (\Exception $e) {
             Log::error('Failed to compress audio file', [
-                'input_path' => $inputPath,
-                'error' => $e->getMessage(),
+                'input_path' => $this->sanitizeForLog($inputPath),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
             ]);
 
             throw $e;

--- a/app/Services/ProcessingInitiator.php
+++ b/app/Services/ProcessingInitiator.php
@@ -59,20 +59,20 @@ class ProcessingInitiator
         if ($preExtractedMetadata !== null) {
             $baseMetadata = $preExtractedMetadata;
             Log::info('Initiating media processing with pre-extracted metadata', [
-                'processing_id' => self::sanitizeForLog($processingId),
+                'processing_id' => $this->sanitizeForLog($processingId),
                 'processing_type' => $processingType->value,
-                'original_filename' => self::sanitizeForLog($file->getClientOriginalName()),
+                'original_filename' => $this->sanitizeForLog($file->getClientOriginalName()),
             ]);
         } else {
             $extractedDateTime = $this->metadataService->extractDateFromVideo($file, $clientFileDate);
             $extractedService = $this->determineService($extractedDateTime, $file->getClientOriginalName());
 
             Log::info('Extracted metadata from media file', [
-                'processing_id' => self::sanitizeForLog($processingId),
+                'processing_id' => $this->sanitizeForLog($processingId),
                 'processing_type' => $processingType->value,
-                'original_filename' => self::sanitizeForLog($file->getClientOriginalName()),
-                'extracted_date' => $extractedDateTime->toDateString(),
-                'extracted_datetime' => $extractedDateTime->toDateTimeString(),
+                'original_filename' => $this->sanitizeForLog($file->getClientOriginalName()),
+                'extracted_date' => $this->sanitizeForLog($extractedDateTime->toDateString()),
+                'extracted_datetime' => $this->sanitizeForLog($extractedDateTime->toDateTimeString()),
                 'extracted_service' => $extractedService->value,
             ]);
 

--- a/app/Services/SermonAnalysisService.php
+++ b/app/Services/SermonAnalysisService.php
@@ -113,7 +113,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
                 'failed',
                 [
                     'total_attempts' => 1,
-                    'final_error' => self::sanitizeForLog($e->getMessage()),
+                    'final_error' => $this->sanitizeForLog($e->getMessage()),
                 ]
             );
 
@@ -162,7 +162,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
 
         if ($this->validator->isTitleTooLong($validatedData['title'])) {
             Log::info('AI-generated title exceeds character limit, retrying', [
-                'title' => self::sanitizeForLog($validatedData['title']),
+                'title' => $this->sanitizeForLog($validatedData['title']),
                 'length' => strlen($validatedData['title']),
                 'max' => SermonAnalysisValidator::MAX_TITLE_CHARACTERS,
                 'attempt' => $attempt,
@@ -201,10 +201,10 @@ class SermonAnalysisService implements SermonAnalysisInterface
 
         if ($e instanceof ErrorException) {
             Log::error('OpenAI API ErrorException details', [
-                'processing_id' => self::sanitizeForLog($processingId),
+                'processing_id' => $this->sanitizeForLog($processingId),
                 'attempt' => $attempt,
                 'error_code' => $e->getCode(),
-                'error_message' => self::sanitizeForLog($e->getMessage()),
+                'error_message' => $this->sanitizeForLog($e->getMessage()),
                 'api_time_ms' => round($apiTime * 1000, 2),
                 'exception_class' => get_class($e),
                 'status_code' => $e->getStatusCode(),
@@ -265,7 +265,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
         // Validate response structure
         if (empty($response->choices)) {
             Log::error('Invalid OpenAI response structure', [
-                'processing_id' => self::sanitizeForLog($processingId),
+                'processing_id' => $this->sanitizeForLog($processingId),
                 'response_type' => gettype($response),
             ]);
 
@@ -316,11 +316,11 @@ class SermonAnalysisService implements SermonAnalysisInterface
         } catch (\TypeError $e) {
             // Handle malformed API response (e.g., non-JSON response body)
             Log::error('OpenAI API response parsing failed (malformed response)', [
-                'processing_id' => self::sanitizeForLog($processingId),
+                'processing_id' => $this->sanitizeForLog($processingId),
                 'attempt' => $attempt,
-                'error' => self::sanitizeForLog($e->getMessage()),
-                'model' => self::sanitizeForLog($model),
-                'exception_file' => self::sanitizeForLog($e->getFile()),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'model' => $this->sanitizeForLog($model),
+                'exception_file' => $this->sanitizeForLog($e->getFile()),
                 'exception_line' => $e->getLine(),
             ]);
 
@@ -338,10 +338,10 @@ class SermonAnalysisService implements SermonAnalysisInterface
             throw new Exception('OpenAI API response malformed.');
         } catch (Exception $e) {
             Log::error('OpenAI API call failed', [
-                'processing_id' => self::sanitizeForLog($processingId),
+                'processing_id' => $this->sanitizeForLog($processingId),
                 'attempt' => $attempt,
-                'error' => self::sanitizeForLog($e->getMessage()),
-                'model' => self::sanitizeForLog($model),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'model' => $this->sanitizeForLog($model),
             ]);
             throw new Exception('OpenAI API call failed.');
         }
@@ -358,7 +358,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
 
         Log::info('Retrieved existing series from database', [
             'count' => count($series),
-            'series' => array_map(fn (string $s) => self::sanitizeForLog($s), $series),
+            'series' => array_map(fn (string $s) => $this->sanitizeForLog($s), $series),
         ]);
 
         return $series;
@@ -384,7 +384,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
             return $analysis->title;
         } catch (Exception $e) {
             Log::warning('Failed to generate title via full analysis, using fallback', [
-                'error' => self::sanitizeForLog($e->getMessage()),
+                'error' => $this->sanitizeForLog($e->getMessage()),
             ]);
 
             return $this->promptBuilder->generateFallbackTitle($transcript);
@@ -412,7 +412,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
             return $analysis->series;
         } catch (Exception $e) {
             Log::warning('Failed to identify series via full analysis', [
-                'error' => self::sanitizeForLog($e->getMessage()),
+                'error' => $this->sanitizeForLog($e->getMessage()),
             ]);
 
             return null;
@@ -439,7 +439,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
             return $analysis->reference;
         } catch (Exception $e) {
             Log::warning('Failed to extract Bible passage via full analysis', [
-                'error' => self::sanitizeForLog($e->getMessage()),
+                'error' => $this->sanitizeForLog($e->getMessage()),
             ]);
 
             return null;
@@ -466,7 +466,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
             return $analysis->points;
         } catch (Exception $e) {
             Log::warning('Failed to extract sermon points via full analysis, using fallback', [
-                'error' => self::sanitizeForLog($e->getMessage()),
+                'error' => $this->sanitizeForLog($e->getMessage()),
             ]);
 
             return ['Main Message'];

--- a/app/Services/SermonCreationService.php
+++ b/app/Services/SermonCreationService.php
@@ -74,7 +74,7 @@ class SermonCreationService
         if ($options->forceOverwrite) {
             Log::warning('SermonCreationService: forceOverwrite bypassed richness downgrade rejection', [
                 'sermon_id' => $existing->id,
-                'processing_id' => $processingLog->processing_id,
+                'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
                 'existing_level' => $existingLevel->name,
                 'incoming_level' => $incomingLevel->name,
             ]);
@@ -84,7 +84,7 @@ class SermonCreationService
 
         Log::warning('SermonCreationService: rejecting richness downgrade', [
             'sermon_id' => $existing->id,
-            'processing_id' => $processingLog->processing_id,
+            'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
             'existing_level' => $existingLevel->name,
             'incoming_level' => $incomingLevel->name,
         ]);
@@ -198,7 +198,7 @@ class SermonCreationService
 
         Log::info('SermonCreationService: enriched existing sermon', [
             'sermon_id' => $existing->id,
-            'processing_id' => $processingLog->processing_id,
+            'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
             'fields_updated' => array_keys($updates),
         ]);
 
@@ -272,7 +272,7 @@ class SermonCreationService
 
         Log::info('SermonCreationService: replaced existing sermon media', [
             'sermon_id' => $existing->id,
-            'processing_id' => $processingLog->processing_id,
+            'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
             'fields_updated' => array_keys($updates),
         ]);
 
@@ -513,9 +513,9 @@ class SermonCreationService
             $processingMetadata = $processingLog->processing_metadata?->toArray() ?? [];
 
             Log::info('SermonCreationService: Using date extracted from file metadata', [
-                'processing_id' => $processingLog->processing_id,
-                'extracted_date' => $extractedDate,
-                'extraction_method' => self::sanitizeForLog((string) ($processingMetadata['date_extraction_method'] ?? 'unknown')),
+                'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
+                'extracted_date' => $this->sanitizeForLog($extractedDate),
+                'extraction_method' => $this->sanitizeForLog((string) ($processingMetadata['date_extraction_method'] ?? 'unknown')),
             ]);
 
             return $extractedDate;
@@ -524,9 +524,9 @@ class SermonCreationService
         $filenameDate = $this->extractDateFromFilename($filename);
 
         Log::info('SermonCreationService: Using date extracted from filename', [
-            'processing_id' => $processingLog->processing_id,
-            'filename' => self::sanitizeForLog($filename),
-            'extracted_date' => $filenameDate,
+            'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
+            'filename' => $this->sanitizeForLog($filename),
+            'extracted_date' => $this->sanitizeForLog($filenameDate),
         ]);
 
         return $filenameDate;
@@ -546,9 +546,9 @@ class SermonCreationService
             $processingMetadata = $processingLog->processing_metadata?->toArray() ?? [];
 
             Log::info('SermonCreationService: Using service extracted from file metadata', [
-                'processing_id' => $processingLog->processing_id,
+                'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
                 'extracted_service' => $processingLog->extracted_service->value,
-                'extraction_method' => self::sanitizeForLog((string) ($processingMetadata['service_extraction_method'] ?? 'unknown')),
+                'extraction_method' => $this->sanitizeForLog((string) ($processingMetadata['service_extraction_method'] ?? 'unknown')),
             ]);
 
             return $processingLog->extracted_service;
@@ -560,8 +560,8 @@ class SermonCreationService
         // Check for evening service indicators (pm or evening)
         if (str_contains($filename, 'evening') || preg_match('/[-_\s]pm\b/i', $filename)) {
             Log::info('SermonCreationService: Detected evening service from filename', [
-                'processing_id' => $processingLog->processing_id,
-                'filename' => self::sanitizeForLog($filename),
+                'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
+                'filename' => $this->sanitizeForLog($filename),
             ]);
 
             return SermonService::Evening;
@@ -570,8 +570,8 @@ class SermonCreationService
         // Check for morning service indicators (am or morning)
         if (str_contains($filename, 'morning') || preg_match('/[-_\s]am\b/i', $filename)) {
             Log::info('SermonCreationService: Detected morning service from filename', [
-                'processing_id' => $processingLog->processing_id,
-                'filename' => self::sanitizeForLog($filename),
+                'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
+                'filename' => $this->sanitizeForLog($filename),
             ]);
 
             return SermonService::Morning;
@@ -582,8 +582,8 @@ class SermonCreationService
         if ($hour !== null) {
             $service = $hour < 12 ? SermonService::Morning : SermonService::Evening;
             Log::info('SermonCreationService: Detected service from time in filename', [
-                'processing_id' => $processingLog->processing_id,
-                'filename' => self::sanitizeForLog($filename),
+                'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
+                'filename' => $this->sanitizeForLog($filename),
                 'extracted_hour' => $hour,
                 'service' => $service->value,
             ]);
@@ -593,8 +593,8 @@ class SermonCreationService
 
         // Strategy 4: Default to morning if no service pattern found
         Log::info('SermonCreationService: Defaulting to morning service', [
-            'processing_id' => $processingLog->processing_id,
-            'filename' => self::sanitizeForLog($filename),
+            'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
+            'filename' => $this->sanitizeForLog($filename),
         ]);
 
         return SermonService::Morning;

--- a/app/Services/SermonVideoQualityAssessmentService.php
+++ b/app/Services/SermonVideoQualityAssessmentService.php
@@ -56,9 +56,10 @@ class SermonVideoQualityAssessmentService
         } catch (\Throwable $e) {
             Log::warning('Sermon video quality assessment failed', [
                 'sermon_id' => $sermon->id,
-                'video_path' => self::sanitizeForLog($videoPath),
+                'video_path' => $this->sanitizeForLog($videoPath),
                 'disk' => $disk,
-                'error' => self::sanitizeForLog($e->getMessage()),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
             ]);
 
             return SermonVideoQualityAssessmentResult::failed();
@@ -102,9 +103,10 @@ class SermonVideoQualityAssessmentService
         } catch (\Throwable $e) {
             Log::warning('Sermon video quality assessment failed', [
                 'sermon_id' => $sermon->id,
-                'video_path' => self::sanitizeForLog($videoPath),
+                'video_path' => $this->sanitizeForLog($videoPath),
                 'disk' => $disk,
-                'error' => self::sanitizeForLog($e->getMessage()),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
             ]);
 
             return ['result' => SermonVideoQualityAssessmentResult::failed(), 'localVideoPath' => null];
@@ -507,8 +509,9 @@ class SermonVideoQualityAssessmentService
             }
         } catch (\Throwable $e) {
             Log::warning('Failed to cleanup video-quality frame', [
-                'frame_path' => self::sanitizeForLog($framePath),
-                'error' => self::sanitizeForLog($e->getMessage()),
+                'frame_path' => $this->sanitizeForLog($framePath),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
             ]);
         }
     }

--- a/app/Services/TranscriptStorageService.php
+++ b/app/Services/TranscriptStorageService.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Traits\SanitizesLogData;
 use Exception;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
 class TranscriptStorageService
 {
+    use SanitizesLogData;
+
     private const TRANSCRIPT_DIRECTORY = 'transcripts';
 
     /** @var array<int, string>|null */
@@ -50,7 +53,7 @@ class TranscriptStorageService
 
             Log::info('Transcript stored successfully', [
                 'sermon_id' => $sermonId,
-                'file_path' => $filePath,
+                'file_path' => $this->sanitizeForLog($filePath),
                 'disk' => $disk,
                 'size' => strlen($transcript),
             ]);
@@ -59,9 +62,10 @@ class TranscriptStorageService
         } catch (Exception $e) {
             Log::error('Failed to store transcript', [
                 'sermon_id' => $sermonId,
-                'file_path' => $filePath,
+                'file_path' => $this->sanitizeForLog($filePath),
                 'disk' => $disk,
-                'error' => $e->getMessage(),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
             ]);
             throw new Exception("Failed to store transcript for sermon {$sermonId}: ".$e->getMessage());
         }
@@ -83,7 +87,7 @@ class TranscriptStorageService
         if (! $storage->exists($filePath)) {
             Log::info('Transcript file not found', [
                 'sermon_id' => $sermonId,
-                'file_path' => $filePath,
+                'file_path' => $this->sanitizeForLog($filePath),
                 'disk' => $disk,
             ]);
 
@@ -99,7 +103,7 @@ class TranscriptStorageService
 
             Log::info('Transcript retrieved successfully', [
                 'sermon_id' => $sermonId,
-                'file_path' => $filePath,
+                'file_path' => $this->sanitizeForLog($filePath),
                 'disk' => $disk,
                 'size' => strlen($content),
             ]);
@@ -108,9 +112,10 @@ class TranscriptStorageService
         } catch (Exception $e) {
             Log::error('Failed to retrieve transcript', [
                 'sermon_id' => $sermonId,
-                'file_path' => $filePath,
+                'file_path' => $this->sanitizeForLog($filePath),
                 'disk' => $disk,
-                'error' => $e->getMessage(),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
             ]);
 
             return null;
@@ -147,7 +152,7 @@ class TranscriptStorageService
         if (! $storage->exists($filePath)) {
             Log::info('Transcript file does not exist, nothing to delete', [
                 'sermon_id' => $sermonId,
-                'file_path' => $filePath,
+                'file_path' => $this->sanitizeForLog($filePath),
                 'disk' => $disk,
             ]);
 
@@ -160,13 +165,13 @@ class TranscriptStorageService
             if ($success) {
                 Log::info('Transcript deleted successfully', [
                     'sermon_id' => $sermonId,
-                    'file_path' => $filePath,
+                    'file_path' => $this->sanitizeForLog($filePath),
                     'disk' => $disk,
                 ]);
             } else {
                 Log::warning('Failed to delete transcript file', [
                     'sermon_id' => $sermonId,
-                    'file_path' => $filePath,
+                    'file_path' => $this->sanitizeForLog($filePath),
                     'disk' => $disk,
                 ]);
             }
@@ -175,9 +180,10 @@ class TranscriptStorageService
         } catch (Exception $e) {
             Log::error('Error deleting transcript', [
                 'sermon_id' => $sermonId,
-                'file_path' => $filePath,
+                'file_path' => $this->sanitizeForLog($filePath),
                 'disk' => $disk,
-                'error' => $e->getMessage(),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
             ]);
 
             return false;
@@ -248,8 +254,9 @@ class TranscriptStorageService
             } catch (Exception $e) {
                 Log::warning('Failed to read transcript from disk', [
                     'disk' => $disk,
-                    'transcript_file_path' => $path,
-                    'error' => $e->getMessage(),
+                    'transcript_file_path' => $this->sanitizeForLog($path),
+                    'error' => $this->sanitizeForLog($e->getMessage()),
+                    'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
                 ]);
             }
         }

--- a/app/Services/UnifiedMediaProcessor.php
+++ b/app/Services/UnifiedMediaProcessor.php
@@ -39,9 +39,9 @@ class UnifiedMediaProcessor
     ): ProcessingResult {
         Log::info('Unified media processing started', [
             'type' => $type,
-            'filename' => self::sanitizeForLog($file->getClientOriginalName()),
+            'filename' => $this->sanitizeForLog($file->getClientOriginalName()),
             'size' => $file->getSize(),
-            'client_file_date' => $clientFileDate ? self::sanitizeForLog($clientFileDate) : null,
+            'client_file_date' => $clientFileDate ? $this->sanitizeForLog($clientFileDate) : null,
         ]);
 
         $mediaType = MediaType::tryFrom($type);
@@ -154,10 +154,10 @@ class UnifiedMediaProcessor
     {
         try {
             Log::info('Starting audio processing', [
-                'original_filename' => self::sanitizeForLog($file->getClientOriginalName()),
+                'original_filename' => $this->sanitizeForLog($file->getClientOriginalName()),
                 'file_size' => $file->getSize(),
                 'mime_type' => $file->getMimeType(),
-                'client_file_date' => $clientFileDate ? self::sanitizeForLog($clientFileDate) : null,
+                'client_file_date' => $clientFileDate ? $this->sanitizeForLog($clientFileDate) : null,
             ]);
 
             $this->mediaValidation->validateUploadedFile(MediaType::Audio, $file);
@@ -182,15 +182,15 @@ class UnifiedMediaProcessor
             );
 
             Log::info('Audio file stored, processing log created', [
-                'processing_id' => self::sanitizeForLog($processingLog->processing_id),
-                'stored_path' => self::sanitizeForLog($storedFilePath),
-                'id3_metadata' => self::sanitizeForLog(json_encode($id3Metadata) ?: ''),
+                'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
+                'stored_path' => $this->sanitizeForLog($storedFilePath),
+                'id3_metadata' => $this->sanitizeForLog(json_encode($id3Metadata) ?: ''),
             ]);
 
             $this->processingRunOrchestrator->start($processingLog);
 
             Log::info('Audio processing jobs dispatched', [
-                'processing_id' => self::sanitizeForLog($processingLog->processing_id),
+                'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
             ]);
 
             return ProcessingResult::success(
@@ -203,9 +203,9 @@ class UnifiedMediaProcessor
             throw $e;
         } catch (\Exception $e) {
             Log::error('Failed to initiate audio processing', [
-                'original_filename' => self::sanitizeForLog($file->getClientOriginalName()),
-                'error' => self::sanitizeForLog($e->getMessage()),
-                'trace' => self::sanitizeStackTrace($e->getTraceAsString()),
+                'original_filename' => $this->sanitizeForLog($file->getClientOriginalName()),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
             ]);
 
             return ProcessingResult::failure(
@@ -283,8 +283,8 @@ class UnifiedMediaProcessor
         }
 
         Log::info('Duplicate upload detected, reusing existing processing run', [
-            'dedup_key' => self::sanitizeForLog($dedupKey),
-            'existing_processing_id' => self::sanitizeForLog($existingLog->processing_id),
+            'dedup_key' => $this->sanitizeForLog($dedupKey),
+            'existing_processing_id' => $this->sanitizeForLog($existingLog->processing_id),
             'processing_type' => $existingLog->processing_type->value,
         ]);
 
@@ -302,8 +302,8 @@ class UnifiedMediaProcessor
 
             if ($racedLog !== null) {
                 Log::info('Concurrent duplicate resolved via constraint violation, reusing raced run', [
-                    'dedup_key' => self::sanitizeForLog($dedupKey),
-                    'existing_processing_id' => self::sanitizeForLog($racedLog->processing_id),
+                    'dedup_key' => $this->sanitizeForLog($dedupKey),
+                    'existing_processing_id' => $this->sanitizeForLog($racedLog->processing_id),
                 ]);
 
                 return ProcessingResult::success(
@@ -368,9 +368,9 @@ class UnifiedMediaProcessor
             throw $e;
         } catch (\Exception $e) {
             Log::error('Failed to initiate video processing', [
-                'original_filename' => self::sanitizeForLog($file->getClientOriginalName()),
-                'error' => self::sanitizeForLog($e->getMessage()),
-                'trace' => self::sanitizeStackTrace($e->getTraceAsString()),
+                'original_filename' => $this->sanitizeForLog($file->getClientOriginalName()),
+                'error' => $this->sanitizeForLog($e->getMessage()),
+                'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
             ]);
 
             return ProcessingResult::failure(


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Inconsistent log sanitization and potential information leakage via stack traces in core media processing services.
🎯 **Impact:** Could lead to log injection vulnerabilities if user-controlled metadata is logged raw, or disclosure of internal server paths and credentials in unredacted stack traces.
🔧 **Fix:** Expanded the use of the `SanitizesLogData` trait to all relevant services and audited every `Log::` call to ensure comprehensive sanitization of filenames, paths, IDs, and error traces.
✅ **Verification:** Verified that `composer phpstan` and `bin pint --dirty` pass, and ensured that the full test suite (5196 tests) completes successfully.

---
*PR created automatically by Jules for task [8510904418387477419](https://jules.google.com/task/8510904418387477419) started by @GarethClarridge*