### PR TITLE
Scribe: Add tests for SermonPageContextService

### DIFF
--- a/tests/Feature/Services/SermonPageContextServiceTest.php
+++ b/tests/Feature/Services/SermonPageContextServiceTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services;
+
+use App\Data\ServiceSectionMetadata;
+use App\Enums\ServiceSectionType;
+use App\Models\ChurchServiceItem;
+use App\Models\MediaProcessingLog;
+use App\Models\Sermon;
+use App\Models\ServiceSection;
+use App\Services\SermonPageContextService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonPageContextServiceTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private SermonPageContextService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new SermonPageContextService();
+    }
+
+    #[Test]
+    public function it_returns_null_values_when_no_processing_log_exists(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'livestream_processing_id' => null,
+        ]);
+
+        $result = $this->service->build($sermon);
+
+        $this->assertNull($result['reading_reference']);
+        $this->assertNull($result['reading_url']);
+    }
+
+    #[Test]
+    public function it_returns_null_values_when_no_reading_section_exists(): void
+    {
+        $sermon = Sermon::factory()->create();
+        $log = MediaProcessingLog::factory()->create(['sermon_id' => $sermon->id]);
+
+        // Create a non-reading section
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $log->id,
+            'section_type' => ServiceSectionType::SERMON,
+        ]);
+
+        $result = $this->service->build($sermon);
+
+        $this->assertNull($result['reading_reference']);
+        $this->assertNull($result['reading_url']);
+    }
+
+    #[Test]
+    public function it_resolves_reference_from_section_metadata(): void
+    {
+        $sermon = Sermon::factory()->create();
+        $log = MediaProcessingLog::factory()->create(['sermon_id' => $sermon->id]);
+
+        $metadata = new ServiceSectionMetadata(readingReference: 'John 3:16');
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $log->id,
+            'section_type' => ServiceSectionType::BIBLE_READING,
+            'metadata' => $metadata,
+            'title' => 'Other Title',
+        ]);
+
+        $result = $this->service->build($sermon);
+
+        $this->assertEquals('John 3:16', $result['reading_reference']);
+        $this->assertStringContainsString('John%203%3A16', $result['reading_url']);
+    }
+
+    #[Test]
+    public function it_resolves_reference_from_church_service_item_title(): void
+    {
+        $sermon = Sermon::factory()->create();
+        $log = MediaProcessingLog::factory()->create(['sermon_id' => $sermon->id]);
+
+        $item = ChurchServiceItem::factory()->create(['title' => 'Genesis 1:1']);
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $log->id,
+            'section_type' => ServiceSectionType::BIBLE_READING,
+            'church_service_item_id' => $item->id,
+            'metadata' => null,
+            'title' => 'Other Title',
+        ]);
+
+        $result = $this->service->build($sermon);
+
+        $this->assertEquals('Genesis 1:1', $result['reading_reference']);
+    }
+
+    #[Test]
+    public function it_resolves_reference_from_section_title(): void
+    {
+        $sermon = Sermon::factory()->create();
+        $log = MediaProcessingLog::factory()->create(['sermon_id' => $sermon->id]);
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $log->id,
+            'section_type' => ServiceSectionType::BIBLE_READING,
+            'church_service_item_id' => null,
+            'metadata' => null,
+            'title' => 'Psalm 23',
+        ]);
+
+        $result = $this->service->build($sermon);
+
+        $this->assertEquals('Psalm 23', $result['reading_reference']);
+    }
+
+    #[Test]
+    public function it_respects_priority_order_metadata_first(): void
+    {
+        $sermon = Sermon::factory()->create();
+        $log = MediaProcessingLog::factory()->create(['sermon_id' => $sermon->id]);
+
+        $item = ChurchServiceItem::factory()->create(['title' => 'Item Title']);
+        $metadata = new ServiceSectionMetadata(readingReference: 'Metadata Reference');
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $log->id,
+            'section_type' => ServiceSectionType::BIBLE_READING,
+            'church_service_item_id' => $item->id,
+            'metadata' => $metadata,
+            'title' => 'Section Title',
+        ]);
+
+        $result = $this->service->build($sermon);
+
+        $this->assertEquals('Metadata Reference', $result['reading_reference']);
+    }
+
+    #[Test]
+    public function it_resolves_via_published_service_section(): void
+    {
+        $log = MediaProcessingLog::factory()->create();
+        $sermon = Sermon::factory()->create();
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $log->id,
+            'section_type' => ServiceSectionType::BIBLE_READING,
+            'title' => 'Isaiah 53',
+            'metadata' => null,
+            'church_service_item_id' => null,
+        ]);
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $log->id,
+            'section_type' => ServiceSectionType::SERMON,
+            'published_sermon_id' => $sermon->id,
+            'metadata' => null,
+            'church_service_item_id' => null,
+        ]);
+
+        $result = $this->service->build($sermon);
+
+        $this->assertEquals('Isaiah 53', $result['reading_reference']);
+    }
+
+    #[Test]
+    public function it_resolves_via_livestream_processing_id(): void
+    {
+        $log = MediaProcessingLog::factory()->create([
+            'processing_id' => 'livestream-123',
+        ]);
+
+        $sermon = Sermon::factory()->create([
+            'livestream_processing_id' => 'livestream-123',
+        ]);
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $log->id,
+            'section_type' => ServiceSectionType::BIBLE_READING,
+            'title' => 'Romans 8',
+            'metadata' => null,
+            'church_service_item_id' => null,
+        ]);
+
+        $result = $this->service->build($sermon);
+
+        $this->assertEquals('Romans 8', $result['reading_reference']);
+    }
+
+    #[Test]
+    public function it_generates_correct_bible_gateway_url(): void
+    {
+        $sermon = Sermon::factory()->create();
+        $log = MediaProcessingLog::factory()->create(['sermon_id' => $sermon->id]);
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $log->id,
+            'section_type' => ServiceSectionType::BIBLE_READING,
+            'title' => 'John 3:16-17',
+            'metadata' => null,
+            'church_service_item_id' => null,
+        ]);
+
+        $result = $this->service->build($sermon);
+
+        $expected = 'https://www.biblegateway.com/passage/?search=John%203%3A16-17&version=NIVUK';
+        $this->assertEquals($expected, $result['reading_url']);
+    }
+
+    #[Test]
+    public function it_trims_references(): void
+    {
+        $sermon = Sermon::factory()->create();
+        $log = MediaProcessingLog::factory()->create(['sermon_id' => $sermon->id]);
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $log->id,
+            'section_type' => ServiceSectionType::BIBLE_READING,
+            'title' => '  Psalm 119  ',
+            'metadata' => null,
+            'church_service_item_id' => null,
+        ]);
+
+        $result = $this->service->build($sermon);
+
+        $this->assertEquals('Psalm 119', $result['reading_reference']);
+    }
+}


