### PR TITLE
🛡️ Sentinel: implement integer bounding security hardening

### DIFF
--- a/app/Http/Requests/CategorizeEventRequest.php
+++ b/app/Http/Requests/CategorizeEventRequest.php
@@ -25,7 +25,11 @@ class CategorizeEventRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'event_id' => ['required', 'integer', 'exists:calendar_events,id'],
+            /**
+             * Security: Integer bounding is enforced to prevent malformed input and
+             * potential integer overflow attacks.
+             */
+            'event_id' => ['required', 'integer', 'max:2147483647', 'exists:calendar_events,id'],
             'meeting_slug' => ['required', 'string', 'max:255', 'exists:meetings,slug'],
         ];
     }

--- a/app/Http/Requests/CategorizeEventRequest.php
+++ b/app/Http/Requests/CategorizeEventRequest.php
@@ -25,10 +25,7 @@ class CategorizeEventRequest extends FormRequest
     public function rules(): array
     {
         return [
-            /**
-             * Security: Integer bounding is enforced to prevent malformed input and
-             * potential integer overflow attacks.
-             */
+            // Security: integer bounding guards against malformed input and overflow before the exists lookup runs.
             'event_id' => ['required', 'integer', 'min:1', 'max:2147483647', 'exists:calendar_events,id'],
             'meeting_slug' => ['required', 'string', 'max:255', 'exists:meetings,slug'],
         ];

--- a/app/Http/Requests/CategorizeEventRequest.php
+++ b/app/Http/Requests/CategorizeEventRequest.php
@@ -29,7 +29,7 @@ class CategorizeEventRequest extends FormRequest
              * Security: Integer bounding is enforced to prevent malformed input and
              * potential integer overflow attacks.
              */
-            'event_id' => ['required', 'integer', 'max:2147483647', 'exists:calendar_events,id'],
+            'event_id' => ['required', 'integer', 'min:1', 'max:2147483647', 'exists:calendar_events,id'],
             'meeting_slug' => ['required', 'string', 'max:255', 'exists:meetings,slug'],
         ];
     }

--- a/app/Http/Requests/SermonIndexRequest.php
+++ b/app/Http/Requests/SermonIndexRequest.php
@@ -38,7 +38,7 @@ class SermonIndexRequest extends FormRequest
              * Security: Integer bounding is enforced to prevent malformed input and
              * potential integer overflow attacks.
              */
-            'preacher_id' => ['nullable', 'integer', 'max:2147483647', 'exists:preachers,id'],
+            'preacher_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:preachers,id'],
             'series' => ['nullable', 'string', 'max:255'],
             'sort' => ['nullable', 'string', 'in:date,title,preacher,series,service'],
             'order' => ['nullable', 'string', 'in:asc,desc'],

--- a/app/Http/Requests/SermonIndexRequest.php
+++ b/app/Http/Requests/SermonIndexRequest.php
@@ -34,10 +34,7 @@ class SermonIndexRequest extends FormRequest
             'search' => ['nullable', 'string', 'max:255'],
             'service' => ['nullable', 'string', Rule::enum(SermonService::class)],
             'preacher' => ['nullable', 'string', 'max:255'],
-            /**
-             * Security: Integer bounding is enforced to prevent malformed input and
-             * potential integer overflow attacks.
-             */
+            // Security: integer bounding guards against malformed input and overflow before the exists lookup runs.
             'preacher_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:preachers,id'],
             'series' => ['nullable', 'string', 'max:255'],
             'sort' => ['nullable', 'string', 'in:date,title,preacher,series,service'],

--- a/app/Http/Requests/SermonIndexRequest.php
+++ b/app/Http/Requests/SermonIndexRequest.php
@@ -34,7 +34,11 @@ class SermonIndexRequest extends FormRequest
             'search' => ['nullable', 'string', 'max:255'],
             'service' => ['nullable', 'string', Rule::enum(SermonService::class)],
             'preacher' => ['nullable', 'string', 'max:255'],
