### PR TITLE
🎨 Palette: Standardise row-level loading states and enhance thumbnail UX

### DIFF
--- a/resources/views/livewire/admin/meetings/list-meetings.blade.php
+++ b/resources/views/livewire/admin/meetings/list-meetings.blade.php
@@ -57,7 +57,7 @@
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
             @forelse($meetings as $meeting)
-                <tr wire:target="delete({{ $meeting->id }})" class="hover:bg-gray-50 data-loading:opacity-50">
+                <tr wire:loading.class="opacity-50" wire:target="delete({{ $meeting->id }})" class="hover:bg-gray-50">
                     {{-- Meeting --}}
                     <td class="px-4 py-3">
                         <p class="font-medium">{{ $meeting->page?->heading ?? $meeting->slug }}</p>

--- a/resources/views/livewire/admin/pages/list-pages.blade.php
+++ b/resources/views/livewire/admin/pages/list-pages.blade.php
@@ -63,7 +63,7 @@
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
             @forelse($pages as $page)
-                <tr wire:target="delete({{ $page->id }})" class="hover:bg-gray-50 data-loading:opacity-50">
+                <tr wire:loading.class="opacity-50" wire:target="delete({{ $page->id }})" class="hover:bg-gray-50">
                     <td class="px-4 py-3">
                         <input type="checkbox" value="{{ $page->id }}" wire:model.live="selected"
                             class="rounded border-gray-300 text-cbc-teal focus:ring-cbc-teal" />

--- a/resources/views/livewire/admin/preachers/list-preachers.blade.php
+++ b/resources/views/livewire/admin/preachers/list-preachers.blade.php
@@ -42,7 +42,7 @@
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
             @forelse($preachers as $preacher)
-                <tr wire:target="delete({{ $preacher->id }})" class="hover:bg-gray-50 data-loading:opacity-50">
+                <tr wire:loading.class="opacity-50" wire:target="delete({{ $preacher->id }})" class="hover:bg-gray-50">
                     {{-- Name --}}
                     <td class="px-4 py-3">
                         <p class="font-medium">{{ $preacher->name }}</p>

--- a/resources/views/livewire/admin/sermons/edit-sermon-thumbnails.blade.php
+++ b/resources/views/livewire/admin/sermons/edit-sermon-thumbnails.blade.php
@@ -12,6 +12,8 @@
                 @foreach($thumbnailCandidates as $candidate)
                     <div
                         wire:key="thumbnail-candidate-{{ $candidate['id'] }}"
+                        wire:loading.class="opacity-50"
+                        wire:target="selectThumbnailCandidate('{{ $candidate['id'] }}')"
                         class="rounded-lg border p-3 {{ $candidate['is_selected'] ? 'border-cbc-teal bg-cbc-teal/5' : 'border-gray-200 bg-white' }}"
                     >
                         <div class="space-y-3">

--- a/resources/views/livewire/admin/sermons/list-sermons.blade.php
+++ b/resources/views/livewire/admin/sermons/list-sermons.blade.php
@@ -59,7 +59,7 @@
                         ? route('childrens-corner.show', ['sermon' => $sermon->slug])
                         : route('sermons.show', ['sermon' => $sermon->slug]);
                 @endphp
-                <tr wire:target="delete({{ $sermon->id }})" class="hover:bg-gray-50 data-loading:opacity-50 {{ $sermon->needs_preacher_review ? 'border-l-4 border-amber-400 bg-amber-50/30' : '' }}">
+                <tr wire:loading.class="opacity-50" wire:target="delete({{ $sermon->id }})" class="hover:bg-gray-50 {{ $sermon->needs_preacher_review ? 'border-l-4 border-amber-400 bg-amber-50/30' : '' }}">
                     {{-- Title --}}
                     <td class="px-4 py-3">
                         <p class="font-medium">{{ Str::limit($sermon->title, 50) }}</p>

