### PR TITLE
🧹 Tidy: consolidate fragmented PHPDoc blocks

### DIFF
--- a/app/Livewire/Auth/Login.php
+++ b/app/Livewire/Auth/Login.php
@@ -25,8 +25,9 @@ class Login extends Component
     /**
      * Security: Explicit length constraints are enforced on input fields to provide
      * Defense in Depth against Denial of Service (DoS) attempts with oversized payloads.
+     *
+     * @var string|array<string, mixed>
      */
-    /** @var string|array<string, mixed> */
     #[Validate('required|string|email|max:255')]
     public string|array $email = '';
 

--- a/app/Models/MediaProcessingLog.php
+++ b/app/Models/MediaProcessingLog.php
@@ -502,9 +502,8 @@ class MediaProcessingLog extends Model
     // Accessors for backward compatibility
 
     /**
-     * Accessor for stored_file_path (maps to source_file_path)
-     */
-    /**
+     * Accessor for stored_file_path (maps to source_file_path).
+     *
      * @return Attribute<string|null, string|null>
      */
     protected function storedFilePath(): Attribute

--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -218,8 +218,7 @@ class Meeting extends Model implements HasMedia, Sitemapable
 
     /**
      * Get the page that provides content for this meeting.
-     */
-    /**
+     *
      * @return BelongsTo<Page, $this>
      */
     public function page(): BelongsTo

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -224,8 +224,7 @@ class Page extends Model implements HasMedia, Sitemapable
 
     /**
      * Get the meeting associated with this page.
-     */
-    /**
+     *
      * @return HasOne<Meeting, $this>
      */
     public function meeting(): HasOne

--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -531,8 +531,7 @@ class Sermon extends Model implements Sitemapable
 
     /**
      * Get the processing logs for this sermon.
-     */
-    /**
+     *
      * @return HasMany<MediaProcessingLog, $this>
      */
     public function processingLogs(): HasMany
@@ -542,8 +541,7 @@ class Sermon extends Model implements Sitemapable
 
     /**
      * Get the livestream processing log for this sermon.
-     */
-    /**
+     *
      * @return BelongsTo<MediaProcessingLog, $this>
      */
     public function livestreamProcessing(): BelongsTo

--- a/app/Services/ChurchServiceItemSyncService.php
+++ b/app/Services/ChurchServiceItemSyncService.php
@@ -310,9 +310,6 @@ class ChurchServiceItemSyncService
 
     /**
      * @param  array{position:int,type:string,section_type:string,title:string,source_title:?string,openlp_search_title:?string,song_id:int|null,metadata:?array<string,mixed>}  $incomingItem
-     */
-    /**
-     * @param  array{position:int,type:string,section_type:string,title:string,source_title:?string,openlp_search_title:?string,song_id:int|null,metadata:?array<string,mixed>}  $incomingItem
      * @param  array<string, mixed>|null  $rawIncomingItem
      */
     private function updateMatchedItem(

--- a/app/Services/GoogleCalendarSyncService.php
+++ b/app/Services/GoogleCalendarSyncService.php
@@ -148,12 +148,11 @@ class GoogleCalendarSyncService
     }
 
     /**
-     * @param  array<string, mixed>  $eventData
-     */
-    /**
      * Push a manual meeting_slug categorization to the Google Calendar event's extended properties.
      *
      * Returns true when the Google write succeeded, false when it failed gracefully.
+     *
+     * @param  array<string, mixed>  $eventData
      */
     public function syncCategorizationToGoogle(string $googleEventId, string $meetingSlug): bool
     {

--- a/app/Services/HistoricVideoImporter.php
+++ b/app/Services/HistoricVideoImporter.php
@@ -631,10 +631,6 @@ class HistoricVideoImporter
      * Dispatch a single work item through the livestream pipeline.
      *
      * @param  array{tag: string, label: string, files: list<string>, date: Carbon, service: SermonService, client_file_date: string, bytes: int}  $item
-     * @return array{tag: string, processing_id: string, detail: string|null}
-     */
-    /**
-     * @param  array{tag: string, label: string, files: list<string>, date: Carbon, service: SermonService, client_file_date: string, bytes: int}  $item
      * @return list<array{tag: string, processing_id: string, detail: string|null}>
      */
     private function dispatchItem(array $item, bool $noConcat, bool $reEncodeMismatched): array

--- a/app/Services/RmsAnalysisService.php
+++ b/app/Services/RmsAnalysisService.php
@@ -138,9 +138,8 @@ class RmsAnalysisService
     }
 
     /**
-     * Get total duration from RMS log content
-     */
-    /**
+     * Get total duration from RMS log content.
+     *
      * @param  array<int, string>  $lines
      */
     public function getTotalDuration(string $logContent, array $lines): float

--- a/app/Services/UnifiedMediaProcessor.php
+++ b/app/Services/UnifiedMediaProcessor.php
@@ -324,8 +324,7 @@ class UnifiedMediaProcessor
     /**
      * Process video by extracting audio and joining existing sermon processing.
      * Uses ProcessingInitiator for shared metadata extraction and log creation.
-     */
-    /**
+     *
      * @param  array<string, mixed>  $options
      */
     private function processDirectVideo(

--- a/app/Services/VideoExtractionService.php
+++ b/app/Services/VideoExtractionService.php
@@ -37,15 +37,12 @@ class VideoExtractionService
     }
 
     /**
-     * Extract video segment with stream copy (no re-encoding) - primary method
+     * Extract video segment with stream copy (no re-encoding) - primary method.
      *
      * @param  string  $inputPath  Path to the original video file
      * @param  object  $segment  Segment data with start_time and end_time
-     * @param  array  $options  Extraction options
+     * @param  array<string, mixed>  $options  Extraction options
      * @return string|UploadedFile Based on options['return_type']
-     */
-    /**
-     * @param  array<string, mixed>  $options
      */
     public function extractSegment(string $inputPath, object $segment, array $options = []): string|UploadedFile
     {


### PR DESCRIPTION
This PR addresses a code quality inconsistency where multiple files contained fragmented PHPDoc blocks (consecutive `/** ... */` headers for a single method or property).

### 💡 What:
- Consolidated split docblocks into single unified headers.
- Merged descriptive text with technical tags (`@var`, `@param`, `@return`).
- Standardized sentence casing and punctuation in modified blocks.

### 🎯 Why:
- Improves code readability by removing redundant boilerplate.
- Ensures static analysis tools (Larastan/PHPStan) and IDEs correctly map descriptions to the documented members.
- Follows the Tidy mission of resolving code smells and inconsistencies.

### 🔄 Behavior:
- No functional changes to logic, visibility, or behavior.

### ✅ Tests:
- Full test suite passed (5225 tests).
- `php artisan test --parallel --compact` confirmed no regressions.
- `composer phpstan` remains at 0 errors.
- Manual verification using a custom script to find duplicate docblocks.

---
*PR created automatically by Jules for task [7877875424141953801](https://jules.google.com/task/7877875424141953801) started by @GarethClarridge*