-            'preacher_id' => ['nullable', 'integer', 'exists:preachers,id'],
+            /**
+             * Security: Integer bounding is enforced to prevent malformed input and
+             * potential integer overflow attacks.
+             */
+            'preacher_id' => ['nullable', 'integer', 'max:2147483647', 'exists:preachers,id'],
             'series' => ['nullable', 'string', 'max:255'],
             'sort' => ['nullable', 'string', 'in:date,title,preacher,series,service'],
             'order' => ['nullable', 'string', 'in:asc,desc'],

--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -286,12 +286,12 @@ class Sermon extends Model implements Sitemapable
              * Security: Integer bounding is enforced on all ID and counter fields to provide
              * Defense in Depth against malformed input and potential integer overflow attacks.
              */
-            'preacher_id' => ['nullable', 'integer', 'max:2147483647', 'exists:preachers,id'],
+            'preacher_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:preachers,id'],
             'preacher_source' => ['nullable', Rule::enum(PreacherSource::class)],
             'preacher_confidence' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'segment_start_time' => ['nullable', 'numeric', 'min:0'],
             'segment_end_time' => ['nullable', 'numeric', 'min:0', 'gte:segment_start_time'],
-            'scripture_passage_id' => ['nullable', 'integer', 'max:2147483647', 'exists:scripture_passages,id'],
+            'scripture_passage_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:scripture_passages,id'],
             'download_count' => ['nullable', 'integer', 'min:0', 'max:2147483647'],
             'duration' => ['nullable', 'numeric', 'min:0'],
             'summary' => ['nullable', 'string', 'max:1000'],

--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -282,10 +282,7 @@ class Sermon extends Model implements Sitemapable
             'series' => ['nullable', 'string', 'max:255'],
             'reference' => ['nullable', 'string', 'max:255', new NotEmptyString],
             'preacher' => ['required', 'string', 'max:255'], // Matches database varchar length and non-empty constraint
-            /**
-             * Security: Integer bounding is enforced on all ID and counter fields to provide
-             * Defense in Depth against malformed input and potential integer overflow attacks.
-             */
+            // Security: integer bounding on ID and counter fields adds defence in depth against malformed input and overflow.
             'preacher_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:preachers,id'],
             'preacher_source' => ['nullable', Rule::enum(PreacherSource::class)],
             'preacher_confidence' => ['nullable', 'numeric', 'min:0', 'max:1'],

--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -282,13 +282,17 @@ class Sermon extends Model implements Sitemapable
             'series' => ['nullable', 'string', 'max:255'],
             'reference' => ['nullable', 'string', 'max:255', new NotEmptyString],
             'preacher' => ['required', 'string', 'max:255'], // Matches database varchar length and non-empty constraint
-            'preacher_id' => ['nullable', 'integer', 'exists:preachers,id'],
+            /**
+             * Security: Integer bounding is enforced on all ID and counter fields to provide
+             * Defense in Depth against malformed input and potential integer overflow attacks.
+             */
+            'preacher_id' => ['nullable', 'integer', 'max:2147483647', 'exists:preachers,id'],
             'preacher_source' => ['nullable', Rule::enum(PreacherSource::class)],
             'preacher_confidence' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'segment_start_time' => ['nullable', 'numeric', 'min:0'],
             'segment_end_time' => ['nullable', 'numeric', 'min:0', 'gte:segment_start_time'],
-            'scripture_passage_id' => ['nullable', 'integer', 'exists:scripture_passages,id'],
-            'download_count' => ['nullable', 'integer', 'min:0'],
+            'scripture_passage_id' => ['nullable', 'integer', 'max:2147483647', 'exists:scripture_passages,id'],
+            'download_count' => ['nullable', 'integer', 'min:0', 'max:2147483647'],
             'duration' => ['nullable', 'numeric', 'min:0'],
             'summary' => ['nullable', 'string', 'max:1000'],
             'points' => ['nullable', 'array', 'max:100'],

--- a/tests/Feature/Api/SermonApiTest.php
+++ b/tests/Feature/Api/SermonApiTest.php
@@ -525,10 +525,13 @@ class SermonApiTest extends TestCase
             ->assertStatus(422)
             ->assertJsonValidationErrors(['preacher_id']);
 
-        // Test out of bounds preacher_id
+        // Test out of bounds preacher_id — assert the max-bound message specifically so this
+        // proves the new max rule fired rather than the pre-existing exists rule.
         $this->getJson('/api/sermons?preacher_id=2147483648')
             ->assertStatus(422)
