### PR TITLE
🔗 Pathfinder: Fix redirecting "All sermons" link

### DIFF
--- a/app/Presenters/PageCardPresenter.php
+++ b/app/Presenters/PageCardPresenter.php
@@ -20,15 +20,19 @@ class PageCardPresenter
     {
         $area = $page->area->value;
 
+        $url = match (true) {
+            $area === 'sermons' && $page->slug === 'all' => route('sermons.index'),
+            $area === 'sermons' => "/christ/sermons/{$page->slug}",
+            default => '/'.$area.'/'.$page->slug,
+        };
+
         return [
             'area' => $area,
             'description' => $page->description,
             'heading' => $page->heading,
             'image_url' => $this->pageImagePresenter->headingImageSmallUrl($page) ?? '/images/headings/small/default.webp',
             'slug' => $page->slug,
-            'url' => $area === 'sermons'
-                ? "/christ/sermons/{$page->slug}"
-                : '/'.$area.'/'.$page->slug,
+            'url' => $url,
         ];
     }
 

--- a/resources/views/components/page-card.blade.php
+++ b/resources/views/components/page-card.blade.php
@@ -16,9 +16,11 @@
     $pageUrl = data_get($page, 'url');
 
     if (! is_string($pageUrl) || $pageUrl === '') {
-        $pageUrl = $pageArea === 'sermons'
-            ? '/christ/sermons/'.$pageSlug
-            : '/'.$pageArea.'/'.$pageSlug;
+        $pageUrl = match (true) {
+            $pageArea === 'sermons' && $pageSlug === 'all' => route('sermons.index'),
+            $pageArea === 'sermons' => '/christ/sermons/'.$pageSlug,
+            default => '/'.$pageArea.'/'.$pageSlug,
+        };
     }
 @endphp
 <div class="group relative mb-4 flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">


### PR DESCRIPTION
Identified and fixed a redundant 301 redirect for the "All sermons" link. The link was previously pointing to `/christ/sermons/all`, which redirected to `/christ/sermons`. By updating the `PageCardPresenter` and the corresponding Blade component, the link now points directly to the canonical index page. Verified via Playwright screenshots and existing feature tests.

---
*PR created automatically by Jules for task [820154545209945784](https://jules.google.com/task/820154545209945784) started by @GarethClarridge*