### PR TITLE
🧪 Steward: Harden SermonListingCacheTest

### DIFF
--- a/tests/Feature/SermonListingCacheTest.php
+++ b/tests/Feature/SermonListingCacheTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use App\Models\Sermon;
+use App\Repositories\SermonRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Test;
@@ -16,24 +17,35 @@ class SermonListingCacheTest extends TestCase
 
     protected $seed = true;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DB::enableQueryLog();
+    }
+
+    protected function tearDown(): void
+    {
+        DB::disableQueryLog();
+        parent::tearDown();
+    }
+
     #[Test]
     public function series_page_caches_sermons(): void
     {
         Sermon::factory()->create(['series' => 'Genesis']);
         $url = '/christ/sermons/series/genesis';
 
-        // Warm the cache
         $this->get($url)->assertOk();
 
-        // Verify caching via behavior: second request should perform no sermon queries
-        DB::enableQueryLog();
+        app(SermonRepository::class)->clearInternalCaches();
+        DB::flushQueryLog();
+
         $this->get($url)->assertOk();
 
         $sermonQueries = collect(DB::getQueryLog())
             ->filter(fn ($query) => str_contains((string) $query['query'], 'sermons'));
 
         $this->assertCount(0, $sermonQueries, 'Sermons should be retrieved from cache, not database');
-        DB::disableQueryLog();
     }
 
     #[Test]
@@ -42,18 +54,17 @@ class SermonListingCacheTest extends TestCase
         Sermon::factory()->create(['service' => 'morning']);
         $url = '/christ/sermons/morning';
 
-        // Warm the cache
         $this->get($url)->assertOk();
 
-        // Verify caching via behavior: second request should perform no sermon queries
-        DB::enableQueryLog();
+        app(SermonRepository::class)->clearInternalCaches();
+        DB::flushQueryLog();
+
         $this->get($url)->assertOk();
 
         $sermonQueries = collect(DB::getQueryLog())
             ->filter(fn ($query) => str_contains((string) $query['query'], 'sermons'));
 
         $this->assertCount(0, $sermonQueries, 'Sermons should be retrieved from cache, not database');
-        DB::disableQueryLog();
     }
 
     #[Test]
@@ -62,20 +73,18 @@ class SermonListingCacheTest extends TestCase
         $sermon = Sermon::factory()->create(['series' => 'Genesis']);
         $url = '/christ/sermons/series/genesis';
 
-        // Warm the cache
         $this->get($url)->assertOk();
 
         $sermon->update(['title' => 'Updated Genesis Sermon']);
 
-        // Verify invalidation: next request should re-query the database
-        DB::enableQueryLog();
+        DB::flushQueryLog();
+
         $this->get($url)->assertOk();
 
         $sermonQueries = collect(DB::getQueryLog())
             ->filter(fn ($query) => str_contains((string) $query['query'], 'sermons'));
 
         $this->assertNotEmpty($sermonQueries, 'Sermon cache should have been invalidated');
-        DB::disableQueryLog();
     }
 
     #[Test]
@@ -84,19 +93,17 @@ class SermonListingCacheTest extends TestCase
         $sermon = Sermon::factory()->create(['service' => 'morning']);
         $url = '/christ/sermons/morning';
 
-        // Warm the cache
         $this->get($url)->assertOk();
 
         $sermon->delete();
 
-        // Verify invalidation: next request should re-query the database
-        DB::enableQueryLog();
+        DB::flushQueryLog();
+
         $this->get($url)->assertOk();
 
         $sermonQueries = collect(DB::getQueryLog())
             ->filter(fn ($query) => str_contains((string) $query['query'], 'sermons'));
 
         $this->assertNotEmpty($sermonQueries, 'Sermon cache should have been invalidated');
-        DB::disableQueryLog();
     }
 }