-            ->assertJsonValidationErrors(['preacher_id']);
+            ->assertJsonValidationErrors([
+                'preacher_id' => 'The preacher id field must not be greater than 2147483647.',
+            ]);
 
         // Test invalid with_thumbnail
         $this->getJson('/api/sermons?with_thumbnail=not_a_boolean')

--- a/tests/Feature/Api/SermonApiTest.php
+++ b/tests/Feature/Api/SermonApiTest.php
@@ -525,6 +525,11 @@ class SermonApiTest extends TestCase
             ->assertStatus(422)
             ->assertJsonValidationErrors(['preacher_id']);
 
+        // Test out of bounds preacher_id
+        $this->getJson('/api/sermons?preacher_id=2147483648')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['preacher_id']);
+
         // Test invalid with_thumbnail
         $this->getJson('/api/sermons?with_thumbnail=not_a_boolean')
             ->assertStatus(422)

--- a/tests/Feature/CalendarAdminControllerTest.php
+++ b/tests/Feature/CalendarAdminControllerTest.php
@@ -217,6 +217,20 @@ class CalendarAdminControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_validates_event_id_is_bounded(): void
+    {
+        Meeting::factory()->create(['slug' => 'sunday-morning']);
+
+        $this->actingAs($this->adminUser);
+        $response = $this->post('/admin/calendar/categorize', [
+            'event_id' => 2147483648, // out of bounds
+            'meeting_slug' => 'sunday-morning',
+        ]);
+
+        $response->assertSessionHasErrors('event_id');
+    }
+
+    #[Test]
     public function it_validates_meeting_slug_exists_in_database(): void
     {
         Meeting::factory()->create(['slug' => 'some-slug']);

--- a/tests/Feature/CalendarAdminControllerTest.php
+++ b/tests/Feature/CalendarAdminControllerTest.php
@@ -227,7 +227,11 @@ class CalendarAdminControllerTest extends TestCase
             'meeting_slug' => 'sunday-morning',
         ]);
 
-        $response->assertSessionHasErrors('event_id');
+        // Assert the max-bound message specifically so this proves the new max rule
+        // fired rather than the pre-existing exists rule.
+        $response->assertSessionHasErrors([
+            'event_id' => 'The event id field must not be greater than 2147483647.',
+        ]);
     }
 
     #[Test]

--- a/tests/Feature/WardenSermonValidationTest.php
+++ b/tests/Feature/WardenSermonValidationTest.php
@@ -103,4 +103,37 @@ class WardenSermonValidationTest extends TestCase
 
         $this->assertFalse($validator->fails());
     }
+
+    #[Test]
+    public function it_rejects_a_download_count_above_the_integer_bound(): void
+    {
+        $rules = Sermon::validationRules();
+
+        // download_count has no exists rule, so a failure here can only come from the max bound.
+        $validator = Validator::make([
+            'download_count' => 2147483648,
+        ], [
+            'download_count' => $rules['download_count'],
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertEquals(
+            'The download count field must not be greater than 2147483647.',
+            $validator->errors()->first('download_count')
+        );
+    }
+
+    #[Test]
+    public function it_accepts_a_download_count_at_the_integer_bound(): void
+    {
+        $rules = Sermon::validationRules();
+
+        $validator = Validator::make([
+            'download_count' => 2147483647,
+        ], [
+            'download_count' => $rules['download_count'],
+        ]);
+
+        $this->assertFalse($validator->fails());
+    }
 }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Lack of upper-bound constraints on integer input fields (IDs and counters) in API and admin requests.
🎯 **Impact:** Potential for integer overflow issues or malformed input causing database or application errors when extremely large numbers are provided.
🔧 **Fix:** Implemented additive hardening by adding `max:2147483647` (the maximum value for a signed 32-bit integer) to relevant validation rules.
✅ **Verification:** Verified by adding new test cases to `SermonApiTest` and `CalendarAdminControllerTest` that specifically attempt to submit out-of-bounds integers, confirming they are rejected with 422 errors. Full test suite and PHPStan also passed.

---
*PR created automatically by Jules for task [17030298810496274346](https://jules.google.com/task/17030298810496274346) started by @GarethClarridge*