### PR TITLE
📖 Editor: Standardise on British English for calendar and church pages

### DIFF
--- a/app/Http/Controllers/Admin/CalendarAdminController.php
+++ b/app/Http/Controllers/Admin/CalendarAdminController.php
@@ -37,7 +37,7 @@ class CalendarAdminController extends Controller
             'uncategorizedEvents' => $uncategorizedEvents,
             'meetings' => $meetings,
             'heading' => 'Categorise Calendar Events',
-            'description' => 'Review uncategorized calendar events.',
+            'description' => 'Review uncategorised calendar events.',
             'content' => '',
             'links' => collect(),
         ]);
@@ -53,8 +53,8 @@ class CalendarAdminController extends Controller
         );
 
         $message = $result->googleSynced
-            ? "Event '{$result->event->title}' categorized and synced to Google Calendar"
-            : "Event '{$result->event->title}' categorized (Google sync failed — will retry on next sync)";
+            ? "Event '{$result->event->title}' categorised and synced to Google Calendar"
+            : "Event '{$result->event->title}' categorised (Google sync failed — will retry on next sync)";
 
         return redirect()->back()->with('success', $message);
     }
@@ -91,7 +91,7 @@ class CalendarAdminController extends Controller
             return redirect()->back()->with('success',
                 "Sync completed! Processed: {$report['processed_events']}, ".
                 "Deleted: {$report['deleted_events']}, ".
-                "Uncategorized: {$report['uncategorized_events']}"
+                "Uncategorised: {$report['uncategorized_events']}"
             );
         } catch (\Exception $e) {
             return redirect()->back()->with('error', 'Sync failed: '.$e->getMessage());

--- a/app/Livewire/Admin/CalendarEvents/ListCalendarEvents.php
+++ b/app/Livewire/Admin/CalendarEvents/ListCalendarEvents.php
@@ -56,7 +56,7 @@ class ListCalendarEvents extends Component
             app(CategorizeCalendarEvent::class)->execute($event, $meetingSlug);
         }
 
-        $this->success('Event categorized');
+        $this->success('Event categorised');
     }
 
     public function render(): View

--- a/resources/views/admin/calendar/patterns.blade.php
+++ b/resources/views/admin/calendar/patterns.blade.php
@@ -4,12 +4,12 @@
 <x-admin.shell heading="Calendar Patterns">
 
 <x-admin.page
-    title="Calendar Categorization Patterns"
-    description="These patterns are used to automatically categorize calendar events based on their titles. Patterns are defined in the config/calendar.php file."
+    title="Categorisation Patterns"
+    description="These patterns are used to automatically categorise calendar events based on their titles. Patterns are defined in the config/calendar.php file."
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.calendar.uncategorized') }}" variant="outline" inline>
-            &larr; Uncategorized Events
+            &larr; Uncategorised Events
         </x-button>
     </x-slot:actions>
 
@@ -69,10 +69,10 @@
             <div>
                 <h3 class="text-sm font-medium text-gray-900">How Pattern Matching Works</h3>
                 <ul class="mt-2 text-sm text-gray-600 list-disc pl-5 space-y-1">
-                    <li>Events are automatically categorized when their title contains any of the defined patterns</li>
+                    <li>Events are automatically categorised when their title contains any of the defined patterns</li>
                     <li>Matching is performed during calendar sync from Google Calendar</li>
-                    <li>Events that don't match any pattern are marked as "uncategorized"</li>
-                    <li>Manual categorization via Extended Properties always takes precedence</li>
+                    <li>Events that don't match any pattern are marked as "uncategorised"</li>
+                    <li>Manual categorisation via Extended Properties always takes precedence</li>
                 </ul>
             </div>
         </div>

--- a/resources/views/admin/calendar/uncategorized.blade.php
+++ b/resources/views/admin/calendar/uncategorized.blade.php
@@ -4,8 +4,8 @@
 <x-admin.shell heading="Categorise Calendar Events">
 
 <x-admin.page
-    title="Uncategorized Events"
-    description="These events couldn't be automatically categorized. Please assign them to the appropriate meeting type."
+    title="Uncategorised Events"
+    description="These events couldn't be automatically categorised. Please assign them to the appropriate meeting type."
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.calendar.patterns') }}" variant="outline" inline>
@@ -42,7 +42,7 @@
                             />
 
                             <x-form-button type="submit" variant="primary" size="sm">
