### PR TITLE
📜 Herald: Add PHPDoc to ProcessingPhaseRegistry

### DIFF
--- a/.Jules/herald.md
+++ b/.Jules/herald.md
@@ -5,3 +5,7 @@
 ## 2026-06-01 - Documenting Sermon Creation Logic and AI Data Shapes
 **Learning:** Core business logic like the "richness-aware" upsert strategy for media processing needs clear PHPDoc explanation to prevent accidental "richness downgrades" during future maintenance. Complex array parameters (like `ai_analysis` or title generation `context`) should use PHPStan array shape annotations with optional keys (`?:`) when the data might be partially populated, which satisfies static analysis without introducing false positives in `isset()` checks.
 **Action:** Use optional keys in array shapes for DTOs and service parameters that handle external API data or flexible context arrays. Ensure `isset()` checks in the implementation remain robust even when PHPDoc suggests keys "should" be there.
+
+## 2026-06-03 - Centralizing Progress and Retry Documentation
+**Learning:** The `ProcessingPhaseRegistry` is a critical bottleneck for user experience (progress bars) and system reliability (retries). Documenting the exact array shapes for retry plans (actions, strategies, and scopes) is essential for maintaining the contract between the registry and the `ProcessingRunOrchestrator`.
+**Action:** When documenting registry-like services, prioritize documenting the return array shapes of mapping methods, as these define the "plans" executed by other services.

--- a/app/Services/ProcessingPhaseRegistry.php
+++ b/app/Services/ProcessingPhaseRegistry.php
@@ -7,9 +7,19 @@ namespace App\Services;
 use App\Enums\MediaType;
 use App\Models\MediaProcessingLog;
 
+/**
+ * Registry for media processing pipeline phases and their associated metadata.
+ *
+ * This class serves as the central source of truth for mapping discrete processing
+ * steps to progress percentages and defining how a failed or cancelled pipeline
+ * should be retried based on its last known state.
+ */
 class ProcessingPhaseRegistry
 {
     /**
+     * Retrieve the ordered collection of phases for a specific pipeline profile.
+     *
+     * @param  string  $pipeline  The pipeline profile (audio, video, video_auto_trim, livestream)
      * @return list<array{
      *     key: string,
      *     progress: int,
@@ -31,6 +41,16 @@ class ProcessingPhaseRegistry
         };
     }
 
+    /**
+     * Resolve the progress percentage for a given processing step.
+     *
+     * Iterates through available pipelines to find a matching step. If a media type
+     * is provided, its associated pipeline is prioritized in the search.
+     *
+     * @param  string|null  $step  The current processing step identifier
+     * @param  MediaType|null  $mediaType  Optional media type for pipeline prioritization
+     * @return int Progress percentage (0-100)
+     */
     public function progressForStep(?string $step, ?MediaType $mediaType = null): int
     {
         $normalizedStep = $this->normalizeStep($step);
@@ -57,6 +77,15 @@ class ProcessingPhaseRegistry
         return 50;
     }
 
+    /**
+     * Calculate the current progress percentage for a processing log.
+     *
+     * Maps the log's current step to its defined progress via the pipeline's
+     * phase registry, ensuring accurate progress reporting for active runs.
+     *
+     * @param  MediaProcessingLog  $processingLog  The processing log to evaluate
+     * @return int Progress percentage (0-100)
+     */
     public function progressForLog(MediaProcessingLog $processingLog): int
     {
         $normalizedStep = $this->normalizeStep($processingLog->current_step);
@@ -66,6 +95,13 @@ class ProcessingPhaseRegistry
     }
 
     /**
+     * Determine the appropriate retry plan for a failed or cancelled processing run.
+     *
+     * Analyzes the current step of the provided log and determines whether the
+     * pipeline can be resumed from a specific job offset, needs a full restart,
+     * or requires manual administrative review.
+     *
+     * @param  MediaProcessingLog  $processingLog  The failed or cancelled log
      * @return array{
      *     action: 'dispatch_chain'|'dispatch_livestream_chain'|'restart_livestream'|'manual_review',
      *     pipeline?: 'audio'|'video'|'video_auto_trim'|'livestream',


### PR DESCRIPTION
💡 **What:** Added comprehensive PHPDoc blocks to `App\Services\ProcessingPhaseRegistry`.
🎯 **Why:** This class manages complex mapping between processing steps, progress reporting, and retry orchestration. Clear documentation and array shape annotations improve DX and static analysis.
🔄 **Behavior:** No functional changes — documentation only.

---
*PR created automatically by Jules for task [1668300207946067477](https://jules.google.com/task/1668300207946067477) started by @GarethClarridge*