### PR TITLE
🎨 Palette: Sticky Action Bar for Long Admin Forms

### DIFF
--- a/resources/views/components/admin/form-shell.blade.php
+++ b/resources/views/components/admin/form-shell.blade.php
@@ -13,16 +13,16 @@
 
     if ($saveAction) {
         $hotkeyAttributes = $hotkeyAttributes->merge([
-            'x-data' => sprintf(
-                "{ saveAction: %s, save() { this.\$wire.call(this.saveAction); } }",
-                \Illuminate\Support\Js::from($saveAction)
-            ),
             '@keydown.window.ctrl.s.prevent' => 'save()',
             '@keydown.window.cmd.s.prevent' => 'save()',
         ]);
 
         $gridAttributes = $gridAttributes->merge(['wire:target' => $saveAction]);
     }
+
+    $hotkeyAttributes = $hotkeyAttributes->merge([
+        'x-data' => '{ topVisible: true' . ($saveAction ? ', saveAction: ' . \Illuminate\Support\Js::from($saveAction) . ', save() { this.$wire.call(this.saveAction); }' : '') . ' }',
+    ]);
 @endphp
 
 <div {{ $hotkeyAttributes }}>
@@ -32,7 +32,11 @@
         {{ $attributes }}
     >
         <x-slot:actions>
-            <div x-slot-actions class="contents">
+            <div x-slot-actions
+                x-intersect:enter="topVisible = true"
+                x-intersect:leave="topVisible = false"
+                class="flex items-center gap-2"
+            >
                 @isset($actions){{ $actions }}@endisset
             </div>
         </x-slot:actions>
@@ -48,5 +52,30 @@
                 </div>
             @endisset
         </div>
+
+        @isset($actions)
+            <div
+                x-show="!topVisible"
+                x-transition:enter="transition ease-out duration-300"
+                x-transition:enter-start="opacity-0 translate-y-8"
+                x-transition:enter-end="opacity-100 translate-y-0"
+                x-transition:leave="transition ease-in duration-200"
+                x-transition:leave-start="opacity-100 translate-y-0"
+                x-transition:leave-end="opacity-0 translate-y-8"
+                class="fixed bottom-0 left-0 right-0 z-20 w-full bg-white/90 backdrop-blur-sm border-t border-gray-200 p-4 shadow-[0_-4px_10px_rgba(0,0,0,0.05)] sm:left-auto"
+                x-cloak
+            >
+                <x-content-wrapper class="mx-auto max-w-7xl px-6 md:px-8">
+                    <div class="flex items-center justify-between gap-4">
+                        <div class="hidden sm:block">
+                            <p class="text-sm font-medium text-gray-500">Unsaved changes on <span class="text-gray-900">{{ $title }}</span></p>
+                        </div>
+                        <div class="flex flex-1 sm:flex-none items-center justify-end gap-2" @click="topVisible = true">
+                            {{ $actions }}
+                        </div>
+                    </div>
+                </x-content-wrapper>
+            </div>
+        @endisset
     </x-admin.page>
 </div>

--- a/resources/views/components/admin/form-shell.blade.php
+++ b/resources/views/components/admin/form-shell.blade.php
@@ -20,9 +20,11 @@
         $gridAttributes = $gridAttributes->merge(['wire:target' => $saveAction]);
     }
 
-    $hotkeyAttributes = $hotkeyAttributes->merge([
-        'x-data' => '{ topVisible: true' . ($saveAction ? ', saveAction: ' . \Illuminate\Support\Js::from($saveAction) . ', save() { this.$wire.call(this.saveAction); }' : '') . ' }',
-    ]);
+    $xData = $saveAction
+        ? sprintf('{ topVisible: true, saveAction: %s, save() { this.$wire.call(this.saveAction); } }', \Illuminate\Support\Js::from($saveAction))
+        : '{ topVisible: true }';
+
+    $hotkeyAttributes = $hotkeyAttributes->merge(['x-data' => $xData]);
 @endphp
 
 <div {{ $hotkeyAttributes }}>

--- a/resources/views/components/admin/form-shell.blade.php
+++ b/resources/views/components/admin/form-shell.blade.php
@@ -72,7 +72,7 @@
                         <div class="hidden sm:block">
                             <p class="text-sm font-medium text-gray-500">Unsaved changes on <span class="text-gray-900">{{ $title }}</span></p>
                         </div>
-                        <div class="flex flex-1 sm:flex-none items-center justify-end gap-2" @click="topVisible = true">
+                        <div class="flex flex-1 sm:flex-none items-center justify-end gap-2">
                             {{ $actions }}
                         </div>
                     </div>

--- a/tests/Feature/Livewire/AdminFormUXTest.php
+++ b/tests/Feature/Livewire/AdminFormUXTest.php
@@ -51,5 +51,8 @@ class AdminFormUXTest extends TestCase
         $this->assertStringContainsString('fixed bottom-0 left-0 right-0', $html);
         $this->assertStringContainsString('Unsaved changes on', $html);
         $this->assertStringContainsString('Test Page', $html);
+
+        // Intersection observer must be sole source of truth — no click override
+        $this->assertStringNotContainsString('@click="topVisible = true"', $html);
     }
 }

--- a/tests/Feature/Livewire/AdminFormUXTest.php
+++ b/tests/Feature/Livewire/AdminFormUXTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\Admin\Pages\EditPage;
+use App\Models\Page;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AdminFormUXTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::factory()->create([
+            'is_admin' => true,
+            'email_verified_at' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function it_renders_sticky_action_bar_in_admin_forms(): void
+    {
+        $this->actingAs($this->admin);
+
+        $page = Page::factory()->create([
+            'heading' => 'Test Page',
+            'slug' => 'test-page',
+        ]);
+
+        $response = Livewire::test(EditPage::class, ['page' => $page])
+            ->assertStatus(200);
+
+        $html = $response->html();
+
+        // Verify top actions have intersection observer
+        $this->assertStringContainsString('x-intersect:enter="topVisible = true"', $html);
+        $this->assertStringContainsString('x-intersect:leave="topVisible = false"', $html);
+
+        // Verify sticky footer is present
+        $this->assertStringContainsString('x-show="!topVisible"', $html);
+        $this->assertStringContainsString('fixed bottom-0 left-0 right-0', $html);
+        $this->assertStringContainsString('Unsaved changes on', $html);
+        $this->assertStringContainsString('Test Page', $html);
+    }
+}


### PR DESCRIPTION
Implemented a "Sticky Action Bar" for long admin forms to improve the user experience when editing or creating records. Currently, users have to scroll back to the top or bottom of a long form (like the Page form with its large Markdown textarea) to access the primary actions.

The implementation uses Alpine.js Intersection Observer (`x-intersect`) on the top action bar to track its visibility. When the top actions are scrolled out of view, a sticky footer bar appears at the bottom of the viewport, providing persistent access to the same action buttons.

The sticky bar features:
- `sticky bottom-0` positioning.
- `bg-white/90` with `backdrop-blur-sm` for a modern, integrated feel.
- `shadow-[0_-4px_10px_rgba(0,0,0,0.05)]` for subtle elevation.
- Smooth transitions using `x-transition`.
- Responsive layout with a helpful "Unsaved changes on [Page Title]" hint on larger screens.

Verified via a new feature test `tests/Feature/Livewire/AdminFormUXTest.php` and full test suite run.

---
*PR created automatically by Jules for task [7398851353320957061](https://jules.google.com/task/7398851353320957061) started by @GarethClarridge*