### PR TITLE
🧪 Steward: Harden ReconcileServiceSections job verification

### DIFF
--- a/app/Jobs/ReconcileServiceSections.php
+++ b/app/Jobs/ReconcileServiceSections.php
@@ -25,8 +25,8 @@ class ReconcileServiceSections implements ShouldBeUnique, ShouldQueue
     public int $timeout = 600;
 
     public function __construct(
-        private MediaProcessingLog $processingLog,
-        private ChurchService $churchService,
+        public readonly MediaProcessingLog $processingLog,
+        public readonly ChurchService $churchService,
     ) {}
 
     public function handle(

--- a/tests/Integration/Services/ChurchServiceReconciliationDispatcherTest.php
+++ b/tests/Integration/Services/ChurchServiceReconciliationDispatcherTest.php
@@ -137,19 +137,9 @@ class ChurchServiceReconciliationDispatcherTest extends TestCase
         $this->assertSame(2, $count);
 
         Bus::assertDispatched(ReconcileServiceSections::class, function (ReconcileServiceSections $job) use ($matchedByColumns, $matchedSecond): bool {
-            $processingLog = $this->jobProperty($job, 'processingLog');
-
-            return $processingLog instanceof MediaProcessingLog
-                && in_array($processingLog->id, [$matchedByColumns->id, $matchedSecond->id], true);
+            return $job->processingLog instanceof MediaProcessingLog
+                && in_array($job->processingLog->id, [$matchedByColumns->id, $matchedSecond->id], true);
         });
         Bus::assertDispatched(ReconcileServiceSections::class, 2);
-    }
-
-    private function jobProperty(ReconcileServiceSections $job, string $property): mixed
-    {
-        $reflection = new \ReflectionProperty($job, $property);
-        $reflection->setAccessible(true);
-
-        return $reflection->getValue($job);
     }
 }


### PR DESCRIPTION
This change addresses test brittleness in `ChurchServiceReconciliationDispatcherTest` by removing the need for PHP reflection to verify dispatched job state.

By making the constructor properties of the `ReconcileServiceSections` job `public readonly`, we allow the test suite to inspect the job's payload directly and safely within `Bus::assertDispatched` callbacks. This is a more robust pattern that prevents tests from breaking on internal refactors that don't change the public-facing contract of the job.

I have verified the change by running the specific test file and the full parallel test suite, ensuring no regressions were introduced.

---
*PR created automatically by Jules for task [1773323552192321466](https://jules.google.com/task/1773323552192321466) started by @GarethClarridge*