### PR TITLE
📖 Editor: Fix typos and Americanisms in static copy

### DIFF
--- a/resources/views/full-width-pages/christ.blade.php
+++ b/resources/views/full-width-pages/christ.blade.php
@@ -92,7 +92,7 @@
       Jesus Christ is by far the most influential person in history.
     </p>
     <p>
-      But how did a man born the son of a carpenter in a vilage
+      But how did a man born the son of a carpenter in a village
       smaller than Crockenhill, in a province on the edge of the
       Roman Empire end up shaping the course of history, the
       culture of nations, and the lives of up to 2 billion people?

--- a/resources/views/full-width-pages/church.blade.php
+++ b/resources/views/full-width-pages/church.blade.php
@@ -300,7 +300,7 @@ Church
 
     <x-clickable-card link="/media/documents/BehaviourPolicy.pdf" heading="Positive behaviour policy">
       Our positive behaviour policy guides how we make sure our
-      childrens' groups are safe and fun for all involved.
+      children's groups are safe and fun for all involved.
     </x-clickable-card>
 
     <x-clickable-card link="privacy-notice" heading="Privacy notice">

--- a/resources/views/livewire/admin/church-services/review-inbound-emails.blade.php
+++ b/resources/views/livewire/admin/church-services/review-inbound-emails.blade.php
@@ -112,7 +112,7 @@
                                     <summary class="list-none cursor-pointer px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 [&::-webkit-details-marker]:hidden">
                                         <span class="flex items-center justify-between gap-3">
                                             <span>Original email</span>
-                                            <span class="text-xs font-normal text-gray-500">Plain text, sanitized HTML, and parser data</span>
+                                            <span class="text-xs font-normal text-gray-500">Plain text, sanitised HTML, and parser data</span>
                                         </span>
                                     </summary>
 
@@ -139,7 +139,7 @@
                                                     </div>
                                                 @elseif($review['has_html_body'] ?? false)
                                                     <p class="rounded-md border border-dashed border-gray-300 bg-white px-3 py-3 text-xs text-gray-500">
-                                                        Stored HTML contained no safe renderable content after sanitization.
+                                                        Stored HTML contained no safe renderable content after sanitisation.
                                                     </p>
                                                 @else
                                                     <p class="rounded-md border border-dashed border-gray-300 bg-white px-3 py-3 text-xs text-gray-500">


### PR DESCRIPTION
This PR improves the application's user-facing copy by addressing typos and ensuring consistency with British English standards.

### Changes:
- **Typo Fix:** Corrected "vilage" to "village" in `resources/views/full-width-pages/christ.blade.php`.
- **Grammar/Consistency:** Fixed "childrens' groups" to use the correct possessive form "children's groups" in `resources/views/full-width-pages/church.blade.php`.
- **British English Conversion:** Updated "sanitized" and "sanitization" to "sanitised" and "sanitisation" in the admin inbound email review view (`resources/views/livewire/admin/church-services/review-inbound-emails.blade.php`).

All changes are strictly to static text in Blade templates. Existing tests were run and passed, and visual verification was performed via Playwright.

---
*PR created automatically by Jules for task [7216491724159976786](https://jules.google.com/task/7216491724159976786) started by @GarethClarridge*