### PR TITLE
fix: resolve Pathfinder-2026-05-28 findings

### DIFF
--- a/config/redirects.php
+++ b/config/redirects.php
@@ -49,7 +49,7 @@ return [
     'about-us/links' => '/church/links',
     'about-us/statementoffaith' => '/church/statement-of-faith',
     'about-us/whatwebelieve' => '/church/what-we-believe',
-    'about-us/privacy-policy' => '/church/privacy-policy',
+    'about-us/privacy-policy' => '/church/privacy-notice',
     'about-us/safeguarding-policy' => '/church/safeguarding-policy',
 
     'buzz-club' => '/community/buzz-club',

--- a/database/factories/SermonFactory.php
+++ b/database/factories/SermonFactory.php
@@ -22,7 +22,7 @@ class SermonFactory extends Factory
             'date' => $this->faker->date(),
             'service' => $this->faker->randomElement([SermonService::Morning->value, SermonService::Evening->value, SermonService::Other->value]),
             'content_type' => SermonContentType::Sermon,
-            'audio_file_path' => Str::slug($title).'.mp3',
+            'audio_file_path' => null,
             'filetype' => 'mp3',
             'title' => $title,
             'slug' => Str::slug($title),

--- a/database/seeders/SermonSeeder.php
+++ b/database/seeders/SermonSeeder.php
@@ -34,6 +34,7 @@ class SermonSeeder extends Seeder
                 'preacher_id' => $markDrury?->id,
                 'preacher_source' => 'manual',
                 'series' => 'Christmas Messages',
+                'audio_file_path' => null,
                 'points' => '1. The historical reality\n2. The divine purpose\n3. The eternal significance',
             ],
             [
@@ -46,6 +47,7 @@ class SermonSeeder extends Seeder
                 'preacher_id' => $markDrury?->id,
                 'preacher_source' => 'manual',
                 'series' => '1 John',
+                'audio_file_path' => null,
                 'points' => '1. God is light\n2. Fellowship with God\n3. Confession and forgiveness',
             ],
             [
@@ -59,6 +61,7 @@ class SermonSeeder extends Seeder
                 'preacher_source' => 'default',
                 'needs_preacher_review' => true,
                 'series' => 'Special Events',
+                'audio_file_path' => null,
                 'points' => '1. Praise\n2. Thanksgiving',
             ],
         ];
@@ -95,6 +98,7 @@ class SermonSeeder extends Seeder
                 'preacher' => $preacher?->name ?? 'Mark Drury',
                 'preacher_id' => $preacher?->id,
                 'preacher_source' => 'manual',
+                'audio_file_path' => null,
                 'content_type' => SermonContentType::ChildrensTalk->value,
             ],
             [
@@ -106,6 +110,7 @@ class SermonSeeder extends Seeder
                 'preacher' => $preacher?->name ?? 'Mark Drury',
                 'preacher_id' => $preacher?->id,
                 'preacher_source' => 'manual',
+                'audio_file_path' => null,
                 'content_type' => SermonContentType::ChildrensTalk->value,
             ],
             [
@@ -117,6 +122,7 @@ class SermonSeeder extends Seeder
                 'preacher' => $preacher?->name ?? 'Mark Drury',
                 'preacher_id' => $preacher?->id,
                 'preacher_source' => 'manual',
+                'audio_file_path' => null,
                 'content_type' => SermonContentType::ChildrensTalk->value,
             ],
         ];
@@ -154,6 +160,7 @@ class SermonSeeder extends Seeder
                 'preacher_id' => $preacher?->id,
                 'preacher_source' => 'manual',
                 'series' => 'Parables of Jesus',
+                'audio_file_path' => null,
                 'points' => '1. The son who wandered\n2. The father who waited\n3. The grace that restores',
                 'livestream_processing_id' => 'seed-prodigal-son-processing',
             ]

