### PR TITLE
Fix tests broken by expanded LivestreamSegment validation rules

### DIFF
--- a/tests/Feature/Api/ConfirmSegmentApiTest.php
+++ b/tests/Feature/Api/ConfirmSegmentApiTest.php
@@ -158,11 +158,15 @@ class ConfirmSegmentApiTest extends TestCase
     #[Test]
     public function it_returns_422_for_an_unknown_processing_id(): void
     {
+        // Create a real segment so the Form Request's exists:livestream_segments,id passes,
+        // letting the controller's InvalidArgumentException path return {'success': false}.
+        $log = $this->makeLivestreamLogAwaitingReview();
+        $segment = LivestreamSegment::factory()->speech()->forProcessingLog($log->id)->create();
         $token = $this->tokenFor($this->admin);
 
         $this->withToken($token)
             ->postJson('/api/media/processing/00000000-0000-0000-0000-000000000000/confirm-segment', [
-                'segment_id' => 1,
+                'segment_id' => $segment->id,
             ])
             ->assertUnprocessable()
             ->assertJsonFragment(['success' => false]);

--- a/tests/Feature/DataIntegrity/DurationConstraintTest.php
+++ b/tests/Feature/DataIntegrity/DurationConstraintTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\DataIntegrity;
 
+use App\Enums\LivestreamSegmentClassification;
 use App\Models\LivestreamSegment;
 use App\Models\MediaProcessingLog;
 use App\Models\SongVideo;
@@ -184,11 +185,21 @@ class DurationConstraintTest extends TestCase
     #[Test]
     public function it_validates_livestream_segment_rules_at_application_level(): void
     {
+        $log = MediaProcessingLog::factory()->create();
         $rules = LivestreamSegment::validationRules();
 
-        $this->assertTrue(Validator::make(['start_time' => 0, 'end_time' => 10, 'duration' => 10], $rules)->passes());
-        $this->assertFalse(Validator::make(['start_time' => -1, 'end_time' => 10, 'duration' => 11], $rules)->passes());
-        $this->assertFalse(Validator::make(['start_time' => 10, 'end_time' => 5, 'duration' => 0], $rules)->passes());
-        $this->assertFalse(Validator::make(['start_time' => 0, 'end_time' => 10, 'duration' => -1], $rules)->passes());
+        $validPayload = [
+            'media_processing_log_id' => $log->id,
+            'segment_index' => 0,
+            'start_time' => 0,
+            'end_time' => 10,
+            'duration' => 10,
+            'classification' => LivestreamSegmentClassification::Speech->value,
+        ];
+
+        $this->assertTrue(Validator::make($validPayload, $rules)->passes());
+        $this->assertFalse(Validator::make(array_merge($validPayload, ['start_time' => -1, 'duration' => 11]), $rules)->passes());
+        $this->assertFalse(Validator::make(array_merge($validPayload, ['start_time' => 10, 'end_time' => 5, 'duration' => 0]), $rules)->passes());
+        $this->assertFalse(Validator::make(array_merge($validPayload, ['duration' => -1]), $rules)->passes());
     }
 }


### PR DESCRIPTION
`validationRules()` was expanded in #678 to require `media_processing_log_id`, `segment_index`, and `classification`. Two existing tests assumed only timing fields were required and broke:

- **`DurationConstraintTest`**: Supply a full valid payload (with a real log ID and classification) for the happy-path assertion; failure cases use `array_merge` to keep invalid values while providing all other required fields.
- **`ConfirmSegmentApiTest`**: Create a real segment so the Form Request's `exists:livestream_segments,id` rule passes, letting the controller's `InvalidArgumentException` path (returning `{success: false}`) be reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)