### PR TITLE
🏛️ Warden: Fortify ScripturePassage data integrity

### DIFF
--- a/app/Models/ScripturePassage.php
+++ b/app/Models/ScripturePassage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Database\Factories\ScripturePassageFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -48,6 +49,63 @@ class ScripturePassage extends Model
         return [
             'fetched_at' => 'datetime',
         ];
+    }
+
+    /**
+     * @return array<string, list<mixed>>
+     */
+    public static function validationRules(): array
+    {
+        return [
+            'bible_id' => ['required', 'string', 'max:255'],
+            'normalized_reference' => ['required', 'string', 'max:255'],
+            'api_passage_id' => ['nullable', 'string', 'max:255'],
+            'display_reference' => ['nullable', 'string', 'max:255'],
+            'html_content' => ['required', 'string'],
+            'copyright' => ['required', 'string'],
+            'fums_token' => ['nullable', 'string', 'max:255'],
+            'fetched_at' => ['required', 'date'],
+        ];
+    }
+
+    /**
+     * @return Attribute<string, string>
+     */
+    protected function bibleId(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value): string => trim($value),
+        );
+    }
+
+    /**
+     * @return Attribute<string, string>
+     */
+    protected function normalizedReference(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value): string => trim($value),
+        );
+    }
+
+    /**
+     * @return Attribute<?string, ?string>
+     */
+    protected function apiPassageId(): Attribute
+    {
+        return Attribute::make(
+            set: fn (?string $value): ?string => $value !== null ? trim($value) : null,
+        );
+    }
+
+    /**
+     * @return Attribute<?string, ?string>
+     */
+    protected function displayReference(): Attribute
+    {
+        return Attribute::make(
+            set: fn (?string $value): ?string => $value !== null ? trim($value) : null,
+        );
     }
 
     /**

--- a/database/migrations/2026_05_23_053404_add_check_constraints_to_scripture_passages_table.php
+++ b/database/migrations/2026_05_23_053404_add_check_constraints_to_scripture_passages_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('scripture_passages', function (Blueprint $table) {
+            // MySQL 8.0+ supports CHECK constraints.
+            // We ensure core identity and content columns are not empty.
+            DB::statement("ALTER TABLE scripture_passages ADD CONSTRAINT scripture_passages_bible_id_check CHECK (bible_id <> '')");
+            DB::statement("ALTER TABLE scripture_passages ADD CONSTRAINT scripture_passages_normalized_reference_check CHECK (normalized_reference <> '')");
+            DB::statement("ALTER TABLE scripture_passages ADD CONSTRAINT scripture_passages_html_content_check CHECK (html_content <> '')");
+            DB::statement("ALTER TABLE scripture_passages ADD CONSTRAINT scripture_passages_copyright_check CHECK (copyright <> '')");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('scripture_passages', function (Blueprint $table) {
+            DB::statement('ALTER TABLE scripture_passages DROP CONSTRAINT scripture_passages_bible_id_check');
+            DB::statement('ALTER TABLE scripture_passages DROP CONSTRAINT scripture_passages_normalized_reference_check');
+            DB::statement('ALTER TABLE scripture_passages DROP CONSTRAINT scripture_passages_html_content_check');
+            DB::statement('ALTER TABLE scripture_passages DROP CONSTRAINT scripture_passages_copyright_check');
+        });
+    }
+};

--- a/database/migrations/2026_05_23_053404_add_check_constraints_to_scripture_passages_table.php
+++ b/database/migrations/2026_05_23_053404_add_check_constraints_to_scripture_passages_table.php
@@ -9,6 +9,14 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    private const BIBLE_ID_CHECK = 'scripture_passages_bible_id_check';
+
+    private const REFERENCE_CHECK = 'scripture_passages_normalized_reference_check';
+
+    private const HTML_CHECK = 'scripture_passages_html_content_check';
+
+    private const COPYRIGHT_CHECK = 'scripture_passages_copyright_check';
+
     /**
      * Run the migrations.
      */
