### PR TITLE
⚡ Bolt: optimize admin listings and image loading

### DIFF
--- a/app/Livewire/Admin/ChurchServices/ListSectionPublications.php
+++ b/app/Livewire/Admin/ChurchServices/ListSectionPublications.php
@@ -61,7 +61,26 @@ class ListSectionPublications extends Component
         $this->hasFilters = $search !== ''
             || $this->publicationStatus !== ServiceSectionPublicationStatus::PendingApproval->value;
 
+        /**
+         * Performance Optimization: Limits retrieved columns for service sections
+         * and eager-loaded relationships to required fields to reduce memory usage
+         * and DB I/O.
+         */
         $sections = ServiceSection::query()
+            ->select([
+                'id',
+                'media_processing_log_id',
+                'section_type',
+                'title',
+                'start_time',
+                'end_time',
+                'publication_status',
+                'published_sermon_id',
+                'confidence',
+                'metadata',
+                'created_at',
+                'updated_at',
+            ])
             ->with([
                 'processingLog:id,processing_id,extracted_date,extracted_service,processing_metadata',
                 'publishedSermon:id,title,slug,content_type',

--- a/resources/views/livewire/admin/components/media-upload-field.blade.php
+++ b/resources/views/livewire/admin/components/media-upload-field.blade.php
@@ -36,7 +36,7 @@
 
         @if($file)
             <div class="mt-4">
-                <img src="{{ $file->temporaryUrl() }}" alt="Preview of selected image" class="w-32 h-32 object-cover rounded-lg mx-auto" />
+                <img src="{{ $file->temporaryUrl() }}" alt="Preview of selected image" class="w-32 h-32 object-cover rounded-lg mx-auto" loading="lazy" />
                 <x-form-button variant="primary" size="sm" wire:click="upload" class="mt-2">
                     Upload
                 </x-form-button>

--- a/resources/views/livewire/admin/sermons/edit-sermon-thumbnails.blade.php
+++ b/resources/views/livewire/admin/sermons/edit-sermon-thumbnails.blade.php
@@ -20,6 +20,7 @@
                                     src="{{ $candidate['preview_url'] }}"
                                     alt="Thumbnail candidate {{ $loop->iteration }}"
                                     class="h-32 w-full rounded-lg border border-gray-200 object-cover"
+                                    loading="lazy"
                                 >
                             @endif
 
@@ -35,6 +36,7 @@
                                         src="{{ $candidate['card_url'] }}"
                                         alt="Card thumbnail candidate {{ $loop->iteration }}"
                                         class="h-16 w-24 rounded-md border border-gray-200 object-cover"
+                                        loading="lazy"
                                     >
                                 @endif
                             </div>
@@ -67,6 +69,7 @@
                     src="{{ route('sermons.thumbnail', $sermon->slug) }}"
                     alt="Current sermon thumbnail"
                     class="h-32 w-full rounded-lg border border-gray-200 object-cover"
+                    loading="lazy"
                 >
                 <p class="text-sm text-gray-600">
                     This sermon has an existing thumbnail but no saved alternatives yet. Regenerate thumbnails to create five selectable options.


### PR DESCRIPTION
This PR implements targeted performance optimizations in the admin panel and sermon detail pages.

Key improvements:
- **Database efficiency**: The `ListSectionPublications` component now uses `select()` to retrieve only required columns from the `service_sections` table and its eager-loaded relationships. This reduces memory pressure and data transfer overhead.
- **Frontend performance**: `loading="lazy"` has been added to image previews in `media-upload-field.blade.php` and `edit-sermon-thumbnails.blade.php`, improving perceived performance in these detail-heavy views.
- **LCP preservation**: Following a code review, I ensured that the primary hero image in `sermon.blade.php` does NOT use lazy loading, as it is a critical Largest Contentful Paint element.
- **Data integrity**: Explicitly included foreign keys (`media_processing_log_id`, `published_sermon_id`) and standard audit columns (`created_at`) in limited queries to ensure stable relationship hydration and UI data consistency.

Tests passing: `SermonControllerTest`, `AdminSectionPublicationQueueTest`, and the full suite (5279 tests). Static analysis and linting are clear.

---
*PR created automatically by Jules for task [4430606790089450354](https://jules.google.com/task/4430606790089450354) started by @GarethClarridge*