### PR TITLE
🛡️ Sentinel: Harden log sanitization and improve exception documentation

### DIFF
--- a/app/Services/SermonProcessingLogger.php
+++ b/app/Services/SermonProcessingLogger.php
@@ -34,7 +34,7 @@ class SermonProcessingLogger
             'timestamp' => now()->toISOString(),
         ];
 
-        Log::info('Sermon processing started', $context);
+        Log::info('Sermon processing started', $this->sanitizeArrayForLog($context));
     }
 
     /**
@@ -74,7 +74,7 @@ class SermonProcessingLogger
 
         $sanitizedStep = $this->sanitizeForLog($step);
         $sanitizedStatus = $this->sanitizeForLog($status);
-        Log::log($logLevel, "Processing step: {$sanitizedStep} - {$sanitizedStatus}", $context);
+        Log::log($logLevel, "Processing step: {$sanitizedStep} - {$sanitizedStatus}", $this->sanitizeArrayForLog($context));
     }
 
     /**
@@ -106,7 +106,7 @@ class SermonProcessingLogger
 
         $logLevel = $statusCode >= 400 ? 'error' : 'info';
         $sanitizedService = $this->sanitizeForLog($service);
-        Log::log($logLevel, "API call to {$sanitizedService}: {$endpoint}", $context);
+        Log::log($logLevel, "API call to {$sanitizedService}: {$endpoint}", $this->sanitizeArrayForLog($context));
     }
 
     /**
@@ -142,7 +142,7 @@ class SermonProcessingLogger
 
         $logLevel = $errorMessage ? 'error' : 'info';
         $sanitizedOperation = $this->sanitizeForLog($operation);
-        Log::log($logLevel, "File operation: {$sanitizedOperation}", $context);
+        Log::log($logLevel, "File operation: {$sanitizedOperation}", $this->sanitizeArrayForLog($context));
     }
 
     /**
@@ -176,7 +176,7 @@ class SermonProcessingLogger
         };
 
         $statusLabel = $status->value;
-        Log::log($logLevel, "Sermon processing {$statusLabel}", $context);
+        Log::log($logLevel, "Sermon processing {$statusLabel}", $this->sanitizeArrayForLog($context));
     }
 
     /**
@@ -204,7 +204,7 @@ class SermonProcessingLogger
         ], $additionalContext);
 
         $sanitizedStep = $this->sanitizeForLog($step);
-        Log::error("Processing error in step: {$sanitizedStep}", $context);
+        Log::error("Processing error in step: {$sanitizedStep}", $this->sanitizeArrayForLog($context));
     }
 
     /**
@@ -220,7 +220,7 @@ class SermonProcessingLogger
             'timestamp' => now()->toISOString(),
         ];
 
-        Log::info('Performance metrics', $context);
+        Log::info('Performance metrics', $this->sanitizeArrayForLog($context));
     }
 
     /**
@@ -245,7 +245,7 @@ class SermonProcessingLogger
         };
 
         $sanitizedCheckName = $this->sanitizeForLog($checkName);
-        Log::log($logLevel, "Health check: {$sanitizedCheckName}", $context);
+        Log::log($logLevel, "Health check: {$sanitizedCheckName}", $this->sanitizeArrayForLog($context));
     }
 
     /**
@@ -308,10 +308,10 @@ class SermonProcessingLogger
         }
         $statistics['error_patterns'] = $errorCounts;
 
-        Log::info('Processing statistics generated', [
+        Log::info('Processing statistics generated', $this->sanitizeArrayForLog([
             'statistics' => $statistics,
             'timestamp' => now()->toISOString(),
-        ]);
+        ]));
 
         return $statistics;
     }
@@ -366,17 +366,19 @@ class SermonProcessingLogger
     public function logWarning(string $processingId, string $step, string $message, array $context = []): void
     {
         $sanitizedStep = $this->sanitizeForLog($step);
-        Log::warning("Processing warning in step: {$sanitizedStep}", [
+        Log::warning("Processing warning in step: {$sanitizedStep}", $this->sanitizeArrayForLog([
             'processing_id' => $processingId,
             'step' => $sanitizedStep,
             'warning_message' => $this->sanitizeForLog($message),
             'timestamp' => now()->toISOString(),
             'context' => $context,
-        ]);
+        ]));
     }
 
     /**
      * Generate a processing report for a livestream processing record.
+     *
+     * @throws \Exception When the processing record is not found.
      */
     public function generateProcessingReport(string $processingId): ProcessingReport
     {

--- a/app/Services/SermonProcessingLogger.php
+++ b/app/Services/SermonProcessingLogger.php
@@ -106,7 +106,8 @@ class SermonProcessingLogger
 
         $logLevel = $statusCode >= 400 ? 'error' : 'info';
         $sanitizedService = $this->sanitizeForLog($service);
-        Log::log($logLevel, "API call to {$sanitizedService}: {$endpoint}", $this->sanitizeArrayForLog($context));
+        $sanitizedEndpoint = $this->sanitizeForLog($endpoint);
+        Log::log($logLevel, "API call to {$sanitizedService}: {$sanitizedEndpoint}", $this->sanitizeArrayForLog($context));
     }
 
     /**

--- a/app/Services/UnifiedMediaProcessor.php
+++ b/app/Services/UnifiedMediaProcessor.php
@@ -204,6 +204,8 @@ class UnifiedMediaProcessor
     /**
      * Process an audio file through the complete automation pipeline.
      * Uses ProcessingInitiator for shared log-creation boundary (same as video/livestream).
+     *
+     * @throws \Illuminate\Database\UniqueConstraintViolationException
      */
     private function processAudio(UploadedFile $file, ?string $clientFileDate, ?string $fileHash, ?string $dedupKey): ProcessingResult
     {
@@ -271,6 +273,9 @@ class UnifiedMediaProcessor
         }
     }
 
+    /**
+     * @throws \RuntimeException
+     */
     private function storeAudioFile(UploadedFile $file, SermonMetadata $metadata): string
     {
         $disk = config('media-processing.storage.sermon_disk', 'public');
@@ -381,6 +386,8 @@ class UnifiedMediaProcessor
      * Uses ProcessingInitiator for shared metadata extraction and log creation.
      *
      * @param  array<string, mixed>  $options
+     *
+     * @throws \Illuminate\Database\UniqueConstraintViolationException
      */
     private function processDirectVideo(
         UploadedFile $file,


### PR DESCRIPTION
This PR implements security hardening by ensuring that all log entries in `SermonProcessingLogger` recursively sanitize their context arrays, preventing potential log injection from external metadata or API responses. It also improves codebase security awareness by explicitly documenting exception paths with `@throws` PHPDoc annotations in `SermonProcessingLogger` and `UnifiedMediaProcessor`.

---
*PR created automatically by Jules for task [3157370076035212237](https://jules.google.com/task/3157370076035212237) started by @GarethClarridge*