### PR TITLE
🎨 Palette: UX and Accessibility Polish

### DIFF
--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -48,6 +48,10 @@ $iconSizeClasses = [
 $wrapperClasses = $inline ? 'inline-block' : 'block';
 $classes = $baseClasses . ' ' . $sizeClasses[$size] . ' ' . $variantClasses[$variant];
 $resolvedIconClass = trim(($iconSizeClasses[$size] ?? 'h-4 w-4').' '.$iconClass);
+
+if ($slot->isEmpty() && $attributes->has('aria-label') && !$attributes->has('title')) {
+    $attributes = $attributes->merge(['title' => $attributes->get('aria-label')]);
+}
 @endphp
 
 <div class="{{ $wrapperClasses }}">

--- a/resources/views/components/form-button.blade.php
+++ b/resources/views/components/form-button.blade.php
@@ -28,6 +28,10 @@ $target = $attributes->get('wire:target', $wireClick ?: $wireSubmit);
 
 // Except wire:target to avoid duplication in merge
 $filteredAttributes = $attributes->except(['wire:target']);
+
+if ($slot->isEmpty() && $attributes->has('aria-label') && !$attributes->has('title')) {
+    $filteredAttributes = $filteredAttributes->merge(['title' => $attributes->get('aria-label')]);
+}
 @endphp
 
 <button {{ $filteredAttributes->merge(['class' => $classes, 'type' => $type]) }} wire:loading.attr="disabled" @if($target) wire:target="{{ $target }}" @endif>

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -48,7 +48,8 @@ $clearLabel = 'Clear ' . ($label ?: ($attributes->get('placeholder') ?: 'input')
                 'type' => 'text',
                 'class' => $inputClasses,
                 'id' => $id,
-                'aria-label' => (!$label && $attributes->get('placeholder')) ? $attributes->get('placeholder') : null
+                'aria-label' => (!$label && $attributes->get('placeholder')) ? $attributes->get('placeholder') : null,
+                'title' => ($shortcut === 'slash') ? 'Press / to focus' : $attributes->get('title')
             ]) }}
             @if($isPassword)
                 :type="showPassword ? 'text' : 'password'"

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -49,7 +49,7 @@ $clearLabel = 'Clear ' . ($label ?: ($attributes->get('placeholder') ?: 'input')
                 'class' => $inputClasses,
                 'id' => $id,
                 'aria-label' => (!$label && $attributes->get('placeholder')) ? $attributes->get('placeholder') : null,
-                'title' => ($shortcut === 'slash') ? 'Press / to focus' : $attributes->get('title')
+                'title' => ($shortcut === 'slash') ? 'Press / to focus' : ($attributes->get('title') ?: null)
             ]) }}
             @if($isPassword)
                 :type="showPassword ? 'text' : 'password'"

--- a/resources/views/livewire/admin/sermons/edit-sermon.blade.php
+++ b/resources/views/livewire/admin/sermons/edit-sermon.blade.php
@@ -98,14 +98,24 @@
 
                 <div>
                     <label class="block text-sm font-medium text-gray-700 mb-2">Points</label>
-                    @foreach($points as $index => $point)
-                        <div class="flex gap-2 mb-2">
-                            <x-input wire:model="form.points.{{ $index }}" class="flex-1" />
-                            <x-form-button variant="ghost" size="sm" icon="trash" class="text-red-600"
-                                wire:click="removePoint({{ $index }})"
-                                aria-label="Remove point" />
-                        </div>
-                    @endforeach
+                    <div class="space-y-2">
+                        @foreach($points as $index => $point)
+                            <div wire:key="point-{{ $index }}"
+                                 x-transition:enter="transition ease-out duration-200"
+                                 x-transition:enter-start="opacity-0 -translate-y-2"
+                                 x-transition:enter-end="opacity-100 translate-y-0"
+                                 x-transition:leave="transition ease-in duration-150"
+                                 x-transition:leave-start="opacity-100 translate-y-0"
+                                 x-transition:leave-end="opacity-0 -translate-y-2"
+                                 class="flex gap-2">
+                                <x-input wire:model="form.points.{{ $index }}" class="flex-1" />
+                                <x-form-button variant="ghost" size="sm" icon="trash" class="text-red-600"
+                                    wire:click="removePoint({{ $index }})"
+                                    wire:confirm="Remove this sermon point?"
+                                    aria-label="Remove point" />
+                            </div>
+                        @endforeach
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
This PR implements a series of micro-UX and accessibility improvements across the application:

### 1. Automatic Tooltips for Icon-Only Buttons
Modified the base `<x-button>` and `<x-form-button>` components to automatically set the `title` attribute to match the `aria-label` when the button has no text slot (icon-only). This provides helpful visual tooltips for administrative actions without requiring manual title attributes on every instance.

### 2. Polished Sermon Points Interaction
Enhanced the sermon points editing interface in the admin panel:
- **`wire:key`**: Added to ensure reliable Livewire DOM diffing during point additions and removals.
- **`x-transition`**: Applied smooth Alpine.js transitions for point entry and exit.
- **`wire:confirm`**: Added a confirmation dialog to the "Remove point" button to prevent accidental deletions.
- **Layout**: Improved vertical rhythm using `space-y-2`.

### 3. Shortcut Discoverability
Updated `<x-input>` to automatically include a "Press / to focus" tooltip when the `shortcut="slash"` prop is provided, making the global search shortcut more discoverable for mouse users.

### 4. Code Quality & Testing
- Verified through standard integration tests (`FormAccessibilityTest`, `SearchShortcutTest`).
- Passed `composer phpstan` and `npm run build`.
- Adhered to TALL stack best practices and accessibility standards.

---
*PR created automatically by Jules for task [6704146122587390828](https://jules.google.com/task/6704146122587390828) started by @GarethClarridge*