--- a/tests/Feature/SermonListingCacheTest.php
+++ b/tests/Feature/SermonListingCacheTest.php
@@ -6,7 +6,7 @@ namespace Tests\Feature;
 
 use App\Models\Sermon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -19,47 +19,84 @@ class SermonListingCacheTest extends TestCase
     #[Test]
     public function series_page_caches_sermons(): void
     {
-        $sermon = Sermon::factory()->create(['series' => 'Genesis']);
-        $slug = 'genesis';
-        Cache::forget("sermons_series_$slug");
+        Sermon::factory()->create(['series' => 'Genesis']);
+        $url = '/christ/sermons/series/genesis';
 
-        $this->get("/christ/sermons/series/$slug");
-        $this->assertTrue(Cache::has("sermons_series_$slug"));
+        // Warm the cache
+        $this->get($url)->assertOk();
+
+        // Verify caching via behavior: second request should perform no sermon queries
+        DB::enableQueryLog();
+        $this->get($url)->assertOk();
+
+        $sermonQueries = collect(DB::getQueryLog())
+            ->filter(fn ($query) => str_contains((string) $query['query'], 'sermons'));
+
+        $this->assertCount(0, $sermonQueries, 'Sermons should be retrieved from cache, not database');
+        DB::disableQueryLog();
     }
 
     #[Test]
     public function service_page_caches_sermons(): void
     {
-        Cache::forget('sermons_service_morning');
+        Sermon::factory()->create(['service' => 'morning']);
+        $url = '/christ/sermons/morning';
 
-        $this->get('/christ/sermons/morning');
-        $this->assertTrue(Cache::has('sermons_service_morning'));
+        // Warm the cache
+        $this->get($url)->assertOk();
+
+        // Verify caching via behavior: second request should perform no sermon queries
+        DB::enableQueryLog();
+        $this->get($url)->assertOk();
+
+        $sermonQueries = collect(DB::getQueryLog())
+            ->filter(fn ($query) => str_contains((string) $query['query'], 'sermons'));
+
+        $this->assertCount(0, $sermonQueries, 'Sermons should be retrieved from cache, not database');
+        DB::disableQueryLog();
     }
 
     #[Test]
     public function series_cache_is_invalidated_when_sermon_in_series_is_updated(): void
     {
         $sermon = Sermon::factory()->create(['series' => 'Genesis']);
-        $slug = 'genesis';
+        $url = '/christ/sermons/series/genesis';
 
-        $this->get("/christ/sermons/series/$slug");
-        $this->assertTrue(Cache::has("sermons_series_$slug"));
+        // Warm the cache
+        $this->get($url)->assertOk();
 
         $sermon->update(['title' => 'Updated Genesis Sermon']);
 
-        $this->assertFalse(Cache::has("sermons_series_$slug"));
+        // Verify invalidation: next request should re-query the database
+        DB::enableQueryLog();
+        $this->get($url)->assertOk();
+
+        $sermonQueries = collect(DB::getQueryLog())
+            ->filter(fn ($query) => str_contains((string) $query['query'], 'sermons'));
+
+        $this->assertNotEmpty($sermonQueries, 'Sermon cache should have been invalidated');
+        DB::disableQueryLog();
     }
 
     #[Test]
     public function service_cache_is_invalidated_when_sermon_in_service_is_deleted(): void
     {
         $sermon = Sermon::factory()->create(['service' => 'morning']);
+        $url = '/christ/sermons/morning';
 
-        $this->get('/christ/sermons/morning');
-        $this->assertTrue(Cache::has('sermons_service_morning'));
+        // Warm the cache
+        $this->get($url)->assertOk();
 
         $sermon->delete();
 
-        $this->assertFalse(Cache::has('sermons_service_morning'));
+        // Verify invalidation: next request should re-query the database
+        DB::enableQueryLog();
+        $this->get($url)->assertOk();
+
+        $sermonQueries = collect(DB::getQueryLog())
+            ->filter(fn ($query) => str_contains((string) $query['query'], 'sermons'));
+
+        $this->assertNotEmpty($sermonQueries, 'Sermon cache should have been invalidated');
+        DB::disableQueryLog();
     }
 }


### PR DESCRIPTION
Refactored `tests/Feature/SermonListingCacheTest.php` to use behavior-based assertions instead of brittle internal cache key checks. The new approach monitors the database query log to verify that the cache successfully prevents redundant queries to the `sermons` table and correctly invalidates when models are updated or deleted. This makes the tests resilient to future changes in internal caching logic or key naming conventions.

---
*PR created automatically by Jules for task [11253288336442611253](https://jules.google.com/task/11253288336442611253) started by @GarethClarridge*