@@ -17,10 +25,10 @@ return new class extends Migration
         Schema::table('scripture_passages', function (Blueprint $table) {
             // MySQL 8.0+ supports CHECK constraints.
             // We ensure core identity and content columns are not empty.
-            DB::statement("ALTER TABLE scripture_passages ADD CONSTRAINT scripture_passages_bible_id_check CHECK (bible_id <> '')");
-            DB::statement("ALTER TABLE scripture_passages ADD CONSTRAINT scripture_passages_normalized_reference_check CHECK (normalized_reference <> '')");
-            DB::statement("ALTER TABLE scripture_passages ADD CONSTRAINT scripture_passages_html_content_check CHECK (html_content <> '')");
-            DB::statement("ALTER TABLE scripture_passages ADD CONSTRAINT scripture_passages_copyright_check CHECK (copyright <> '')");
+            DB::statement(sprintf("ALTER TABLE scripture_passages ADD CONSTRAINT %s CHECK (bible_id <> '')", self::BIBLE_ID_CHECK));
+            DB::statement(sprintf("ALTER TABLE scripture_passages ADD CONSTRAINT %s CHECK (normalized_reference <> '')", self::REFERENCE_CHECK));
+            DB::statement(sprintf("ALTER TABLE scripture_passages ADD CONSTRAINT %s CHECK (html_content <> '')", self::HTML_CHECK));
+            DB::statement(sprintf("ALTER TABLE scripture_passages ADD CONSTRAINT %s CHECK (copyright <> '')", self::COPYRIGHT_CHECK));
         });
     }
 
@@ -30,10 +38,10 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('scripture_passages', function (Blueprint $table) {
-            DB::statement('ALTER TABLE scripture_passages DROP CONSTRAINT scripture_passages_bible_id_check');
-            DB::statement('ALTER TABLE scripture_passages DROP CONSTRAINT scripture_passages_normalized_reference_check');
-            DB::statement('ALTER TABLE scripture_passages DROP CONSTRAINT scripture_passages_html_content_check');
-            DB::statement('ALTER TABLE scripture_passages DROP CONSTRAINT scripture_passages_copyright_check');
+            DB::statement(sprintf('ALTER TABLE scripture_passages DROP CHECK %s', self::BIBLE_ID_CHECK));
+            DB::statement(sprintf('ALTER TABLE scripture_passages DROP CHECK %s', self::REFERENCE_CHECK));
+            DB::statement(sprintf('ALTER TABLE scripture_passages DROP CHECK %s', self::HTML_CHECK));
+            DB::statement(sprintf('ALTER TABLE scripture_passages DROP CHECK %s', self::COPYRIGHT_CHECK));
         });
     }
 };

