### PR TITLE
♿ Aria: Accessibility improvements for headings, images, and forms

### DIFF
--- a/resources/views/components/h1-picture.blade.php
+++ b/resources/views/components/h1-picture.blade.php
@@ -15,6 +15,7 @@
     <img
       src="{{ $headingpicture }}"
       alt=""
+      role="presentation"
       class="w-full h-full object-cover"
       loading="eager"
       fetchpriority="high"

--- a/resources/views/components/toggle.blade.php
+++ b/resources/views/components/toggle.blade.php
@@ -79,7 +79,7 @@
             @endif
             @if($modelName)
                 @error($modelName)
-                    <p @if($id) id="{{ $id }}-error" @endif class="mt-1 text-sm text-red-600" role="alert">{{ $message }}</p>
+                    <p id="{{ $id }}-error" class="mt-1 text-sm text-red-600" role="alert">{{ $message }}</p>
                 @enderror
             @endif
         </div>

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -408,10 +408,10 @@
 
                     @if ($sermon->source_type === 'livestream' && $sermon->livestreamProcessing)
                     <div class="mb-4 p-4 bg-gray-50 border border-gray-200 rounded-xl">
-                        <h4 class="font-display text-lg text-gray-900 mb-3 flex items-center gap-2">
+                        <h3 class="font-display text-lg text-gray-900 mb-3 flex items-center gap-2">
                             <x-heroicon-o-signal class="h-4 w-4 text-cbc-teal" />
                             Livestream Processing
-                        </h4>
+                        </h3>
                         <div class="grid grid-cols-1 gap-4 text-sm">
                             <div>
                                 <span class="font-medium text-gray-700">Original File:</span>


### PR DESCRIPTION
I have implemented three accessibility improvements across the codebase:
1. **Heading Hierarchy**: In `resources/views/sermons/sermon.blade.php`, I changed an `<h4>` heading to an `<h3>` for the "Livestream Processing" section to ensure a strict sequential heading order (following the `<h2>` sections above it).
2. **Form Association**: In `resources/views/components/toggle.blade.php`, I ensured that the error message `<p>` element always has an `id` matching the `aria-describedby` attribute, which is critical for screen readers to announce validation errors.
3. **Decorative Media**: In `resources/views/components/h1-picture.blade.php`, I added `role="presentation"` to the decorative background image to ensure it is correctly ignored by assistive technology.

These changes improve the experience for screen-reader and keyboard users without altering the visual design.

---
*PR created automatically by Jules for task [12523122850857467809](https://jules.google.com/task/12523122850857467809) started by @GarethClarridge*