### PR TITLE
♿ Aria: Improve icon and loading state accessibility

### DIFF
--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -57,11 +57,11 @@ if ($slot->isEmpty() && $attributes->has('aria-label') && !$attributes->has('tit
 <div class="{{ $wrapperClasses }}">
   <a {{ $attributes->merge(['class' => $classes]) }} href="{{ $link }}" @if($navigate && !str_starts_with($link, '#')) wire:navigate @endif>
     @if($icon && $iconPosition !== 'trailing')
-      <x-dynamic-component :component="$iconComponent" class="{{ $resolvedIconClass }}" />
+      <x-dynamic-component :component="$iconComponent" class="{{ $resolvedIconClass }}" aria-hidden="true" />
     @endif
     {{ $slot }}
     @if($icon && $iconPosition === 'trailing')
-      <x-dynamic-component :component="$iconComponent" class="{{ $resolvedIconClass }}" />
+      <x-dynamic-component :component="$iconComponent" class="{{ $resolvedIconClass }}" aria-hidden="true" />
     @endif
   </a>
 </div>

--- a/resources/views/components/form-button.blade.php
+++ b/resources/views/components/form-button.blade.php
@@ -37,11 +37,11 @@ if ($slot->isEmpty() && $attributes->has('aria-label') && !$attributes->has('tit
 <button {{ $filteredAttributes->merge(['class' => $classes, 'type' => $type]) }} wire:loading.attr="disabled" @if($target) wire:target="{{ $target }}" @endif>
     @if($icon)
       <span wire:loading.remove @if($target) wire:target="{{ $target }}" @endif class="contents">
-        <x-dynamic-component :component="'heroicon-o-' . $icon" class="w-4 h-4 {{ $slot->isNotEmpty() ? 'mr-2' : '' }}" />
+        <x-dynamic-component :component="'heroicon-o-' . $icon" class="w-4 h-4 {{ $slot->isNotEmpty() ? 'mr-2' : '' }}" aria-hidden="true" />
       </span>
     @endif
     <span wire:loading @if($target) wire:target="{{ $target }}" @endif role="status" aria-live="polite" class="{{ $slot->isNotEmpty() ? 'mr-2' : '' }}">
-        <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
         </svg>

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -35,7 +35,7 @@ $clearLabel = 'Clear ' . ($label ?: ($attributes->get('placeholder') ?: 'input')
     <div class="relative">
         @if($icon)
             <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                <x-dynamic-component :component="'heroicon-o-' . $icon" class="h-5 w-5 text-gray-400" />
+                <x-dynamic-component :component="'heroicon-o-' . $icon" class="h-5 w-5 text-gray-400" aria-hidden="true" />
             </div>
         @endif
 
@@ -64,8 +64,8 @@ $clearLabel = 'Clear ' . ($label ?: ($attributes->get('placeholder') ?: 'input')
         />
 
         @if($modelName)
-            <div wire:loading wire:target="{{ $modelName }}" class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                <svg class="animate-spin h-4 w-4 text-cbc-teal" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <div wire:loading wire:target="{{ $modelName }}" class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none" role="status">
+                <svg class="animate-spin h-4 w-4 text-cbc-teal" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -45,8 +45,8 @@ $describedBy = implode(' ', $describedBy);
         </select>
 
         @if($modelName)
-            <div wire:loading wire:target="{{ $modelName }}" class="absolute inset-y-0 right-0 pr-8 flex items-center pointer-events-none">
-                <svg class="animate-spin h-4 w-4 text-cbc-teal" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <div wire:loading wire:target="{{ $modelName }}" class="absolute inset-y-0 right-0 pr-8 flex items-center pointer-events-none" role="status">
+                <svg class="animate-spin h-4 w-4 text-cbc-teal" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -67,8 +67,8 @@ $describedBy = implode(' ', $describedBy);
         >{{ $slot }}</textarea>
 
         @if($modelName)
-            <div wire:loading wire:target="{{ $modelName }}" class="absolute top-0 right-0 pt-2 pr-3 flex items-center pointer-events-none">
-                <svg class="animate-spin h-4 w-4 text-cbc-teal" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <div wire:loading wire:target="{{ $modelName }}" class="absolute top-0 right-0 pt-2 pr-3 flex items-center pointer-events-none" role="status">
+                <svg class="animate-spin h-4 w-4 text-cbc-teal" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>

--- a/resources/views/components/toggle.blade.php
+++ b/resources/views/components/toggle.blade.php
@@ -33,7 +33,7 @@
                 :class="$wire['{{ $modelName }}'] ? 'bg-cbc-teal' : 'bg-gray-200'">
                 <span :class="$wire['{{ $modelName }}'] ? 'translate-x-5' : 'translate-x-0'"
                     class="pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out">
-                    <svg wire:loading wire:target="{{ $modelName }}" class="absolute inset-0 h-full w-full animate-spin text-cbc-teal p-1" style="display:none" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <svg wire:loading wire:target="{{ $modelName }}" class="absolute inset-0 h-full w-full animate-spin text-cbc-teal p-1" style="display:none" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                     </svg>


### PR DESCRIPTION
This change improves the accessibility of core UI components by addressing two common "programmable" a11y issues:

1. **Redundant Icon Announcements**: Screen readers often announce the names of icons (e.g., "plus", "trash") even when they are decorative and sit next to descriptive text. By adding `aria-hidden="true"` to these icons in `Button`, `FormButton`, and `Input` components, we silence this noise.
2. **Missing Loading State Context**: When a Livewire action is processing, the visual loading spinner is now correctly identified as a status update for assistive technology using `role="status"`. The spinner itself is hidden from screen readers, but the existing `sr-only` text remains to provide a clear, non-visual notification of the loading state.

These changes are "under the hood" and do not affect the visual layout of the site, making the interface cleaner and more informative for users relying on screen readers.

---
*PR created automatically by Jules for task [17249903378999163434](https://jules.google.com/task/17249903378999163434) started by @GarethClarridge*