### PR TITLE
📖 Editor: British English spelling for uncategorised events

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -71,7 +71,7 @@ class CalendarController extends Controller
 
         return view('calendar.uncategorized', [
             'uncategorizedEvents' => $uncategorizedEvents,
-            'heading' => 'Uncategorized Events',
+            'heading' => 'Uncategorised Events',
             'description' => 'Calendar events that still need assigning to a meeting.',
             'content' => '',
             'links' => collect(),


### PR DESCRIPTION
Updated the 'Uncategorized Events' heading in CalendarController to use the canonical British English spelling 'Uncategorised Events', ensuring consistency with the rest of the application's calendar system. No functional changes.

---
*PR created automatically by Jules for task [16938760153648093305](https://jules.google.com/task/16938760153648093305) started by @GarethClarridge*