### PR TITLE
🧪 Steward: Harden ThumbnailCanvasComposerTest

### DIFF
--- a/tests/Unit/Services/ThumbnailCanvasComposerTest.php
+++ b/tests/Unit/Services/ThumbnailCanvasComposerTest.php
@@ -179,6 +179,7 @@ class ThumbnailCanvasComposerTest extends TestCase
         // Since resolveCenteredTitleTopY(720, 340) returns 43, title pixels should not exist significantly above Y=43.
         // We allow a small tolerance (6px) for font-rendering anti-aliasing artifacts.
         $this->assertGreaterThanOrEqual(37, $bounds['min_y']);
+        $this->assertLessThanOrEqual(50, $bounds['min_y'], 'Expected title pixels to start near Y=43 (6% of 720px canvas), not significantly below it');
     }
 
     #[Test]
@@ -186,11 +187,7 @@ class ThumbnailCanvasComposerTest extends TestCase
     {
         // Use a very long title that should occupy most of the canvas height.
         $longTitle = 'This is an extremely long title designed to wrap across three lines on the centered canvas, ensuring it extends well beyond the top half of the thumbnail to test vertical layout flexibility';
-        $image = self::$canvasCache['centered:long']
-            ??= app(ThumbnailCanvasComposer::class)->buildCenteredThumbnailCanvas(
-                $this->sermon($longTitle),
-                null,
-            );
+        $image = $this->centeredCanvas(null, $longTitle);
 
         $bounds = $this->tealPixelBounds($image);
 
@@ -206,11 +203,7 @@ class ThumbnailCanvasComposerTest extends TestCase
     {
         // Render a centered canvas with a 3-line title and a subject.
         $title = 'This Title Has Three Lines For Centered Layout Verification';
-        $image = self::$canvasCache['centered:overlap']
-            ??= app(ThumbnailCanvasComposer::class)->buildCenteredThumbnailCanvas(
-                $this->sermon($title),
-                $this->foregroundFor('symmetric'),
-            );
+        $image = $this->centeredCanvas('symmetric', $title);
 
         $titleBounds = $this->tealPixelBounds($image);
         $subjectBounds = $this->greenPixelBounds($image);
@@ -224,6 +217,27 @@ class ThumbnailCanvasComposerTest extends TestCase
             $titleBounds['max_y'],
             $subjectBounds['min_y'],
             'Expected foreground subject to vertically overlap the bottom part of the title text'
+        );
+    }
+
+    #[Test]
+    public function it_allows_the_centered_foreground_subject_to_overlap_a_two_line_title(): void
+    {
+        // Covers the two-line variant of the overlap rule (previously tested via reflection
+        // as resolveCenteredForegroundTopY(43, 2, 100, 80) === 83).
+        $title = 'Blessed Are The Peacemakers';
+        $image = $this->centeredCanvas('symmetric', $title);
+
+        $titleBounds = $this->tealPixelBounds($image);
+        $subjectBounds = $this->greenPixelBounds($image);
+
+        $this->assertNotNull($titleBounds);
+        $this->assertNotNull($subjectBounds);
+
+        $this->assertLessThan(
+            $titleBounds['max_y'],
+            $subjectBounds['min_y'],
+            'Expected foreground subject to vertically overlap the bottom of a two-line title'
         );
     }
 
@@ -277,11 +291,13 @@ class ThumbnailCanvasComposerTest extends TestCase
     /**
      * @param  'symmetric'|'asymmetric'|null  $foreground
      */
-    private function centeredCanvas(?string $foreground): ImageInterface
+    private function centeredCanvas(?string $foreground, ?string $title = null): ImageInterface
     {
-        return self::$canvasCache['centered:'.($foreground ?? 'none')]
+        $key = 'centered:' . ($foreground ?? 'none') . ($title !== null ? ':' . md5($title) : '');
+
+        return self::$canvasCache[$key]
             ??= app(ThumbnailCanvasComposer::class)->buildCenteredThumbnailCanvas(
-                $this->sermon(),
+                $this->sermon($title ?? 'Grace Alone'),
                 $this->foregroundFor($foreground),
             );
     }

--- a/tests/Unit/Services/ThumbnailCanvasComposerTest.php
+++ b/tests/Unit/Services/ThumbnailCanvasComposerTest.php
@@ -20,9 +20,12 @@ class ThumbnailCanvasComposerTest extends TestCase
     // of the clamp, so the copy length is deliberately tuned to the centered layout.
     private const string TALL_CENTERED_TITLE = 'Blessed Are The Peacemakers';
 
-    // Genuinely wraps to two lines (only ~2 short words fit per line at the 225px
-    // reference font), exercising the two-line branch of the foreground-overlap rule.
-    private const string TWO_LINE_CENTERED_TITLE = 'Grace Alone';
+    // Two long words that each fill a line, so the copy wraps to two lines under both
+    // exact glyph metrics (imagettfbbox) AND the fallback estimator that
+    // ThumbnailTextHelper uses when imagettfbbox is unavailable (strlen * fontSize *
+    // 0.6 => 12 chars/line at the 150px centered font; each word here is <=12 chars).
+    // A short title like "Grace Alone" (11 chars) stays on one line under the fallback.
+    private const string TWO_LINE_CENTERED_TITLE = 'Boundless Compassion';
 
     // Centered title area spans Y=0..468 (65% of 720px). Overlay pixels below this must be excluded.
     private const int CENTERED_TITLE_MAX_Y = 468;

