### PR TITLE
♿ Aria: Add ARIA attributes to media upload progress bars

### DIFF
--- a/resources/views/livewire/media-upload/progress.blade.php
+++ b/resources/views/livewire/media-upload/progress.blade.php
@@ -19,6 +19,11 @@
                     <div
                         class="h-3 rounded-full bg-blue-600 transition-all duration-300 ease-out"
                         style="width: {{ $uploadProgress }}%"
+                        role="progressbar"
+                        aria-valuenow="{{ $uploadProgress }}"
+                        aria-valuemin="0"
+                        aria-valuemax="100"
+                        aria-label="Upload progress"
                     ></div>
                 </div>
             </div>

--- a/resources/views/livewire/media-upload/status.blade.php
+++ b/resources/views/livewire/media-upload/status.blade.php
@@ -18,6 +18,11 @@
                 <div
                     class="h-3 rounded-full transition-all duration-500 ease-out {{ $manualReviewMessage ? 'bg-amber-400' : ($status === 'failed' ? 'bg-red-500' : ($status === 'cancelled' ? 'bg-gray-400' : ($status === 'completed' ? 'bg-green-500' : 'bg-blue-500'))) }}"
                     style="width: {{ $progressPercentage }}%"
+                    role="progressbar"
+                    aria-valuenow="{{ $progressPercentage }}"
+                    aria-valuemin="0"
+                    aria-valuemax="100"
+                    aria-label="Processing progress"
                 ></div>
             </div>
         </div>


### PR DESCRIPTION
Improved the accessibility of the media upload interface by adding standard ARIA progressbar attributes to both the file upload progress bar and the backend processing status indicator. This allows screen readers to correctly identify and announce progress updates to users.

Modified files:
- resources/views/livewire/media-upload/progress.blade.php
- resources/views/livewire/media-upload/status.blade.php

Verification:
- Confirmed ARIA attributes via manual inspection of Blade templates.
- Ran Feature/Livewire tests for MediaUpload components (30 tests passed).
- Confirmed no visual regressions.

---
*PR created automatically by Jules for task [1125332724967260151](https://jules.google.com/task/1125332724967260151) started by @GarethClarridge*