### PR TITLE
🔦 Lighthouse: Enhance Sermon Structured Data

### DIFF
--- a/app/Presenters/SermonItemListPresenter.php
+++ b/app/Presenters/SermonItemListPresenter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Presenters;
 
 use App\Models\Sermon;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
 class SermonItemListPresenter
@@ -168,7 +169,11 @@ class SermonItemListPresenter
         array $contentLocation,
         string $logoUrl
     ): array {
-        return [
+        $lastModified = ($sermon->updated_at instanceof Carbon && $sermon->updated_at->year > 0)
+            ? $sermon->updated_at->toIso8601String()
+            : $datePublished;
+
+        $article = [
             '@type' => 'Article',
             '@id' => $sermonView['canonical_url'].'#sermon',
             'headline' => $sermon->title,
@@ -176,7 +181,7 @@ class SermonItemListPresenter
             'url' => $sermonView['canonical_url'],
             'description' => $metaDescription,
             'datePublished' => $datePublished,
-            'dateModified' => $sermon->updated_at?->toIso8601String() ?? $datePublished,
+            'dateModified' => $lastModified,
             'inLanguage' => 'en-GB',
             'genre' => 'Sermon',
             'contentLocation' => $contentLocation,
@@ -188,6 +193,25 @@ class SermonItemListPresenter
             ],
             'image' => $sermonView['thumbnail_url'] ?: $logoUrl,
         ];
+
+        if ($sermon->series) {
+            $article['keywords'] = $sermon->series;
+            $article['isPartOf'] = [
+                '@type' => 'CreativeWorkSeries',
+                'name' => $sermon->series,
+                'url' => $sermonView['series_url'],
+                '@id' => $sermonView['series_url'].'#series',
+            ];
+        }
+
+        if ($displayReference = $sermonView['display_reference']) {
+            $article['about'] = [
+                '@type' => 'Thing',
+                'name' => $displayReference,
+            ];
+        }
+
+        return $article;
     }
 
     /**

--- a/resources/views/components/schema/sermon.blade.php
+++ b/resources/views/components/schema/sermon.blade.php
@@ -12,6 +12,9 @@
     $preacherName = $sermonView['preacher_name'];
     $thumbnailUrl = $sermonView['thumbnail_url'] ?: asset('images/Primary.png');
     $datePublished = $sermon->date->toIso8601String();
+    $lastModified = ($sermon->updated_at instanceof \Carbon\CarbonInterface && $sermon->updated_at->year > 0)
+        ? $sermon->updated_at->toIso8601String()
+        : $datePublished;
 
     $author = [
         '@type' => 'Person',
@@ -38,9 +41,7 @@
         'description' => $metaDescription,
         'image' => $thumbnailUrl,
         'datePublished' => $datePublished,
-        'dateModified' => ($sermon->updated_at instanceof \Carbon\CarbonInterface && $sermon->updated_at->year > 0)
-            ? $sermon->updated_at->toIso8601String()
-            : $datePublished,
+        'dateModified' => $lastModified,
         'inLanguage' => 'en-GB',
         'genre' => 'Sermon',
         'author' => $author,
@@ -58,6 +59,23 @@
             '@id' => $sermonView['canonical_url'] . '#webpage',
         ],
     ];
+
+    if ($sermon->series) {
+        $schema['keywords'] = $sermon->series;
+        $schema['isPartOf'] = [
+            '@type' => 'CreativeWorkSeries',
+            'name' => $sermon->series,
+            'url' => $sermonView['series_url'],
+            '@id' => $sermonView['series_url'] . '#series',
+        ];
+    }
+
+    if ($displayReference = $sermonView['display_reference']) {
+        $schema['about'] = [
+            '@type' => 'Thing',
+            'name' => $displayReference,
+        ];
+    }
 
     if ($sermonView['video_url']) {
         $schema['video'] = [

--- a/tests/Integration/SermonSchemaTest.php
+++ b/tests/Integration/SermonSchemaTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use App\Models\Sermon;
+use App\Presenters\SermonItemListPresenter;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonSchemaTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('public');
+        Config::set('media-processing.storage.sermon_disk', 'public');
+        $this->travelTo(Carbon::parse('2024-05-20 12:00:00'));
+    }
+
+    #[Test]
+    public function it_includes_enhanced_metadata_in_individual_sermon_schema(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'title' => 'Enhanced Schema Sermon',
+            'slug' => 'enhanced-schema-sermon',
+            'date' => '2024-05-19',
+            'series' => 'Test Series',
+            'reference' => 'John 3:16',
+        ]);
+
+        $response = $this->get("/christ/sermons/2024/05/{$sermon->slug}");
+
+        $response->assertStatus(200);
+        $content = $response->getContent();
+
+        // Verify keywords
+        $this->assertStringContainsString('"keywords": "Test Series"', $content);
+
+        // Verify isPartOf (Series)
+        $this->assertStringContainsString('"isPartOf": {', $content);
+        $this->assertStringContainsString('"@type": "CreativeWorkSeries"', $content);
+        $this->assertStringContainsString('"name": "Test Series"', $content);
+        $this->assertStringContainsString('/christ/sermons/series/test-series', $content);
+
+        // Verify about (Scripture)
+        $this->assertStringContainsString('"about": {', $content);
+        $this->assertStringContainsString('"@type": "Thing"', $content);
+        $this->assertStringContainsString('"name": "John 3:16"', $content);
+    }
+
+    #[Test]
+    public function it_includes_enhanced_metadata_in_item_list_schema(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'title' => 'List Item Sermon',
+            'date' => '2024-05-19',
+            'series' => 'List Series',
+            'reference' => 'Genesis 1:1',
+        ]);
+
+        $presenter = app(SermonItemListPresenter::class);
+        $result = $presenter->toItemList(collect([$sermon]));
+
+        $item = $result['itemListElement'][0]['item'];
+
+        $this->assertEquals('List Series', $item['keywords']);
+
+        $this->assertArrayHasKey('isPartOf', $item);
+        $this->assertEquals('CreativeWorkSeries', $item['isPartOf']['@type']);
+        $this->assertEquals('List Series', $item['isPartOf']['name']);
+        $this->assertStringContainsString('/christ/sermons/series/list-series', $item['isPartOf']['url']);
+
+        $this->assertArrayHasKey('about', $item);
+        $this->assertEquals('Thing', $item['about']['@type']);
+        $this->assertEquals('Genesis 1:1', $item['about']['name']);
+    }
+
+    #[Test]
+    public function it_handles_sermons_without_series_or_reference(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'title' => 'Minimal Sermon',
+            'series' => null,
+            'reference' => null,
+        ]);
+
+        $presenter = app(SermonItemListPresenter::class);
+        $result = $presenter->toItemList(collect([$sermon]));
+
+        $item = $result['itemListElement'][0]['item'];
+
+        $this->assertArrayNotHasKey('keywords', $item);
+        $this->assertArrayNotHasKey('isPartOf', $item);
+        $this->assertArrayNotHasKey('about', $item);
+    }
+
+    #[Test]
+    public function date_modified_handles_legacy_timestamps_safely(): void
+    {
+        $sermon = Sermon::factory()->make([
+            'date' => Carbon::parse('2024-01-01'),
+        ]);
+
+        // Manually set an invalid date that might come from DB as '0000-00-00'
+        // We use year 0 to simulate the legacy condition.
+        $sermon->updated_at = Carbon::create(0, 1, 1, 0, 0, 0);
+
+        $presenter = app(SermonItemListPresenter::class);
+        $result = $presenter->toItemList(collect([$sermon]));
+
+        $item = $result['itemListElement'][0]['item'];
+
+        // Should fall back to datePublished if updated_at is invalid
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $item['datePublished']);
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $item['dateModified']);
+    }
+}


### PR DESCRIPTION
💡 **What:** Improved the structured data (JSON-LD) for sermons on individual pages and in listings.
- Added `isPartOf` linking to the sermon series (`CreativeWorkSeries`).
- Added `about` property linking to the Bible reference (`Thing`).
- Added `keywords` using the series name.
- Robustified `dateModified` to safely handle legacy zero-timestamps.

🎯 **Why:** Providing search engines with machine-readable links between sermons, series, and scripture helps build a richer knowledge graph and improves the chances of appearing in relevant rich search results.

📊 **Impact:** All individual sermon pages and sermon archive listings (including preacher and series pages) now have more complete and robust metadata.

🔍 **Verification:** Verified via new integration tests in `tests/Integration/SermonSchemaTest.php` and by inspecting the generated HTML for the new properties.

---
*PR created automatically by Jules for task [16075195935796647802](https://jules.google.com/task/16075195935796647802) started by @GarethClarridge*