-                                Categorize
+                                Categorise
                             </x-form-button>
                         </form>
                     </div>
@@ -52,8 +52,8 @@
     @else
         <div class="text-center py-12">
             <x-heroicon-o-check-circle class="mx-auto h-12 w-12 text-green-400" />
-            <h3 class="mt-2 text-sm font-medium text-gray-900">All events are categorized</h3>
-            <p class="mt-1 text-sm text-gray-500">Great! All calendar events have been properly categorized.</p>
+            <h3 class="mt-2 text-sm font-medium text-gray-900">All events are categorised</h3>
+            <p class="mt-1 text-sm text-gray-500">Great! All calendar events have been properly categorised.</p>
         </div>
     @endif
 

--- a/resources/views/calendar/uncategorized.blade.php
+++ b/resources/views/calendar/uncategorized.blade.php
@@ -19,7 +19,7 @@
     @endif
 
     <div class="prose max-w-none mb-8">
-        <p>These events from our calendar haven't been automatically categorized into a specific meeting type. They may be special events or one-off occasions.</p>
+        <p>These events from our calendar haven't been automatically categorised into a specific meeting type. They may be special events or one-off occasions.</p>
     </div>
 
     @if($uncategorizedEvents->count() > 0)
@@ -35,8 +35,8 @@
     @else
         <div class="text-center py-12">
             <x-heroicon-o-check-circle class="mx-auto h-12 w-12 text-green-400" />
-            <h3 class="mt-2 text-sm font-medium text-gray-900">All events are categorized</h3>
-            <p class="mt-1 text-sm text-gray-500">Great! All calendar events have been properly categorized.</p>
+            <h3 class="mt-2 text-sm font-medium text-gray-900">All events are categorised</h3>
+            <p class="mt-1 text-sm text-gray-500">Great! All calendar events have been properly categorised.</p>
         </div>
     @endif
 </x-page.shell>

--- a/resources/views/components/calendar-event-card.blade.php
+++ b/resources/views/components/calendar-event-card.blade.php
@@ -13,7 +13,7 @@
 @php
 $meeting = $meeting ?? $event->meeting;
 $isUncategorized = $event->meeting_slug === null;
-$meetingLabel = $event->meeting_slug ?? 'Uncategorized';
+$meetingLabel = $event->meeting_slug ?? 'Uncategorised';
 $cardClasses = match($variant) {
     'compact' => 'bg-gray-50 rounded-lg border border-gray-200 p-4',
     'admin'   => 'max-w-full rounded-lg shadow bg-white border-1 border-gray-300 p-0 m-2',

--- a/resources/views/components/calendar-event-meta.blade.php
+++ b/resources/views/components/calendar-event-meta.blade.php
@@ -13,7 +13,7 @@
 @php
 $meeting = $meeting ?? $event->meeting;
 $isUncategorized = $event->meeting_slug === null;
-$meetingLabel = $event->meeting_slug ?? 'Uncategorized';
+$meetingLabel = $event->meeting_slug ?? 'Uncategorised';
 @endphp
 
 <div class="flex items-center flex-wrap gap-x-4 gap-y-1 text-sm text-gray-600 mb-3">

--- a/resources/views/full-width-pages/church.blade.php
+++ b/resources/views/full-width-pages/church.blade.php
@@ -213,7 +213,7 @@ Church
       good news of salvation to all people through Jesus Christ.
     </p>
     <p>
-      We believe that the gospel centers on the death of Jesus
+      We believe that the gospel centres on the death of Jesus
       Christ on the cross in our place.
     </p>
     <p>

--- a/resources/views/livewire/admin/calendar-events/edit-calendar-event.blade.php
+++ b/resources/views/livewire/admin/calendar-events/edit-calendar-event.blade.php
@@ -36,7 +36,7 @@
     </x-card>
 
     <x-slot:sidebar>
-        <x-card heading="Categorization">
+        <x-card heading="Categorisation">
             <div class="space-y-4">
                 <x-select label="Meeting" wire:model="meetingSlug"
                     :options="$meetings->map(fn($name, $slug) => ['id' => $slug, 'name' => $name])->values()->toArray()"
@@ -54,7 +54,7 @@
                 @if($calendarEvent->google_event_id)
                     <p class="text-sm"><span class="font-semibold">Google ID:</span> {{ Str::limit($calendarEvent->google_event_id, 20) }}</p>
                 @endif
-                <p class="text-sm"><span class="font-semibold">Auto-categorized:</span> {{ $calendarEvent->is_categorized_automatically ? 'Yes' : 'No' }}</p>
+                <p class="text-sm"><span class="font-semibold">Auto-categorised:</span> {{ $calendarEvent->is_categorized_automatically ? 'Yes' : 'No' }}</p>
             </div>
         </x-card>
     </x-slot:sidebar>

--- a/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
+++ b/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
@@ -1,6 +1,6 @@
 <x-admin.list-shell
     title="Calendar Events"
-    description="Manage and categorize calendar events"
+    description="Manage and categorise calendar events"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.calendar.sync') }}" variant="secondary" icon="arrow-path" inline>
@@ -17,7 +17,7 @@
                 :options="$meetings->map(fn($name, $slug) => ['id' => $slug, 'name' => $name])->values()->toArray()"
                 class="w-48" />
 
-            <x-toggle label="Uncategorized Only" wire:model.live="uncategorizedOnly" />
+            <x-toggle label="Uncategorised Only" wire:model.live="uncategorizedOnly" />
             <x-toggle label="Upcoming Only" wire:model.live="upcomingOnly" />
 
             <x-slot:actions>
@@ -76,11 +76,11 @@
                         @else
                             <div class="flex gap-2 items-center">
                                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
-                                    Uncategorized
+                                    Uncategorised
                                 </span>
                                 <select wire:change="categorize({{ $event->id }}, $event.target.value)"
                                     class="text-xs rounded-md border-gray-300 shadow-sm focus:border-cbc-teal focus:ring-cbc-teal w-40">
-                                    <option value="">Categorize...</option>
+                                    <option value="">Categorise...</option>
                                     @foreach($meetings as $slug => $name)
                                         <option value="{{ $slug }}">{{ $name }}</option>
                                     @endforeach

--- a/tests/Feature/CalendarAdminControllerTest.php
+++ b/tests/Feature/CalendarAdminControllerTest.php
@@ -175,6 +175,7 @@ class CalendarAdminControllerTest extends TestCase
 
         $response->assertSessionHas('success');
         $this->assertStringContainsString('synced to Google Calendar', session('success'));
+        $this->assertStringContainsString('categorised', session('success'));
     }
 
     #[Test]
