### PR TITLE
📝 Scribe: Add tests for SermonArchiveSeoPresenter

### DIFF
--- a/tests/Integration/Presenters/SermonArchiveSeoPresenterTest.php
+++ b/tests/Integration/Presenters/SermonArchiveSeoPresenterTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Presenters;
+
+use App\Models\Preacher;
+use App\Presenters\SermonArchiveSeoPresenter;
+use App\Repositories\PreacherListRepository;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonArchiveSeoPresenterTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private SermonArchiveSeoPresenter $presenter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->presenter = app(SermonArchiveSeoPresenter::class);
+    }
+
+    #[Test]
+    public function title_returns_default_when_no_filters_active(): void
+    {
+        $filters = [
+            'book' => null,
+            'chapter' => null,
+            'preacherId' => null,
+            'series' => null,
+        ];
+
+        $this->assertSame('Sermons', $this->presenter->title($filters));
+    }
+
+    #[Test]
+    public function title_includes_book_filter(): void
+    {
+        $filters = [
+            'book' => 'Genesis',
+            'chapter' => null,
+            'preacherId' => null,
+            'series' => null,
+        ];
+
+        $this->assertSame('Genesis | Sermons', $this->presenter->title($filters));
+    }
+
+    #[Test]
+    public function title_includes_book_and_chapter_filter(): void
+    {
+        $filters = [
+            'book' => 'John',
+            'chapter' => 3,
+            'preacherId' => null,
+            'series' => null,
+        ];
+
+        $this->assertSame('John 3 | Sermons', $this->presenter->title($filters));
+    }
+
+    #[Test]
+    public function title_includes_preacher_filter(): void
+    {
+        $preacher = Preacher::factory()->create(['name' => 'Charles Spurgeon']);
+
+        $filters = [
+            'book' => null,
+            'chapter' => null,
+            'preacherId' => $preacher->id,
+            'series' => null,
+        ];
+
+        $this->assertSame('Charles Spurgeon | Sermons', $this->presenter->title($filters));
+    }
+
+    #[Test]
+    public function title_includes_series_filter(): void
+    {
+        $filters = [
+            'book' => null,
+            'chapter' => null,
+            'preacherId' => null,
+            'series' => 'Life of David',
+        ];
+
+        $this->assertSame('Life of David | Sermons', $this->presenter->title($filters));
+    }
+
+    #[Test]
+    public function title_joins_multiple_filters(): void
+    {
+        $preacher = Preacher::factory()->create(['name' => 'Mark Drury']);
+
+        $filters = [
+            'book' => 'Romans',
+            'chapter' => 8,
+            'preacherId' => $preacher->id,
+            'series' => 'The Gospel',
+        ];
+
+        $this->assertSame('Romans 8 | Mark Drury | The Gospel | Sermons', $this->presenter->title($filters));
+    }
+
+    #[Test]
+    public function description_returns_default_when_no_filters_active(): void
+    {
+        $filters = [
+            'book' => null,
+            'chapter' => null,
+            'preacherId' => null,
+            'series' => null,
+        ];
+
+        $this->assertStringContainsString('Explore the sermon archive at Crockenhill Baptist Church', $this->presenter->description($filters));
+    }
+
+    #[Test]
+    public function description_includes_book_and_chapter(): void
+    {
+        $filters = [
+            'book' => 'Psalms',
+            'chapter' => 23,
+            'preacherId' => null,
+            'series' => null,
+        ];
+
+        $description = $this->presenter->description($filters);
+        $this->assertStringContainsString('on Psalms 23', $description);
+    }
+
+    #[Test]
+    public function description_includes_preacher(): void
+    {
+        $preacher = Preacher::factory()->create(['name' => 'Alistair Begg']);
+
+        $filters = [
+            'book' => null,
+            'chapter' => null,
+            'preacherId' => $preacher->id,
+            'series' => null,
+        ];
+
+        $description = $this->presenter->description($filters);
+        $this->assertStringContainsString('by Alistair Begg', $description);
+    }
+
+    #[Test]
+    public function description_includes_series(): void
+    {
+        $filters = [
+            'book' => null,
+            'chapter' => null,
+            'preacherId' => null,
+            'series' => 'Parables',
+        ];
+
+        $description = $this->presenter->description($filters);
+        $this->assertStringContainsString("in the 'Parables' series", $description);
+    }
+
+    #[Test]
+    public function description_joins_multiple_filters_correctly(): void
+    {
+        $preacher = Preacher::factory()->create(['name' => 'Peter Test']);
+
+        $filters = [
+            'book' => 'Acts',
+            'chapter' => 2,
+            'preacherId' => $preacher->id,
+            'series' => 'Holy Spirit',
+        ];
+
+        $description = $this->presenter->description($filters);
+        $this->assertStringContainsString('on Acts 2 by Peter Test in the \'Holy Spirit\' series', $description);
+    }
+
+    #[Test]
+    public function canonical_returns_base_archive_url_when_no_filters(): void
+    {
+        $filters = [
+            'book' => null,
+            'chapter' => null,
+            'preacherId' => null,
+            'series' => null,
+        ];
+
+        $this->assertSame('http://localhost/christ/sermons', $this->presenter->canonical($filters));
+    }
+
+    #[Test]
+    public function canonical_includes_filters_in_query_string(): void
+    {
+        $filters = [
+            'book' => 'John',
+            'chapter' => 3,
+            'preacherId' => 123,
+            'series' => 'Gospel',
+        ];
+
+        $url = $this->presenter->canonical($filters);
+        $this->assertStringContainsString('book=John', $url);
+        $this->assertStringContainsString('chapter=3', $url);
+        $this->assertStringContainsString('preacher=123', $url);
+        $this->assertStringContainsString('series=Gospel', $url);
+    }
+
+    #[Test]
+    public function canonical_includes_page_number_when_greater_than_one(): void
+    {
+        $filters = ['book' => null, 'chapter' => null, 'preacherId' => null, 'series' => null];
+
+        $this->assertSame('http://localhost/christ/sermons', $this->presenter->canonical($filters, 1));
+        $this->assertStringContainsString('page=2', $this->presenter->canonical($filters, 2));
+    }
+
+    #[Test]
+    public function it_resolves_preacher_name_from_active_list(): void
+    {
+        $preacher = Preacher::factory()->create(['name' => 'Active Preacher', 'is_active' => true]);
+
+        // PreacherListRepository is a scoped singleton, we need to ensure the cache is clear
+        // or just let it load since we are in an integration test.
+        app(PreacherListRepository::class)->clearInternalCaches();
+
+        $filters = [
+            'book' => null,
+            'chapter' => null,
+            'preacherId' => $preacher->id,
+            'series' => null,
+        ];
+
+        // Should use PreacherListRepository::forPublicList() which includes active preachers
+        $this->assertStringContainsString('Active Preacher', $this->presenter->title($filters));
+    }
+
+    #[Test]
+    public function it_resolves_preacher_name_from_database_for_inactive_preachers(): void
+    {
+        $preacher = Preacher::factory()->inactive()->create(['name' => 'Inactive Preacher']);
+
+        app(PreacherListRepository::class)->clearInternalCaches();
+
+        $filters = [
+            'book' => null,
+            'chapter' => null,
+            'preacherId' => $preacher->id,
+            'series' => null,
+        ];
+
+        // Inactive preacher won't be in forPublicList(), so it falls back to DB find()
+        $this->assertStringContainsString('Inactive Preacher', $this->presenter->title($filters));
+    }
+}


### PR DESCRIPTION
I have identified that the `SermonArchiveSeoPresenter` class, which is responsible for generating dynamic SEO metadata (titles, descriptions, and canonical URLs) for the sermon archive page, was lacking dedicated test coverage.

I have implemented a comprehensive integration test suite in `tests/Integration/Presenters/SermonArchiveSeoPresenterTest.php`. These tests verify:
- The default output when no search filters are applied.
- The correct inclusion and formatting of various filters (Bible book, chapter, preacher name, and sermon series) in both the page title and meta description.
- The generation of canonical URLs, ensuring that all active filters and pagination are correctly preserved in the query string.
- The internal logic for resolving preacher names, ensuring it correctly handles both active preachers (using the `PreacherListRepository` public cache) and inactive or legacy preachers (falling back to a direct database lookup).

These tests provide confidence that the SEO metadata for the sermon archive remains accurate as the application evolves, which is critical for search engine discoverability.

All tests passed successfully, and the changes are compliant with the project's coding and testing standards.

---
*PR created automatically by Jules for task [7972865195138939068](https://jules.google.com/task/7972865195138939068) started by @GarethClarridge*