### PR TITLE
📖 Editor: Polish authentication headings

### DIFF
--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.main')
 
 @section('content')
-<x-auth.shell heading="Forgot Password" description="Reset your password">
+<x-auth.shell heading="Forgot password" description="Reset your password">
     <livewire:auth.forgot-password />
 </x-auth.shell>
 @endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.main')
 
 @section('content')
-<x-auth.shell heading="Login" description="Log in to your account">
+<x-auth.shell heading="Log in" description="Log in to your account">
     <livewire:auth.login />
 </x-auth.shell>
 @endsection

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.main')
 
 @section('content')
-<x-auth.shell heading="Reset Password" description="Set a new password for your account">
+<x-auth.shell heading="Reset password" description="Set a new password for your account">
     <livewire:auth.reset-password :token="$token" />
 </x-auth.shell>
 @endsection

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.main')
 
 @section('content')
-<x-auth.shell heading="Verify Email" description="Verify your email address to continue">
+<x-auth.shell heading="Verify email" description="Verify your email address to continue">
     <livewire:auth.verify-email />
 </x-auth.shell>
 @endsection

--- a/tests/Feature/BladeShellRenderingTest.php
+++ b/tests/Feature/BladeShellRenderingTest.php
@@ -24,7 +24,7 @@ class BladeShellRenderingTest extends TestCase
         $response = $this->get('/login');
 
         $response->assertOk();
-        $response->assertSee('<title>Login | Crockenhill Baptist Church</title>', false);
+        $response->assertSee('<title>Log in | Crockenhill Baptist Church</title>', false);
     }
 
     #[Test]
@@ -42,7 +42,7 @@ class BladeShellRenderingTest extends TestCase
         $response = $this->get('/forgot-password');
 
         $response->assertOk();
-        $response->assertSee('<title>Forgot Password | Crockenhill Baptist Church</title>', false);
+        $response->assertSee('<title>Forgot password | Crockenhill Baptist Church</title>', false);
     }
 
     #[Test]


### PR DESCRIPTION
Standardised authentication headings to use sentence case and corrected "Login" to "Log in". Updated tests to match.

---
*PR created automatically by Jules for task [10894116727948342162](https://jules.google.com/task/10894116727948342162) started by @GarethClarridge*