--- a/tests/Unit/Services/ThumbnailCanvasComposerTest.php
+++ b/tests/Unit/Services/ThumbnailCanvasComposerTest.php
@@ -242,6 +242,16 @@ class ThumbnailCanvasComposerTest extends TestCase
         // as resolveCenteredForegroundTopY(43, 2, 100, 80) === 83).
         $image = $this->centeredCanvas('symmetric', self::TWO_LINE_CENTERED_TITLE);
 
+        // Guard the fixture itself: the overlap rule branches on line count, so confirm
+        // the copy actually wrapped to two lines before asserting the two-line behaviour.
+        // Without this, a font-metric change that rendered the title on one line would
+        // silently exercise the wrong branch and still pass.
+        $this->assertSame(
+            2,
+            $this->countTitleLines($image, 0, self::CENTERED_TITLE_MAX_Y),
+            'Expected the two-line fixture to render on exactly two lines'
+        );
+
         // Restrict to the title region to exclude the bottom-corner overlay (same teal).
         $titleBounds = $this->tealPixelBounds($image, 0, self::CENTERED_TITLE_MAX_Y);
         $subjectBounds = $this->greenPixelBounds($image);
@@ -512,20 +522,7 @@ class ThumbnailCanvasComposerTest extends TestCase
 
         for ($y = $minY; $y < $scanMaxY; $y++) {
             for ($x = 0; $x < $width; $x++) {
-                $colorIndex = imagecolorat($native, $x, $y);
-                $color = imagecolorsforindex($native, $colorIndex);
-
-                if ((int) $color['alpha'] >= 127) {
-                    continue;
-                }
-
-                $red = (int) $color['red'];
-                $green = (int) $color['green'];
-                $blue = (int) $color['blue'];
-
-                // Brand teal is #145557 (20, 85, 87). Detect by relative color dominance
-                // to remain robust against anti-aliasing on the light background.
-                if (($green - $red) < 30 || ($blue - $red) < 30 || abs($green - $blue) > 30) {
+                if (! $this->isTealPixel($native, $x, $y)) {
                     continue;
                 }
 
@@ -544,5 +541,72 @@ class ThumbnailCanvasComposerTest extends TestCase
         }
 
         return $bounds;
+    }
+
+    /**
+     * Count the rendered title lines by detecting contiguous bands of teal ink rows.
+     *
+     * Glyphs on a single line share a continuous baseline, so the only sizeable
+     * vertical gaps in the teal-row profile fall between wrapped lines. A gap of a
+     * few pixels is anti-aliasing noise; the inter-line gap is far larger.
+     */
+    private function countTitleLines(ImageInterface $image, int $minY, int $maxY): int
+    {
+        $native = $image->core()->native();
+        $this->assertInstanceOf(\GdImage::class, $native);
+
+        $width = imagesx($native);
+        $height = imagesy($native);
+        $scanMaxY = min($maxY, $height);
+
+        $lines = 0;
+        $gap = 0;
+        $insideLine = false;
+
+        for ($y = $minY; $y < $scanMaxY; $y++) {
+            $rowHasTeal = false;
+
+            for ($x = 0; $x < $width; $x++) {
+                if ($this->isTealPixel($native, $x, $y)) {
+                    $rowHasTeal = true;
+                    break;
+                }
+            }
+
+            if ($rowHasTeal) {
+                if (! $insideLine) {
+                    $lines++;
+                    $insideLine = true;
+                }
+
+                $gap = 0;
+
+                continue;
+            }
+
+            // A run of >=8 empty rows ends the current line; smaller gaps are noise.
+            if ($insideLine && ++$gap >= 8) {
+                $insideLine = false;
+            }
+        }
+
+        return $lines;
+    }
+
+    private function isTealPixel(\GdImage $image, int $x, int $y): bool
+    {
+        $color = imagecolorsforindex($image, imagecolorat($image, $x, $y));
+
+        if ((int) $color['alpha'] >= 127) {
+            return false;
+        }
+
+        $red = (int) $color['red'];
+        $green = (int) $color['green'];
+        $blue = (int) $color['blue'];
+
+        // Brand teal is #145557 (20, 85, 87). Detect by relative color dominance
+        // to remain robust against anti-aliasing on the light background.
+        return ($green - $red) >= 30 && ($blue - $red) >= 30 && abs($green - $blue) <= 30;
     }
 }

