### PR TITLE
📜 Herald: Add PHPDoc shapes to SermonAnalysis and document thresholds

### DIFF
--- a/.Jules/herald.md
+++ b/.Jules/herald.md
@@ -9,3 +9,7 @@
 ## 2026-06-03 - Centralizing Progress and Retry Documentation
 **Learning:** The `ProcessingPhaseRegistry` is a critical bottleneck for user experience (progress bars) and system reliability (retries). Documenting the exact array shapes for retry plans (actions, strategies, and scopes) is essential for maintaining the contract between the registry and the `ProcessingRunOrchestrator`.
 **Action:** When documenting registry-like services, prioritize documenting the return array shapes of mapping methods, as these define the "plans" executed by other services.
+
+## 2026-06-05 - Enhancing Type Safety and Business Context
+**Learning:** Added precise array shapes to `SermonAnalysis` DTO and its interface, and documented a magic number in `SermonCandidateConfidenceService`. Explicit array shapes are particularly useful for DTOs that interact with AI services or database attributes, as they clarify the expected keys and types which might otherwise be opaque. Documenting magic numbers like the 20-minute sermon threshold provides essential business context for why specific values were chosen.
+**Action:** Continue to prioritize array shape documentation for DTOs and services that return or consume complex associative arrays. Always look for magic numbers in business logic and provide a "why" comment explaining their calibration or rationale.

--- a/app/Contracts/SermonAnalysisInterface.php
+++ b/app/Contracts/SermonAnalysisInterface.php
@@ -14,6 +14,7 @@ interface SermonAnalysisInterface
      * @param  string  $transcript  The sermon transcript text to analyze
      * @param  array<int, string>  $existingSeries  Existing sermon series for context
      * @param  string|null  $processingId  Processing run identifier used for log correlation
+     * @return SermonAnalysis The analyzed sermon data
      */
     public function analyzeSermon(string $transcript, array $existingSeries = [], ?string $processingId = null): SermonAnalysis;
 }

--- a/app/Data/SermonAnalysis.php
+++ b/app/Data/SermonAnalysis.php
@@ -103,9 +103,16 @@ class SermonAnalysis extends Data implements ArrayAccess
     }
 
     /**
-     * Create from raw AI analysis data with validation
+     * Create from raw AI analysis data with validation.
      *
-     * @param  array<string, mixed>  $analysisData
+     * @param  array{
+     *     title?: string,
+     *     series?: string|null,
+     *     reference?: string|null,
+     *     points?: list<string>,
+     *     summary?: string|null,
+     *     transcript?: string,
+     * }  $analysisData
      */
     public static function fromAiAnalysis(array $analysisData): self
     {
@@ -120,9 +127,15 @@ class SermonAnalysis extends Data implements ArrayAccess
     }
 
     /**
-     * Transform the analysis for database insertion
+     * Transform the analysis for database insertion.
      *
-     * @return array<string, mixed>
+     * @return array{
+     *     title: string,
+     *     series: string|null,
+     *     reference: string|null,
+     *     points: string,
+     *     summary: string|null,
+     * }
      */
     public function toSermonAttributes(): array
     {
@@ -146,9 +159,17 @@ class SermonAnalysis extends Data implements ArrayAccess
     }
 
     /**
-     * Get a summary of the analysis for logging/debugging
+     * Get a summary of the analysis for logging/debugging.
      *
-     * @return array<string, mixed>
+     * @return array{
+     *     title: string,
+     *     title_word_count: int,
+     *     series: string,
+     *     reference: string,
+     *     points_count: int,
+     *     transcript_length: int,
+     *     has_valid_transcript: bool,
+     * }
      */
     public function getSummary(): array
     {

--- a/app/Services/Sermon/SermonCandidateConfidenceService.php
+++ b/app/Services/Sermon/SermonCandidateConfidenceService.php
@@ -29,7 +29,15 @@ class SermonCandidateConfidenceService
             ->sortByDesc(fn (LivestreamSegment $segment): float => (float) $segment->duration)
             ->values();
 
-        /** @var Collection<int, LivestreamSegment> $qualifyingSegments */
+        /**
+         * Filter segments that meet the minimum sermon duration threshold.
+         *
+         * Default threshold is 20 minutes (1200.0 seconds). This is calibrated to
+         * distinguish main sermons from other speech elements like notices,
+         * prayers, or readings, which are typically shorter in this context.
+         *
+         * @var Collection<int, LivestreamSegment> $qualifyingSegments
+         */
         $qualifyingSegments = $orderedByDuration
             ->filter(fn (LivestreamSegment $segment): bool => (float) $segment->duration >= 1200.0)
             ->values();


### PR DESCRIPTION
### 💡 What: Documentation added or corrected
- Added precise PHPStan array shapes to key methods in `App\Data\SermonAnalysis` (`fromAiAnalysis`, `toSermonAttributes`, `getSummary`).
- Added missing `@return SermonAnalysis` annotation to `App\Contracts\SermonAnalysisInterface::analyzeSermon`.
- Added a descriptive comment to `App\Services\Sermon\SermonCandidateConfidenceService` explaining the rationale behind the 20-minute (1200.0s) sermon detection threshold.

### 🎯 Why: What was unclear and how this helps
- The structure of AI analysis results and sermon attributes was opaque, making it difficult for developers to know which keys were available and for PHPStan to provide full type safety.
- The 1200.0s threshold was a "magic number" without context; documenting it provides essential business logic background for why this specific value is used for sermon detection.

### 🔄 Behavior: 
No functional changes — documentation only. Verified with `composer phpstan` and relevant unit/integration tests.

---
*PR created automatically by Jules for task [9309448196986833734](https://jules.google.com/task/9309448196986833734) started by @GarethClarridge*