--- a/database/seeders/SermonSeeder.php
+++ b/database/seeders/SermonSeeder.php
@@ -34,7 +34,6 @@ class SermonSeeder extends Seeder
                 'preacher_id' => $markDrury?->id,
                 'preacher_source' => 'manual',
                 'series' => 'Christmas Messages',
-                'audio_file_path' => 'christmas-2024-morning.mp3',
                 'points' => '1. The historical reality\n2. The divine purpose\n3. The eternal significance',
             ],
             [
@@ -47,7 +46,6 @@ class SermonSeeder extends Seeder
                 'preacher_id' => $markDrury?->id,
                 'preacher_source' => 'manual',
                 'series' => '1 John',
-                'audio_file_path' => '1-john-walking-in-light.mp3',
                 'points' => '1. God is light\n2. Fellowship with God\n3. Confession and forgiveness',
             ],
             [
@@ -61,7 +59,6 @@ class SermonSeeder extends Seeder
                 'preacher_source' => 'default',
                 'needs_preacher_review' => true,
                 'series' => 'Special Events',
-                'audio_file_path' => 'special-2024-other.mp3',
                 'points' => '1. Praise\n2. Thanksgiving',
             ],
         ];
@@ -98,7 +95,6 @@ class SermonSeeder extends Seeder
                 'preacher' => $preacher?->name ?? 'Mark Drury',
                 'preacher_id' => $preacher?->id,
                 'preacher_source' => 'manual',
-                'audio_file_path' => 'childrens-talk-who-is-jesus.mp3',
                 'content_type' => SermonContentType::ChildrensTalk->value,
             ],
             [
@@ -110,7 +106,6 @@ class SermonSeeder extends Seeder
                 'preacher' => $preacher?->name ?? 'Mark Drury',
                 'preacher_id' => $preacher?->id,
                 'preacher_source' => 'manual',
-                'audio_file_path' => 'childrens-talk-god-made-world.mp3',
                 'content_type' => SermonContentType::ChildrensTalk->value,
             ],
             [
@@ -122,7 +117,6 @@ class SermonSeeder extends Seeder
                 'preacher' => $preacher?->name ?? 'Mark Drury',
                 'preacher_id' => $preacher?->id,
                 'preacher_source' => 'manual',
-                'audio_file_path' => 'childrens-talk-good-shepherd.mp3',
                 'content_type' => SermonContentType::ChildrensTalk->value,
             ],
         ];
@@ -160,7 +154,6 @@ class SermonSeeder extends Seeder
                 'preacher_id' => $preacher?->id,
                 'preacher_source' => 'manual',
                 'series' => 'Parables of Jesus',
-                'audio_file_path' => 'the-prodigal-son.mp3',
                 'points' => '1. The son who wandered\n2. The father who waited\n3. The grace that restores',
                 'livestream_processing_id' => 'seed-prodigal-son-processing',
             ]

--- a/resources/views/meetings/index.blade.php
+++ b/resources/views/meetings/index.blade.php
@@ -28,7 +28,7 @@
             @forelse($meetings as $meeting)
                 <tr class="hover:bg-gray-50">
                     <td class="px-4 py-3">
-                        <a href="/meetings/{{ $meeting->slug }}" class="font-medium hover:text-cbc-teal">
+                        <a href="{{ route('meetings.show', $meeting) }}" class="font-medium hover:text-cbc-teal">
                             {{ $meeting->slug }}
                         </a>
                     </td>


### PR DESCRIPTION
- Use route('meetings.show') instead of hardcoded /meetings/{slug} in
  meetings index (fixes 13 broken links pointing to deprecated prefix)
- Update about-us/privacy-policy redirect target from /church/privacy-policy
  to /church/privacy-notice (slug that actually exists in the pages table)
- Null out audio_file_path in SermonFactory default and all SermonSeeder
  records — seeded fixtures reference filenames that never exist on disk,
  and the column is already nullable with views guarding on null

https://claude.ai/code/session_01WTy9VSYhpxY8TYpyuWptF3