### PR TITLE
Add unit tests for NotEmptyString validation rule

### DIFF
--- a/tests/Unit/Rules/NotEmptyStringTest.php
+++ b/tests/Unit/Rules/NotEmptyStringTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Rules;
+
+use App\Rules\NotEmptyString;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class NotEmptyStringTest extends TestCase
+{
+    private NotEmptyString $rule;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->rule = new NotEmptyString;
+    }
+
+    #[Test]
+    public function it_passes_for_valid_strings(): void
+    {
+        $this->rule->validate('attribute', 'valid string', function (): void {
+            $this->fail('Rule should have passed.');
+        });
+
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function it_passes_for_null(): void
+    {
+        $this->rule->validate('attribute', null, function (): void {
+            $this->fail('Rule should have passed for null.');
+        });
+
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function it_fails_for_empty_string(): void
+    {
+        $failed = false;
+        $this->rule->validate('attribute', '', function ($message) use (&$failed): void {
+            $failed = true;
+            $this->assertEquals('The :attribute field must not be empty or contain only whitespace.', $message);
+        });
+
+        $this->assertTrue($failed, 'Rule should have failed for empty string.');
+    }
+
+    #[Test]
+    public function it_fails_for_whitespace_only_strings(): void
+    {
+        $failed = false;
+        $this->rule->validate('attribute', '   ', function ($message) use (&$failed): void {
+            $failed = true;
+            $this->assertEquals('The :attribute field must not be empty or contain only whitespace.', $message);
+        });
+
+        $this->assertTrue($failed, 'Rule should have failed for whitespace.');
+    }
+
+    #[Test]
+    public function it_fails_for_non_string_values(): void
+    {
+        $failed = false;
+        $this->rule->validate('attribute', 123, function ($message) use (&$failed): void {
+            $failed = true;
+            $this->assertEquals('The :attribute field must not be empty or contain only whitespace.', $message);
+        });
+
+        $this->assertTrue($failed, 'Rule should have failed for non-string value.');
+    }
+}


### PR DESCRIPTION
I've added a comprehensive unit test suite for the `NotEmptyString` validation rule in `tests/Unit/Rules/NotEmptyStringTest.php`. This rule was identified as a coverage gap.

### 🎯 Coverage
Added tests for `App\Rules\NotEmptyString`.

### 📋 Tests added
- `it_passes_for_valid_strings`: Verifies that standard text passes.
- `it_passes_for_null`: Verifies that `null` passes (so it can be paired with `nullable`).
- `it_fails_for_empty_string`: Verifies that `''` triggers a failure.
- `it_fails_for_whitespace_only_strings`: Verifies that strings containing only spaces trigger a failure.
- `it_fails_for_non_string_values`: Verifies that integers or other types trigger a failure.

### 🔍 Why
The `NotEmptyString` rule is used in the `Sermon` model to ensure that Bible references, when provided, are not just empty or whitespace. Testing custom validation rules directly ensures data integrity at the model layer and provides documentation on how the rule is intended to behave.

### ✅ Results
- `NotEmptyStringTest.php` passed 5/5 tests.
- Full test suite passed (5331 tests).
- PHPStan is clean.
- Code review: #Correct#

---
*PR created automatically by Jules for task [11330958251618825884](https://jules.google.com/task/11330958251618825884) started by @GarethClarridge*