### PR TITLE
🧹 Tidy: refactor ChurchServiceCanonicalConflict enums to TitleCase

### DIFF
--- a/app/Enums/ChurchServiceCanonicalConflictReason.php
+++ b/app/Enums/ChurchServiceCanonicalConflictReason.php
@@ -6,8 +6,8 @@ namespace App\Enums;
 
 enum ChurchServiceCanonicalConflictReason: string
 {
-    case UNSPECIFIED = 'unspecified';
-    case CONFLICTS_ONLY = 'conflicts_only';
-    case CANONICAL_CHANGED = 'canonical_changed';
-    case CANONICAL_CHANGED_WITH_CONFLICTS = 'canonical_changed_with_conflicts';
+    case Unspecified = 'unspecified';
+    case ConflictsOnly = 'conflicts_only';
+    case CanonicalChanged = 'canonical_changed';
+    case CanonicalChangedWithConflicts = 'canonical_changed_with_conflicts';
 }

--- a/app/Enums/ChurchServiceCanonicalConflictState.php
+++ b/app/Enums/ChurchServiceCanonicalConflictState.php
@@ -6,7 +6,7 @@ namespace App\Enums;
 
 enum ChurchServiceCanonicalConflictState: string
 {
-    case NONE = 'none';
-    case DETECTED = 'detected';
-    case REOPENED = 'reopened';
+    case None = 'none';
+    case Detected = 'detected';
+    case Reopened = 'reopened';
 }

