### PR TITLE
Fix CI quality checks

### DIFF
--- a/.github/actions/setup-laravel/action.yml
+++ b/.github/actions/setup-laravel/action.yml
@@ -65,7 +65,11 @@ runs:
         set -euo pipefail
         mkdir -p storage/framework/{cache,sessions,views} storage/logs bootstrap/cache
         cp .env.example .env
-        echo "VIEW_COMPILED_PATH=${{ inputs.view-compiled-path }}" >> .env
+        view_compiled_path="${{ inputs.view-compiled-path }}"
+        if [[ "$view_compiled_path" != /* ]]; then
+          view_compiled_path="$PWD/$view_compiled_path"
+        fi
+        echo "VIEW_COMPILED_PATH=$view_compiled_path" >> .env
 
     - name: Install PHP dependencies
       if: inputs.composer-install == 'true'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,7 +50,8 @@ jobs:
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             base_sha="${{ github.event.pull_request.base.sha }}"
-            changed_files="$(git diff --name-only "$base_sha" "$GITHUB_SHA")"
+            head_sha="${{ github.event.pull_request.head.sha }}"
+            changed_files="$(git diff --name-only "$base_sha...$head_sha")"
 
             if grep -Eq '^(app/Http/Controllers/|app/Livewire/|resources/|routes/web.php|public/|tests/Browser/|playwright\.config\.ts|lighthouserc\.json|package(-lock)?\.json|vite\.config\.mjs)' <<<"$changed_files"; then
               frontend_changed=true

--- a/app/Services/SermonAnalysisService.php
+++ b/app/Services/SermonAnalysisService.php
@@ -109,7 +109,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
      *     transcript: string,
      * } The parsed analysis results
      *
-     * @throws Exception|\OpenAI\Exceptions\ErrorException|\OpenAI\Exceptions\TransporterException
+     * @throws Exception|ErrorException|TransporterException
      */
     private function performAiAnalysis(string $transcript, array $existingSeries, string $processingId): array
     {
@@ -149,7 +149,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
      *     transcript: string,
      * }
      *
-     * @throws Exception|\TypeError|\OpenAI\Exceptions\ErrorException|\OpenAI\Exceptions\TransporterException
+     * @throws Exception|\TypeError|ErrorException|TransporterException
      */
     private function runAnalysisAttempt(string $transcript, array $existingSeries, string $processingId, int $attempt, float $apiStartTime): array
     {
@@ -318,7 +318,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
     /**
      * Execute AI analysis request via OpenAI SDK.
      *
-     * @throws Exception|\OpenAI\Exceptions\ErrorException|\TypeError
+     * @throws Exception|ErrorException|\TypeError
      */
     private function executeAiRequest(string $prompt, string $model, string $processingId, int $attempt): CreateResponse
     {

--- a/app/Services/UnifiedMediaProcessor.php
+++ b/app/Services/UnifiedMediaProcessor.php
@@ -205,7 +205,7 @@ class UnifiedMediaProcessor
      * Process an audio file through the complete automation pipeline.
      * Uses ProcessingInitiator for shared log-creation boundary (same as video/livestream).
      *
-     * @throws \Illuminate\Database\UniqueConstraintViolationException
+     * @throws UniqueConstraintViolationException
      */
     private function processAudio(UploadedFile $file, ?string $clientFileDate, ?string $fileHash, ?string $dedupKey): ProcessingResult
     {
@@ -387,7 +387,7 @@ class UnifiedMediaProcessor
      *
      * @param  array<string, mixed>  $options
      *
-     * @throws \Illuminate\Database\UniqueConstraintViolationException
+     * @throws UniqueConstraintViolationException
      */
     private function processDirectVideo(
         UploadedFile $file,

--- a/tests/Integration/Models/MeetingTest.php
+++ b/tests/Integration/Models/MeetingTest.php
@@ -137,6 +137,7 @@ class MeetingTest extends TestCase
         $dailyMeeting = Meeting::factory()->recurring('daily')->create([
             'meeting_date' => $now->copy()->subDays(5),
             'start_time' => $now->format('H:i:s'),
+            'end_time' => $now->copy()->addHour()->format('H:i:s'),
         ]);
         $nextDaily = $dailyMeeting->getNextOccurrence();
         $this->assertNotNull($nextDaily, 'Daily meeting occurrence should not be null');
@@ -153,6 +154,7 @@ class MeetingTest extends TestCase
         $weeklyMeeting = Meeting::factory()->recurring('weekly')->create([
             'meeting_date' => $now->copy()->subWeeks(2),
             'start_time' => $now->format('H:i:s'),
+            'end_time' => $now->copy()->addHour()->format('H:i:s'),
         ]);
         $nextWeekly = $weeklyMeeting->getNextOccurrence();
         $this->assertTrue($nextWeekly->isSameDay($now));
@@ -161,6 +163,7 @@ class MeetingTest extends TestCase
         $monthlyMeeting = Meeting::factory()->recurring('monthly')->create([
             'meeting_date' => $now->copy()->subMonths(2),
             'start_time' => $now->format('H:i:s'),
+            'end_time' => $now->copy()->addHour()->format('H:i:s'),
         ]);
         $nextMonthly = $monthlyMeeting->getNextOccurrence();
         $this->assertTrue($nextMonthly->isSameDay($now));
@@ -186,6 +189,7 @@ class MeetingTest extends TestCase
         $annualMeeting = Meeting::factory()->recurring('annually')->create([
             'meeting_date' => $now->copy()->subYears(1),
             'start_time' => $now->format('H:i:s'),
+            'end_time' => $now->copy()->addHour()->format('H:i:s'),
         ]);
         $nextAnnual = $annualMeeting->getNextOccurrence();
         $this->assertTrue($nextAnnual->isSameDay($now));

--- a/tests/Integration/Services/SermonPageContextServiceTest.php
+++ b/tests/Integration/Services/SermonPageContextServiceTest.php
@@ -123,6 +123,7 @@ class SermonPageContextServiceTest extends TestCase
         // Create several non-reading sections that should not be fetched
         ServiceSection::factory()->count(5)->create([
             'media_processing_log_id' => $processingLog->id,
+            'church_service_item_id' => null,
             'section_type' => ServiceSectionType::SERMON->value,
         ]);
 

--- a/tests/Unit/Services/SermonValidationServiceTest.php
+++ b/tests/Unit/Services/SermonValidationServiceTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services;
 
+use App\Enums\MediaType;
+use App\Enums\SermonService;
 use App\Enums\SermonSourceType;
 use App\Models\MediaProcessingLog;
 use App\Models\Sermon;
 use App\Repositories\SermonRepository;
 use App\Services\MediaValidationService;
 use App\Services\SermonValidationService;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Config;
@@ -53,7 +56,7 @@ class SermonValidationServiceTest extends TestCase
         $file = UploadedFile::fake()->create('sermon.mp3');
         $this->mediaValidation->shouldReceive('validateUploadedFile')
             ->once()
-            ->with(\App\Enums\MediaType::Audio, $file);
+            ->with(MediaType::Audio, $file);
 
         $this->service->validateAudioFile($file);
     }
@@ -141,10 +144,10 @@ class SermonValidationServiceTest extends TestCase
     #[Test]
     public function generate_fallback_title_uses_date_fallback_when_filename_invalid(): void
     {
-        $date = \Carbon\Carbon::parse('2024-05-20');
+        $date = Carbon::parse('2024-05-20');
         $sermon = Sermon::factory()->make([
             'date' => $date,
-            'service' => \App\Enums\SermonService::Morning,
+            'service' => SermonService::Morning,
         ]);
         $log = MediaProcessingLog::factory()->make([
             'original_filename' => 'abc.mp3', // Too short after processing


### PR DESCRIPTION
## Summary
- format three inherited PHP files so the PR quality gate passes Pint
- normalize `VIEW_COMPILED_PATH` to an absolute path in the shared Laravel setup action
- compare PR base and head with a three-dot diff when detecting frontend-impacting changes

## Verification
- `vendor/bin/sail bin pint --test --format agent`
- `vendor/bin/sail composer phpstan`
- `vendor/bin/sail artisan test --parallel --compact --exclude-group=dedicated --exclude-group=performance`
- bootstrap safety checker, deploy view-cache safety guard, schema dump freshness guard
- YAML parsing for the edited workflow files
- detector simulation for PR #657 reports `frontend_changed=false`