### PR TITLE
🔦 Lighthouse: Unique metadata for paginated listings

### DIFF
--- a/app/Http/Controllers/PublicSongListController.php
+++ b/app/Http/Controllers/PublicSongListController.php
@@ -22,13 +22,14 @@ class PublicSongListController extends Controller
 
         $search = is_array($request->query('q')) ? '' : (string) $request->query('q', '');
         $range = is_array($request->query('range')) ? PublicSongCatalogService::RANGE_RECENT : (string) $request->query('range', PublicSongCatalogService::RANGE_RECENT);
+        $page = $request->integer('page', 1);
 
         return view('church.songs.index', [
-            'heading' => $seoPresenter->title($search, $range),
+            'heading' => $seoPresenter->title($search, $range, $page),
             'area' => 'church',
             'slug' => 'songs',
-            'description' => $seoPresenter->description($search, $range),
-            'canonical_url' => $seoPresenter->canonical($search, $range, $request->integer('page', 1)),
+            'description' => $seoPresenter->description($search, $range, $page),
+            'canonical_url' => $seoPresenter->canonical($search, $range, $page),
             'links' => collect(),
         ]);
     }

--- a/app/Http/Controllers/SermonController.php
+++ b/app/Http/Controllers/SermonController.php
@@ -52,10 +52,12 @@ class SermonController extends Controller
             $request->query('series'),
         );
 
