### PR TITLE
🔦 Lighthouse: Implement consistent BreadcrumbList schema across listing and detail pages

### DIFF
--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -25,6 +25,7 @@
             description="Upcoming events at Crockenhill Baptist Church."
             :image="asset('/images/homepage/may2024wide.webp')"
         />
+        <x-breadcrumbs area="community" heading="Church Calendar" jsonOnly />
 
         @if($allEvents->isNotEmpty())
             {{--

--- a/resources/views/childrens-corner/index.blade.php
+++ b/resources/views/childrens-corner/index.blade.php
@@ -25,6 +25,7 @@
             :description="$description"
             :image="asset('/images/homepage/may2024wide.webp')"
         />
+        <x-breadcrumbs area="christ" heading="Children's Corner" jsonOnly />
 
         @if (isset($json_ld_data))
             <script type="application/ld+json">

--- a/resources/views/church/songs/index.blade.php
+++ b/resources/views/church/songs/index.blade.php
@@ -25,6 +25,7 @@
             :description="$description"
             :canonical="$canonical_url ?? null"
         />
+        <x-breadcrumbs area="church" :$heading jsonOnly />
     @endpush
 
     <livewire:church.songs.browse-songs />

--- a/resources/views/church/songs/show.blade.php
+++ b/resources/views/church/songs/show.blade.php
@@ -11,8 +11,8 @@
     :heading="$heading"
     :description="$description"
     :main-entity="route('church.songs.show', $song->slug) . '#song'"
-    :breadcrumb-items="app(\App\Presenters\BreadcrumbPresenter::class)->items('church', $heading)"
 />
+<x-breadcrumbs :$area :$heading jsonOnly />
 <x-schema.music-composition :$song />
 @stop
 

--- a/resources/views/meetings/events.blade.php
+++ b/resources/views/meetings/events.blade.php
@@ -22,6 +22,7 @@
             :heading="$heading"
             :description="$description"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
 
         @if($schemaEvents->isNotEmpty())
             <script type="application/ld+json">

--- a/resources/views/meetings/show.blade.php
+++ b/resources/views/meetings/show.blade.php
@@ -35,6 +35,7 @@
             :description="$description ?? $heading"
             :image="$headingpicture"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
 
         @if($meeting->is_recurring && $meeting->frequency)
             <script type="application/ld+json">

--- a/resources/views/sermons/index.blade.php
+++ b/resources/views/sermons/index.blade.php
@@ -28,6 +28,7 @@
             :image="asset('/images/headings/large/sermons.webp')"
             :canonical="$canonical_url"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
     @endpush
 
     @if (isset($content))

--- a/resources/views/sermons/preacher.blade.php
+++ b/resources/views/sermons/preacher.blade.php
@@ -27,8 +27,8 @@
             :description="$description"
             :image="$share_image"
             :main-entity="url('/christ/sermons/preachers/' . $preacher->slug) . '#person'"
-            :breadcrumb-items="app(\App\Presenters\BreadcrumbPresenter::class)->items('christ', $heading)"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
         <x-schema.person :$preacher />
 
         <script type="application/ld+json">

--- a/resources/views/sermons/preachers.blade.php
+++ b/resources/views/sermons/preachers.blade.php
@@ -25,6 +25,7 @@
             :description="$description"
             :image="asset('/images/headings/large/sermons.webp')"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
 
         @if(isset($json_ld_data))
             <script type="application/ld+json">

--- a/resources/views/sermons/series.blade.php
+++ b/resources/views/sermons/series.blade.php
@@ -27,6 +27,7 @@
             :description="$description"
             :image="$share_image ?? asset('/images/headings/large/sermons.webp')"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
 
         <script type="application/ld+json">
             {!! json_encode($json_ld_data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}

--- a/resources/views/sermons/serieses.blade.php
+++ b/resources/views/sermons/serieses.blade.php
@@ -25,6 +25,7 @@
             :description="$description"
             :image="asset('/images/headings/large/sermons.webp')"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
 
         @if(isset($json_ld_data))
             <script type="application/ld+json">

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -49,8 +49,8 @@
             :description="$description ?? $metaDescription"
             :image="$sermonView['thumbnail_url']"
             :main-entity="$sermonView['canonical_url'] . '#sermon'"
-            :breadcrumb-items="app(\App\Presenters\BreadcrumbPresenter::class)->items('christ', $fullTitle)"
         />
+        <x-breadcrumbs :$area heading="{{ $fullTitle }}" jsonOnly />
     @endpush
 
     <article class="space-y-6">

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -50,7 +50,7 @@
             :image="$sermonView['thumbnail_url']"
             :main-entity="$sermonView['canonical_url'] . '#sermon'"
         />
-        <x-breadcrumbs :$area heading="{{ $fullTitle }}" jsonOnly />
+        <x-breadcrumbs :$area :heading="$fullTitle" jsonOnly />
     @endpush
 
     <article class="space-y-6">

--- a/resources/views/sermons/service.blade.php
+++ b/resources/views/sermons/service.blade.php
@@ -25,6 +25,7 @@
             :description="$description"
             :image="asset('/images/headings/large/sermons.webp')"
         />
+        <x-breadcrumbs :$area :$heading jsonOnly />
 
         <script type="application/ld+json">
             {!! json_encode($json_ld_data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}


### PR DESCRIPTION
This change implements consistent BreadcrumbList JSON-LD structured data across all major public-facing areas of the website, including sermons, meetings, calendar, and songs. It standardizes the implementation by using the dedicated <x-breadcrumbs> component with the jsonOnly prop, which improves maintainability and ensures search engines can correctly index the site's hierarchy for rich result snippets.

---
*PR created automatically by Jules for task [9021199341953171182](https://jules.google.com/task/9021199341953171182) started by @GarethClarridge*