### PR TITLE
📖 Editor: Standardise to British English (catalogue, synchronised)

### DIFF
--- a/app/Console/Commands/SyncSongsCommand.php
+++ b/app/Console/Commands/SyncSongsCommand.php
@@ -14,7 +14,7 @@ class SyncSongsCommand extends Command
                             {--path= : Path to OpenLP songs SQLite file}
                             {--dry-run : Preview sync changes without persisting anything}';
 
-    protected $description = 'Sync OpenLP songs catalog into canonical songs/authors/songbooks tables';
+    protected $description = 'Sync OpenLP songs catalogue into canonical songs/authors/songbooks tables';
 
     public function handle(SongCatalogSyncService $syncService): int
     {
@@ -29,7 +29,7 @@ class SyncSongsCommand extends Command
             return self::FAILURE;
         }
 
-        $this->info('Song catalog sync completed.');
+        $this->info('Song catalogue sync completed.');
         $this->line('Path: '.$metrics['path']);
 
         if ($metrics['dry_run']) {

--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -103,7 +103,7 @@
     @endif
 
     <div class="prose max-w-none mb-8">
-        <p>Here are all upcoming events from our church calendar. Events are automatically synchronized from our Google Calendar.</p>
+        <p>Here are all upcoming events from our church calendar. Events are automatically synchronised from our Google Calendar.</p>
     </div>
 
     @if($allEvents->count() > 0)

--- a/resources/views/livewire/admin/church-services/list-church-services.blade.php
+++ b/resources/views/livewire/admin/church-services/list-church-services.blade.php
@@ -13,7 +13,7 @@
             Review emails
         </x-button>
         <x-button link="{{ route('admin.services.songs.index') }}" variant="outline" icon="musical-note" inline>
-            Song catalog
+            Song catalogue
         </x-button>
         <x-button link="{{ route('admin.services.create') }}" variant="outline" icon="plus" inline>
             Create service

--- a/resources/views/livewire/admin/church-services/list-section-publications.blade.php
+++ b/resources/views/livewire/admin/church-services/list-section-publications.blade.php
@@ -9,7 +9,7 @@
             Review dashboard
         </x-button>
         <x-button link="{{ route('admin.services.songs.index') }}" variant="outline" icon="musical-note" inline>
-            Song catalog
+            Song catalogue
         </x-button>
         <x-button link="{{ route('admin.services.index') }}" variant="outline" inline>
             Back to services

--- a/resources/views/livewire/admin/church-services/manage-church-service.blade.php
+++ b/resources/views/livewire/admin/church-services/manage-church-service.blade.php
@@ -98,7 +98,7 @@
 
                     @if($item['section_type'] === \App\Enums\ServiceSectionType::SONG->value)
                         <div class="mt-4 space-y-3">
-                            <p class="text-sm text-gray-500">Search the song catalog to link this item to a canonical song.</p>
+                            <p class="text-sm text-gray-500">Search the song catalogue to link this item to a canonical song.</p>
 
                             @if(($songSuggestions[$index] ?? []) !== [])
                                 <div class="overflow-hidden rounded-md border border-gray-200">
@@ -142,7 +142,7 @@
         <x-card heading="Guidance">
             <div class="space-y-3 text-sm text-gray-600">
                 <p>Use the service type dropdown to capture the planned structure, not just the spoken title.</p>
-                <p>Songs can be saved as free text, but linking them to the catalog improves later matching and reporting.</p>
+                <p>Songs can be saved as free text, but linking them to the catalogue improves later matching and reporting.</p>
                 <p>Manual saves become the canonical reviewed service list and clear any existing review flag.</p>
             </div>
         </x-card>

--- a/resources/views/livewire/admin/church-services/show-church-service.blade.php
+++ b/resources/views/livewire/admin/church-services/show-church-service.blade.php
@@ -10,7 +10,7 @@
             Edit service
         </x-button>
         <x-button link="{{ route('admin.services.songs.index') }}" variant="outline" icon="musical-note" inline>
-            Song catalog
+            Song catalogue
         </x-button>
         <x-button link="{{ route('admin.services.section-publications') }}" variant="outline" inline>
             Section queue

--- a/resources/views/livewire/admin/church-services/upload-church-service.blade.php
+++ b/resources/views/livewire/admin/church-services/upload-church-service.blade.php
@@ -7,7 +7,7 @@
             Create service
         </x-button>
         <x-button link="{{ route('admin.services.songs.index') }}" variant="outline" icon="musical-note" inline>
-            Song catalog
+            Song catalogue
         </x-button>
         <x-button link="{{ route('admin.services.submit-email') }}" variant="outline" icon="envelope" inline>
             Submit email text

--- a/resources/views/members/home.blade.php
+++ b/resources/views/members/home.blade.php
@@ -69,7 +69,7 @@
             </x-button>
 
             <x-button link="{{ route('admin.services.songs.index') }}" icon="musical-note" iconStyle="solid">
-              Song catalog
+              Song catalogue
             </x-button>
           </div>
         </div>

--- a/tests/Feature/Console/SyncSongsCommandTest.php
+++ b/tests/Feature/Console/SyncSongsCommandTest.php
@@ -41,7 +41,7 @@ class SyncSongsCommandTest extends TestCase
 
         $this->artisan('service-tracking:sync-songs', ['--path' => $path])
             ->assertExitCode(0)
-            ->expectsOutputToContain('Song catalog sync completed.');
+            ->expectsOutputToContain('Song catalogue sync completed.');
 
         $this->assertDatabaseCount('songs', 3);
         $this->assertDatabaseCount('song_authors', 3);


### PR DESCRIPTION
Standardised "catalog" to "catalogue" and "synchronized" to "synchronised" across various Blade templates and admin tools to maintain British English consistency.

---
*PR created automatically by Jules for task [11936157258982308696](https://jules.google.com/task/11936157258982308696) started by @GarethClarridge*