### PR TITLE
📖 Editor: Improve Forgot Password button microcopy

### DIFF
--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -26,7 +26,7 @@
 
         <div class="mt-6">
             <x-form-button variant="primary" class="w-full text-xl py-3">
-                Send Password Reset Link
+                Send reset link
             </x-form-button>
         </div>
 

--- a/tests/Browser/Auth/ForgotPasswordTest.php
+++ b/tests/Browser/Auth/ForgotPasswordTest.php
@@ -30,7 +30,7 @@ class ForgotPasswordTest extends DuskTestCase
         $this->browse(function (Browser $browser) use ($user) {
             $browser->visit('/forgot-password')
                 ->type('input[type="email"]', $user->email)
-                ->press('Send Password Reset Link')
+                ->press('Send reset link')
                 ->waitForText('We have emailed your password reset link')
                 ->assertSee('We have emailed your password reset link');
         });


### PR DESCRIPTION
This change improves the user-facing microcopy on the "Forgot Password" page.

### 💡 What
The button label in `resources/views/livewire/auth/forgot-password.blade.php` has been changed from "Send Password Reset Link" to "Send reset link".

### 🎯 Why
The new label follows sentence case (house style) and is more concise and action-oriented, improving the user experience during the password reset flow.

### 🔄 Behavior
No functional changes were made. The corresponding Dusk test in `tests/Browser/Auth/ForgotPasswordTest.php` was updated to ensure the test suite continues to pass with the new label.

### 📍 Where
- `resources/views/livewire/auth/forgot-password.blade.php`
- `tests/Browser/Auth/ForgotPasswordTest.php`

---
*PR created automatically by Jules for task [13049026029989205911](https://jules.google.com/task/13049026029989205911) started by @GarethClarridge*