### PR TITLE
🛡️ Sentinel: Implement additive security hardening

### DIFF
--- a/app/Http/Controllers/Api/MediaController.php
+++ b/app/Http/Controllers/Api/MediaController.php
@@ -248,7 +248,7 @@ class MediaController extends Controller
      */
     private function handleApiException(\Exception $e, string $logMessage, array $context = [], array $body = []): JsonResponse
     {
-        Log::error($logMessage, array_merge($context, [
+        Log::error($logMessage, array_merge($this->sanitizeArrayForLog($context), [
             'error' => $this->sanitizeForLog($e->getMessage()),
             'trace' => $this->sanitizeStackTrace($e->getTraceAsString()),
         ]));

--- a/app/Http/Requests/CategorizeEventRequest.php
+++ b/app/Http/Requests/CategorizeEventRequest.php
@@ -26,7 +26,7 @@ class CategorizeEventRequest extends FormRequest
     {
         return [
             'event_id' => ['required', 'integer', 'exists:calendar_events,id'],
-            'meeting_slug' => ['required', 'string', 'exists:meetings,slug'],
+            'meeting_slug' => ['required', 'string', 'max:255', 'exists:meetings,slug'],
         ];
     }
 

--- a/app/Http/Requests/MediaProcessingRequest.php
+++ b/app/Http/Requests/MediaProcessingRequest.php
@@ -33,6 +33,8 @@ abstract class MediaProcessingRequest extends FormRequest
      * External uploader tools predate the Form Request migration and already
      * handle 400 for a malformed processingId. Preserving that contract here
      * means only body-field validation failures surface as 422.
+     *
+     * @throws HttpException
      */
     protected function assertProcessingIdShape(): void
     {

--- a/app/Http/Requests/ProcessMediaRequest.php
+++ b/app/Http/Requests/ProcessMediaRequest.php
@@ -36,7 +36,7 @@ class ProcessMediaRequest extends MediaProcessingRequest
 
         return [
             ...$fileRules,
-            'type' => [$this->route('type') ? 'nullable' : 'required', Rule::enum(MediaType::class)],
+            'type' => [$this->route('type') ? 'nullable' : 'required', 'max:20', Rule::enum(MediaType::class)],
             ...VideoProcessingOptions::validationRules($mediaType),
         ];
     }

--- a/app/Http/Requests/UpdateSermonRequest.php
+++ b/app/Http/Requests/UpdateSermonRequest.php
@@ -43,7 +43,7 @@ class UpdateSermonRequest extends FormRequest
             'duration' => $modelRules['duration'],
             'segment_start_time' => $modelRules['segment_start_time'],
             'segment_end_time' => $modelRules['segment_end_time'],
-            'points' => ['nullable', 'json'],
+            'points' => ['nullable', 'json', 'max:10000'],
             'summary' => ['nullable', 'string', 'max:1000'],
             'show_summary' => ['nullable', 'boolean'],
             'show_points' => ['nullable', 'boolean'],


### PR DESCRIPTION
This PR implements several additive security hardening measures:

1. **Input Validation Tightening**: Added `max:` length constraints to potentially large or unbounded fields in `UpdateSermonRequest` (sermon points), `ProcessMediaRequest` (media type), and `CategorizeEventRequest` (meeting slug) to provide defense in depth against Denial of Service (DoS) attempts using oversized payloads.
2. **Log Sanitization Enhancement**: Updated `MediaController::handleApiException` to use the `sanitizeArrayForLog` trait method. This ensures that any contextual data passed to the error logger is recursively sanitized, preventing log injection and reducing the risk of leaking sensitive information in error logs.
3. **Documentation Improvement**: Added accurate `@throws` PHPDoc annotations to `MediaProcessingRequest::assertProcessingIdShape` to clearly document its role in enforcing input shape integrity via exceptions.

All changes were verified using the full test suite, PHPStan (ignoring pre-existing baseline issues), and Laravel Pint. Misleading documentation identified during code review was corrected.

---
*PR created automatically by Jules for task [11119100903426687173](https://jules.google.com/task/11119100903426687173) started by @GarethClarridge*