### PR TITLE
🧪 Steward: Harden VideoStorageService tests

### DIFF
--- a/tests/Unit/Services/VideoStorageServiceCompressionTest.php
+++ b/tests/Unit/Services/VideoStorageServiceCompressionTest.php
@@ -90,12 +90,28 @@ class VideoStorageServiceCompressionTest extends TestCase
 
     public function test_container_resolves_video_storage_with_audio_compression_service(): void
     {
-        $resolvedService = app(VideoStorageService::class);
-        $reflection = new \ReflectionClass($resolvedService);
-        $property = $reflection->getProperty('audioCompressor');
-        $property->setAccessible(true);
+        $mockCompression = $this->createMock(AudioCompressionService::class);
+        $this->app->instance(AudioCompressionService::class, $mockCompression);
 
-        $this->assertInstanceOf(AudioCompressionService::class, $property->getValue($resolvedService));
+        $mockCompression->expects($this->once())
+            ->method('extractOptimizedAudio')
+            ->willReturn([
+                'audio_path' => 'sermons/audio/test_sermon.mp3',
+                'full_path' => '/path/to/full/audio.mp3',
+                'original_size' => 1024 * 1024,
+                'final_size' => 1024 * 1024,
+                'compression_applied' => false,
+                'compression_ratio' => 1.0,
+                'valid_for_transcription' => true,
+            ]);
+
+        $resolvedService = app(VideoStorageService::class);
+
+        $resolvedService->extractOptimizedAudioFromSegment(
+            $this->testVideoPath,
+            $this->testSegment,
+            'test_sermon.mp3'
+        );
     }
 
     public function test_video_segment_extraction_delegates_to_extraction_service(): void

--- a/tests/Unit/Services/VideoStorageServiceTest.php
+++ b/tests/Unit/Services/VideoStorageServiceTest.php
@@ -128,7 +128,9 @@ class VideoStorageServiceTest extends TestCase
                 file_put_contents($outputPath, 'audio content');
             }
         );
-        $this->injectFfmpeg($this->service, $ffmpeg);
+
+        $this->storageHelper->method('createFFMpeg')->willReturn($ffmpeg);
+        $this->service = $this->makeService();
 
         $result = $this->service->moveToSermonStorage($tempPath, 'test-sermon');
 
@@ -146,7 +148,6 @@ class VideoStorageServiceTest extends TestCase
         Config::set('filesystems.disks.s3_perm', ['driver' => 's3']);
         Storage::fake('s3_perm', ['driver' => 's3']);
         Config::set('media-processing.storage.sermon_disk', 's3_perm');
-        $this->service = $this->makeService();
 
         $tempPath = 'livestream/temp/test.mp4';
         Storage::disk('local_temp')->put($tempPath, 'video content');
@@ -156,7 +157,9 @@ class VideoStorageServiceTest extends TestCase
                 file_put_contents($outputPath, 'audio content');
             }
         );
-        $this->injectFfmpeg($this->service, $ffmpeg);
+
+        $this->storageHelper->method('createFFMpeg')->willReturn($ffmpeg);
+        $this->service = $this->makeService();
 
         $result = $this->service->moveToSermonStorage($tempPath, 'test-sermon');
 
@@ -207,14 +210,6 @@ class VideoStorageServiceTest extends TestCase
             $this->audioCompressor,
             $this->storageHelper
         );
-    }
-
-    private function injectFfmpeg(VideoStorageService $service, FFMpeg $ffmpeg): void
-    {
-        $reflection = new \ReflectionClass($service);
-        $property = $reflection->getProperty('ffmpeg');
-        $property->setAccessible(true);
-        $property->setValue($service, $ffmpeg);
     }
 
     /**


### PR DESCRIPTION
Hardened `VideoStorageServiceTest` and `VideoStorageServiceCompressionTest` by removing the use of `ReflectionClass` to access or modify private properties. Replaced with robust behavioral assertions and proper dependency injection mocking patterns. Verified with 5x test runs and full suite execution.

---
*PR created automatically by Jules for task [3588292758344832309](https://jules.google.com/task/3588292758344832309) started by @GarethClarridge*