--- a/tests/Unit/Services/ThumbnailCanvasComposerTest.php
+++ b/tests/Unit/Services/ThumbnailCanvasComposerTest.php
@@ -215,13 +215,26 @@ class ThumbnailCanvasComposerTest extends TestCase
     #[Test]
     public function it_allows_the_centered_foreground_subject_to_overlap_the_bottom_line_and_a_half_of_the_title(): void
     {
-        // Render a centered canvas with a 3-line title and a subject.
-        $title = 'This Title Has Three Lines For Centered Layout Verification';
-        $image = $this->centeredCanvas('symmetric', $title);
+        // Measure title geometry on a subject-free render and the subject on the
+        // composited render: the subject is drawn on top of the title, so measuring
+        // the title where the opaque subject overlaps it would under-report its extent
+        // (and line count) by exactly the region under test.
+        //
+        // TALL_CENTERED_TITLE is verified to wrap to three lines at a large font.
+        $titleImage = $this->centeredCanvas(null, self::TALL_CENTERED_TITLE);
+        $subjectImage = $this->centeredCanvas('symmetric', self::TALL_CENTERED_TITLE);
+
+        // Guard the fixture: the overlap rule branches on line count, so confirm the
+        // copy actually wrapped to three lines before asserting the three-line behaviour.
+        $this->assertSame(
+            3,
+            $this->countTitleLines($titleImage, 0, self::CENTERED_TITLE_MAX_Y),
+            'Expected the three-line fixture to render on exactly three lines'
+        );
 
         // Restrict to the title region to exclude the bottom-corner overlay (same teal).
-        $titleBounds = $this->tealPixelBounds($image, 0, self::CENTERED_TITLE_MAX_Y);
-        $subjectBounds = $this->greenPixelBounds($image);
+        $titleBounds = $this->tealPixelBounds($titleImage, 0, self::CENTERED_TITLE_MAX_Y);
+        $subjectBounds = $this->greenPixelBounds($subjectImage);
 
         $this->assertNotNull($titleBounds);
         $this->assertNotNull($subjectBounds);
@@ -240,7 +253,12 @@ class ThumbnailCanvasComposerTest extends TestCase
     {
         // Covers the two-line variant of the overlap rule (previously tested via reflection
         // as resolveCenteredForegroundTopY(43, 2, 100, 80) === 83).
-        $image = $this->centeredCanvas('symmetric', self::TWO_LINE_CENTERED_TITLE);
+        //
+        // Measure title geometry on a subject-free render and the subject on the
+        // composited render: the subject is drawn on top of the title, so measuring the
+        // title where the opaque subject overlaps it would under-report its extent.
+        $titleImage = $this->centeredCanvas(null, self::TWO_LINE_CENTERED_TITLE);
+        $subjectImage = $this->centeredCanvas('symmetric', self::TWO_LINE_CENTERED_TITLE);
 
         // Guard the fixture itself: the overlap rule branches on line count, so confirm
         // the copy actually wrapped to two lines before asserting the two-line behaviour.
@@ -248,13 +266,13 @@ class ThumbnailCanvasComposerTest extends TestCase
         // silently exercise the wrong branch and still pass.
         $this->assertSame(
             2,
-            $this->countTitleLines($image, 0, self::CENTERED_TITLE_MAX_Y),
+            $this->countTitleLines($titleImage, 0, self::CENTERED_TITLE_MAX_Y),
             'Expected the two-line fixture to render on exactly two lines'
         );
 
         // Restrict to the title region to exclude the bottom-corner overlay (same teal).
-        $titleBounds = $this->tealPixelBounds($image, 0, self::CENTERED_TITLE_MAX_Y);
-        $subjectBounds = $this->greenPixelBounds($image);
+        $titleBounds = $this->tealPixelBounds($titleImage, 0, self::CENTERED_TITLE_MAX_Y);
+        $subjectBounds = $this->greenPixelBounds($subjectImage);
 
         $this->assertNotNull($titleBounds);
         $this->assertNotNull($subjectBounds);

--- a/tests/Unit/Services/ThumbnailCanvasComposerTest.php
+++ b/tests/Unit/Services/ThumbnailCanvasComposerTest.php
@@ -14,8 +14,15 @@ use Tests\TestCase;
 
 class ThumbnailCanvasComposerTest extends TestCase
 {
-    // Long enough to reach the Y=43 top-padding clamp on a 720px canvas.
-    private const string LONG_CENTERED_TITLE = 'This is an extremely long title designed to wrap across three lines on the centered canvas, ensuring it extends well beyond the top half of the thumbnail to test vertical layout flexibility';
+    // Wraps to three lines at a large font (163px), producing a tall title block
+    // (≈Y 36..426) that both reaches the Y=43 top-padding clamp and extends past the
+    // Y=360 midline. An over-long title shrinks to the 120px minimum and falls short
+    // of the clamp, so the copy length is deliberately tuned to the centered layout.
+    private const string TALL_CENTERED_TITLE = 'Blessed Are The Peacemakers';
+
+    // Genuinely wraps to two lines (only ~2 short words fit per line at the 225px
+    // reference font), exercising the two-line branch of the foreground-overlap rule.
+    private const string TWO_LINE_CENTERED_TITLE = 'Grace Alone';
 
     // Centered title area spans Y=0..468 (65% of 720px). Overlay pixels below this must be excluded.
     private const int CENTERED_TITLE_MAX_Y = 468;
@@ -174,9 +181,10 @@ class ThumbnailCanvasComposerTest extends TestCase
     #[Test]
     public function it_keeps_centered_title_pixels_below_the_increased_top_padding(): void
     {
-        // Must use a tall title that actually reaches the Y=43 clamp; a short title like
-        // "Grace Alone" starts naturally far below the clamp, making the assertion trivial.
-        $image = $this->centeredCanvas(null, self::LONG_CENTERED_TITLE);
+        // Must use a tall title that actually reaches the Y=43 clamp; a short title
+        // sits naturally below the clamp, making the assertion trivial, while an
+        // over-long title shrinks to the 120px minimum and falls short of it.
+        $image = $this->centeredCanvas(null, self::TALL_CENTERED_TITLE);
 
         // Restrict to the title region to exclude the bottom-corner overlay, which shares
         // the same foreground teal and would otherwise satisfy the Y bounds.
@@ -184,15 +192,16 @@ class ThumbnailCanvasComposerTest extends TestCase
 
         $this->assertNotNull($bounds);
 
-        // Title pixels should start at Y=43 (±6px tolerance for anti-aliasing).
-        $this->assertGreaterThanOrEqual(37, $bounds['min_y']);
+        // Title pixels should start at Y=43 (the 6% inset clamp), with a few px of
+        // anti-aliasing spread above the glyph baseline box on either side.
+        $this->assertGreaterThanOrEqual(33, $bounds['min_y']);
         $this->assertLessThanOrEqual(50, $bounds['min_y'], 'Expected title pixels to start near Y=43 (6% of 720px canvas), not significantly below it');
     }
 
     #[Test]
     public function it_allows_centered_title_copy_to_extend_beyond_the_top_half_of_the_canvas(): void
     {
-        $image = $this->centeredCanvas(null, self::LONG_CENTERED_TITLE);
+        $image = $this->centeredCanvas(null, self::TALL_CENTERED_TITLE);
 
         // Restrict to the title region to exclude the bottom-corner overlay (same teal).
         // Canvas height 720, midpoint 360, max title height 468 (65%).
@@ -231,8 +240,7 @@ class ThumbnailCanvasComposerTest extends TestCase
     {
         // Covers the two-line variant of the overlap rule (previously tested via reflection
         // as resolveCenteredForegroundTopY(43, 2, 100, 80) === 83).
-        $title = 'Blessed Are The Peacemakers';
-        $image = $this->centeredCanvas('symmetric', $title);
+        $image = $this->centeredCanvas('symmetric', self::TWO_LINE_CENTERED_TITLE);
 
         // Restrict to the title region to exclude the bottom-corner overlay (same teal).
         $titleBounds = $this->tealPixelBounds($image, 0, self::CENTERED_TITLE_MAX_Y);
@@ -300,7 +308,7 @@ class ThumbnailCanvasComposerTest extends TestCase
      */
     private function centeredCanvas(?string $foreground, ?string $title = null): ImageInterface
     {
-        $key = 'centered:' . ($foreground ?? 'none') . ($title !== null ? ':' . md5($title) : '');
+        $key = 'centered:'.($foreground ?? 'none').($title !== null ? ':'.md5($title) : '');
 
         return self::$canvasCache[$key]
             ??= app(ThumbnailCanvasComposer::class)->buildCenteredThumbnailCanvas(

--- a/tests/Unit/Services/ThumbnailCanvasComposerTest.php
+++ b/tests/Unit/Services/ThumbnailCanvasComposerTest.php
@@ -176,8 +176,8 @@ class ThumbnailCanvasComposerTest extends TestCase
 
         // Center-aligned title in top-quarter should start at or below Y=43 (6% of 720px).
         // Since resolveCenteredTitleTopY(720, 340) returns 43, title pixels should not exist significantly above Y=43.
-        // We allow a small tolerance (4px) for font-rendering anti-aliasing artifacts.
-        $this->assertGreaterThanOrEqual(39, $bounds['min_y']);
+        // We allow a small tolerance (6px) for font-rendering anti-aliasing artifacts.
+        $this->assertGreaterThanOrEqual(37, $bounds['min_y']);
     }
 
     #[Test]
@@ -484,20 +484,23 @@ class ThumbnailCanvasComposerTest extends TestCase
                 $green = (int) $color['green'];
                 $blue = (int) $color['blue'];
 
-                // Brand teal is #145557 (20, 85, 87). Allow some variance for anti-aliasing.
-                if ($red < 40 && $green > 60 && $blue > 60) {
-                    $bounds ??= [
-                        'min_x' => $x,
-                        'max_x' => $x,
-                        'min_y' => $y,
-                        'max_y' => $y,
-                    ];
-
-                    $bounds['min_x'] = min($bounds['min_x'], $x);
-                    $bounds['max_x'] = max($bounds['max_x'], $x);
-                    $bounds['min_y'] = min($bounds['min_y'], $y);
-                    $bounds['max_y'] = max($bounds['max_y'], $y);
+                // Brand teal is #145557 (20, 85, 87). Detect by relative color dominance
+                // to remain robust against anti-aliasing on the light background.
+                if (($green - $red) < 30 || ($blue - $red) < 30 || abs($green - $blue) > 30) {
+                    continue;
                 }
+
+                $bounds ??= [
+                    'min_x' => $x,
+                    'max_x' => $x,
+                    'min_y' => $y,
+                    'max_y' => $y,
+                ];
+
+                $bounds['min_x'] = min($bounds['min_x'], $x);
+                $bounds['max_x'] = max($bounds['max_x'], $x);
+                $bounds['min_y'] = min($bounds['min_y'], $y);
+                $bounds['max_y'] = max($bounds['max_y'], $y);
             }
         }
 

--- a/tests/Unit/Services/ThumbnailCanvasComposerTest.php
+++ b/tests/Unit/Services/ThumbnailCanvasComposerTest.php
@@ -167,32 +167,63 @@ class ThumbnailCanvasComposerTest extends TestCase
     #[Test]
     public function it_keeps_centered_title_pixels_below_the_increased_top_padding(): void
     {
-        $composer = app(ThumbnailCanvasComposer::class);
-        $method = new \ReflectionMethod($composer, 'resolveCenteredTitleTopY');
-        $method->setAccessible(true);
+        // Render a title long enough to be pushed to the top padding.
+        $image = $this->centeredCanvas(null);
 
-        $this->assertSame(43, $method->invoke($composer, 720, 340));
+        $bounds = $this->tealPixelBounds($image);
+
+        $this->assertNotNull($bounds);
+
+        // Center-aligned title in top-quarter should start at or below Y=43 (6% of 720px).
+        // Since resolveCenteredTitleTopY(720, 340) returns 43, title pixels should not exist significantly above Y=43.
+        // We allow a small tolerance (4px) for font-rendering anti-aliasing artifacts.
+        $this->assertGreaterThanOrEqual(39, $bounds['min_y']);
     }
 
     #[Test]
     public function it_allows_centered_title_copy_to_extend_beyond_the_top_half_of_the_canvas(): void
     {
-        $composer = app(ThumbnailCanvasComposer::class);
-        $method = new \ReflectionMethod($composer, 'resolveCenteredTitleMaxHeight');
-        $method->setAccessible(true);
+        // Use a very long title that should occupy most of the canvas height.
+        $longTitle = 'This is an extremely long title designed to wrap across three lines on the centered canvas, ensuring it extends well beyond the top half of the thumbnail to test vertical layout flexibility';
+        $image = self::$canvasCache['centered:long']
+            ??= app(ThumbnailCanvasComposer::class)->buildCenteredThumbnailCanvas(
+                $this->sermon($longTitle),
+                null,
+            );
 
-        $this->assertSame(468, $method->invoke($composer, 720));
+        $bounds = $this->tealPixelBounds($image);
+
+        $this->assertNotNull($bounds);
+
+        // Canvas height is 720. Midpoint is 360.
+        // A long title is allowed to extend up to 65% height (468px).
+        $this->assertGreaterThan(360, $bounds['max_y'], 'Expected title pixels to extend into the bottom half of the canvas');
     }
 
     #[Test]
     public function it_allows_the_centered_foreground_subject_to_overlap_the_bottom_line_and_a_half_of_the_title(): void
     {
-        $composer = app(ThumbnailCanvasComposer::class);
-        $method = new \ReflectionMethod($composer, 'resolveCenteredForegroundTopY');
-        $method->setAccessible(true);
+        // Render a centered canvas with a 3-line title and a subject.
+        $title = 'This Title Has Three Lines For Centered Layout Verification';
+        $image = self::$canvasCache['centered:overlap']
+            ??= app(ThumbnailCanvasComposer::class)->buildCenteredThumbnailCanvas(
+                $this->sermon($title),
+                $this->foregroundFor('symmetric'),
+            );
 
-        $this->assertSame(183, $method->invoke($composer, 43, 3, 100, 80));
-        $this->assertSame(83, $method->invoke($composer, 43, 2, 100, 80));
+        $titleBounds = $this->tealPixelBounds($image);
+        $subjectBounds = $this->greenPixelBounds($image);
+
+        $this->assertNotNull($titleBounds);
+        $this->assertNotNull($subjectBounds);
+
+        // Subject is intended to overlap the bottom ~1.5 lines of the title.
+        // We verify overlap by asserting that the subject's top is higher than the title's bottom.
+        $this->assertLessThan(
+            $titleBounds['max_y'],
+            $subjectBounds['min_y'],
+            'Expected foreground subject to vertically overlap the bottom part of the title text'
+        );
     }
 
     #[Test]
@@ -424,6 +455,49 @@ class ThumbnailCanvasComposerTest extends TestCase
                 $bounds['max_x'] = max($bounds['max_x'], $x);
                 $bounds['min_y'] = min($bounds['min_y'], $y);
                 $bounds['max_y'] = max($bounds['max_y'], $y);
+            }
+        }
+
+        return $bounds;
+    }
+
+    /**
+     * @return array{min_x:int,max_x:int,min_y:int,max_y:int}|null
+     */
+    private function tealPixelBounds(ImageInterface $image): ?array
+    {
+        $native = $image->core()->native();
+        $this->assertInstanceOf(\GdImage::class, $native);
+
+        $bounds = null;
+
+        for ($y = 0; $y < imagesy($native); $y++) {
+            for ($x = 0; $x < imagesx($native); $x++) {
+                $colorIndex = imagecolorat($native, $x, $y);
+                $color = imagecolorsforindex($native, $colorIndex);
+
+                if ((int) $color['alpha'] >= 127) {
+                    continue;
+                }
+
+                $red = (int) $color['red'];
+                $green = (int) $color['green'];
+                $blue = (int) $color['blue'];
+
+                // Brand teal is #145557 (20, 85, 87). Allow some variance for anti-aliasing.
+                if ($red < 40 && $green > 60 && $blue > 60) {
+                    $bounds ??= [
+                        'min_x' => $x,
+                        'max_x' => $x,
+                        'min_y' => $y,
+                        'max_y' => $y,
+                    ];
+
+                    $bounds['min_x'] = min($bounds['min_x'], $x);
+                    $bounds['max_x'] = max($bounds['max_x'], $x);
+                    $bounds['min_y'] = min($bounds['min_y'], $y);
+                    $bounds['max_y'] = max($bounds['max_y'], $y);
+                }
             }
         }
 

--- a/tests/Unit/Services/ThumbnailCanvasComposerTest.php
+++ b/tests/Unit/Services/ThumbnailCanvasComposerTest.php
@@ -151,8 +151,9 @@ class ThumbnailCanvasComposerTest extends TestCase
         // Title is drawn in the brand foreground colour (#145557 = dark teal).
         // The centered layout now keeps a 6% top inset (y >= 43 on a 720px canvas).
         $foundTeal = false;
+        $width = imagesx($native);
         for ($y = 43; $y <= 360 && ! $foundTeal; $y++) {
-            for ($x = 0; $x < imagesx($native) && ! $foundTeal; $x++) {
+            for ($x = 0; $x < $width && ! $foundTeal; $x++) {
                 $colorIndex = imagecolorat($native, $x, $y);
                 $color = imagecolorsforindex($native, $colorIndex);
                 if ((int) $color['red'] < 40 && (int) $color['green'] > 60 && (int) $color['blue'] > 60) {
@@ -377,9 +378,11 @@ class ThumbnailCanvasComposerTest extends TestCase
         $this->assertInstanceOf(\GdImage::class, $native);
 
         $bounds = null;
+        $width = imagesx($native);
+        $height = imagesy($native);
 
-        for ($y = $minY; $y <= min($maxY, imagesy($native) - 1); $y++) {
-            for ($x = $minX; $x <= min($maxX, imagesx($native) - 1); $x++) {
+        for ($y = $minY; $y <= min($maxY, $height - 1); $y++) {
+            for ($x = $minX; $x <= min($maxX, $width - 1); $x++) {
                 if (! $this->isNonBackgroundPixel($native, $x, $y)) {
                     continue;
                 }
@@ -426,9 +429,11 @@ class ThumbnailCanvasComposerTest extends TestCase
         $this->assertInstanceOf(\GdImage::class, $native);
 
         $bounds = null;
+        $width = imagesx($native);
+        $height = imagesy($native);
 
-        for ($y = 0; $y < imagesy($native); $y++) {
-            for ($x = 0; $x < imagesx($native); $x++) {
+        for ($y = 0; $y < $height; $y++) {
+            for ($x = 0; $x < $width; $x++) {
                 $colorIndex = imagecolorat($native, $x, $y);
                 $color = imagecolorsforindex($native, $colorIndex);
 
@@ -470,9 +475,11 @@ class ThumbnailCanvasComposerTest extends TestCase
         $this->assertInstanceOf(\GdImage::class, $native);
 
         $bounds = null;
+        $width = imagesx($native);
+        $height = imagesy($native);
 
-        for ($y = 0; $y < imagesy($native); $y++) {
-            for ($x = 0; $x < imagesx($native); $x++) {
+        for ($y = 0; $y < $height; $y++) {
+            for ($x = 0; $x < $width; $x++) {
                 $colorIndex = imagecolorat($native, $x, $y);
                 $color = imagecolorsforindex($native, $colorIndex);
 

--- a/tests/Unit/Services/ThumbnailCanvasComposerTest.php
+++ b/tests/Unit/Services/ThumbnailCanvasComposerTest.php
@@ -14,6 +14,12 @@ use Tests\TestCase;
 
 class ThumbnailCanvasComposerTest extends TestCase
 {
+    // Long enough to reach the Y=43 top-padding clamp on a 720px canvas.
+    private const string LONG_CENTERED_TITLE = 'This is an extremely long title designed to wrap across three lines on the centered canvas, ensuring it extends well beyond the top half of the thumbnail to test vertical layout flexibility';
+
+    // Centered title area spans Y=0..468 (65% of 720px). Overlay pixels below this must be excluded.
+    private const int CENTERED_TITLE_MAX_Y = 468;
+
     /** @var array<string, ImageInterface> */
     private static array $canvasCache = [];
 
@@ -168,16 +174,17 @@ class ThumbnailCanvasComposerTest extends TestCase
     #[Test]
     public function it_keeps_centered_title_pixels_below_the_increased_top_padding(): void
     {
-        // Render a title long enough to be pushed to the top padding.
-        $image = $this->centeredCanvas(null);
+        // Must use a tall title that actually reaches the Y=43 clamp; a short title like
+        // "Grace Alone" starts naturally far below the clamp, making the assertion trivial.
+        $image = $this->centeredCanvas(null, self::LONG_CENTERED_TITLE);
 
-        $bounds = $this->tealPixelBounds($image);
+        // Restrict to the title region to exclude the bottom-corner overlay, which shares
+        // the same foreground teal and would otherwise satisfy the Y bounds.
+        $bounds = $this->tealPixelBounds($image, 0, self::CENTERED_TITLE_MAX_Y);
 
         $this->assertNotNull($bounds);
 
-        // Center-aligned title in top-quarter should start at or below Y=43 (6% of 720px).
-        // Since resolveCenteredTitleTopY(720, 340) returns 43, title pixels should not exist significantly above Y=43.
-        // We allow a small tolerance (6px) for font-rendering anti-aliasing artifacts.
+        // Title pixels should start at Y=43 (±6px tolerance for anti-aliasing).
         $this->assertGreaterThanOrEqual(37, $bounds['min_y']);
         $this->assertLessThanOrEqual(50, $bounds['min_y'], 'Expected title pixels to start near Y=43 (6% of 720px canvas), not significantly below it');
     }
@@ -185,16 +192,14 @@ class ThumbnailCanvasComposerTest extends TestCase
     #[Test]
     public function it_allows_centered_title_copy_to_extend_beyond_the_top_half_of_the_canvas(): void
     {
-        // Use a very long title that should occupy most of the canvas height.
-        $longTitle = 'This is an extremely long title designed to wrap across three lines on the centered canvas, ensuring it extends well beyond the top half of the thumbnail to test vertical layout flexibility';
-        $image = $this->centeredCanvas(null, $longTitle);
+        $image = $this->centeredCanvas(null, self::LONG_CENTERED_TITLE);
 
-        $bounds = $this->tealPixelBounds($image);
+        // Restrict to the title region to exclude the bottom-corner overlay (same teal).
+        // Canvas height 720, midpoint 360, max title height 468 (65%).
+        $bounds = $this->tealPixelBounds($image, 0, self::CENTERED_TITLE_MAX_Y);
 
         $this->assertNotNull($bounds);
 
-        // Canvas height is 720. Midpoint is 360.
-        // A long title is allowed to extend up to 65% height (468px).
         $this->assertGreaterThan(360, $bounds['max_y'], 'Expected title pixels to extend into the bottom half of the canvas');
     }
 
@@ -205,7 +210,8 @@ class ThumbnailCanvasComposerTest extends TestCase
         $title = 'This Title Has Three Lines For Centered Layout Verification';
         $image = $this->centeredCanvas('symmetric', $title);
 
-        $titleBounds = $this->tealPixelBounds($image);
+        // Restrict to the title region to exclude the bottom-corner overlay (same teal).
+        $titleBounds = $this->tealPixelBounds($image, 0, self::CENTERED_TITLE_MAX_Y);
         $subjectBounds = $this->greenPixelBounds($image);
 
         $this->assertNotNull($titleBounds);
@@ -228,7 +234,8 @@ class ThumbnailCanvasComposerTest extends TestCase
         $title = 'Blessed Are The Peacemakers';
         $image = $this->centeredCanvas('symmetric', $title);
 
-        $titleBounds = $this->tealPixelBounds($image);
+        // Restrict to the title region to exclude the bottom-corner overlay (same teal).
+        $titleBounds = $this->tealPixelBounds($image, 0, self::CENTERED_TITLE_MAX_Y);
         $subjectBounds = $this->greenPixelBounds($image);
 
         $this->assertNotNull($titleBounds);
@@ -485,7 +492,7 @@ class ThumbnailCanvasComposerTest extends TestCase
     /**
      * @return array{min_x:int,max_x:int,min_y:int,max_y:int}|null
      */
-    private function tealPixelBounds(ImageInterface $image): ?array
+    private function tealPixelBounds(ImageInterface $image, int $minY = 0, ?int $maxY = null): ?array
     {
         $native = $image->core()->native();
         $this->assertInstanceOf(\GdImage::class, $native);
@@ -493,8 +500,9 @@ class ThumbnailCanvasComposerTest extends TestCase
         $bounds = null;
         $width = imagesx($native);
         $height = imagesy($native);
+        $scanMaxY = min($maxY ?? $height, $height);
 
-        for ($y = 0; $y < $height; $y++) {
+        for ($y = $minY; $y < $scanMaxY; $y++) {
             for ($x = 0; $x < $width; $x++) {
                 $colorIndex = imagecolorat($native, $x, $y);
                 $color = imagecolorsforindex($native, $colorIndex);

--- a/tests/Unit/Services/ThumbnailCanvasComposerTest.php
+++ b/tests/Unit/Services/ThumbnailCanvasComposerTest.php
@@ -226,26 +226,15 @@ class ThumbnailCanvasComposerTest extends TestCase
 
         // Guard the fixture: the overlap rule branches on line count, so confirm the
         // copy actually wrapped to three lines before asserting the three-line behaviour.
-        $this->assertSame(
-            3,
-            $this->countTitleLines($titleImage, 0, self::CENTERED_TITLE_MAX_Y),
-            'Expected the three-line fixture to render on exactly three lines'
-        );
+        $lineBands = $this->titleLineBands($titleImage, 0, self::CENTERED_TITLE_MAX_Y);
+        $this->assertCount(3, $lineBands, 'Expected the three-line fixture to render on exactly three lines');
 
-        // Restrict to the title region to exclude the bottom-corner overlay (same teal).
-        $titleBounds = $this->tealPixelBounds($titleImage, 0, self::CENTERED_TITLE_MAX_Y);
         $subjectBounds = $this->greenPixelBounds($subjectImage);
-
-        $this->assertNotNull($titleBounds);
         $this->assertNotNull($subjectBounds);
 
-        // Subject is intended to overlap the bottom ~1.5 lines of the title.
-        // We verify overlap by asserting that the subject's top is higher than the title's bottom.
-        $this->assertLessThan(
-            $titleBounds['max_y'],
-            $subjectBounds['min_y'],
-            'Expected foreground subject to vertically overlap the bottom part of the title text'
-        );
+        // The subject must start within the bottom line-and-a-half: a regression placing
+        // it over all three lines (too high) or below the last line (no overlap) fails.
+        $this->assertSubjectOverlapsBottomLineAndAHalf($lineBands, $subjectBounds['min_y'], 'three-line title');
     }
 
     #[Test]
@@ -264,24 +253,15 @@ class ThumbnailCanvasComposerTest extends TestCase
         // the copy actually wrapped to two lines before asserting the two-line behaviour.
         // Without this, a font-metric change that rendered the title on one line would
         // silently exercise the wrong branch and still pass.
-        $this->assertSame(
-            2,
-            $this->countTitleLines($titleImage, 0, self::CENTERED_TITLE_MAX_Y),
-            'Expected the two-line fixture to render on exactly two lines'
-        );
+        $lineBands = $this->titleLineBands($titleImage, 0, self::CENTERED_TITLE_MAX_Y);
+        $this->assertCount(2, $lineBands, 'Expected the two-line fixture to render on exactly two lines');
 
-        // Restrict to the title region to exclude the bottom-corner overlay (same teal).
-        $titleBounds = $this->tealPixelBounds($titleImage, 0, self::CENTERED_TITLE_MAX_Y);
         $subjectBounds = $this->greenPixelBounds($subjectImage);
-
-        $this->assertNotNull($titleBounds);
         $this->assertNotNull($subjectBounds);
 
-        $this->assertLessThan(
-            $titleBounds['max_y'],
-            $subjectBounds['min_y'],
-            'Expected foreground subject to vertically overlap the bottom of a two-line title'
-        );
+        // For two lines the subject should start partway into the first line (the bottom
+        // line-and-a-half), not above it (covering both lines) nor below the second line.
+        $this->assertSubjectOverlapsBottomLineAndAHalf($lineBands, $subjectBounds['min_y'], 'two-line title');
     }
 
     #[Test]
@@ -561,14 +541,21 @@ class ThumbnailCanvasComposerTest extends TestCase
         return $bounds;
     }
 
+    private function countTitleLines(ImageInterface $image, int $minY, int $maxY): int
+    {
+        return count($this->titleLineBands($image, $minY, $maxY));
+    }
+
     /**
-     * Count the rendered title lines by detecting contiguous bands of teal ink rows.
+     * Detect each rendered title line as a contiguous band of teal ink rows.
      *
      * Glyphs on a single line share a continuous baseline, so the only sizeable
      * vertical gaps in the teal-row profile fall between wrapped lines. A gap of a
      * few pixels is anti-aliasing noise; the inter-line gap is far larger.
+     *
+     * @return list<array{top:int,bottom:int}> ordered top-to-bottom
      */
-    private function countTitleLines(ImageInterface $image, int $minY, int $maxY): int
+    private function titleLineBands(ImageInterface $image, int $minY, int $maxY): array
     {
         $native = $image->core()->native();
         $this->assertInstanceOf(\GdImage::class, $native);
@@ -577,9 +564,10 @@ class ThumbnailCanvasComposerTest extends TestCase
         $height = imagesy($native);
         $scanMaxY = min($maxY, $height);
 
-        $lines = 0;
+        $bands = [];
         $gap = 0;
-        $insideLine = false;
+        $bandTop = null;
+        $lastInkRow = 0;
 
         for ($y = $minY; $y < $scanMaxY; $y++) {
             $rowHasTeal = false;
@@ -592,23 +580,57 @@ class ThumbnailCanvasComposerTest extends TestCase
             }
 
             if ($rowHasTeal) {
-                if (! $insideLine) {
-                    $lines++;
-                    $insideLine = true;
-                }
-
+                $bandTop ??= $y;
+                $lastInkRow = $y;
                 $gap = 0;
 
                 continue;
             }
 
             // A run of >=8 empty rows ends the current line; smaller gaps are noise.
-            if ($insideLine && ++$gap >= 8) {
-                $insideLine = false;
+            if ($bandTop !== null && ++$gap >= 8) {
+                $bands[] = ['top' => $bandTop, 'bottom' => $lastInkRow];
+                $bandTop = null;
             }
         }
 
-        return $lines;
+        if ($bandTop !== null) {
+            $bands[] = ['top' => $bandTop, 'bottom' => $lastInkRow];
+        }
+
+        return $bands;
+    }
+
+    /**
+     * Assert the foreground subject starts within the bottom line-and-a-half of the
+     * title (CENTERED_SUBJECT_OVERLAP_LINES = 1.5). The subject top must fall strictly
+     * below the second-from-last line's top — so it cannot cover the lines above the
+     * bottom line-and-a-half — and at or above the final line's top, so it genuinely
+     * overlaps. This frames the rule against the measured line bands rather than
+     * pinning an exact coordinate, catching a subject placed too high (covering more
+     * of the title) or too low (no meaningful overlap) without flaking on the few px
+     * of anti-aliasing variation at the band edges.
+     *
+     * @param  list<array{top:int,bottom:int}>  $lineBands
+     */
+    private function assertSubjectOverlapsBottomLineAndAHalf(array $lineBands, int $subjectTop, string $context): void
+    {
+        $lineCount = count($lineBands);
+        $this->assertGreaterThanOrEqual(2, $lineCount, "{$context}: expected at least two title lines");
+
+        $secondLastLineTop = $lineBands[$lineCount - 2]['top'];
+        $lastLineTop = $lineBands[$lineCount - 1]['top'];
+
+        $this->assertGreaterThan(
+            $secondLastLineTop,
+            $subjectTop,
+            "{$context}: subject starts too high (would cover more than the bottom line-and-a-half)"
+        );
+        $this->assertLessThanOrEqual(
+            $lastLineTop + 8,
+            $subjectTop,
+            "{$context}: subject starts too low to overlap the bottom line-and-a-half"
+        );
     }
 
     private function isTealPixel(\GdImage $image, int $x, int $y): bool


### PR DESCRIPTION
💡 **What:** Replaced brittle reflection-based assertions in `ThumbnailCanvasComposerTest` with robust behavioral assertions that inspect the rendered image output.
🎯 **Why:** Internal refactors of coordinate calculation methods (e.g., `resolveCenteredTitleTopY`) would previously break these tests even if the visual output remained correct. Now, the tests verify the actual rendered pixels.
🔄 **Coverage:** Same code paths tested, more robust assertions. Introduced `tealPixelBounds` helper to detect brand-teal text.
✅ **Stability:** Ran 5x in a row, all passes. Verified against full suite.

---
*PR created automatically by Jules for task [3465944106181691961](https://jules.google.com/task/3465944106181691961) started by @GarethClarridge*