@@ -198,6 +199,7 @@ class CalendarAdminControllerTest extends TestCase
         $response->assertSessionHas('success');
         $this->assertStringContainsString('Google sync failed', session('success'));
         $this->assertStringContainsString('will retry on next sync', session('success'));
+        $this->assertStringContainsString('categorised', session('success'));
     }
 
     #[Test]
@@ -340,6 +342,6 @@ class CalendarAdminControllerTest extends TestCase
         $successMessage = session('success');
         $this->assertStringContainsString('Processed: 5', $successMessage);
         $this->assertStringContainsString('Deleted: 1', $successMessage);
-        $this->assertStringContainsString('Uncategorized: 2', $successMessage);
+        $this->assertStringContainsString('Uncategorised: 2', $successMessage);
     }
 }

--- a/tests/Feature/CalendarControllerTest.php
+++ b/tests/Feature/CalendarControllerTest.php
@@ -189,7 +189,7 @@ class CalendarControllerTest extends TestCase
             'start_datetime' => now()->addDays(1),
             'end_datetime' => now()->addDays(1)->addHour(),
             'status' => 'confirmed',
-            'title' => 'Uncategorized Upcoming',
+            'title' => 'Uncategorised Upcoming',
         ]);
 
         CalendarEvent::factory()->create([
@@ -197,7 +197,7 @@ class CalendarControllerTest extends TestCase
             'start_datetime' => now()->subDays(1),
             'end_datetime' => now()->subDays(1)->addHour(),
             'status' => 'confirmed',
-            'title' => 'Uncategorized Past',
+            'title' => 'Uncategorised Past',
         ]);
 
         CalendarEvent::factory()->create([
@@ -205,7 +205,7 @@ class CalendarControllerTest extends TestCase
             'start_datetime' => now()->addDays(2),
             'end_datetime' => now()->addDays(2)->addHour(),
             'status' => 'tentative',
-            'title' => 'Uncategorized Tentative',
+            'title' => 'Uncategorised Tentative',
         ]);
 
         CalendarEvent::factory()->create([
@@ -213,16 +213,16 @@ class CalendarControllerTest extends TestCase
             'start_datetime' => now()->addDays(1),
             'end_datetime' => now()->addDays(1)->addHour(),
             'status' => 'confirmed',
-            'title' => 'Categorized Upcoming',
+            'title' => 'Categorised Upcoming',
         ]);
 
         $response = $this->get(route('calendar.uncategorized'));
 
         $response->assertStatus(200);
