### PR TITLE
Upgrade production Docker image from PHP 8.4 to 8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN composer dump-autoload --optimize --no-dev --no-scripts
 # =============================================================================
 # Stage 3: Production Image
 # =============================================================================
-FROM php:8.4-fpm-bookworm
+FROM php:8.5-fpm-bookworm
 
 LABEL maintainer="Crockenhill Baptist Church"
 


### PR DESCRIPTION
## Summary

- Bumps the production Docker image from `php:8.4-fpm-bookworm` to `php:8.5-fpm-bookworm`

PHP 8.5 was released ~6 months ago and is a stable release. This was originally opened as Dependabot PR #663 but was mistakenly closed under the assumption it was a pre-release.

## Test plan
- [ ] CI quality gate passes
- [ ] Deploy pipeline succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)