### PR TITLE
🧪 Steward: Harden Job Dispatch Assertions

### DIFF
--- a/app/Jobs/AutoPublishServiceSection.php
+++ b/app/Jobs/AutoPublishServiceSection.php
@@ -26,7 +26,7 @@ class AutoPublishServiceSection implements ShouldQueue
     public int $timeout = 600;
 
     public function __construct(
-        private int $serviceSectionId
+        public readonly int $serviceSectionId
     ) {}
 
     /**

--- a/app/Jobs/PrepareSectionPublicationCandidates.php
+++ b/app/Jobs/PrepareSectionPublicationCandidates.php
@@ -37,7 +37,7 @@ class PrepareSectionPublicationCandidates extends ProcessingJob implements Shoul
     public int $timeout = 1800;
 
     public function __construct(
-        private MediaProcessingLog $processingLog
+        public MediaProcessingLog $processingLog
     ) {}
 
     /**

--- a/tests/Feature/Actions/ServiceReview/MergeAdjacentServiceSectionsTest.php
+++ b/tests/Feature/Actions/ServiceReview/MergeAdjacentServiceSectionsTest.php
@@ -270,11 +270,8 @@ class MergeAdjacentServiceSectionsTest extends TestCase
 
         $this->action->execute($section1, $section2, $this->admin->id);
 
-        Bus::assertDispatched(PrepareSectionPublicationCandidates::class, function ($job) use ($log) {
-            $reflection = new \ReflectionClass($job);
-            $property = $reflection->getProperty('processingLog');
-
-            return $property->getValue($job)->id === $log->id;
+        Bus::assertDispatched(PrepareSectionPublicationCandidates::class, function (PrepareSectionPublicationCandidates $job) use ($log) {
+            return $job->processingLog->id === $log->id;
         });
     }
 

--- a/tests/Integration/Jobs/PrepareSectionPublicationCandidatesTest.php
+++ b/tests/Integration/Jobs/PrepareSectionPublicationCandidatesTest.php
@@ -540,10 +540,7 @@ class PrepareSectionPublicationCandidatesTest extends TestCase
 
         Bus::assertDispatched(AutoPublishServiceSection::class, function (AutoPublishServiceSection $job) use ($section) {
             // Verify it was dispatched for the correct section.
-            $reflection = new \ReflectionClass($job);
-            $property = $reflection->getProperty('serviceSectionId');
-
-            return $property->getValue($job) === $section->id;
+            return $job->serviceSectionId === $section->id;
         });
     }
 


### PR DESCRIPTION
Hardened test assertions for job dispatching by replacing ReflectionClass usage with direct property access. This was achieved by making the relevant properties in AutoPublishServiceSection and PrepareSectionPublicationCandidates publicly accessible. This change improves test readability and maintainability while adhering to the Steward persona's mission of reducing test brittleness.

---
*PR created automatically by Jules for task [18161763167375559780](https://jules.google.com/task/18161763167375559780) started by @GarethClarridge*