### PR TITLE
🔦 Lighthouse: Standardise JSON-LD structured data IDs

### DIFF
--- a/app/Presenters/PreacherItemListPresenter.php
+++ b/app/Presenters/PreacherItemListPresenter.php
@@ -19,12 +19,12 @@ class PreacherItemListPresenter
     {
         $orgName = (string) config('organization.name');
         $appUrl = (string) config('app.url');
-        $appId = $appUrl.'/';
+        $orgId = $appUrl.'/#organization';
 
         $worksFor = [
             '@type' => 'Organization',
             'name' => $orgName,
-            '@id' => $appId,
+            '@id' => $orgId,
         ];
 
         return [
@@ -32,10 +32,12 @@ class PreacherItemListPresenter
             '@type' => 'ItemList',
             'numberOfItems' => $preachers->count(),
             'itemListElement' => $preachers->map(function ($preacher, $index) use ($worksFor) {
+                $preacherUrl = route('sermons.preacher', ['preacher' => $preacher->slug]);
                 $item = [
                     '@type' => 'Person',
+                    '@id' => $preacherUrl.'#person',
                     'name' => $preacher->name,
-                    'url' => route('sermons.preacher', ['preacher' => $preacher->slug]),
+                    'url' => $preacherUrl,
                     'jobTitle' => 'Preacher',
                     'worksFor' => $worksFor,
                 ];

--- a/app/Presenters/SeriesItemListPresenter.php
+++ b/app/Presenters/SeriesItemListPresenter.php
@@ -17,18 +17,31 @@ class SeriesItemListPresenter
      */
     public function toItemList(Collection $series): array
     {
+        $appUrl = (string) config('app.url');
+        $orgId = $appUrl.'/#organization';
+        $orgName = (string) config('organization.name');
+
         return [
             '@context' => 'https://schema.org',
             '@type' => 'ItemList',
             'numberOfItems' => $series->count(),
-            'itemListElement' => $series->map(function ($seriesName, $index) {
+            'itemListElement' => $series->map(function ($seriesName, $index) use ($orgId, $orgName) {
+                $seriesUrl = route('sermons.series.show', ['series' => Str::slug($seriesName)]);
+
                 return [
                     '@type' => 'ListItem',
                     'position' => $index + 1,
                     'item' => [
                         '@type' => 'CreativeWorkSeries',
+                        '@id' => $seriesUrl.'#series',
                         'name' => $seriesName,
-                        'url' => route('sermons.series.show', ['series' => Str::slug($seriesName)]),
+                        'url' => $seriesUrl,
+                        'inLanguage' => 'en-GB',
+                        'publisher' => [
+                            '@type' => 'Organization',
+                            'name' => $orgName,
+                            '@id' => $orgId,
+                        ],
                     ],
                 ];
             })->values()->all(),

--- a/app/Presenters/SermonItemListPresenter.php
+++ b/app/Presenters/SermonItemListPresenter.php
@@ -55,11 +55,11 @@ class SermonItemListPresenter
         $orgName = (string) config('organization.name');
         $logoUrl = asset('images/Primary.png');
         $appUrl = (string) config('app.url');
-        $appId = $appUrl.'/';
+        $orgId = $appUrl.'/#organization';
 
-        $publisher = $this->buildPublisher($orgName, $logoUrl, $appId);
+        $publisher = $this->buildPublisher($orgName, $logoUrl, $orgId);
         $contentLocation = $this->buildContentLocation($orgName);
-        $worksFor = $this->buildWorksFor($orgName, $appId);
+        $worksFor = $this->buildWorksFor($orgName, $orgId);
 
         return [
             '@context' => 'https://schema.org',
@@ -79,12 +79,12 @@ class SermonItemListPresenter
     /**
      * @return array<string, mixed>
      */
-    private function buildPublisher(string $orgName, string $logoUrl, string $appId): array
+    private function buildPublisher(string $orgName, string $logoUrl, string $orgId): array
     {
         return [
             '@type' => 'Organization',
             'name' => $orgName,
-            '@id' => $appId,
+            '@id' => $orgId,
             'logo' => [
                 '@type' => 'ImageObject',
                 'url' => $logoUrl,
@@ -106,12 +106,12 @@ class SermonItemListPresenter
     /**
      * @return array<string, mixed>
      */
-    private function buildWorksFor(string $orgName, string $appId): array
+    private function buildWorksFor(string $orgName, string $orgId): array
     {
         return [
             '@type' => 'Organization',
             'name' => $orgName,
-            '@id' => $appId,
+            '@id' => $orgId,
         ];
     }
 
@@ -135,6 +135,7 @@ class SermonItemListPresenter
 
         $author = [
             '@type' => 'Person',
+            '@id' => $sermonView['preacher_url'].'#person',
             'name' => $sermonView['preacher_name'],
             'url' => $sermonView['preacher_url'],
             'jobTitle' => 'Preacher',
@@ -182,7 +183,7 @@ class SermonItemListPresenter
             'publisher' => $publisher,
             'mainEntityOfPage' => [
                 '@type' => 'WebPage',
-                '@id' => $sermonView['canonical_url'],
+                '@id' => $sermonView['canonical_url'].'#webpage',
             ],
             'image' => $sermonView['thumbnail_url'] ?: $logoUrl,
         ];


### PR DESCRIPTION
💡 **What:** Improved the structured data graph connectivity across the site by standardising `@id` references for the Organization, Person, and CreativeWorkSeries entities in the JSON-LD presenters.
🎯 **Why:** This ensures search engines can correctly connect individual items (like sermons and preachers) to the main church entity, forming a cohesive knowledge graph and preventing entity disambiguation issues.
📊 **Impact:** Sermon archive pages, preacher list pages, and series list pages now provide a more robust and connected structured data representation of church content.
🔍 **Verification:** Verified via manual file inspection and a custom unit test which confirmed the presence of the new fragment IDs (#organization, #person, #webpage, #series) in the JSON output. All static analysis (Pint, PHPStan) passed.

---
*PR created automatically by Jules for task [16447355663034659457](https://jules.google.com/task/16447355663034659457) started by @GarethClarridge*