### PR TITLE
📖 Editor: Standardise "Import Email Text" terminology and casing

### DIFF
--- a/app/Livewire/Admin/ChurchServices/SubmitEmailText.php
+++ b/app/Livewire/Admin/ChurchServices/SubmitEmailText.php
@@ -82,7 +82,7 @@ class SubmitEmailText extends Component
     public function render(): View
     {
         return view('livewire.admin.church-services.submit-email-text')
-            ->layout('layouts.admin', ['title' => 'Submit Email Text', 'heading' => 'Submit Email Text']);
+            ->layout('layouts.admin', ['title' => 'Import Email Text', 'heading' => 'Import Email Text']);
     }
 
     private function abortIfDisabled(): void

--- a/resources/views/livewire/admin/church-services/review-inbound-emails.blade.php
+++ b/resources/views/livewire/admin/church-services/review-inbound-emails.blade.php
@@ -1,5 +1,5 @@
 <x-admin.list-shell
-    title="Inbound email review"
+    title="Inbound Email Review"
     description="Review low-confidence or failed order-of-service emails before they become canonical."
 >
     <x-slot:actions>
@@ -10,7 +10,7 @@
             Upload service
         </x-button>
         <x-button link="{{ route('admin.services.submit-email') }}" variant="outline" icon="envelope" inline>
-            Submit email text
+            Import email text
         </x-button>
     </x-slot:actions>
 

--- a/resources/views/livewire/admin/church-services/submit-email-text.blade.php
+++ b/resources/views/livewire/admin/church-services/submit-email-text.blade.php
@@ -1,5 +1,5 @@
 <x-admin.form-shell
-    title="Submit email text"
+    title="Import Email Text"
     description="Paste an order-of-service email into the same parsing pipeline used by inbound mail."
     save-action="submit"
 >
@@ -17,7 +17,7 @@
                 wire:click="submit"
                 icon="paper-airplane"
             >
-                Submit for parsing
+                Import email
             </x-form-button>
         @endunless
     </x-slot:actions>
@@ -29,7 +29,7 @@
                     <x-heroicon-o-check-circle class="h-8 w-8 text-green-600" />
                 </div>
                 <div>
-                    <h2 class="text-lg font-semibold text-gray-900">Email submitted for parsing</h2>
+                    <h2 class="text-lg font-semibold text-gray-900">Email imported for review</h2>
                     <p class="mt-1 text-sm text-gray-600">The email has been queued for processing. Check the review list to see the parsed result.</p>
                 </div>
                 <div class="flex justify-center gap-3">
@@ -37,7 +37,7 @@
                         View in review list
                     </x-button>
                     <x-form-button type="button" variant="outline" wire:click="$set('submitted', false)">
-                        Submit another
+                        Import another email
                     </x-form-button>
                 </div>
             </div>
@@ -77,7 +77,7 @@
                 </div>
             </x-card>
 
-            <x-card heading="Submit">
+            <x-card heading="Importing">
                 <div class="space-y-3 text-sm text-gray-600">
                     <p>The email will be queued via the same pipeline as Mailgun webhook emails.</p>
                     <p>After submission you can review the parse result in the inbound email list.</p>

--- a/resources/views/livewire/admin/church-services/upload-church-service.blade.php
+++ b/resources/views/livewire/admin/church-services/upload-church-service.blade.php
@@ -10,7 +10,7 @@
             Song catalogue
         </x-button>
         <x-button link="{{ route('admin.services.submit-email') }}" variant="outline" icon="envelope" inline>
-            Submit email text
+            Import email text
         </x-button>
         <x-form-button variant="primary" wire:click="save" icon="arrow-up-tray">
             Import

--- a/tests/Feature/Livewire/Admin/ChurchServices/ShowChurchServiceTest.php
+++ b/tests/Feature/Livewire/Admin/ChurchServices/ShowChurchServiceTest.php
@@ -135,7 +135,7 @@ class ShowChurchServiceTest extends TestCase
 
         Livewire::actingAs($this->admin)
             ->test(SubmitEmailText::class)
-            ->assertSee('Submit email text')
+            ->assertSee('Import Email Text')
             ->assertSeeHtml('wire:target="submit"');
     }
 


### PR DESCRIPTION
Renamed the "Submit Email Text" feature to "Import Email Text" across the admin area for better clarity and consistency. Standardised admin page headers and sidebar titles to Title Case, while maintaining sentence case for buttons. Updated relevant tests and navigation links.

Functional changes: None - copy and casing only.
Files touched:
- `app/Livewire/Admin/ChurchServices/SubmitEmailText.php`
- `resources/views/livewire/admin/church-services/submit-email-text.blade.php`
- `resources/views/livewire/admin/church-services/review-inbound-emails.blade.php`
- `resources/views/livewire/admin/church-services/upload-church-service.blade.php`
- `tests/Feature/Livewire/Admin/ChurchServices/ShowChurchServiceTest.php`

---
*PR created automatically by Jules for task [14357844578643827035](https://jules.google.com/task/14357844578643827035) started by @GarethClarridge*