### PR TITLE
🏛️ Warden: Fortify sermons.reference data integrity

### DIFF
--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -206,6 +206,24 @@ class Sermon extends Model implements Sitemapable
     }
 
     /**
+     * @return Attribute<?string, ?string>
+     */
+    protected function reference(): Attribute
+    {
+        return Attribute::make(
+            set: function (?string $value): ?string {
+                if ($value === null) {
+                    return null;
+                }
+
+                $trimmed = trim($value);
+
+                return $trimmed === '' ? null : $trimmed;
+            },
+        );
+    }
+
+    /**
      * Preacher name attribute.
      *
      * Note: The relationship is named 'preacherProfile' to avoid conflict with
@@ -259,7 +277,18 @@ class Sermon extends Model implements Sitemapable
             'source_type' => ['nullable', Rule::enum(SermonSourceType::class)],
             'service' => ['nullable', Rule::enum(SermonService::class)],
             'series' => ['nullable', 'string', 'max:255'],
-            'reference' => ['nullable', 'string', 'max:255'],
+            'reference' => ['nullable', 'string', 'max:255', new class implements \Illuminate\Contracts\Validation\ImplicitRule
+            {
+                public function passes($attribute, $value): bool
+                {
+                    return $value !== '';
+                }
+
+                public function message(): string
+                {
+                    return 'The :attribute field must not be empty.';
+                }
+            }],
             'preacher' => ['required', 'string', 'max:255'], // Matches database varchar length and non-empty constraint
             'preacher_id' => ['nullable', 'integer', 'exists:preachers,id'],
             'preacher_source' => ['nullable', Rule::enum(PreacherSource::class)],

--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -14,6 +14,7 @@ use App\Enums\SermonSourceType;
 use App\Enums\SermonVideoQualityStatus;
 use App\Enums\SermonVideoVisibilityOverride;
 use App\Presenters\SermonSitemapPresenter;
+use App\Rules\NotEmptyString;
 use Database\Factories\SermonFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -277,18 +278,7 @@ class Sermon extends Model implements Sitemapable
             'source_type' => ['nullable', Rule::enum(SermonSourceType::class)],
             'service' => ['nullable', Rule::enum(SermonService::class)],
             'series' => ['nullable', 'string', 'max:255'],
-            'reference' => ['nullable', 'string', 'max:255', new class implements \Illuminate\Contracts\Validation\ImplicitRule
-            {
-                public function passes($attribute, $value): bool
-                {
-                    return $value !== '';
-                }
-
-                public function message(): string
-                {
-                    return 'The :attribute field must not be empty.';
-                }
-            }],
+            'reference' => ['nullable', 'string', 'max:255', new NotEmptyString],
             'preacher' => ['required', 'string', 'max:255'], // Matches database varchar length and non-empty constraint
             'preacher_id' => ['nullable', 'integer', 'exists:preachers,id'],
             'preacher_source' => ['nullable', Rule::enum(PreacherSource::class)],

--- a/app/Rules/NotEmptyString.php
+++ b/app/Rules/NotEmptyString.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+class NotEmptyString implements ValidationRule
+{
+    /**
+     * Always run this rule, even when the value is an empty string.
+     * Equivalent to the deprecated ImplicitRule interface.
+     */
+    public bool $implicit = true;
+
+    /**
+     * Run the validation rule.
+     *
+     * Rejects empty strings and whitespace-only strings. Passes null (pair
+     * with 'nullable' in the rule set to allow null values).
+     *
+     * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            $fail('The :attribute field must not be empty or contain only whitespace.');
+        }
+    }
+}

--- a/database/migrations/2026_05_24_052601_add_integrity_check_to_sermons_reference_table.php
+++ b/database/migrations/2026_05_24_052601_add_integrity_check_to_sermons_reference_table.php
@@ -19,12 +19,9 @@ return new class extends Migration
             return;
         }
 
-        // 1. Data Cleanup: Trim existing data and convert whitespace-only to NULL
-        DB::table('sermons')->update([
-            'reference' => DB::raw("NULLIF(TRIM(reference), '')"),
-        ]);
-
-        // 2. Add CHECK constraint (MySQL 8.0.16+)
+        // Add CHECK constraint (MySQL 8.0.16+)
+        // We do not modify existing data here per Warden standards;
+        // if violations exist, the migration will fail loudly.
         if (DB::getDriverName() === 'mysql') {
             DB::statement(sprintf(
                 "ALTER TABLE sermons ADD CONSTRAINT %s CHECK (reference IS NULL OR (BINARY reference = TRIM(reference) AND reference != ''))",

--- a/database/migrations/2026_05_24_052601_add_integrity_check_to_sermons_reference_table.php
+++ b/database/migrations/2026_05_24_052601_add_integrity_check_to_sermons_reference_table.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const CONSTRAINT_NAME = 'sermons_reference_format_check';
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasTable('sermons')) {
+            return;
+        }
+
+        // 1. Data Cleanup: Trim existing data and convert whitespace-only to NULL
+        DB::table('sermons')->update([
+            'reference' => DB::raw("NULLIF(TRIM(reference), '')"),
+        ]);
+
+        // 2. Add CHECK constraint (MySQL 8.0.16+)
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement(sprintf(
+                "ALTER TABLE sermons ADD CONSTRAINT %s CHECK (reference IS NULL OR (BINARY reference = TRIM(reference) AND reference != ''))",
+                self::CONSTRAINT_NAME
+            ));
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'mysql' && Schema::hasTable('sermons')) {
+            DB::statement(sprintf('ALTER TABLE sermons DROP CHECK %s', self::CONSTRAINT_NAME));
+        }
+    }
+};

--- a/tests/Feature/SermonReferenceIntegrityTest.php
+++ b/tests/Feature/SermonReferenceIntegrityTest.php
@@ -8,27 +8,29 @@ use App\Models\Sermon;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class SermonReferenceIntegrityTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_trims_reference_in_model_setter(): void
     {
         $sermon = new Sermon(['reference' => '  John 3:16  ']);
         $this->assertEquals('John 3:16', $sermon->reference);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_nullifies_empty_reference_in_model_setter(): void
     {
         $sermon = new Sermon(['reference' => '   ']);
         $this->assertNull($sermon->reference);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_rejects_untrimmed_reference_at_database_level(): void
     {
         if (DB::getDriverName() !== 'mysql') {
@@ -49,7 +51,7 @@ class SermonReferenceIntegrityTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_rejects_empty_string_reference_at_database_level(): void
     {
         if (DB::getDriverName() !== 'mysql') {
@@ -70,7 +72,7 @@ class SermonReferenceIntegrityTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_allows_null_reference_at_database_level(): void
     {
         $id = DB::table('sermons')->insertGetId([
@@ -89,11 +91,11 @@ class SermonReferenceIntegrityTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_validation_for_empty_string_reference(): void
     {
         $rules = Sermon::validationRules();
-        $validator = \Illuminate\Support\Facades\Validator::make(
+        $validator = Validator::make(
             ['reference' => ''],
             ['reference' => $rules['reference']]
         );
@@ -101,11 +103,23 @@ class SermonReferenceIntegrityTest extends TestCase
         $this->assertTrue($validator->fails());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
+    public function it_fails_validation_for_whitespace_only_reference(): void
+    {
+        $rules = Sermon::validationRules();
+        $validator = Validator::make(
+            ['reference' => '   '],
+            ['reference' => $rules['reference']]
+        );
+
+        $this->assertTrue($validator->fails());
+    }
+
+    #[Test]
     public function it_passes_validation_for_null_reference(): void
     {
         $rules = Sermon::validationRules();
-        $validator = \Illuminate\Support\Facades\Validator::make(
+        $validator = Validator::make(
             ['reference' => null],
             ['reference' => $rules['reference']]
         );

--- a/tests/Feature/SermonReferenceIntegrityTest.php
+++ b/tests/Feature/SermonReferenceIntegrityTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Sermon;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class SermonReferenceIntegrityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_trims_reference_in_model_setter(): void
+    {
+        $sermon = new Sermon(['reference' => '  John 3:16  ']);
+        $this->assertEquals('John 3:16', $sermon->reference);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_nullifies_empty_reference_in_model_setter(): void
+    {
+        $sermon = new Sermon(['reference' => '   ']);
+        $this->assertNull($sermon->reference);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_rejects_untrimmed_reference_at_database_level(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            $this->markTestSkipped('CHECK constraints are specifically tested on MySQL.');
+        }
+
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('sermons_reference_format_check');
+
+        DB::table('sermons')->insert([
+            'date' => now()->toDateString(),
+            'title' => 'Test Sermon',
+            'slug' => 'test-sermon-'.uniqid(),
+            'preacher' => 'Test Preacher',
+            'reference' => '  Invalid  ',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_rejects_empty_string_reference_at_database_level(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            $this->markTestSkipped('CHECK constraints are specifically tested on MySQL.');
+        }
+
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('sermons_reference_format_check');
+
+        DB::table('sermons')->insert([
+            'date' => now()->toDateString(),
+            'title' => 'Test Sermon',
+            'slug' => 'test-sermon-'.uniqid(),
+            'preacher' => 'Test Preacher',
+            'reference' => '',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_allows_null_reference_at_database_level(): void
+    {
+        $id = DB::table('sermons')->insertGetId([
+            'date' => now()->toDateString(),
+            'title' => 'Test Sermon',
+            'slug' => 'test-sermon-'.uniqid(),
+            'preacher' => 'Test Preacher',
+            'reference' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->assertDatabaseHas('sermons', [
+            'id' => $id,
+            'reference' => null,
+        ]);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_fails_validation_for_empty_string_reference(): void
+    {
+        $rules = Sermon::validationRules();
+        $validator = \Illuminate\Support\Facades\Validator::make(
+            ['reference' => ''],
+            ['reference' => $rules['reference']]
+        );
+
+        $this->assertTrue($validator->fails());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_passes_validation_for_null_reference(): void
+    {
+        $rules = Sermon::validationRules();
+        $validator = \Illuminate\Support\Facades\Validator::make(
+            ['reference' => null],
+            ['reference' => $rules['reference']]
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+}


### PR DESCRIPTION
### 🏛️ Warden: Fortify `sermons.reference` data integrity

#### 💡 What:
I have implemented the full 'Three-Layer Pattern' for the `reference` column in the `sermons` table. This ensures that scripture references are always normalized (trimmed) and never stored as empty strings in the database.

#### 🎯 Why:
This prevents data corruption where whitespace-only or empty strings could be saved as references, which affects display consistency and could potentially interfere with scripture-based filtering and SEO logic.

#### 🗄️ Migration:
- Added a `CHECK` constraint to the `sermons` table: `reference IS NULL OR (BINARY reference = TRIM(reference) AND reference != '')`.
- This constraint is applied only for MySQL 8.0.16+ environments.

#### ✅ Verification:
- **Model Tests**: Verified that the `Sermon` model correctly trims and nullifies `reference` values.
- **Validation Tests**: Verified that `Sermon::validationRules()` allows `null` but rejects `''`.
- **Database Tests**: Verified that the MySQL `CHECK` constraint rejects invalid data if bypassed via raw DB queries.
- **Regression Tests**: All 5207 tests passed in parallel.

#### ⚠️ Rollback:
`vendor/bin/sail artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [4682581975513154586](https://jules.google.com/task/4682581975513154586) started by @GarethClarridge*