### PR TITLE
🏛️ Warden: Align meeting day validation with database schema

### DIFF
--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -197,7 +197,7 @@ class Meeting extends Model implements HasMedia, Sitemapable
         return [
             'slug' => $slugRule,
             'type' => ['required', Rule::enum(MeetingType::class)],
-            'day' => ['nullable', 'string', 'max:255', $trimmedTextRule],
+            'day' => ['nullable', 'string', 'max:75', $trimmedTextRule],
             'location' => ['nullable', 'string', 'max:255', $trimmedTextRule],
             'who' => ['required', 'string', 'max:255', $trimmedTextRule],
             'leaders_phone' => ['nullable', 'string', 'max:255', $trimmedTextRule],

--- a/tests/Integration/Models/MeetingValidationTest.php
+++ b/tests/Integration/Models/MeetingValidationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Meeting;
+use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MeetingValidationTest extends TestCase
+{
+    #[Test]
+    public function it_validates_day_length(): void
+    {
+        $rules = Meeting::validationRules();
+
+        // 75 characters - should pass
+        $validDay = str_repeat('a', 75);
+        $validator = Validator::make(['day' => $validDay], ['day' => $rules['day']]);
+        $this->assertFalse($validator->fails(), '75 characters should pass');
+
+        // 76 characters - should fail
+        $invalidDay = str_repeat('a', 76);
+        $validator = Validator::make(['day' => $invalidDay], ['day' => $rules['day']]);
+        $this->assertTrue($validator->fails(), '76 characters should fail');
+        $this->assertEquals('The day field must not be greater than 75 characters.', $validator->errors()->first('day'));
+    }
+}


### PR DESCRIPTION
💡 **What:** Updated the `Meeting` model's validation rules to enforce a 75-character limit on the `day` column.
🎯 **Why:** The database column `meetings.day` is defined as `VARCHAR(75)`, but the validation was previously allowing `max:255`, which could lead to database-level truncation or errors.
🗄️ **Migration:** No schema changes; application-layer validation update only.
✅ **Verification:** Added `tests/Integration/Models/MeetingValidationTest.php` which verifies that 75 characters pass and 76 characters fail. Ran full test suite.
⚠️ **Rollback:** Revert change in `app/Models/Meeting.php` and delete the new test file.

---
*PR created automatically by Jules for task [636541070284400061](https://jules.google.com/task/636541070284400061) started by @GarethClarridge*