--- a/app/Services/ChurchService/ChurchServiceReviewStateService.php
+++ b/app/Services/ChurchService/ChurchServiceReviewStateService.php
@@ -20,11 +20,11 @@ class ChurchServiceReviewStateService
     public function hasOutstandingCanonicalConflict(ChurchService|array $source): bool
     {
         if ($source instanceof ChurchService) {
-            return $source->canonical_conflict_state === ChurchServiceCanonicalConflictState::REOPENED;
+            return $source->canonical_conflict_state === ChurchServiceCanonicalConflictState::Reopened;
         }
 
         return $this->normalizedColumns($source)['canonical_conflict_state']
-            === ChurchServiceCanonicalConflictState::REOPENED->value;
+            === ChurchServiceCanonicalConflictState::Reopened->value;
     }
 
     /**
@@ -60,19 +60,19 @@ class ChurchServiceReviewStateService
             ?? $this->normalizeOptionalString($fallbackIncomingSource)
             ?? 'unknown';
         $canonicalConflictState = match (true) {
-            ! $canonicalConflict instanceof ChurchServiceCanonicalConflictMetadata => ChurchServiceCanonicalConflictState::NONE,
-            ! $detectedAt instanceof CarbonImmutable => ChurchServiceCanonicalConflictState::NONE,
+            ! $canonicalConflict instanceof ChurchServiceCanonicalConflictMetadata => ChurchServiceCanonicalConflictState::None,
+            ! $detectedAt instanceof CarbonImmutable => ChurchServiceCanonicalConflictState::None,
             $canonicalConflict->reviewReopened === true
                 && $reviewedAt instanceof CarbonImmutable
-                && ! $reviewedAt->lt($detectedAt) => ChurchServiceCanonicalConflictState::NONE,
-            $canonicalConflict->reviewReopened === true => ChurchServiceCanonicalConflictState::REOPENED,
-            default => ChurchServiceCanonicalConflictState::DETECTED,
+                && ! $reviewedAt->lt($detectedAt) => ChurchServiceCanonicalConflictState::None,
+            $canonicalConflict->reviewReopened === true => ChurchServiceCanonicalConflictState::Reopened,
+            default => ChurchServiceCanonicalConflictState::Detected,
         };
 
-        $canonicalConflictDetectedAt = $canonicalConflictState === ChurchServiceCanonicalConflictState::NONE
+        $canonicalConflictDetectedAt = $canonicalConflictState === ChurchServiceCanonicalConflictState::None
             ? null
             : $detectedAt?->toIso8601String();
-        $canonicalConflictIncomingSource = $canonicalConflictState === ChurchServiceCanonicalConflictState::NONE
+        $canonicalConflictIncomingSource = $canonicalConflictState === ChurchServiceCanonicalConflictState::None
             ? null
             : $incomingSource;
         $canonicalConflictReviewedPreviously = null;
@@ -80,7 +80,7 @@ class ChurchServiceReviewStateService
         $canonicalConflictReason = null;
 
         if (
-            $canonicalConflictState !== ChurchServiceCanonicalConflictState::NONE
+            $canonicalConflictState !== ChurchServiceCanonicalConflictState::None
             && $canonicalConflict instanceof ChurchServiceCanonicalConflictMetadata
         ) {
             $canonicalConflictReviewedPreviously = $canonicalConflict->reviewedPreviously;
@@ -134,10 +134,10 @@ class ChurchServiceReviewStateService
         $hasConflicts = $conflicts !== [];
 
         return match (true) {
-            $hasChanges && $hasConflicts => ChurchServiceCanonicalConflictReason::CANONICAL_CHANGED_WITH_CONFLICTS,
-            $hasChanges => ChurchServiceCanonicalConflictReason::CANONICAL_CHANGED,
-            $hasConflicts => ChurchServiceCanonicalConflictReason::CONFLICTS_ONLY,
-            default => ChurchServiceCanonicalConflictReason::UNSPECIFIED,
+            $hasChanges && $hasConflicts => ChurchServiceCanonicalConflictReason::CanonicalChangedWithConflicts,
+            $hasChanges => ChurchServiceCanonicalConflictReason::CanonicalChanged,
+            $hasConflicts => ChurchServiceCanonicalConflictReason::ConflictsOnly,
+            default => ChurchServiceCanonicalConflictReason::Unspecified,
         };
     }
 

--- a/app/Services/ChurchService/ChurchServiceReviewSynchronizer.php
+++ b/app/Services/ChurchService/ChurchServiceReviewSynchronizer.php
@@ -45,7 +45,7 @@ class ChurchServiceReviewSynchronizer
             'needs_review' => $reviewTriggers !== []
                 || $needsSectionReview
                 || $this->hasImportReviewSignal($churchService, $importMetadata)
-                || $normalizedColumns['canonical_conflict_state'] === ChurchServiceCanonicalConflictState::REOPENED->value,
+                || $normalizedColumns['canonical_conflict_state'] === ChurchServiceCanonicalConflictState::Reopened->value,
             'import_metadata' => $importMetadata,
             ...$normalizedColumns,
         ])->saveQuietly();

--- a/database/migrations/2026_03_22_120000_formalize_review_publication_state_and_ordering_invariants.php
+++ b/database/migrations/2026_03_22_120000_formalize_review_publication_state_and_ordering_invariants.php
@@ -119,7 +119,7 @@ return new class extends Migration
                 $table->enum('canonical_conflict_state', array_map(
                     static fn (ChurchServiceCanonicalConflictState $state): string => $state->value,
                     ChurchServiceCanonicalConflictState::cases()
-                ))->default(ChurchServiceCanonicalConflictState::NONE->value)->after('manual_review_reopened_by_source');
+                ))->default(ChurchServiceCanonicalConflictState::None->value)->after('manual_review_reopened_by_source');
             }
 
             if (! Schema::hasColumn('church_services', 'canonical_conflict_detected_at')) {
@@ -454,14 +454,14 @@ return new class extends Migration
             ?? $this->normalizeOptionalString($fallbackIncomingSource)
             ?? 'unknown';
         $canonicalConflictState = match (true) {
-            $canonicalConflict === null => ChurchServiceCanonicalConflictState::NONE,
-            ! $detectedAt instanceof Carbon => ChurchServiceCanonicalConflictState::NONE,
+            $canonicalConflict === null => ChurchServiceCanonicalConflictState::None,
+            ! $detectedAt instanceof Carbon => ChurchServiceCanonicalConflictState::None,
             $canonicalConflict->reviewReopened === true
                 && $reviewedAt instanceof Carbon
                 && $detectedAt instanceof Carbon
-                && ! $reviewedAt->lt($detectedAt) => ChurchServiceCanonicalConflictState::NONE,
-            $canonicalConflict->reviewReopened === true => ChurchServiceCanonicalConflictState::REOPENED,
-            default => ChurchServiceCanonicalConflictState::DETECTED,
+                && ! $reviewedAt->lt($detectedAt) => ChurchServiceCanonicalConflictState::None,
+            $canonicalConflict->reviewReopened === true => ChurchServiceCanonicalConflictState::Reopened,
+            default => ChurchServiceCanonicalConflictState::Detected,
         };
 
         $canonicalConflictReason = $this->canonicalConflictReason(
@@ -469,10 +469,10 @@ return new class extends Migration
             $canonicalConflict?->conflicts ?? []
         );
 
-        $canonicalConflictDetectedAt = $canonicalConflictState === ChurchServiceCanonicalConflictState::NONE
+        $canonicalConflictDetectedAt = $canonicalConflictState === ChurchServiceCanonicalConflictState::None
             ? null
             : $detectedAt?->toIso8601String();
-        $canonicalConflictIncomingSource = $canonicalConflictState === ChurchServiceCanonicalConflictState::NONE
+        $canonicalConflictIncomingSource = $canonicalConflictState === ChurchServiceCanonicalConflictState::None
             ? null
             : $incomingSource;
 
@@ -485,13 +485,13 @@ return new class extends Migration
             'canonical_conflict_state' => $canonicalConflictState->value,
             'canonical_conflict_detected_at' => $canonicalConflictDetectedAt,
             'canonical_conflict_incoming_source' => $canonicalConflictIncomingSource,
-            'canonical_conflict_reviewed_previously' => $canonicalConflictState === ChurchServiceCanonicalConflictState::NONE
+            'canonical_conflict_reviewed_previously' => $canonicalConflictState === ChurchServiceCanonicalConflictState::None
                 ? null
                 : $canonicalConflict?->reviewedPreviously,
-            'canonical_conflict_canonical_changed' => $canonicalConflictState === ChurchServiceCanonicalConflictState::NONE
+            'canonical_conflict_canonical_changed' => $canonicalConflictState === ChurchServiceCanonicalConflictState::None
                 ? null
                 : $canonicalConflict?->canonicalChanged,
-            'canonical_conflict_reason' => $canonicalConflictState === ChurchServiceCanonicalConflictState::NONE
+            'canonical_conflict_reason' => $canonicalConflictState === ChurchServiceCanonicalConflictState::None
                 ? null
                 : $canonicalConflictReason->value,
         ];
@@ -507,10 +507,10 @@ return new class extends Migration
         $hasConflicts = $conflicts !== [];
 
         return match (true) {
-            $hasChanges && $hasConflicts => ChurchServiceCanonicalConflictReason::CANONICAL_CHANGED_WITH_CONFLICTS,
-            $hasChanges => ChurchServiceCanonicalConflictReason::CANONICAL_CHANGED,
-            $hasConflicts => ChurchServiceCanonicalConflictReason::CONFLICTS_ONLY,
-            default => ChurchServiceCanonicalConflictReason::UNSPECIFIED,
+            $hasChanges && $hasConflicts => ChurchServiceCanonicalConflictReason::CanonicalChangedWithConflicts,
+            $hasChanges => ChurchServiceCanonicalConflictReason::CanonicalChanged,
+            $hasConflicts => ChurchServiceCanonicalConflictReason::ConflictsOnly,
+            default => ChurchServiceCanonicalConflictReason::Unspecified,
         };
     }
 

--- a/tests/Feature/Actions/ServiceReview/MarkServiceReviewedTest.php
+++ b/tests/Feature/Actions/ServiceReview/MarkServiceReviewedTest.php
@@ -62,7 +62,7 @@ class MarkServiceReviewedTest extends TestCase
         $metadata = $fresh?->import_metadata?->toArray() ?? [];
         $this->assertArrayNotHasKey('canonical_conflict', $metadata);
         $this->assertCount(1, $metadata['canonical_conflict_history'] ?? []);
-        $this->assertSame(ChurchServiceCanonicalConflictState::NONE, $fresh?->canonical_conflict_state);
+        $this->assertSame(ChurchServiceCanonicalConflictState::None, $fresh?->canonical_conflict_state);
     }
 
     #[Test]

--- a/tests/Feature/Database/ChurchServiceSchemaTest.php
+++ b/tests/Feature/Database/ChurchServiceSchemaTest.php
@@ -66,7 +66,7 @@ class ChurchServiceSchemaTest extends TestCase
                 'manual_reviewed_by_user_id' => null,
                 'manual_review_reopened_at' => null,
                 'manual_review_reopened_by_source' => null,
-                'canonical_conflict_state' => ChurchServiceCanonicalConflictState::NONE->value,
+                'canonical_conflict_state' => ChurchServiceCanonicalConflictState::None->value,
                 'canonical_conflict_detected_at' => null,
                 'canonical_conflict_incoming_source' => null,
                 'canonical_conflict_reviewed_previously' => null,
@@ -82,11 +82,11 @@ class ChurchServiceSchemaTest extends TestCase
         $this->assertSame(ChurchServiceReviewState::Reopened, $service->review_state);
         $this->assertSame($reviewer->id, $service->manual_reviewed_by_user_id);
         $this->assertSame('openlp', $service->manual_review_reopened_by_source);
-        $this->assertSame(ChurchServiceCanonicalConflictState::REOPENED, $service->canonical_conflict_state);
+        $this->assertSame(ChurchServiceCanonicalConflictState::Reopened, $service->canonical_conflict_state);
         $this->assertTrue($service->canonical_conflict_reviewed_previously);
         $this->assertTrue($service->canonical_conflict_canonical_changed);
         $this->assertSame(
-            ChurchServiceCanonicalConflictReason::CANONICAL_CHANGED_WITH_CONFLICTS,
+            ChurchServiceCanonicalConflictReason::CanonicalChangedWithConflicts,
             $service->canonical_conflict_reason
         );
     }

--- a/tests/Integration/Services/ChurchServiceCanonicalUpdateServiceTest.php
+++ b/tests/Integration/Services/ChurchServiceCanonicalUpdateServiceTest.php
@@ -61,7 +61,7 @@ class ChurchServiceCanonicalUpdateServiceTest extends TestCase
         $this->assertFalse($result->needs_review);
         $this->assertNull($result->import_metadata['canonical_conflict'] ?? null);
         $this->assertNull($result->import_metadata['canonical_conflict_history'] ?? null);
-        $this->assertSame(ChurchServiceCanonicalConflictState::NONE, $result->canonical_conflict_state);
+        $this->assertSame(ChurchServiceCanonicalConflictState::None, $result->canonical_conflict_state);
         $this->assertSame(ChurchServiceReviewState::NotReviewed, $result->review_state);
 
         Event::assertNotDispatched(ChurchServiceCanonicalListChanged::class);
@@ -105,8 +105,8 @@ class ChurchServiceCanonicalUpdateServiceTest extends TestCase
         $this->assertFalse($result->import_metadata['canonical_conflict']['review_reopened']);
         $this->assertFalse($result->import_metadata['canonical_conflict']['reviewed_previously']);
         $this->assertCount(1, $result->import_metadata['canonical_conflict_history']);
-        $this->assertSame(ChurchServiceCanonicalConflictState::DETECTED, $result->canonical_conflict_state);
-        $this->assertSame(ChurchServiceCanonicalConflictReason::CANONICAL_CHANGED, $result->canonical_conflict_reason);
+        $this->assertSame(ChurchServiceCanonicalConflictState::Detected, $result->canonical_conflict_state);
+        $this->assertSame(ChurchServiceCanonicalConflictReason::CanonicalChanged, $result->canonical_conflict_reason);
 
         Event::assertDispatched(
             ChurchServiceCanonicalListChanged::class,
@@ -154,7 +154,7 @@ class ChurchServiceCanonicalUpdateServiceTest extends TestCase
         $this->assertSame('openlp', $result->import_metadata['manual_review']['reopened_by_source'] ?? null);
         $this->assertArrayHasKey('reopened_at', $result->import_metadata['manual_review']);
         $this->assertSame(ChurchServiceReviewState::Reopened, $result->review_state);
-        $this->assertSame(ChurchServiceCanonicalConflictState::REOPENED, $result->canonical_conflict_state);
+        $this->assertSame(ChurchServiceCanonicalConflictState::Reopened, $result->canonical_conflict_state);
     }
 
     #[Test]
@@ -191,7 +191,7 @@ class ChurchServiceCanonicalUpdateServiceTest extends TestCase
 
         $this->assertTrue($result->needs_review);
         $this->assertFalse($result->import_metadata['canonical_conflict']['canonical_changed']);
-        $this->assertSame(ChurchServiceCanonicalConflictReason::CONFLICTS_ONLY, $result->canonical_conflict_reason);
+        $this->assertSame(ChurchServiceCanonicalConflictReason::ConflictsOnly, $result->canonical_conflict_reason);
 
         // No canonical list change — event must not fire
         Event::assertNotDispatched(ChurchServiceCanonicalListChanged::class);

--- a/tests/Integration/Services/ChurchServiceReviewSynchronizerTest.php
+++ b/tests/Integration/Services/ChurchServiceReviewSynchronizerTest.php
@@ -189,6 +189,6 @@ class ChurchServiceReviewSynchronizerTest extends TestCase
 
         $churchService->refresh();
         $this->assertTrue($churchService->needs_review);
-        $this->assertSame(ChurchServiceCanonicalConflictState::REOPENED, $churchService->canonical_conflict_state);
+        $this->assertSame(ChurchServiceCanonicalConflictState::Reopened, $churchService->canonical_conflict_state);
     }
 }


### PR DESCRIPTION
💡 **What:** Refactored `ChurchServiceCanonicalConflictState` and `ChurchServiceCanonicalConflictReason` Enums to use TitleCase keys (`None`, `Detected`, `Reopened`, etc.) instead of `UPPER_SNAKE_CASE`.
🎯 **Why:** To maintain consistency with the project's standard for Enum keys and reduce cognitive load.
🔄 **Behavior:** No functional changes. Backing string values are preserved, ensuring database compatibility.
✅ **Tests:** All relevant integration and feature tests pass. PHPStan reports 0 errors.

---
*PR created automatically by Jules for task [18123625484241710338](https://jules.google.com/task/18123625484241710338) started by @GarethClarridge*