--- a/database/migrations/2026_05_23_053404_add_check_constraints_to_scripture_passages_table.php
+++ b/database/migrations/2026_05_23_053404_add_check_constraints_to_scripture_passages_table.php
@@ -24,11 +24,11 @@ return new class extends Migration
     {
         Schema::table('scripture_passages', function (Blueprint $table) {
             // MySQL 8.0+ supports CHECK constraints.
-            // We ensure core identity and content columns are not empty.
-            DB::statement(sprintf("ALTER TABLE scripture_passages ADD CONSTRAINT %s CHECK (bible_id <> '')", self::BIBLE_ID_CHECK));
-            DB::statement(sprintf("ALTER TABLE scripture_passages ADD CONSTRAINT %s CHECK (normalized_reference <> '')", self::REFERENCE_CHECK));
-            DB::statement(sprintf("ALTER TABLE scripture_passages ADD CONSTRAINT %s CHECK (html_content <> '')", self::HTML_CHECK));
-            DB::statement(sprintf("ALTER TABLE scripture_passages ADD CONSTRAINT %s CHECK (copyright <> '')", self::COPYRIGHT_CHECK));
+            // We ensure core identity and content columns are not empty and are properly trimmed.
+            DB::statement(sprintf("ALTER TABLE scripture_passages ADD CONSTRAINT %s CHECK (BINARY bible_id = TRIM(bible_id) AND bible_id <> '')", self::BIBLE_ID_CHECK));
+            DB::statement(sprintf("ALTER TABLE scripture_passages ADD CONSTRAINT %s CHECK (BINARY normalized_reference = TRIM(normalized_reference) AND normalized_reference <> '')", self::REFERENCE_CHECK));
+            DB::statement(sprintf("ALTER TABLE scripture_passages ADD CONSTRAINT %s CHECK (BINARY html_content = TRIM(html_content) AND html_content <> '')", self::HTML_CHECK));
+            DB::statement(sprintf("ALTER TABLE scripture_passages ADD CONSTRAINT %s CHECK (BINARY copyright = TRIM(copyright) AND copyright <> '')", self::COPYRIGHT_CHECK));
         });
     }
 

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -507,7 +507,11 @@ CREATE TABLE `scripture_passages` (
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `scripture_passages_bible_id_normalized_reference_unique` (`bible_id`,`normalized_reference`),
-  KEY `scripture_passages_fetched_at_index` (`fetched_at`)
+  KEY `scripture_passages_fetched_at_index` (`fetched_at`),
+  CONSTRAINT `scripture_passages_bible_id_check` CHECK (((cast(`bible_id` as char charset binary) = trim(`bible_id`)) and (`bible_id` <> _utf8mb4''))),
+  CONSTRAINT `scripture_passages_copyright_check` CHECK (((cast(`copyright` as char charset binary) = trim(`copyright`)) and (`copyright` <> _utf8mb4''))),
+  CONSTRAINT `scripture_passages_html_content_check` CHECK (((cast(`html_content` as char charset binary) = trim(`html_content`)) and (`html_content` <> _utf8mb4''))),
+  CONSTRAINT `scripture_passages_normalized_reference_check` CHECK (((cast(`normalized_reference` as char charset binary) = trim(`normalized_reference`)) and (`normalized_reference` <> _utf8mb4'')))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `scripture_references`;
@@ -623,7 +627,8 @@ CREATE TABLE `sermons` (
   CONSTRAINT `sermons_download_count_check` CHECK ((`download_count` >= 0)),
   CONSTRAINT `sermons_duration_check` CHECK (((`duration` >= 0) or (`duration` is null))),
   CONSTRAINT `sermons_preacher_confidence_check` CHECK (((`preacher_confidence` >= 0) and (`preacher_confidence` <= 1))),
-  CONSTRAINT `sermons_preacher_format_check` CHECK (((cast(`preacher` as char charset binary) = trim(`preacher`)) and (`preacher` <> _utf8mb4''))),
+  CONSTRAINT `sermons_preacher_format_check` CHECK (((cast(`preacher` as char charset binary) = trim(`preacher`)) and (`preacher` <> _utf8mb3''))),
+  CONSTRAINT `sermons_reference_format_check` CHECK (((`reference` is null) or ((cast(`reference` as char charset binary) = trim(`reference`)) and (`reference` <> _utf8mb4'')))),
   CONSTRAINT `sermons_series_format_check` CHECK (((`series` is null) or ((cast(`series` as char charset binary) = trim(`series`)) and (`series` <> _utf8mb3'')))),
   CONSTRAINT `sermons_slug_format_check` CHECK (regexp_like(`slug`,_utf8mb3'^[a-z0-9]+(?:-[a-z0-9]+)*$',_utf8mb4'c')),
   CONSTRAINT `sermons_timing_invariants_check` CHECK (((`segment_start_time` >= 0) and ((`segment_end_time` >= `segment_start_time`) or (`segment_end_time` is null) or (`segment_start_time` is null)))),
@@ -1135,3 +1140,5 @@ INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_05_15_053846_forti
 INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_05_13_051713_fortify_meetings_integrity',69);
 INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_05_17_053346_add_foreign_key_to_church_services_manual_reviewed_by_user_id',69);
 INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_05_20_054000_add_integrity_check_to_song_videos_table',69);
+INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_05_24_052601_add_integrity_check_to_sermons_reference_table',70);
+INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_05_23_053404_add_check_constraints_to_scripture_passages_table',71);

--- a/tests/Feature/Warden/ScripturePassageIntegrityTest.php
+++ b/tests/Feature/Warden/ScripturePassageIntegrityTest.php
@@ -11,6 +11,7 @@ use App\Services\ScriptureHtmlSanitizer;
 use App\Services\ScriptureOperatorService;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Validator;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -94,5 +95,82 @@ class ScripturePassageIntegrityTest extends TestCase
 
         // Assert: validation catches the empty copyright and returns 'failed'
         $this->assertSame('failed', $outcome);
+    }
+
+    #[Test]
+    public function it_validates_scripture_passage_data(): void
+    {
+        $validData = [
+            'bible_id' => 'de4e12af7f895db2-01',
+            'normalized_reference' => 'JHN.3.16',
+            'html_content' => '<p>For God so loved the world...</p>',
+            'copyright' => 'Public Domain',
+            'fetched_at' => now()->toDateTimeString(),
+        ];
+
+        $this->assertTrue(Validator::make($validData, ScripturePassage::validationRules())->passes());
+
+        // Test required fields
+        foreach (['bible_id', 'normalized_reference', 'html_content', 'copyright', 'fetched_at'] as $field) {
+            $invalidData = $validData;
+            unset($invalidData[$field]);
+            $this->assertFalse(Validator::make($invalidData, ScripturePassage::validationRules())->passes(), "Validation should fail when $field is missing");
+        }
+
+        // Test max length
+        foreach (['bible_id', 'normalized_reference', 'api_passage_id', 'display_reference', 'fums_token'] as $field) {
+            $invalidData = $validData;
+            $invalidData[$field] = str_repeat('a', 256);
+            $this->assertFalse(Validator::make($invalidData, ScripturePassage::validationRules())->passes(), "Validation should fail when $field exceeds 255 chars");
+        }
+    }
+
+    #[Test]
+    public function it_trims_identifying_strings(): void
+    {
+        $passage = new ScripturePassage([
+            'bible_id' => '  de4e12af7f895db2-01  ',
+            'normalized_reference' => '  JHN.3.16  ',
+            'api_passage_id' => '  JHN.3.16  ',
+            'display_reference' => '  John 3:16  ',
+            'html_content' => '<p>content</p>',
+            'copyright' => 'copyright',
+            'fetched_at' => now(),
+        ]);
+
+        $this->assertEquals('de4e12af7f895db2-01', $passage->bible_id);
+        $this->assertEquals('JHN.3.16', $passage->normalized_reference);
+        $this->assertEquals('JHN.3.16', $passage->api_passage_id);
+        $this->assertEquals('John 3:16', $passage->display_reference);
+    }
+
+    #[Test]
+    public function it_enforces_database_check_constraints(): void
+    {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('scripture_passages_bible_id_check');
+
+        ScripturePassage::query()->insert([
+            'bible_id' => '',
+            'normalized_reference' => 'JHN.3.16',
+            'html_content' => '<p>content</p>',
+            'copyright' => 'copyright',
+            'fetched_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_enforces_copyright_check_constraint(): void
+    {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('scripture_passages_copyright_check');
+
+        ScripturePassage::query()->insert([
+            'bible_id' => 'de4e12af7f895db2-01',
+            'normalized_reference' => 'JHN.3.16',
+            'html_content' => '<p>content</p>',
+            'copyright' => '',
+            'fetched_at' => now(),
+        ]);
     }
 }

--- a/tests/Feature/Warden/ScripturePassageIntegrityTest.php
+++ b/tests/Feature/Warden/ScripturePassageIntegrityTest.php
@@ -52,7 +52,7 @@ class ScripturePassageIntegrityTest extends TestCase
     #[Test]
     public function it_handles_long_copyright_text(): void
     {
-        $longCopyright = str_repeat('Copyright notice content. ', 100); // 2600 chars
+        $longCopyright = trim(str_repeat('Copyright notice content. ', 100)); // 2600 chars
 
         $passage = ScripturePassage::factory()->create([
             'copyright' => $longCopyright,

--- a/tests/Integration/Models/SermonDisplayTest.php
+++ b/tests/Integration/Models/SermonDisplayTest.php
@@ -132,35 +132,29 @@ class SermonDisplayTest extends TestCase
     }
 
     #[Test]
-    public function it_falls_back_to_column_when_relation_is_loaded_but_invalid(): void
+    public function it_falls_back_to_column_when_relation_is_loaded_but_both_references_are_empty(): void
     {
-        // Use a state where normalized_reference is technically non-empty but maybe something invalid
-        // for the purpose of the test, though normalized_reference check will prevent actual empty strings.
-        $passage = ScripturePassage::factory()->create([
+        // Build an unsaved passage instance with both reference fields empty (bypasses DB constraints)
+        // to simulate a legacy row that somehow has no usable reference text.
+        $passage = new ScripturePassage;
+        $passage->setRawAttributes([
+            'id' => 99999,
+            'bible_id' => 'de4e12af7f895db2-01',
+            'normalized_reference' => '',
             'display_reference' => null,
-            'normalized_reference' => 'INVALID',
+            'html_content' => '<p>content</p>',
+            'copyright' => 'Public Domain',
+            'fetched_at' => now()->toDateTimeString(),
         ]);
-
-        // Force empty strings via DB to test fallback if we want, but better to test with nulls
-        // which are allowed for display_reference.
-        // Actually the test was trying to simulate a loaded but "empty" state.
-        // If we want to test fallback, we should ensure displayReference presenter logic handles it.
 
         $sermon = Sermon::factory()->create([
             'reference' => 'John 3:16',
             'scripture_passage_id' => null,
         ]);
 
-        // Manually set relation to simulate loaded but invalid state
-        // We bypass the model setters by using setRawAttributes if we really wanted empty strings,
-        // but let's just use what's allowed.
-        $passage->display_reference = null;
-        $passage->normalized_reference = ' '; // will be trimmed to '' by setter if we use it, but factory might allow it if we are careful.
-
         $sermon->setRelation('scripturePassage', $passage);
 
         $this->assertTrue($sermon->relationLoaded('scripturePassage'));
-        // If presenter sees empty display and empty normalized, it should fall back to $sermon->reference
         $this->assertEquals('John 3:16', $this->presenter->displayReference($sermon));
     }
 

--- a/tests/Integration/Models/SermonDisplayTest.php
+++ b/tests/Integration/Models/SermonDisplayTest.php
@@ -114,10 +114,10 @@ class SermonDisplayTest extends TestCase
     }
 
     #[Test]
-    public function it_displays_reference_from_relation_normalized_reference_when_display_is_empty(): void
+    public function it_displays_reference_from_relation_normalized_reference_when_display_is_null(): void
     {
         $passage = ScripturePassage::factory()->create([
-            'display_reference' => '',
+            'display_reference' => null,
             'normalized_reference' => 'Romans 8:28',
         ]);
         $sermon = Sermon::factory()->create([
@@ -132,21 +132,35 @@ class SermonDisplayTest extends TestCase
     }
 
     #[Test]
-    public function it_falls_back_to_column_when_relation_is_loaded_but_empty(): void
+    public function it_falls_back_to_column_when_relation_is_loaded_but_invalid(): void
     {
+        // Use a state where normalized_reference is technically non-empty but maybe something invalid
+        // for the purpose of the test, though normalized_reference check will prevent actual empty strings.
         $passage = ScripturePassage::factory()->create([
-            'display_reference' => '',
-            'normalized_reference' => '',
+            'display_reference' => null,
+            'normalized_reference' => 'INVALID',
         ]);
+
+        // Force empty strings via DB to test fallback if we want, but better to test with nulls
+        // which are allowed for display_reference.
+        // Actually the test was trying to simulate a loaded but "empty" state.
+        // If we want to test fallback, we should ensure displayReference presenter logic handles it.
+
         $sermon = Sermon::factory()->create([
             'reference' => 'John 3:16',
             'scripture_passage_id' => null,
         ]);
 
-        // Manually set relation to simulate loaded but empty/invalid state
+        // Manually set relation to simulate loaded but invalid state
+        // We bypass the model setters by using setRawAttributes if we really wanted empty strings,
+        // but let's just use what's allowed.
+        $passage->display_reference = null;
+        $passage->normalized_reference = ' '; // will be trimmed to '' by setter if we use it, but factory might allow it if we are careful.
+
         $sermon->setRelation('scripturePassage', $passage);
 
         $this->assertTrue($sermon->relationLoaded('scripturePassage'));
+        // If presenter sees empty display and empty normalized, it should fall back to $sermon->reference
         $this->assertEquals('John 3:16', $this->presenter->displayReference($sermon));
     }
 


### PR DESCRIPTION
💡 **What:** Implemented the "Three-Layer Pattern" (Database, Model, and Validation) for the `ScripturePassage` model.

🎯 **Why:** To prevent data corruption and ensure consistency by enforcing non-empty strings for critical content columns and automatically trimming whitespace from identifying strings.

🗄️ **Migration:** Added MySQL 8.0+ `CHECK` constraints to the `scripture_passages` table for `bible_id`, `normalized_reference`, `html_content`, and `copyright` columns.

✅ **Verification:** 
- Added new test cases to `ScripturePassageIntegrityTest.php` covering validation rules, attribute setters, and database-level constraint enforcement.
- Updated `SermonDisplayTest.php` to use `null` instead of empty strings for testing fallback logic, ensuring compatibility with the new constraints.
- Verified with `php artisan test`, `composer phpstan`, and `./vendor/bin/pint --dirty`.

⚠️ **Rollback:** `php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [15919688478672469176](https://jules.google.com/task/15919688478672469176) started by @GarethClarridge*