### PR TITLE
🧹 Tidy: remove redundant else blocks after return statements

### DIFF
--- a/app/Data/SermonMetadata.php
+++ b/app/Data/SermonMetadata.php
@@ -108,9 +108,9 @@ class SermonMetadata extends Data
                 // If created before 2 PM, assume morning service
                 if ($creationTime->hour < 14) {
                     return SermonService::Morning;
-                } else {
-                    return SermonService::Evening;
                 }
+
+                return SermonService::Evening;
             }
         } catch (\Exception $e) {
             // If we can't determine from file time, fall back to default

--- a/app/Http/Controllers/Admin/SermonAdminController.php
+++ b/app/Http/Controllers/Admin/SermonAdminController.php
@@ -87,11 +87,11 @@ class SermonAdminController extends Controller
                 return redirect()
                     ->route('sermons.index')
                     ->with('message', "Processing started for \"{$file->getClientOriginalName()}\". Processing ID: {$result->processingId}");
-            } else {
-                return redirect()
-                    ->back()
-                    ->with('error', $result->message);
             }
+
+            return redirect()
+                ->back()
+                ->with('error', $result->message);
 
         } catch (\Exception $e) {
             Log::error('Sermon upload failed', [

--- a/app/Http/Controllers/Api/MediaController.php
+++ b/app/Http/Controllers/Api/MediaController.php
@@ -67,9 +67,9 @@ class MediaController extends Controller
 
             if ($result->success) {
                 return response()->json($result->toArray(), 202);
-            } else {
-                return response()->json($result->toArray(), 422);
             }
+
+            return response()->json($result->toArray(), 422);
 
         } catch (\Exception $e) {
             return $this->handleApiException($e, 'Media upload failed', [

--- a/app/Services/MetadataExtractionService.php
+++ b/app/Services/MetadataExtractionService.php
@@ -267,9 +267,9 @@ class MetadataExtractionService
                 // Use the same 2 PM (14:00) cutoff
                 if ($hour < 14) {
                     return SermonService::Morning;
-                } else {
-                    return SermonService::Evening;
                 }
+
+                return SermonService::Evening;
             }
         }
 

--- a/app/Services/MockSermonAnalysisService.php
+++ b/app/Services/MockSermonAnalysisService.php
@@ -244,9 +244,9 @@ class MockSermonAnalysisService implements SermonAnalysisInterface
                         $endVerse = isset($matches[4]) ? $matches[4] : null;
 
                         return $endVerse ? "{$book} {$chapter}:{$verse}-{$endVerse}" : "{$book} {$chapter}:{$verse}";
-                    } else {
-                        return "{$book} {$chapter}";
                     }
+
+                    return "{$book} {$chapter}";
                 }
             }
         }


### PR DESCRIPTION
💡 **What:** Removed redundant `else` blocks following `return` statements across several files in the codebase.
🎯 **Why:** To improve code readability, reduce mental nesting, and follow the project's "Tidy" coding standards.
🔄 **Behavior:** No functional changes. The refactored code is logically equivalent to the original.
✅ **Tests:** All relevant unit and feature tests passed, including `SermonMetadataDataTest`, `MediaControllerTest`, `SermonAdminControllerTest`, `MetadataExtractionServiceTest`, and `MockSermonAnalysisServiceTest`. Quality gates (Pint and PHPStan) also passed.

Files refactored:
- `app/Data/SermonMetadata.php`
- `app/Http/Controllers/Api/MediaController.php`
- `app/Http/Controllers/Admin/SermonAdminController.php`
- `app/Services/MetadataExtractionService.php`
- `app/Services/MockSermonAnalysisService.php`

---
*PR created automatically by Jules for task [14824881654135798664](https://jules.google.com/task/14824881654135798664) started by @GarethClarridge*