### PR TITLE
🔦 Lighthouse: Enhance technical SEO and sitemap accuracy

### DIFF
--- a/app/Presenters/SeriesItemListPresenter.php
+++ b/app/Presenters/SeriesItemListPresenter.php
@@ -28,7 +28,7 @@ class SeriesItemListPresenter
                     'item' => [
                         '@type' => 'CreativeWorkSeries',
                         'name' => $seriesName,
-                        'url' => url('/christ/sermons/series/'.Str::slug($seriesName)),
+                        'url' => route('sermons.series.show', ['series' => Str::slug($seriesName)]),
                     ],
                 ];
             })->values()->all(),

--- a/app/Presenters/SermonItemListPresenter.php
+++ b/app/Presenters/SermonItemListPresenter.php
@@ -171,7 +171,7 @@ class SermonItemListPresenter
             '@type' => 'Article',
             'headline' => $sermon->title,
             'name' => $sermon->title,
-            'url' => $sermonView['public_url'],
+            'url' => $sermonView['canonical_url'],
             'description' => $metaDescription,
             'datePublished' => $datePublished,
             'dateModified' => $sermon->updated_at?->toIso8601String() ?? $datePublished,
@@ -182,7 +182,7 @@ class SermonItemListPresenter
             'publisher' => $publisher,
             'mainEntityOfPage' => [
                 '@type' => 'WebPage',
-                '@id' => $sermonView['public_url'],
+                '@id' => $sermonView['canonical_url'],
             ],
             'image' => $sermonView['thumbnail_url'] ?: $logoUrl,
         ];

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -840,6 +840,26 @@ class SermonViewPresenter
      * Checks for existing database-stored descriptions before falling back
      * to dynamic generation.
      */
+    /**
+     * Get the descriptive alt text for a sermon thumbnail image.
+     */
+    public function imageAlt(Sermon $sermon): string
+    {
+        $preacherName = $this->displayPreacherName($sermon);
+
+        return 'Sermon: '.$sermon->title.($preacherName ? ' by '.$preacherName : '');
+    }
+
+    /**
+     * Get the descriptive alt text for a Children's Corner talk thumbnail image.
+     */
+    public function childrensTalkImageAlt(Sermon $sermon): string
+    {
+        $preacherName = $this->displayPreacherName($sermon);
+
+        return "Children's Corner: ".$sermon->title.($preacherName ? ' by '.$preacherName : '');
+    }
+
     public function metaDescription(Sermon $sermon): string
     {
         $key = $this->cacheKey($sermon, 'meta_desc');

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -197,6 +197,11 @@ class SitemapService
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY);
 
             $latestSermon = $representativeSermons->get($book);
+
+            if ($latestSermon && $latestSermon->updated_at && $latestSermon->updated_at->year > 0) {
+                $url->setLastModificationDate($latestSermon->updated_at);
+            }
+
             $image = $latestSermon ? $this->sermonViewPresenter->thumbnailUrl($latestSermon) : null;
 
             $url->addImage($image ?: $sermonsImage, "Sermons on {$book}");
@@ -309,6 +314,11 @@ class SitemapService
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_MONTHLY);
 
             $latestSermon = $representativeSermons->get($series);
+
+            if ($latestSermon && $latestSermon->updated_at && $latestSermon->updated_at->year > 0) {
+                $url->setLastModificationDate($latestSermon->updated_at);
+            }
+
             $image = $latestSermon ? $this->sermonViewPresenter->thumbnailUrl($latestSermon) : null;
 
             $url->addImage($image ?: $sermonsImage, "Sermon Series: {$series}");

--- a/resources/views/childrens-corner/show.blade.php
+++ b/resources/views/childrens-corner/show.blade.php
@@ -24,7 +24,7 @@
             :image="$sermonView['thumbnail_url']"
             :image-width="$sermonView['thumbnail_url'] ? 1280 : 800"
             :image-height="$sermonView['thumbnail_url'] ? 720 : 600"
-            :image-alt="\"Children's Corner: {$sermon->title}\""
+            :image-alt="app(\App\Presenters\SermonViewPresenter::class)->childrensTalkImageAlt($sermon)"
             :audio="$sermonView['audio_url']"
             :video="$sermonView['video_url']"
             :canonical="$sermonView['public_url']"

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -29,7 +29,7 @@
             :image="$sermonView['thumbnail_url']"
             :image-width="$sermonView['thumbnail_url'] ? 1280 : 800"
             :image-height="$sermonView['thumbnail_url'] ? 720 : 600"
-            :image-alt="'Sermon: ' . $sermon->title . ($sermonView['preacher_name'] ? ' by ' . $sermonView['preacher_name'] : '')"
+            :image-alt="app(\App\Presenters\SermonViewPresenter::class)->imageAlt($sermon)"
             :audio="$sermonView['audio_url']"
             :video="$sermonView['video_url']"
             :canonical="$sermonView['canonical_url']"

--- a/tests/Feature/SermonOpenGraphTest.php
+++ b/tests/Feature/SermonOpenGraphTest.php
@@ -52,7 +52,7 @@ class SermonOpenGraphTest extends TestCase
         $response->assertSee('<meta property="og:image"', false);
         $response->assertSee('<meta property="og:image:width"', false);
         $response->assertSee('<meta property="og:image:height"', false);
-        $response->assertSee('<meta property="og:image:alt" content="Sermon: Test Sermon Title">', false);
+        $response->assertSee('<meta property="og:image:alt" content="Sermon: Test Sermon Title by John Smith">', false);
         $response->assertSee('<meta property="og:audio"', false);
 
         // Check Twitter Card meta tags


### PR DESCRIPTION
🔦 **Lighthouse: SEO & Metadata Enhancements**

💡 **What:** A suite of technical SEO improvements focusing on sitemap accuracy, structured data consistency, and social sharing metadata.

🎯 **Why:** To improve search engine indexing efficiency and make sermon content more discoverable and descriptive when shared on social platforms.

📊 **Impact:**
- **Sitemap:** Search engines can now detect fresh content in scripture and series archives via the new `lastmod` dates.
- **Structured Data:** Sermon `ItemList` elements now point directly to canonical dated URLs, removing unnecessary redirect hops for crawlers.
- **Social Sharing:** Sermon pages now include more descriptive `og:image:alt` tags (including preacher names), improving accessibility and image search context.

🔍 **Verification:**
- `php artisan test --compact tests/Unit/Services/SitemapServiceTest.php`
- `php artisan test --compact tests/Integration/SermonItemListPresenterTest.php`
- `php artisan test --compact tests/Feature/SermonOpenGraphTest.php`
- `composer phpstan` (0 errors in modified files)
- `pint --dirty` (formatting applied)

---
*PR created automatically by Jules for task [6484021908242744491](https://jules.google.com/task/6484021908242744491) started by @GarethClarridge*