### PR TITLE
📜 Herald: Add PHPDoc to Sermon Analysis Pipeline

### DIFF
--- a/app/Services/SermonAnalysisService.php
+++ b/app/Services/SermonAnalysisService.php
@@ -33,13 +33,17 @@ class SermonAnalysisService implements SermonAnalysisInterface
     }
 
     /**
-     * Analyze sermon transcript using AI to extract comprehensive information
+     * Analyze sermon transcript using AI to extract comprehensive information.
+     *
+     * Coordinates the full analysis pipeline: validation, optional series retrieval,
+     * AI interaction, and data normalization into a SermonAnalysis DTO.
      *
      * @param  string  $transcript  The sermon transcript to analyze
-     * @param  array<int, string>  $existingSeries  Optional array of existing series names
+     * @param  array<int, string>  $existingSeries  Optional array of existing series names for context
+     * @param  string|null  $processingId  Processing ID for log correlation
      * @return SermonAnalysis The analyzed sermon data
      *
-     * @throws Exception When analysis fails
+     * @throws Exception When validation fails, AI analysis fails, or response is malformed
      */
     public function analyzeSermon(string $transcript, array $existingSeries = [], ?string $processingId = null): SermonAnalysis
     {
@@ -91,12 +95,21 @@ class SermonAnalysisService implements SermonAnalysisInterface
     }
 
     /**
-     * Perform comprehensive AI analysis using OpenAI GPT API with retry logic.
+     * Perform comprehensive AI analysis using OpenAI GPT API.
      *
      * @param  string  $transcript  The sermon transcript
      * @param  array<int, string>  $existingSeries  Array of existing series names
      * @param  string  $processingId  Processing ID for logging
-     * @return array<string, mixed> The parsed analysis results
+     * @return array{
+     *     title: string,
+     *     series: string|null,
+     *     reference: string|null,
+     *     points: list<string>,
+     *     summary: string|null,
+     *     transcript: string,
+     * } The parsed analysis results
+     *
+     * @throws Exception|\OpenAI\Exceptions\ErrorException|\OpenAI\Exceptions\TransporterException
      */
     private function performAiAnalysis(string $transcript, array $existingSeries, string $processingId): array
     {
@@ -127,9 +140,16 @@ class SermonAnalysisService implements SermonAnalysisInterface
      * Execute a single AI analysis attempt.
      *
      * @param  array<int, string>  $existingSeries
-     * @return array<string, mixed>
+     * @return array{
+     *     title: string,
+     *     series: string|null,
+     *     reference: string|null,
+     *     points: list<string>,
+     *     summary: string|null,
+     *     transcript: string,
+     * }
      *
-     * @throws Exception|\TypeError
+     * @throws Exception|\TypeError|\OpenAI\Exceptions\ErrorException|\OpenAI\Exceptions\TransporterException
      */
     private function runAnalysisAttempt(string $transcript, array $existingSeries, string $processingId, int $attempt, float $apiStartTime): array
     {
@@ -256,9 +276,16 @@ class SermonAnalysisService implements SermonAnalysisInterface
     /**
      * Parse and validate OpenAI API response.
      *
-     * @return array<string, mixed>
+     * @return array{
+     *     title?: string,
+     *     series?: string|null,
+     *     reference?: string|null,
+     *     points?: array<int, string>,
+     *     summary?: string|null,
+     *     transcript?: string,
+     * }
      *
-     * @throws Exception
+     * @throws Exception If the response structure is invalid or JSON parsing fails
      */
     private function parseAiResponse(CreateResponse $response, string $processingId): array
     {
@@ -291,7 +318,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
     /**
      * Execute AI analysis request via OpenAI SDK.
      *
-     * @throws Exception
+     * @throws Exception|\OpenAI\Exceptions\ErrorException|\TypeError
      */
     private function executeAiRequest(string $prompt, string $model, string $processingId, int $attempt): CreateResponse
     {

--- a/app/Services/SermonAnalysisValidator.php
+++ b/app/Services/SermonAnalysisValidator.php
@@ -53,11 +53,21 @@ class SermonAnalysisValidator
     }
 
     /**
-     * Validate and clean the AI analysis data
+     * Validate and clean raw AI analysis data.
+     *
+     * Normalises types, applies British English spelling corrections, enforces
+     * word limits on titles, and ensures a valid structure for the SermonAnalysis DTO.
      *
      * @param  array<string, mixed>  $analysisData  Raw analysis data from AI
      * @param  string  $originalTranscript  Original transcript for fallback
-     * @return array<string, mixed> Validated and cleaned analysis data
+     * @return array{
+     *     title: string,
+     *     series: string|null,
+     *     reference: string|null,
+     *     points: list<string>,
+     *     summary: string|null,
+     *     transcript: string,
+     * } Validated and cleaned analysis data
      */
     public function validateAndCleanAnalysisData(array $analysisData, string $originalTranscript): array
     {
@@ -116,7 +126,10 @@ class SermonAnalysisValidator
     }
 
     /**
-     * Validate and clean sermon title
+     * Validate and clean sermon title.
+     *
+     * Trims whitespace, removes wrapping quotes, applies British English
+     * spelling corrections, and enforces the MAX_TITLE_WORDS limit.
      *
      * @param  string  $title  Raw title from AI
      * @return string Validated and cleaned title
@@ -159,7 +172,10 @@ class SermonAnalysisValidator
     }
 
     /**
-     * Validate Bible reference format
+     * Validate Bible reference format.
+     *
+     * Checks if the reference matches a basic book + chapter pattern
+     * (e.g. "John 3", "1 Peter 2").
      *
      * @param  string  $reference  Raw Bible reference
      * @return string|null Validated reference or null if invalid
@@ -178,7 +194,10 @@ class SermonAnalysisValidator
     }
 
     /**
-     * Validate and clean sermon summary
+     * Validate and clean sermon summary.
+     *
+     * Trims whitespace, removes quotes, applies British English corrections,
+     * and limits to approximately 200 words, attempting to end on a full sentence.
      *
      * @param  string  $summary  Raw summary from AI
      * @return string|null Validated and cleaned summary or null if invalid

--- a/app/Services/VideoSegmentationService.php
+++ b/app/Services/VideoSegmentationService.php
@@ -166,8 +166,8 @@ class VideoSegmentationService
     }
 
     /**
-     * @param  array<int, array<string, float>>  $loudSections
-     * @param  array<string, mixed>  $rmsData
+     * @param  array<int, array{start: float, end: float}>  $loudSections
+     * @param  array<int, array{time: float, rms: float}>  $rmsData
      * @return array<int, LivestreamSegment>
      */
     private function combineLoudAndQuietSections(array $loudSections, float $totalDuration, array $rmsData): array
@@ -390,7 +390,7 @@ class VideoSegmentationService
 
             $rmsData = $this->rmsAnalysisService->extractRmsData($logContent);
 
-            $songRmsValues = $this->rmsAnalysisService->extractRmsForTimestamps($rmsData, $songCluster['samples']);
+            $songRmsValues = $this->rmsAnalysisService->extractRmsForTimestamps($rmsData, array_values($songCluster['samples']));
 
             if (empty($songRmsValues)) {
                 throw new SegmentationException('No RMS data found for song period');


### PR DESCRIPTION
💡 **What:** Added detailed PHPDoc blocks and array shape annotations to `SermonAnalysisService` and `SermonAnalysisValidator`.
🎯 **Why:** The AI analysis pipeline involves complex data structures and third-party exception handling (OpenAI SDK) that were previously undocumented, making the code harder to understand and maintain.
🔄 **Behavior:** No functional changes to the sermon analysis logic. Added `array_values()` in `VideoSegmentationService` to satisfy PHPStan list requirements for the new annotations.

---
*PR created automatically by Jules for task [16498855750505390091](https://jules.google.com/task/16498855750505390091) started by @GarethClarridge*