+        $page = $request->integer('page', 1);
+
         return view('sermons.index', [
-            'heading' => $this->seoPresenter->title($filters),
-            'description' => $this->seoPresenter->description($filters),
-            'canonical_url' => $this->seoPresenter->canonical($filters, $request->integer('page', 1)),
+            'heading' => $this->seoPresenter->title($filters, $page),
+            'description' => $this->seoPresenter->description($filters, $page),
+            'canonical_url' => $this->seoPresenter->canonical($filters, $page),
             'area' => 'christ',
             'links' => $this->sermonLinks('sermons'),
             'slug' => 'sermons',

--- a/app/Livewire/Sermons/BrowseSermons.php
+++ b/app/Livewire/Sermons/BrowseSermons.php
@@ -88,6 +88,11 @@ class BrowseSermons extends Component
         $this->dispatchMetadataUpdate();
     }
 
+    public function updatedPage(): void
+    {
+        $this->dispatchMetadataUpdate();
+    }
+
     public function clearFilters(): void
     {
         $this->reset([

--- a/app/Livewire/Sermons/BrowseSermons.php
+++ b/app/Livewire/Sermons/BrowseSermons.php
@@ -250,13 +250,13 @@ class BrowseSermons extends Component
     #[Computed]
     public function seoTitle(): string
     {
-        return app(SermonArchiveSeoPresenter::class)->title($this->activeFilters());
+        return app(SermonArchiveSeoPresenter::class)->title($this->activeFilters(), $this->getPage());
     }
 
     #[Computed]
     public function seoDescription(): string
     {
-        return app(SermonArchiveSeoPresenter::class)->description($this->activeFilters());
+        return app(SermonArchiveSeoPresenter::class)->description($this->activeFilters(), $this->getPage());
     }
 
     #[Computed]

--- a/app/Presenters/SermonArchiveSeoPresenter.php
+++ b/app/Presenters/SermonArchiveSeoPresenter.php
@@ -19,30 +19,36 @@ class SermonArchiveSeoPresenter
      *
      * @param  array{book: string|null, chapter: int|null, preacherId: int|null, series: string|null}  $filters
      */
-    public function title(array $filters): string
+    public function title(array $filters, int $page = 1): string
     {
-        if (! array_filter($filters)) {
-            return 'Sermons';
-        }
+        $base = 'Sermons';
 
-        $parts = [];
+        if (array_filter($filters)) {
+            $parts = [];
 
-        if ($filters['book']) {
-            $parts[] = $filters['chapter'] ? "{$filters['book']} {$filters['chapter']}" : $filters['book'];
-        }
-
-        if ($filters['preacherId']) {
-            $preacherName = $this->resolvePreacherName($filters['preacherId']);
-            if ($preacherName) {
-                $parts[] = $preacherName;
+            if ($filters['book']) {
+                $parts[] = $filters['chapter'] ? "{$filters['book']} {$filters['chapter']}" : $filters['book'];
             }
+
+            if ($filters['preacherId']) {
+                $preacherName = $this->resolvePreacherName($filters['preacherId']);
+                if ($preacherName) {
+                    $parts[] = $preacherName;
+                }
+            }
+
+            if ($filters['series']) {
+                $parts[] = $filters['series'];
+            }
+
+            $base = implode(' | ', $parts).' | Sermons';
         }
 
-        if ($filters['series']) {
-            $parts[] = $filters['series'];
+        if ($page > 1) {
+            return "{$base} (Page {$page})";
         }
 
-        return implode(' | ', $parts).' | Sermons';
+        return $base;
     }
 
     /**
@@ -50,31 +56,37 @@ class SermonArchiveSeoPresenter
      *
      * @param  array{book: string|null, chapter: int|null, preacherId: int|null, series: string|null}  $filters
      */
-    public function description(array $filters): string
+    public function description(array $filters, int $page = 1): string
     {
         if (! array_filter($filters)) {
-            return 'Explore the sermon archive at Crockenhill Baptist Church. Watch or listen to Bible teaching from our Sunday services, filtered by scripture, preacher, or series.';
-        }
+            $desc = 'Explore the sermon archive at Crockenhill Baptist Church. Watch or listen to Bible teaching from our Sunday services, filtered by scripture, preacher, or series.';
+        } else {
+            $parts = [];
 
-        $parts = [];
-
-        if ($filters['book']) {
-            $scripture = $filters['chapter'] ? "{$filters['book']} {$filters['chapter']}" : $filters['book'];
-            $parts[] = "on {$scripture}";
-        }
-
-        if ($filters['preacherId']) {
-            $preacherName = $this->resolvePreacherName($filters['preacherId']);
-            if ($preacherName) {
-                $parts[] = "by {$preacherName}";
+            if ($filters['book']) {
+                $scripture = $filters['chapter'] ? "{$filters['book']} {$filters['chapter']}" : $filters['book'];
+                $parts[] = "on {$scripture}";
             }
+
+            if ($filters['preacherId']) {
+                $preacherName = $this->resolvePreacherName($filters['preacherId']);
+                if ($preacherName) {
+                    $parts[] = "by {$preacherName}";
+                }
+            }
+
+            if ($filters['series']) {
+                $parts[] = "in the '{$filters['series']}' series";
+            }
+
+            $desc = 'Watch or listen to Bible-based sermons '.implode(' ', $parts).' from Crockenhill Baptist Church. Explore recent teaching from our morning and evening services.';
         }
 
-        if ($filters['series']) {
-            $parts[] = "in the '{$filters['series']}' series";
+        if ($page > 1) {
+            return "{$desc} - Page {$page}";
         }
 
-        return 'Watch or listen to Bible-based sermons '.implode(' ', $parts).' from Crockenhill Baptist Church. Explore recent teaching from our morning and evening services.';
+        return $desc;
     }
 
     /**

--- a/app/Presenters/SongArchiveSeoPresenter.php
+++ b/app/Presenters/SongArchiveSeoPresenter.php
@@ -10,26 +10,38 @@ class SongArchiveSeoPresenter
 {
     public function __construct(private readonly PublicSongCatalogService $catalog) {}
 
-    public function title(?string $search, string $range): string
+    public function title(?string $search, string $range, int $page = 1): string
     {
         if (filled($search)) {
-            return "{$search} | Songs";
+            $base = "{$search} | Songs";
+        } else {
+            $base = $this->catalog->normalizeRange($range) === PublicSongCatalogService::RANGE_RECENT
+                ? 'Recent Songs'
+                : 'All Songs';
         }
 
-        return $this->catalog->normalizeRange($range) === PublicSongCatalogService::RANGE_RECENT
-            ? 'Recent Songs'
-            : 'All Songs';
+        if ($page > 1) {
+            return "{$base} (Page {$page})";
+        }
+
+        return $base;
     }
 
-    public function description(?string $search, string $range): string
+    public function description(?string $search, string $range, int $page = 1): string
     {
         if (filled($search)) {
-            return "Browse songs matching '{$search}' at Crockenhill Baptist Church.";
+            $desc = "Browse songs matching '{$search}' at Crockenhill Baptist Church.";
+        } else {
+            $desc = $this->catalog->normalizeRange($range) === PublicSongCatalogService::RANGE_RECENT
+                ? 'Browse the songs most recently sung at Crockenhill Baptist Church.'
+                : 'Browse the full song catalogue of Crockenhill Baptist Church.';
         }
 
-        return $this->catalog->normalizeRange($range) === PublicSongCatalogService::RANGE_RECENT
-            ? 'Browse the songs most recently sung at Crockenhill Baptist Church.'
-            : 'Browse the full song catalogue of Crockenhill Baptist Church.';
+        if ($page > 1) {
+            return "{$desc} - Page {$page}";
+        }
+
+        return $desc;
     }
 
     public function canonical(?string $search, string $range, int $page = 1): string

--- a/resources/views/full-width-pages/christmas.blade.php
+++ b/resources/views/full-width-pages/christmas.blade.php
@@ -90,7 +90,7 @@
 @stop
 
 @section('content')
-<main id="main-content" tabindex="-1" class="-mb-10 bg-size-cover bg-center bg-[url('/public/images/homepage/christmas2023.webp')] bg-gray-700 bg-blend-multiply">
+<main id="main-content" tabindex="-1" class="-mb-10 bg-size-cover bg-center bg-[url('/images/homepage/christmas2023.webp')] bg-gray-700 bg-blend-multiply">
 
   <x-h1>
     <span class="text-white">Christmas at Crockenhill Baptist Church</span>

--- a/resources/views/full-width-pages/home.blade.php
+++ b/resources/views/full-width-pages/home.blade.php
@@ -111,7 +111,7 @@
       title=""
     /> -->
 
-  <!-- <section class="-mb-10 bg-size-cover bg-center bg-[url('/public/images/homepage/christmas2023.webp')] bg-gray-700 bg-blend-multiply">
+  <!-- <section class="-mb-10 bg-size-cover bg-center bg-[url('/images/homepage/christmas2023.webp')] bg-gray-700 bg-blend-multiply">
     <div class="my-10 px-4 mx-auto max-w-screen-xl text-center pt-24 pb-12">
       <h2 class="mb-20 text-4xl font-display leading-none text-white md:text-5xl lg:text-6xl">
         Christmas at Crockenhill Baptist Church

--- a/tests/Feature/Livewire/Sermons/BrowseSermonsTest.php
+++ b/tests/Feature/Livewire/Sermons/BrowseSermonsTest.php
@@ -75,6 +75,27 @@ class BrowseSermonsTest extends TestCase
     }
 
     #[Test]
+    public function pagination_change_dispatches_metadata_update_event(): void
+    {
+        Sermon::factory()->count(25)->create();
+
+        Livewire::test(BrowseSermons::class)
+            ->call('gotoPage', 2)
+            ->assertDispatched('sermon-filters-updated');
+    }
+
+    #[Test]
+    public function seo_title_includes_page_number_on_paginated_pages(): void
+    {
+        Sermon::factory()->count(25)->create();
+
+        $component = Livewire::test(BrowseSermons::class)
+            ->call('gotoPage', 2);
+
+        $this->assertStringContainsString('Page 2', $component->get('seoTitle'));
+    }
+
+    #[Test]
     public function book_filter_returns_matching_sermons(): void
     {
         $john = $this->createIndexedSermon([

--- a/tests/Integration/Presenters/SongArchiveSeoPresenterTest.php
+++ b/tests/Integration/Presenters/SongArchiveSeoPresenterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Presenters;
+
+use App\Presenters\SongArchiveSeoPresenter;
+use App\Services\PublicSongCatalogService;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SongArchiveSeoPresenterTest extends TestCase
+{
+    private SongArchiveSeoPresenter $presenter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->presenter = app(SongArchiveSeoPresenter::class);
+    }
+
+    #[Test]
+    public function title_returns_default_when_no_search(): void
+    {
+        $this->assertSame('Recent Songs', $this->presenter->title(null, PublicSongCatalogService::RANGE_RECENT));
+        $this->assertSame('All Songs', $this->presenter->title(null, PublicSongCatalogService::RANGE_ALL));
+    }
+
+    #[Test]
+    public function title_includes_search_term(): void
+    {
+        $this->assertSame('In Christ Alone | Songs', $this->presenter->title('In Christ Alone', PublicSongCatalogService::RANGE_ALL));
+    }
+
+    #[Test]
+    public function title_includes_page_number_when_greater_than_one(): void
+    {
+        $this->assertSame('Recent Songs (Page 2)', $this->presenter->title(null, PublicSongCatalogService::RANGE_RECENT, 2));
+        $this->assertSame('In Christ Alone | Songs (Page 3)', $this->presenter->title('In Christ Alone', PublicSongCatalogService::RANGE_ALL, 3));
+    }
+
+    #[Test]
+    public function description_includes_page_number_when_greater_than_one(): void
+    {
+        $this->assertStringEndsWith('- Page 2', $this->presenter->description(null, PublicSongCatalogService::RANGE_RECENT, 2));
+        $this->assertStringEndsWith('- Page 3', $this->presenter->description('Amazing Grace', PublicSongCatalogService::RANGE_ALL, 3));
+    }
+}

--- a/tests/Integration/SEO/PaginationSeoTest.php
+++ b/tests/Integration/SEO/PaginationSeoTest.php
@@ -5,16 +5,18 @@ declare(strict_types=1);
 namespace Tests\Integration\SEO;
 
 use App\Models\Sermon;
+use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class PaginationSeoTest extends TestCase
 {
     use DatabaseTransactions;
 
-    public function test_sermon_archive_page_2_has_correct_title(): void
+    #[Test]
+    public function sermon_archive_page_2_has_correct_title(): void
     {
-        // Create enough sermons to have 2 pages (24 per page)
         Sermon::factory()->count(30)->create();
 
         $response = $this->get('/christ/sermons?page=2');
@@ -24,9 +26,10 @@ class PaginationSeoTest extends TestCase
         $response->assertSee('<meta name="description" content="Explore the sermon archive at Crockenhill Baptist Church. Watch or listen to Bible teaching from our Sunday services, filtered by scripture, preacher, or series. - Page 2">', false);
     }
 
-    public function test_song_archive_page_2_has_correct_title(): void
+    #[Test]
+    public function song_archive_page_2_has_correct_title(): void
     {
-        $user = \App\Models\User::factory()->create(['email_verified_at' => now()]);
+        $user = User::factory()->create(['email_verified_at' => now()]);
         $response = $this->actingAs($user)->get('/church/songs?page=2');
 
         $response->assertStatus(200);

--- a/tests/Integration/SEO/PaginationSeoTest.php
+++ b/tests/Integration/SEO/PaginationSeoTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\SEO;
+
+use App\Models\Sermon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class PaginationSeoTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_sermon_archive_page_2_has_correct_title(): void
+    {
+        // Create enough sermons to have 2 pages (24 per page)
+        Sermon::factory()->count(30)->create();
+
+        $response = $this->get('/christ/sermons?page=2');
+
+        $response->assertStatus(200);
+        $response->assertSee('<title>Sermons (Page 2) | Crockenhill Baptist Church</title>', false);
+        $response->assertSee('<meta name="description" content="Explore the sermon archive at Crockenhill Baptist Church. Watch or listen to Bible teaching from our Sunday services, filtered by scripture, preacher, or series. - Page 2">', false);
+    }
+
+    public function test_song_archive_page_2_has_correct_title(): void
+    {
+        $user = \App\Models\User::factory()->create(['email_verified_at' => now()]);
+        $response = $this->actingAs($user)->get('/church/songs?page=2');
+
+        $response->assertStatus(200);
+        $response->assertSee('<title>Recent Songs (Page 2) | Crockenhill Baptist Church</title>', false);
+        $response->assertSee('<meta name="description" content="Browse the songs most recently sung at Crockenhill Baptist Church. - Page 2">', false);
+    }
+}


### PR DESCRIPTION
💡 **What:** This PR implements unique SEO metadata for all paginated listing pages (Sermons and Songs) and fixes several 404ing background image paths.

🎯 **Why:** Previously, all pages in a paginated list (e.g., page 1, 2, 3 of sermons) shared identical `<title>` and `<meta name="description">` tags. This creates "Duplicate Metadata" issues in search consoles. By appending "(Page X)" to titles and " - Page X" to descriptions, each page is now uniquely identified for search engines.

📊 **Impact:**
- **Sermon Archive**: All paginated pages now have unique titles and descriptions.
- **Song Catalogue**: All paginated pages now have unique titles and descriptions.
- **Christmas Landing Page**: Fixed a 404ing background image by correcting the asset path.
- **Homepage**: Fixed a commented-out section with an incorrect asset path.

🔍 **Verification:**
- **Integration Tests**: Added `tests/Integration/SEO/PaginationSeoTest.php` which verifies that `/christ/sermons?page=2` and `/church/songs?page=2` return the expected unique metadata.
- **Unit/Integration Presenter Tests**: Updated `SermonArchiveSeoPresenterTest` and created `SongArchiveSeoPresenterTest`.
- **Manual Verification**: Verified via `curl` on a local development server that pagination parameters correctly alter the rendered HTML `<title>` and `<meta>` tags.

---
*PR created automatically by Jules for task [10476225495505902494](https://jules.google.com/task/10476225495505902494) started by @GarethClarridge*