### PR TITLE
📖 Editor: Standardise Log in/Log out verb phrases

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.main')
 
 @section('content')
-<x-auth.shell heading="Login" description="Login to your account">
+<x-auth.shell heading="Login" description="Log in to your account">
     <livewire:auth.login />
 </x-auth.shell>
 @endsection

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -29,7 +29,7 @@
 
         <div class="mt-6">
             <x-form-button variant="primary" class="w-full text-xl py-3">
-                Login
+                Log in
             </x-form-button>
         </div>
 

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -52,7 +52,7 @@
         </div>
 
         <div class="mt-4 text-center text-sm">
-            <a href="{{ route('login') }}" wire:navigate class="text-cbc-teal-dark hover:text-cbc-teal transition-colors">Already have an account? Login</a>
+            <a href="{{ route('login') }}" wire:navigate class="text-cbc-teal-dark hover:text-cbc-teal transition-colors">Already have an account? Log in</a>
         </div>
     </div>
 </form>

--- a/resources/views/livewire/auth/verify-email.blade.php
+++ b/resources/views/livewire/auth/verify-email.blade.php
@@ -17,7 +17,7 @@
         <div class="mt-4">
             <form method="POST" action="{{ route('logout') }}">
                 @csrf
-                <button type="submit" class="text-cbc-crimson hover:text-cbc-crimson/80 transition-colors font-medium">Logout</button>
+                <button type="submit" class="text-cbc-crimson hover:text-cbc-crimson/80 transition-colors font-medium">Log out</button>
             </form>
         </div>
     </div>

--- a/tests/Browser/Auth/LoginTest.php
+++ b/tests/Browser/Auth/LoginTest.php
@@ -43,7 +43,7 @@ class LoginTest extends DuskTestCase
             $browser->visit('/login')
                 ->type('input[type="email"]', $user->email)
                 ->type('input[type="password"]', 'password')
-                ->press('Login')
+                ->press('Log in')
                 ->waitForLocation('/church/members')
                 ->assertPathIs('/church/members');
         });
@@ -59,7 +59,7 @@ class LoginTest extends DuskTestCase
             $browser->visit('/login')
                 ->type('input[type="email"]', $user->email)
                 ->type('input[type="password"]', 'wrong-password')
-                ->press('Login')
+                ->press('Log in')
                 ->waitForText('These credentials do not match our records')
                 ->assertSee('These credentials do not match our records');
         });
@@ -76,14 +76,14 @@ class LoginTest extends DuskTestCase
                 $browser->visit('/login')
                     ->type('input[type="email"]', $email)
                     ->type('input[type="password"]', 'wrong-password')
-                    ->press('Login')
+                    ->press('Log in')
                     ->pause(500);
             }
 
             $browser->visit('/login')
                 ->type('input[type="email"]', $email)
                 ->type('input[type="password"]', 'wrong-password')
-                ->press('Login')
+                ->press('Log in')
                 ->waitForText('Too many login attempts', 15)
                 ->assertSee('Too many login attempts');
         });
@@ -101,7 +101,7 @@ class LoginTest extends DuskTestCase
                 ->type('input[type="email"]', $user->email)
                 ->type('input[type="password"]', 'password')
                 ->check('#remember')
-                ->press('Login')
+                ->press('Log in')
                 ->waitForLocation('/church/members')
                 ->assertHasCookie('remember_web_'.sha1('Illuminate\Auth\SessionGuard'));
         });

--- a/tests/Feature/BladeShellRenderingTest.php
+++ b/tests/Feature/BladeShellRenderingTest.php
@@ -33,7 +33,7 @@ class BladeShellRenderingTest extends TestCase
         $response = $this->get('/login');
 
         $response->assertOk();
-        $response->assertSee('<meta name="description" content="Login to your account">', false);
+        $response->assertSee('<meta name="description" content="Log in to your account">', false);
     }
 
     #[Test]


### PR DESCRIPTION
Standardised the use of "Log in" and "Log out" as verb phrases across authentication views and updated relevant tests to match the new labels. This improvement follows British English conventions and enhances microcopy clarity.

---
*PR created automatically by Jules for task [12003821075974586288](https://jules.google.com/task/12003821075974586288) started by @GarethClarridge*