### PR TITLE
⚡ Bolt: optimize CleanupUnpublishedSectionAssetsCommand memory usage

### DIFF
--- a/app/Console/Commands/CleanupUnpublishedSectionAssetsCommand.php
+++ b/app/Console/Commands/CleanupUnpublishedSectionAssetsCommand.php
@@ -47,8 +47,7 @@ class CleanupUnpublishedSectionAssetsCommand extends Command
                             ->whereNotNull('extracted_at')
                             ->where('extracted_at', '<=', $cutoff);
                     });
-            })
-            ->orderBy('id');
+            });
 
         if (! $query->exists()) {
             $this->info('No unpublished section assets require cleanup.');
@@ -64,7 +63,13 @@ class CleanupUnpublishedSectionAssetsCommand extends Command
         $cleanedCount = 0;
         $failedCount = 0;
 
-        foreach ($query->lazy() as $section) {
+        /**
+         * Performance Optimization: Use lazyById() instead of lazy() to ensure all sections
+         * are processed. Since the publication_status is updated within the loop,
+         * offset-based chunking (used by lazy()) would skip records as the
+         * result set shrinks.
+         */
+        foreach ($query->lazyById() as $section) {
             $totalCandidateCount++;
             $videoPath = $section->extracted_video_path;
             $audioPath = $section->extracted_audio_path;

--- a/app/Console/Commands/CleanupUnpublishedSectionAssetsCommand.php
+++ b/app/Console/Commands/CleanupUnpublishedSectionAssetsCommand.php
@@ -32,7 +32,11 @@ class CleanupUnpublishedSectionAssetsCommand extends Command
             ServiceSectionPublicationStatus::Approved->value,
         ];
 
-        $sections = ServiceSection::query()
+        /**
+         * Performance Optimization: Use exists() for initial check and lazy() for processing
+         * to keep memory usage low even when cleaning up many thousands of sections.
+         */
+        $query = ServiceSection::query()
             ->whereIn('publication_status', $targetStatuses)
             ->whereNull('published_sermon_id')
             ->where(function ($query) use ($cutoff): void {
@@ -44,10 +48,9 @@ class CleanupUnpublishedSectionAssetsCommand extends Command
                             ->where('extracted_at', '<=', $cutoff);
                     });
             })
-            ->orderBy('id')
-            ->get();
+            ->orderBy('id');
 
-        if ($sections->isEmpty()) {
+        if (! $query->exists()) {
             $this->info('No unpublished section assets require cleanup.');
 
             return self::SUCCESS;
@@ -57,10 +60,12 @@ class CleanupUnpublishedSectionAssetsCommand extends Command
             $this->warn('DRY RUN enabled. No files or rows will be modified.');
         }
 
+        $totalCandidateCount = 0;
         $cleanedCount = 0;
         $failedCount = 0;
 
-        foreach ($sections as $section) {
+        foreach ($query->lazy() as $section) {
+            $totalCandidateCount++;
             $videoPath = $section->extracted_video_path;
             $audioPath = $section->extracted_audio_path;
 
@@ -94,7 +99,7 @@ class CleanupUnpublishedSectionAssetsCommand extends Command
         }
 
         if ($dryRun) {
-            $this->info('Dry run complete: '.$sections->count().' sections would be cleaned.');
+            $this->info('Dry run complete: '.$totalCandidateCount.' sections would be cleaned.');
 
             return self::SUCCESS;
         }


### PR DESCRIPTION
### 💡 What:
Optimized the `CleanupUnpublishedSectionAssetsCommand` to use memory-efficient streaming for processing service sections.

### 🎯 Why:
The command previously used `->get()`, which loads all matching `ServiceSection` models into memory at once. For an environment with a large number of orphaned or expired assets, this could lead to PHP memory limit exhaustion.

### 📊 Impact:
- Reduces memory footprint to a constant level regardless of the number of sections being processed.
- Improves performance of the initial check by using `EXISTS` instead of loading a collection to check if it's empty.

### 🔬 Measurement:
- Verified via existing feature tests (`CleanupUnpublishedSectionAssetsCommandTest`).
- Confirmed logic integrity for dry-run and execution modes through manual code review and `sed` verification.

---
*PR created automatically by Jules for task [9272152667775774912](https://jules.google.com/task/9272152667775774912) started by @GarethClarridge*