### PR TITLE
⚡ Bolt: Repository Memoization for Preacher and Meeting Lists

### DIFF
--- a/app/Observers/SitemapCacheObserver.php
+++ b/app/Observers/SitemapCacheObserver.php
@@ -8,7 +8,9 @@ use App\Models\Meeting;
 use App\Models\Page;
 use App\Models\Preacher;
 use App\Models\Sermon;
+use App\Repositories\MeetingListRepository;
 use App\Repositories\PageRepository;
+use App\Repositories\PreacherListRepository;
 use App\Repositories\SermonRepository;
 use App\Services\PageImageCacheService;
 use App\Services\PodcastFeedService;
@@ -22,6 +24,8 @@ class SitemapCacheObserver implements ShouldHandleEventsAfterCommit
 {
     public function __construct(
         private readonly SermonRepository $sermonRepository,
+        private readonly PreacherListRepository $preacherListRepository,
+        private readonly MeetingListRepository $meetingListRepository,
         private readonly PageRepository $pageRepository,
         private readonly PageImageCacheService $pageImageCacheService,
         private readonly PodcastFeedService $podcastFeedService,
@@ -61,9 +65,11 @@ class SitemapCacheObserver implements ShouldHandleEventsAfterCommit
     {
         Cache::forget('sitemap');
         Cache::forget('nav_pages');
-        Cache::forget('admin_preacher_list');
-        Cache::forget('public_preacher_list');
-        Cache::forget('admin_meeting_list');
+
+        $this->preacherListRepository->forgetFlexibleCaches();
+        $this->preacherListRepository->clearInternalCaches();
+        $this->meetingListRepository->forgetFlexibleCaches();
+        $this->meetingListRepository->clearInternalCaches();
 
         if ($model instanceof Page) {
             $this->pageRepository->clearAreaCache($model->area);

--- a/app/Observers/SitemapCacheObserver.php
+++ b/app/Observers/SitemapCacheObserver.php
@@ -73,6 +73,7 @@ class SitemapCacheObserver implements ShouldHandleEventsAfterCommit
 
         if ($model instanceof Page) {
             $this->pageRepository->clearAreaCache($model->area);
+            $this->pageRepository->clearInternalCaches();
             $this->pageImageCacheService->forget($model);
             $this->publicPageReadModelCache->forget($model);
             $model->loadMissing('meeting');

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,10 +38,10 @@ class AppServiceProvider extends ServiceProvider
          * Performance Optimization: Register core stateless repositories, services, and presenters
          * as singletons to reduce object instantiation overhead during the request cycle.
          */
-        $this->app->singleton(SermonRepository::class);
-        $this->app->singleton(PreacherListRepository::class);
         $this->app->singleton(MeetingListRepository::class);
         $this->app->singleton(PageRepository::class);
+        $this->app->singleton(PreacherListRepository::class);
+        $this->app->singleton(SermonRepository::class);
         $this->app->singleton(PageImageCacheService::class);
         $this->app->singleton(PageImagePresenter::class);
         $this->app->singleton(PageCardPresenter::class);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,7 +14,9 @@ use App\Presenters\SermonArchiveSeoPresenter;
 use App\Presenters\SermonItemListPresenter;
 use App\Presenters\SermonSitemapPresenter;
 use App\Presenters\SermonViewPresenter;
+use App\Repositories\MeetingListRepository;
 use App\Repositories\PageRepository;
+use App\Repositories\PreacherListRepository;
 use App\Repositories\SermonRepository;
 use App\Services\PageImageCacheService;
 use App\Services\PublicMeetingReadModelCache;
@@ -37,6 +39,8 @@ class AppServiceProvider extends ServiceProvider
          * as singletons to reduce object instantiation overhead during the request cycle.
          */
         $this->app->singleton(SermonRepository::class);
+        $this->app->singleton(PreacherListRepository::class);
+        $this->app->singleton(MeetingListRepository::class);
         $this->app->singleton(PageRepository::class);
         $this->app->singleton(PageImageCacheService::class);
         $this->app->singleton(PageImagePresenter::class);

--- a/app/Repositories/MeetingListRepository.php
+++ b/app/Repositories/MeetingListRepository.php
@@ -15,19 +15,56 @@ class MeetingListRepository
     private const CACHE_TTL = [86400, 172800];
 
     /**
+     * @var array<string, Collection<string, string>>
+     */
+    private array $memoizedPresents = [];
+
+    /**
      * Meetings as a slug => heading map for admin dropdowns. Cached for 24 hours
      * to avoid the join + heading lookup on every render.
+     *
+     * Performance Optimization: Implements request-level memoization to avoid
+     * redundant flexible cache lookups when referenced multiple times.
      *
      * @return Collection<string, string>
      */
     public function forAdminList(): Collection
     {
-        return Cache::flexible(self::ADMIN_LIST_CACHE_KEY, self::CACHE_TTL, function (): Collection {
+        if (isset($this->memoizedPresents[self::ADMIN_LIST_CACHE_KEY])) {
+            return $this->memoizedPresents[self::ADMIN_LIST_CACHE_KEY];
+        }
+
+        return $this->memoizedPresents[self::ADMIN_LIST_CACHE_KEY] = Cache::flexible(self::ADMIN_LIST_CACHE_KEY, self::CACHE_TTL, function (): Collection {
             return Meeting::query()
                 ->select(['id', 'slug', 'page_id'])
                 ->with('page:id,heading')
                 ->get()
                 ->mapWithKeys(fn (Meeting $m) => [$m->slug => $m->page->heading ?? $m->slug]);
         });
+    }
+
+    /**
+     * Clear the internal request-level memoization.
+     */
+    public function clearInternalCaches(): void
+    {
+        $this->memoizedPresents = [];
+    }
+
+    /**
+     * Clear the external flexible caches.
+     */
+    public function forgetFlexibleCaches(): void
+    {
+        $this->forgetFlexible(self::ADMIN_LIST_CACHE_KEY);
+    }
+
+    /**
+     * Internal helper to clear flexible cache and its created metadata.
+     */
+    private function forgetFlexible(string $key): void
+    {
+        Cache::forget($key);
+        Cache::forget("illuminate:cache:flexible:created:{$key}");
     }
 }

--- a/app/Repositories/PageRepository.php
+++ b/app/Repositories/PageRepository.php
@@ -21,15 +21,28 @@ class PageRepository
     ];
 
     /**
+     * @var array<string, Collection<int, Page>>
+     */
+    private array $memoizedPresents = [];
+
+    /**
      * Get and cache all public links for an area.
+     *
+     * Performance Optimization: Implements request-level memoization to avoid
+     * redundant flexible cache lookups when referenced multiple times.
      *
      * @return Collection<int, Page>
      */
     public function getAllLinksForArea(string|PageArea $area): Collection
     {
         $areaValue = $area instanceof PageArea ? $area->value : $area;
+        $cacheKey = "page_links_{$areaValue}";
 
-        return Cache::flexible("page_links_{$areaValue}", [86400, 172800], function () use ($areaValue) {
+        if (isset($this->memoizedPresents[$cacheKey])) {
+            return $this->memoizedPresents[$cacheKey];
+        }
+
+        return $this->memoizedPresents[$cacheKey] = Cache::flexible($cacheKey, [86400, 172800], function () use ($areaValue) {
             return Page::query()
                 ->public()
                 ->select(['id', 'slug', 'heading', 'area', 'description', 'admin'])
@@ -45,6 +58,10 @@ class PageRepository
      */
     public function getLinksForAreaSlugs(string|PageArea $area, array $slugs, string $cacheKey): Collection
     {
+        if (isset($this->memoizedPresents[$cacheKey])) {
+            return $this->memoizedPresents[$cacheKey];
+        }
+
         $areaValue = $area instanceof PageArea ? $area->value : $area;
         $orderedSlugs = array_values(array_unique($slugs));
 
@@ -52,7 +69,7 @@ class PageRepository
             return collect();
         }
 
-        return Cache::flexible($cacheKey, [86400, 172800], function () use ($areaValue, $orderedSlugs) {
+        return $this->memoizedPresents[$cacheKey] = Cache::flexible($cacheKey, [86400, 172800], function () use ($areaValue, $orderedSlugs) {
             return Page::query()
                 ->public()
                 ->select(['id', 'slug', 'heading', 'area', 'description', 'admin'])
@@ -67,6 +84,14 @@ class PageRepository
                 })
                 ->values();
         });
+    }
+
+    /**
+     * Clear the internal request-level memoization.
+     */
+    public function clearInternalCaches(): void
+    {
+        $this->memoizedPresents = [];
     }
 
     /**

--- a/app/Repositories/PageRepository.php
+++ b/app/Repositories/PageRepository.php
@@ -39,6 +39,7 @@ class PageRepository
         $cacheKey = "page_links_{$areaValue}";
 
         if (isset($this->memoizedPresents[$cacheKey])) {
+            /** @var Collection<int, Page> */
             return $this->memoizedPresents[$cacheKey];
         }
 
@@ -59,6 +60,7 @@ class PageRepository
     public function getLinksForAreaSlugs(string|PageArea $area, array $slugs, string $cacheKey): Collection
     {
         if (isset($this->memoizedPresents[$cacheKey])) {
+            /** @var Collection<int, Page> */
             return $this->memoizedPresents[$cacheKey];
         }
 

--- a/app/Repositories/PreacherListRepository.php
+++ b/app/Repositories/PreacherListRepository.php
@@ -19,14 +19,27 @@ class PreacherListRepository
     private const CACHE_TTL = [86400, 172800];
 
     /**
+     * @var array<string, Collection<int, string>|EloquentCollection<int, Preacher>>
+     */
+    private array $memoizedPresents = [];
+
+    /**
      * Active preachers as an id => name map, sorted by name.
      * Cached for 24 hours to avoid recomputing in admin dropdowns.
+     *
+     * Performance Optimization: Implements request-level memoization to avoid
+     * redundant flexible cache lookups when referenced multiple times.
      *
      * @return Collection<int, string>
      */
     public function forAdminList(): Collection
     {
-        return Cache::flexible(self::ADMIN_LIST_CACHE_KEY, self::CACHE_TTL, function (): Collection {
+        if (isset($this->memoizedPresents[self::ADMIN_LIST_CACHE_KEY])) {
+            /** @var Collection<int, string> */
+            return $this->memoizedPresents[self::ADMIN_LIST_CACHE_KEY];
+        }
+
+        return $this->memoizedPresents[self::ADMIN_LIST_CACHE_KEY] = Cache::flexible(self::ADMIN_LIST_CACHE_KEY, self::CACHE_TTL, function (): Collection {
             return Preacher::query()->active()->orderBy('name')->pluck('name', 'id');
         });
     }
@@ -35,11 +48,19 @@ class PreacherListRepository
      * Active preachers with sermon counts, ordered by sermon count then name,
      * for the public preachers index. Cached for 24 hours.
      *
+     * Performance Optimization: Implements request-level memoization to avoid
+     * redundant flexible cache lookups when referenced multiple times.
+     *
      * @return EloquentCollection<int, Preacher>
      */
     public function forPublicList(): EloquentCollection
     {
-        return Cache::flexible(self::PUBLIC_LIST_CACHE_KEY, self::CACHE_TTL, function (): EloquentCollection {
+        if (isset($this->memoizedPresents[self::PUBLIC_LIST_CACHE_KEY])) {
+            /** @var EloquentCollection<int, Preacher> */
+            return $this->memoizedPresents[self::PUBLIC_LIST_CACHE_KEY];
+        }
+
+        return $this->memoizedPresents[self::PUBLIC_LIST_CACHE_KEY] = Cache::flexible(self::PUBLIC_LIST_CACHE_KEY, self::CACHE_TTL, function (): EloquentCollection {
             return Preacher::query()->active()
                 ->select(['id', 'name', 'slug', 'image_path'])
                 ->withCount([
@@ -49,5 +70,31 @@ class PreacherListRepository
                 ->orderBy('name')
                 ->get();
         });
+    }
+
+    /**
+     * Clear the internal request-level memoization.
+     */
+    public function clearInternalCaches(): void
+    {
+        $this->memoizedPresents = [];
+    }
+
+    /**
+     * Clear the external flexible caches.
+     */
+    public function forgetFlexibleCaches(): void
+    {
+        $this->forgetFlexible(self::ADMIN_LIST_CACHE_KEY);
+        $this->forgetFlexible(self::PUBLIC_LIST_CACHE_KEY);
+    }
+
+    /**
+     * Internal helper to clear flexible cache and its created metadata.
+     */
+    private function forgetFlexible(string $key): void
+    {
+        Cache::forget($key);
+        Cache::forget("illuminate:cache:flexible:created:{$key}");
     }
 }


### PR DESCRIPTION
Implemented request-level memoization in `PreacherListRepository` and `MeetingListRepository`. Both are now singletons, and `SitemapCacheObserver` has been refactored to use repository-managed cache clearing methods. Verified with `phpstan`, `pint`, and full test suite.

---
*PR created automatically by Jules for task [9840031115138316408](https://jules.google.com/task/9840031115138316408) started by @GarethClarridge*