### PR TITLE
Pathfinder Diagnostic Report: Broken Redirects Identified

### DIFF
--- a/sitemap_urls.txt
+++ b/sitemap_urls.txt
@@ -1,0 +1,11 @@
+http://localhost
+http://localhost/christ
+http://localhost/christmas
+http://localhost/church
+http://localhost/community
+http://localhost/calendar
+http://localhost/christ/sermons
+http://localhost/christ/sermons/preachers
+http://localhost/christ/sermons/series
+http://localhost/christ/sermons/morning
+http://localhost/christ/sermons/evening


### PR DESCRIPTION
I have completed a diagnostic crawl of the Crockenhill Baptist Church website. My primary finding is a set of broken redirect targets in `config/redirects.php`. Specifically, the redirects for 'carolsatthechequers' point to a non-existent slug (a typo), and the 'reopening' redirect points to a page that is no longer in the system. I also identified some unreferenced image assets. I have verified these findings with multiple hits and cross-referencing with the database seeders. No other major broken links or missing core assets were found.

---
*PR created automatically by Jules for task [15775428131901888339](https://jules.google.com/task/15775428131901888339) started by @GarethClarridge*