### PR TITLE
🧹 Tidy: refactor DB facade usage and Enum comparison inconsistencies

### DIFF
--- a/app/Repositories/SermonRepository.php
+++ b/app/Repositories/SermonRepository.php
@@ -364,8 +364,8 @@ class SermonRepository
 
         return Sermon::query()
             ->where('date', $dateString)
-            ->where('service', $service->value)
-            ->where('content_type', $contentType->value)
+            ->where('service', $service)
+            ->where('content_type', $contentType)
             ->first();
     }
 

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -17,7 +17,6 @@ use App\Presenters\SermonSitemapPresenter;
 use App\Presenters\SermonViewPresenter;
 use App\Repositories\SermonRepository;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Spatie\Sitemap\Sitemap;
 use Spatie\Sitemap\Tags\Url;
@@ -165,9 +164,9 @@ class SitemapService
             return;
         }
 
-        $subquery = DB::table('sermons')
+        $subquery = Sermon::query()
             ->join('sermon_scripture_filters', 'sermons.id', '=', 'sermon_scripture_filters.sermon_id')
-            ->where('sermons.content_type', SermonContentType::Sermon->value)
+            ->whereSermon()
             ->select([
                 'sermons.id',
                 'sermons.title',
@@ -217,7 +216,7 @@ class SitemapService
     {
         $pages = Page::query()
             ->public()
-            ->where('area', '!=', PageArea::Members->value)
+            ->where('area', '!=', PageArea::Members)
             ->select(['id', 'slug', 'area', 'updated_at', 'description', 'heading'])
             /**
              * Performance Optimization: Only eager load 'media' (needed for images),
@@ -281,8 +280,8 @@ class SitemapService
             return;
         }
 
-        $subquery = DB::table('sermons')
-            ->where('content_type', SermonContentType::Sermon->value)
+        $subquery = Sermon::query()
+            ->whereSermon()
             ->whereNotNull('series')
             ->where('series', '!=', '')
             ->select([


### PR DESCRIPTION
### 💡 What: The code smell addressed
The codebase contained inconsistencies in how database queries were performed and how Enums were handled in `where` clauses. Specifically:
- `SitemapService` was using the `DB` facade for subqueries instead of the `Sermon` model.
- Multiple files were manually accessing Enum `->value` properties when passing them to Eloquent's `where` method, despite the attributes being cast to those Enums in the models.

### 🎯 Why: How this improves maintainability
- **Consistency:** Moving from `DB::table()` to `Model::query()` ensures that global scopes and project-wide query conventions are respected, and makes the code more idiomatic Laravel.
- **Readability:** Using the `whereSermon()` scope and passing Enum instances directly makes the intent of the code clearer and more concise.
- **Type Safety:** Leveraging Laravel's Enum casting in queries reduces the risk of errors from raw string comparisons and improves static analysis.

### 🔄 Behavior: Explicitly state "No functional changes"
No functional changes. The resulting SQL queries and application logic remain identical in outcome.

### ✅ Tests: All existing tests pass unchanged
- Ran `tests/Unit/Services/SitemapServiceTest.php` and `tests/Feature/SitemapTest.php` (All passed).
- Ran `tests/Feature/Repositories/SermonRepositoryTest.php` (All passed).
- Ran full test suite via `php artisan test --parallel --compact` (5317 tests, all passed).

---
*PR created automatically by Jules for task [7226397017528540131](https://jules.google.com/task/7226397017528540131) started by @GarethClarridge*