-        $response->assertSee('Uncategorized Upcoming');
-        $response->assertDontSee('Uncategorized Past');
-        $response->assertDontSee('Uncategorized Tentative');
-        $response->assertDontSee('Categorized Upcoming');
+        $response->assertSee('Uncategorised Upcoming');
+        $response->assertDontSee('Uncategorised Past');
+        $response->assertDontSee('Uncategorised Tentative');
+        $response->assertDontSee('Categorised Upcoming');
     }
 
     #[Test]

--- a/tests/Feature/CalendarEventCardRenderingTest.php
+++ b/tests/Feature/CalendarEventCardRenderingTest.php
@@ -143,7 +143,7 @@ class CalendarEventCardRenderingTest extends TestCase
             ['event' => $uncategorized],
         );
 
-        $this->assertStringContainsString('Uncategorized', $rendered);
+        $this->assertStringContainsString('Uncategorised', $rendered);
         $this->assertStringContainsString('bg-yellow-100', $rendered);
     }
 

--- a/tests/Feature/Livewire/Admin/CalendarEvents/ListCalendarEventsTest.php
+++ b/tests/Feature/Livewire/Admin/CalendarEvents/ListCalendarEventsTest.php
@@ -84,13 +84,13 @@ class ListCalendarEventsTest extends TestCase
         $this->actingAs($this->admin);
 
         Meeting::factory()->create(['slug' => 'existing-meeting']);
-        CalendarEvent::factory()->create(['title' => 'Categorized Event', 'meeting_slug' => 'existing-meeting', 'start_datetime' => now()->addDay()]);
-        CalendarEvent::factory()->create(['title' => 'Uncategorized Event', 'meeting_slug' => null, 'start_datetime' => now()->addDays(2)]);
+        CalendarEvent::factory()->create(['title' => 'Categorised Event', 'meeting_slug' => 'existing-meeting', 'start_datetime' => now()->addDay()]);
+        CalendarEvent::factory()->create(['title' => 'Uncategorised Event', 'meeting_slug' => null, 'start_datetime' => now()->addDays(2)]);
 
         Livewire::test(ListCalendarEvents::class)
             ->set('uncategorizedOnly', true)
-            ->assertSee('Uncategorized Event')
-            ->assertDontSee('Categorized Event');
+            ->assertSee('Uncategorised Event')
+            ->assertDontSee('Categorised Event');
     }
 
     #[Test]
@@ -134,7 +134,7 @@ class ListCalendarEventsTest extends TestCase
 
         Livewire::test(ListCalendarEvents::class)
             ->call('categorize', $event->id, 'new-meeting')
-            ->assertDispatched('notify', type: 'success', message: 'Event categorized');
+            ->assertDispatched('notify', type: 'success', message: 'Event categorised');
     }
 
     #[Test]


### PR DESCRIPTION
💡 **What:** Converted American English spellings ('categorize', 'center') to British English ('categorise', 'centre') in user-facing static text and admin microcopy.
🎯 **Why:** Consistency with project standards and British English house style.
🔄 **Behavior:** No functional changes — copy and test assertions only.
📍 **Where:**
- `resources/views/admin/calendar/uncategorized.blade.php`
- `resources/views/admin/calendar/patterns.blade.php`
- `resources/views/calendar/uncategorized.blade.php`
- `resources/views/full-width-pages/church.blade.php`
- `resources/views/components/calendar-event-card.blade.php`
- `resources/views/components/calendar-event-meta.blade.php`
- `resources/views/livewire/admin/calendar-events/edit-calendar-event.blade.php`
- `resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php`
- `app/Http/Controllers/Admin/CalendarAdminController.php`
- `app/Livewire/Admin/CalendarEvents/ListCalendarEvents.php`
- `tests/Feature/CalendarEventCardRenderingTest.php`
- `tests/Feature/Livewire/Admin/CalendarEvents/ListCalendarEventsTest.php`
- `tests/Feature/CalendarControllerTest.php`
- `tests/Feature/CalendarAdminControllerTest.php`

---
*PR created automatically by Jules for task [17065890553182474754](https://jules.google.com/task/17065890553182474754) started by @GarethClarridge*