### PR DESCRIPTION
I have identified `SermonPageContextService` as an untested component and added a comprehensive feature test suite for it.

### Coverage
- `SermonPageContextService::build()` is now fully tested.
- Priority resolution for reading references (Metadata > Church Service Item > Section Title).
- Multiple ways to find the associated `MediaProcessingLog` (via `publishedServiceSection`, `livestream_processing_id`, or `latestProcessingLog`).
- Handling of missing data and edge cases (null references, no reading sections).
- Bible Gateway URL generation logic.
- Trimming of extracted references.

### Tests Added
- `it_returns_null_values_when_no_processing_log_exists`
- `it_returns_null_values_when_no_reading_section_exists`
- `it_resolves_reference_from_section_metadata`
- `it_resolves_reference_from_church_service_item_title`
- `it_resolves_reference_from_section_title`
- `it_respects_priority_order_metadata_first`
- `it_resolves_via_published_service_section`
- `it_resolves_via_livestream_processing_id`
- `it_generates_correct_bible_gateway_url`
- `it_trims_references`

### Verification
- Ran the specific test suite: `php artisan test tests/Feature/Services/SermonPageContextServiceTest.php` (10 passed).
- Ran quality checks (`phpstan`, `pint`).
- Requested and received positive code review.

---
*PR created automatically by Jules for task [8236860116582892041](https://jules.google.com/task/8236860116582892041) started by @GarethClarridge*