### PR TITLE
🏛️ Warden: Fortify Sermon livestream processing ID validation

### DIFF
--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Data\ThumbnailMetadata;
 use App\Data\ThumbnailMetadataCast;
+use App\Enums\MediaType;
 use App\Enums\PreacherSource;
 use App\Enums\ProcessingStatus;
 use App\Enums\SermonContentType;
@@ -288,7 +289,12 @@ class Sermon extends Model implements Sitemapable
             'scripture_passage_id' => ['nullable', 'integer', 'exists:scripture_passages,id'],
             'download_count' => ['nullable', 'integer', 'min:0'],
             'duration' => ['nullable', 'numeric', 'min:0'],
-            'livestream_processing_id' => ['nullable', 'uuid', 'exists:media_processing_logs,processing_id'],
+            'livestream_processing_id' => [
+                'nullable',
+                'uuid',
+                Rule::exists('media_processing_logs', 'processing_id')
+                    ->where('processing_type', MediaType::Livestream->value),
+            ],
         ];
     }
 

--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -288,7 +288,7 @@ class Sermon extends Model implements Sitemapable
             'scripture_passage_id' => ['nullable', 'integer', 'exists:scripture_passages,id'],
             'download_count' => ['nullable', 'integer', 'min:0'],
             'duration' => ['nullable', 'numeric', 'min:0'],
-            'livestream_processing_id' => ['nullable', 'string', 'size:36', 'exists:media_processing_logs,processing_id'],
+            'livestream_processing_id' => ['nullable', 'uuid', 'exists:media_processing_logs,processing_id'],
         ];
     }
 

--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -288,6 +288,7 @@ class Sermon extends Model implements Sitemapable
             'scripture_passage_id' => ['nullable', 'integer', 'exists:scripture_passages,id'],
             'download_count' => ['nullable', 'integer', 'min:0'],
             'duration' => ['nullable', 'numeric', 'min:0'],
+            'livestream_processing_id' => ['nullable', 'string', 'size:36', 'exists:media_processing_logs,processing_id'],
         ];
     }
 

--- a/tests/Feature/WardenSermonValidationTest.php
+++ b/tests/Feature/WardenSermonValidationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\MediaProcessingLog;
+use App\Models\Sermon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class WardenSermonValidationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_rejects_a_non_existent_livestream_processing_id(): void
+    {
+        $rules = Sermon::validationRules();
+
+        $validator = Validator::make([
+            'livestream_processing_id' => '00000000-0000-0000-0000-000000000000',
+        ], [
+            'livestream_processing_id' => $rules['livestream_processing_id'],
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('livestream_processing_id', $validator->errors()->toArray());
+        $this->assertEquals(
+            'The selected livestream processing id is invalid.',
+            $validator->errors()->first('livestream_processing_id')
+        );
+    }
+
+    #[Test]
+    public function it_rejects_a_malformed_livestream_processing_id(): void
+    {
+        $rules = Sermon::validationRules();
+
+        $validator = Validator::make([
+            'livestream_processing_id' => 'too-short',
+        ], [
+            'livestream_processing_id' => $rules['livestream_processing_id'],
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('livestream_processing_id', $validator->errors()->toArray());
+    }
+
+    #[Test]
+    public function it_accepts_a_valid_existing_livestream_processing_id(): void
+    {
+        $log = MediaProcessingLog::factory()->create([
+            'processing_id' => '12345678-1234-1234-1234-1234567890ab',
+        ]);
+
+        $rules = Sermon::validationRules();
+
+        $validator = Validator::make([
+            'livestream_processing_id' => $log->processing_id,
+        ], [
+            'livestream_processing_id' => $rules['livestream_processing_id'],
+        ]);
+
+        $this->assertFalse($validator->fails());
+    }
+
+    #[Test]
+    public function it_accepts_a_null_livestream_processing_id(): void
+    {
+        $rules = Sermon::validationRules();
+
+        $validator = Validator::make([
+            'livestream_processing_id' => null,
+        ], [
+            'livestream_processing_id' => $rules['livestream_processing_id'],
+        ]);
+
+        $this->assertFalse($validator->fails());
+    }
+}

--- a/tests/Feature/WardenSermonValidationTest.php
+++ b/tests/Feature/WardenSermonValidationTest.php
@@ -47,6 +47,10 @@ class WardenSermonValidationTest extends TestCase
 
         $this->assertTrue($validator->fails());
         $this->assertArrayHasKey('livestream_processing_id', $validator->errors()->toArray());
+        $this->assertEquals(
+            'The livestream processing id field must be a valid UUID.',
+            $validator->errors()->first('livestream_processing_id')
+        );
     }
 
     #[Test]

--- a/tests/Feature/WardenSermonValidationTest.php
+++ b/tests/Feature/WardenSermonValidationTest.php
@@ -56,7 +56,7 @@ class WardenSermonValidationTest extends TestCase
     #[Test]
     public function it_accepts_a_valid_existing_livestream_processing_id(): void
     {
-        $log = MediaProcessingLog::factory()->create([
+        $log = MediaProcessingLog::factory()->livestream()->create([
             'processing_id' => '12345678-1234-1234-1234-1234567890ab',
         ]);
 
@@ -69,6 +69,25 @@ class WardenSermonValidationTest extends TestCase
         ]);
 
         $this->assertFalse($validator->fails());
+    }
+
+    #[Test]
+    public function it_rejects_a_non_livestream_processing_id(): void
+    {
+        $log = MediaProcessingLog::factory()->audio()->create([
+            'processing_id' => 'abcdef12-3456-7890-abcd-ef1234567890',
+        ]);
+
+        $rules = Sermon::validationRules();
+
+        $validator = Validator::make([
+            'livestream_processing_id' => $log->processing_id,
+        ], [
+            'livestream_processing_id' => $rules['livestream_processing_id'],
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('livestream_processing_id', $validator->errors()->toArray());
     }
 
     #[Test]


### PR DESCRIPTION
💡 **What:** Added missing validation rules for the `livestream_processing_id` field in the `Sermon` model.
🎯 **Why:** To ensure referential integrity between Sermons and MediaProcessingLogs at the validation layer and prevent malformed UUIDs from being saved.
🗄️ **Migration:** No schema changes; purely additive validation logic.
✅ **Verification:** Added `tests/Feature/WardenSermonValidationTest.php` to verify rejection of non-existent and malformed IDs.
⚠️ **Rollback:** Revert changes to `app/Models/Sermon.php`.

---
*PR created automatically by Jules for task [13459276843715033014](https://jules.google.com/task/13459276843715033014) started by @GarethClarridge*