### PR TITLE
🧹 Tidy: Refactor ChurchServiceReviewState to TitleCase keys

### DIFF
--- a/app/Enums/ChurchServiceReviewState.php
+++ b/app/Enums/ChurchServiceReviewState.php
@@ -6,7 +6,7 @@ namespace App\Enums;
 
 enum ChurchServiceReviewState: string
 {
-    case NOT_REVIEWED = 'not_reviewed';
-    case REVIEWED = 'reviewed';
-    case REOPENED = 'reopened';
+    case NotReviewed = 'not_reviewed';
+    case Reviewed = 'reviewed';
+    case Reopened = 'reopened';
 }

--- a/app/Services/ChurchServiceReviewStateService.php
+++ b/app/Services/ChurchServiceReviewStateService.php
@@ -48,9 +48,9 @@ class ChurchServiceReviewStateService
         $metadata = ChurchServiceImportMetadata::fromArray($importMetadata);
 
         $reviewState = match (true) {
-            is_string($metadata->manualReview?->reopenedAt) => ChurchServiceReviewState::REOPENED,
-            is_string($metadata->manualReview?->reviewedAt) => ChurchServiceReviewState::REVIEWED,
-            default => ChurchServiceReviewState::NOT_REVIEWED,
+            is_string($metadata->manualReview?->reopenedAt) => ChurchServiceReviewState::Reopened,
+            is_string($metadata->manualReview?->reviewedAt) => ChurchServiceReviewState::Reviewed,
+            default => ChurchServiceReviewState::NotReviewed,
         };
 
         $canonicalConflict = $metadata->canonicalConflict;

--- a/app/Services/LegacyPlayDateSongUsageImporter.php
+++ b/app/Services/LegacyPlayDateSongUsageImporter.php
@@ -393,7 +393,7 @@ class LegacyPlayDateSongUsageImporter
             'source' => self::LEGACY_SERVICE_SOURCE,
             'original_filename' => basename($path),
             'needs_review' => false,
-            'review_state' => ChurchServiceReviewState::REVIEWED->value,
+            'review_state' => ChurchServiceReviewState::Reviewed->value,
             'manual_reviewed_at' => now(),
             'manual_reviewed_by_user_id' => null,
             'manual_review_reopened_at' => null,

--- a/database/migrations/2026_03_22_120000_formalize_review_publication_state_and_ordering_invariants.php
+++ b/database/migrations/2026_03_22_120000_formalize_review_publication_state_and_ordering_invariants.php
@@ -90,7 +90,7 @@ return new class extends Migration
                 $table->enum('review_state', array_map(
                     static fn (ChurchServiceReviewState $state): string => $state->value,
                     ChurchServiceReviewState::cases()
-                ))->default(ChurchServiceReviewState::NOT_REVIEWED->value)->after('needs_review');
+                ))->default(ChurchServiceReviewState::NotReviewed->value)->after('needs_review');
             }
 
             if (! Schema::hasColumn('church_services', 'manual_reviewed_at')) {
@@ -442,9 +442,9 @@ return new class extends Migration
         $metadata = ChurchServiceImportMetadata::fromArray($importMetadata);
 
         $reviewState = match (true) {
-            is_string($metadata->manualReview?->reopenedAt) => ChurchServiceReviewState::REOPENED,
-            is_string($metadata->manualReview?->reviewedAt) => ChurchServiceReviewState::REVIEWED,
-            default => ChurchServiceReviewState::NOT_REVIEWED,
+            is_string($metadata->manualReview?->reopenedAt) => ChurchServiceReviewState::Reopened,
+            is_string($metadata->manualReview?->reviewedAt) => ChurchServiceReviewState::Reviewed,
+            default => ChurchServiceReviewState::NotReviewed,
         };
 
         $canonicalConflict = $metadata->canonicalConflict;

--- a/tests/Feature/Actions/ServiceReview/MarkServiceReviewedTest.php
+++ b/tests/Feature/Actions/ServiceReview/MarkServiceReviewedTest.php
@@ -75,7 +75,7 @@ class MarkServiceReviewedTest extends TestCase
         $metadata = $service->fresh()?->import_metadata?->toArray() ?? [];
         $this->assertArrayHasKey('manual_review', $metadata);
         $this->assertSame($this->admin->id, $metadata['manual_review']['reviewed_by_user_id'] ?? null);
-        $this->assertSame(ChurchServiceReviewState::REVIEWED, $service->fresh()?->review_state);
+        $this->assertSame(ChurchServiceReviewState::Reviewed, $service->fresh()?->review_state);
     }
 
     #[Test]

--- a/tests/Feature/Console/ImportLegacySongUsageCommandTest.php
+++ b/tests/Feature/Console/ImportLegacySongUsageCommandTest.php
@@ -67,7 +67,7 @@ class ImportLegacySongUsageCommandTest extends TestCase
             ->firstOrFail();
 
         $this->assertSame('legacy_play_date', $morningService->source);
