### PR TITLE
⚡ Bolt: Optimize admin song listing columns

### DIFF
--- a/app/Livewire/Admin/ChurchServices/ListSongs.php
+++ b/app/Livewire/Admin/ChurchServices/ListSongs.php
@@ -85,10 +85,15 @@ class ListSongs extends Component
         $servicesCountSubQuery = $this->usageBaseQuery()->selectRaw('COUNT(DISTINCT church_service_items.church_service_id)');
         $lastUsedDateSubQuery = $this->usageBaseQuery()->selectRaw('MAX(church_services.date)');
 
+        /**
+         * Performance Optimization: Limits retrieved columns for songs and eager-loaded
+         * authors to required fields for the admin listing. This avoids loading large
+         * longText columns (lyrics_xml, lyrics_plain) to reduce memory usage and DB I/O.
+         */
         $songs = Song::query()
-            ->select('songs.*')
+            ->select(['songs.id', 'songs.slug', 'songs.title', 'songs.alternate_title', 'songs.ccli_number', 'songs.canonical_key'])
             ->with([
-                'authors' => fn ($query) => $query->orderBy('display_name'),
+                'authors' => fn ($query) => $query->select(['song_authors.id', 'song_authors.display_name'])->orderBy('display_name'),
             ])
             ->selectSub($usageSubQuery, 'usage_count')
             ->selectSub($servicesCountSubQuery, 'services_count')


### PR DESCRIPTION
Optimized the `ListSongs` admin component by replacing `select('songs.*')` with explicit selection of required columns (`id`, `slug`, `title`, `alternate_title`, `ccli_number`, `canonical_key`). Also constrained the `authors` eager load to only retrieve `id` and `display_name`. This prevents the retrieval of large, unused `longText` columns (`lyrics_xml` and `lyrics_plain`), improving performance for large song collections. Verified with existing tests and PHPStan.

---
*PR created automatically by Jules for task [15565177791154332066](https://jules.google.com/task/15565177791154332066) started by @GarethClarridge*