### PR TITLE
🧹 Tidy: Standardize string presence checks using filled()

### DIFF
--- a/app/Data/StandardProcessingResponse.php
+++ b/app/Data/StandardProcessingResponse.php
@@ -277,7 +277,7 @@ readonly class StandardProcessingResponse
                     : null,
             ],
             MediaType::Video => [
-                'has_thumbnail' => $log->sermon && ! empty($log->sermon->thumbnail_file_path),
+                'has_thumbnail' => $log->sermon && $log->sermon->hasThumbnail(),
                 'video_duration' => $log->duration,
             ],
             MediaType::Audio => [
@@ -288,8 +288,8 @@ readonly class StandardProcessingResponse
         // Add thumbnail data if sermon exists
         $sermon = $log->sermon;
         if ($sermon instanceof Sermon) {
-            $metadata['thumbnail_generated'] = ! empty($sermon->thumbnail_file_path);
-            $metadata['thumbnail_url'] = $sermon->thumbnail_file_path
+            $metadata['thumbnail_generated'] = $sermon->hasThumbnail();
+            $metadata['thumbnail_url'] = $sermon->hasThumbnail()
                 ? app(SermonStorageService::class)->getThumbnailUrl($sermon)
                 : null;
             $metadata['thumbnail_generated_at'] = $sermon->thumbnail_generated_at?->toISOString();

--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -567,7 +567,7 @@ class Sermon extends Model implements Sitemapable
      */
     public function hasTranscript(): bool
     {
-        return ! empty($this->transcript_file_path) && trim((string) $this->transcript_file_path) !== '';
+        return filled($this->transcript_file_path);
     }
 
     /**
@@ -581,7 +581,7 @@ class Sermon extends Model implements Sitemapable
      */
     public function hasThumbnail(): bool
     {
-        return ! empty($this->thumbnail_file_path) && trim((string) $this->thumbnail_file_path) !== '';
+        return filled($this->thumbnail_file_path);
     }
 
     public function hasPlainThumbnail(): bool
@@ -750,7 +750,7 @@ class Sermon extends Model implements Sitemapable
      */
     public function hasVideo(): bool
     {
-        return ! empty($this->video_file_path);
+        return filled($this->video_file_path);
     }
 
     public function videoQualityStatus(): SermonVideoQualityStatus

--- a/app/Services/SermonStorageService.php
+++ b/app/Services/SermonStorageService.php
@@ -217,7 +217,7 @@ class SermonStorageService
     {
         $path = $this->getThumbnailCandidatePath($sermon, $candidateId, $variant);
 
-        if (! is_string($path) || $path === '') {
+        if (! filled($path)) {
             return null;
         }
 
@@ -278,11 +278,11 @@ class SermonStorageService
     {
         $videoPath = $sermon->video_file_path;
 
-        if (! is_string($videoPath) || $videoPath === '') {
+        if (! filled($videoPath)) {
             return null;
         }
 
-        $this->validatePath($videoPath, 'video file');
+        $this->validatePath((string) $videoPath, 'video file');
 
         if ($this->requiresGuardedDelivery($videoPath)) {
             return route('sermons.video', ['sermon' => $sermon->slug]);
@@ -503,26 +503,26 @@ class SermonStorageService
 
     private function resolveThumbnailUrl(Sermon $sermon, mixed $path, string $type): ?string
     {
-        if (! is_string($path) || $path === '') {
+        if (! filled($path)) {
             return null;
         }
 
-        $this->ensurePubliclyResolvable($path, $type);
+        $this->ensurePubliclyResolvable((string) $path, $type);
 
         return $this->resolvePublicUrl(
-            $this->resolveThumbnailDisk($path),
-            $path,
-            $this->thumbnailVersion($sermon, $path),
+            $this->resolveThumbnailDisk((string) $path),
+            (string) $path,
+            $this->thumbnailVersion($sermon, (string) $path),
         );
     }
 
     private function resolveThumbnailDeliveryUrl(Sermon $sermon, mixed $path, string $type, string $routeName): ?string
     {
-        if (! is_string($path) || $path === '') {
+        if (! filled($path)) {
             return null;
         }
 
-        $this->validatePath($path, $type);
+        $this->validatePath((string) $path, $type);
 
         if ($this->requiresGuardedDelivery($path)) {
             return route($routeName, ['sermon' => $sermon->slug]);


### PR DESCRIPTION
Identified and fixed inconsistent string presence checks across the `Sermon` model, `SermonStorageService`, and `StandardProcessingResponse`. 

The refactor replaces verbose checks like `! empty($var) && trim((string) $var) !== ''` or manual `is_string` checks with Laravel's idiomatic `filled()` helper. It also promotes the use of encapsulated model logic (`hasThumbnail()`) over direct property inspection in the data layer.

This cleanup improves code readability, reduces cognitive load, and ensures a standardized approach to optional string validation throughout the media processing and storage components.

**Changes:**
- **`app/Models/Sermon.php`**: Refactored `hasTranscript()`, `hasThumbnail()`, and `hasVideo()` to use `filled()`.
- **`app/Services/SermonStorageService.php`**: Standardized guard clauses in `getVideoDeliveryUrl()`, `getAdminThumbnailCandidatePreviewUrl()`, `resolveThumbnailUrl()`, and `resolveThumbnailDeliveryUrl()`.
- **`app/Data/StandardProcessingResponse.php`**: Switched from direct property checks to `$sermon->hasThumbnail()`.

**Verification:**
- **Code Style**: Ran `./vendor/bin/pint --dirty`.
- **Static Analysis**: `composer phpstan` reported 0 errors.
- **Testing**: Ran relevant feature and model tests (`SermonProcessingScopesTest`, `SermonIntegrityTest`, `UnifiedMediaProcessingTest`, `SermonThumbnailUXTest`). All 22 tests passed.
- **Manual Review**: Verified that `filled()` correctly handles null, empty strings, and whitespace strings in alignment with existing logic.

---
*PR created automatically by Jules for task [9949788903143528242](https://jules.google.com/task/9949788903143528242) started by @GarethClarridge*