--- a/resources/views/livewire/admin/users/list-users.blade.php
+++ b/resources/views/livewire/admin/users/list-users.blade.php
@@ -54,7 +54,7 @@
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
             @forelse($users as $user)
-                <tr wire:target="delete({{ $user->id }}), toggleAdmin({{ $user->id }})" class="hover:bg-gray-50 data-loading:opacity-50">
+                <tr wire:loading.class="opacity-50" wire:target="delete({{ $user->id }}), toggleAdmin({{ $user->id }})" class="hover:bg-gray-50">
                     {{-- Name --}}
                     <td class="px-4 py-3">
                         <p class="font-medium">{{ $user->name }}</p>

--- a/resources/views/livewire/church/songs/browse-songs.blade.php
+++ b/resources/views/livewire/church/songs/browse-songs.blade.php
@@ -25,8 +25,10 @@
         <div class="flex flex-wrap items-center justify-center gap-3">
             <button
                 wire:click="$set('range', '{{ \App\Services\PublicSongCatalogService::RANGE_ALL }}')"
+                wire:loading.attr="disabled"
+                wire:loading.class="opacity-50"
+                wire:target="$set('range', '{{ \App\Services\PublicSongCatalogService::RANGE_ALL }}')"
                 type="button"
-                class="data-loading:opacity-50 data-loading:pointer-events-none"
                 @class([
                     'inline-flex items-center rounded-full px-4 py-1.5 text-sm font-semibold shadow-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2',
                     'bg-cbc-teal-dark text-white' => $selectedRange === \App\Services\PublicSongCatalogService::RANGE_ALL,
@@ -38,8 +40,10 @@
             </button>
             <button
                 wire:click="$set('range', '{{ \App\Services\PublicSongCatalogService::RANGE_RECENT }}')"
+                wire:loading.attr="disabled"
+                wire:loading.class="opacity-50"
+                wire:target="$set('range', '{{ \App\Services\PublicSongCatalogService::RANGE_RECENT }}')"
                 type="button"
-                class="data-loading:opacity-50 data-loading:pointer-events-none"
                 @class([
                     'inline-flex items-center rounded-full px-4 py-1.5 text-sm font-semibold shadow-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2',
                     'bg-cbc-teal-dark text-white' => $selectedRange === \App\Services\PublicSongCatalogService::RANGE_RECENT,
@@ -53,7 +57,7 @@
     </section>
 
     {{-- Results area --}}
-    <div id="song-results" tabindex="-1" class="focus:outline-none data-loading:opacity-60 data-loading:pointer-events-none" wire:target="search, range">
+    <div id="song-results" tabindex="-1" class="focus:outline-none" wire:loading.class="opacity-60 pointer-events-none" wire:target="search, range">
 
         {{-- Empty state --}}
         @if ($songs->isEmpty())

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -132,7 +132,7 @@
         Updating sermon results…
     </div>
 
-    <div id="sermon-results" tabindex="-1" class="data-loading:pointer-events-none data-loading:opacity-60" wire:target="bookFilter, chapterFilter, preacherFilter, seriesFilter, removeFilter, clearFilters">
+    <div id="sermon-results" tabindex="-1" wire:loading.class="pointer-events-none opacity-60" wire:target="bookFilter, chapterFilter, preacherFilter, seriesFilter, removeFilter, clearFilters">
         @php
             /** @var \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, \App\Models\Sermon> $sermons */
         @endphp


### PR DESCRIPTION
This PR standardises the row-level loading states in admin list views by replacing the non-standard (and deprecated) 'data-loading' classes with Livewire's 'wire:loading.class="opacity-50"'. It also adds loading feedback to the sermon thumbnail candidate selection to provide immediate visual confirmation of actions. Public browse pages for songs and sermons have also been updated to follow these standards, ensuring a more responsive and professional feel across the application.

---
*PR created automatically by Jules for task [599452481232015750](https://jules.google.com/task/599452481232015750) started by @GarethClarridge*