-        $this->assertSame(ChurchServiceReviewState::REVIEWED, $morningService->review_state);
+        $this->assertSame(ChurchServiceReviewState::Reviewed, $morningService->review_state);
         $this->assertNotNull($morningService->manual_reviewed_at);
 
         $morningItems = ChurchServiceItem::query()

--- a/tests/Feature/Database/ChurchServiceSchemaTest.php
+++ b/tests/Feature/Database/ChurchServiceSchemaTest.php
@@ -69,7 +69,7 @@ class ChurchServiceSchemaTest extends TestCase
         DB::table('church_services')
             ->where('id', $service->id)
             ->update([
-                'review_state' => ChurchServiceReviewState::NOT_REVIEWED->value,
+                'review_state' => ChurchServiceReviewState::NotReviewed->value,
                 'manual_reviewed_at' => null,
                 'manual_reviewed_by_user_id' => null,
                 'manual_review_reopened_at' => null,
@@ -87,7 +87,7 @@ class ChurchServiceSchemaTest extends TestCase
 
         $service->refresh();
 
-        $this->assertSame(ChurchServiceReviewState::REOPENED, $service->review_state);
+        $this->assertSame(ChurchServiceReviewState::Reopened, $service->review_state);
         $this->assertSame($reviewer->id, $service->manual_reviewed_by_user_id);
         $this->assertSame('openlp', $service->manual_review_reopened_by_source);
         $this->assertSame(ChurchServiceCanonicalConflictState::REOPENED, $service->canonical_conflict_state);

--- a/tests/Feature/Services/LegacyPlayDateSongUsageImporterTest.php
+++ b/tests/Feature/Services/LegacyPlayDateSongUsageImporterTest.php
@@ -59,7 +59,7 @@ INSERT INTO `play_date` VALUES (2,'102','2024-03-24','p','');
         $this->assertDatabaseHas('church_services', [
             'date' => '2024-03-24',
             'service' => SermonService::Morning->value,
-            'review_state' => ChurchServiceReviewState::REVIEWED->value,
+            'review_state' => ChurchServiceReviewState::Reviewed->value,
         ]);
 
         $this->assertDatabaseHas('church_service_items', [

--- a/tests/Integration/Services/ChurchServiceCanonicalUpdateServiceTest.php
+++ b/tests/Integration/Services/ChurchServiceCanonicalUpdateServiceTest.php
@@ -62,7 +62,7 @@ class ChurchServiceCanonicalUpdateServiceTest extends TestCase
         $this->assertNull($result->import_metadata['canonical_conflict'] ?? null);
         $this->assertNull($result->import_metadata['canonical_conflict_history'] ?? null);
         $this->assertSame(ChurchServiceCanonicalConflictState::NONE, $result->canonical_conflict_state);
-        $this->assertSame(ChurchServiceReviewState::NOT_REVIEWED, $result->review_state);
+        $this->assertSame(ChurchServiceReviewState::NotReviewed, $result->review_state);
 
         Event::assertNotDispatched(ChurchServiceCanonicalListChanged::class);
     }
@@ -153,7 +153,7 @@ class ChurchServiceCanonicalUpdateServiceTest extends TestCase
         $this->assertTrue($result->import_metadata['canonical_conflict']['review_reopened']);
         $this->assertSame('openlp', $result->import_metadata['manual_review']['reopened_by_source'] ?? null);
         $this->assertArrayHasKey('reopened_at', $result->import_metadata['manual_review']);
-        $this->assertSame(ChurchServiceReviewState::REOPENED, $result->review_state);
+        $this->assertSame(ChurchServiceReviewState::Reopened, $result->review_state);
         $this->assertSame(ChurchServiceCanonicalConflictState::REOPENED, $result->canonical_conflict_state);
     }
 

--- a/tests/Unit/Database/ChurchServiceIntegrityTest.php
+++ b/tests/Unit/Database/ChurchServiceIntegrityTest.php
@@ -24,7 +24,7 @@ class ChurchServiceIntegrityTest extends TestCase
         // 2. Create a church service reviewed by that user
         $service = ChurchService::factory()->create([
             'manual_reviewed_by_user_id' => $user->id,
-            'review_state' => ChurchServiceReviewState::REVIEWED,
+            'review_state' => ChurchServiceReviewState::Reviewed,
             'manual_reviewed_at' => now(),
         ]);
 


### PR DESCRIPTION
💡 **What:** Refactored `ChurchServiceReviewState` enum keys from `SCREAMING_SNAKE_CASE` to `TitleCase` (e.g., `NOT_REVIEWED` -> `NotReviewed`).
🎯 **Why:** Standardizes Enum naming conventions across the codebase to reduce cognitive load and follow project standards.
🔄 **Behavior:** No functional changes; backed string values remain unchanged.
✅ **Tests:** All affected tests passed, and the full suite was run to ensure no regressions.

---
*PR created automatically by Jules for task [951688084606479643](https://jules.google.com/task/951688084606479643) started by @GarethClarridge*