### PR TITLE
📜 Herald: Add PHPDoc to ProcessingRunOrchestrator

### DIFF
--- a/app/Services/Processing/ProcessingRunOrchestrator.php
+++ b/app/Services/Processing/ProcessingRunOrchestrator.php
@@ -13,6 +13,14 @@ use Illuminate\Bus\Batch;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Log;
 
+/**
+ * Central dispatcher and state manager for media processing runs.
+ *
+ * Orchestrates the execution of media processing pipelines by dispatching
+ * job chains or batches to their appropriate queues based on the media type.
+ * Handles the logic for starting fresh runs, resuming after manual review,
+ * retrying failed/cancelled runs, and user-initiated cancellations.
+ */
 class ProcessingRunOrchestrator
 {
     public function __construct(
@@ -23,6 +31,17 @@ class ProcessingRunOrchestrator
         private readonly VideoStorageService $videoStorageService,
     ) {}
 
+    /**
+     * Start a new media processing run.
+     *
+     * Dispatches the appropriate job pipeline based on the log's profile.
+     * Audio and direct video runs use linear chains, while livestream runs
+     * start with a parallel processing phase before chaining.
+     *
+     * @param  MediaProcessingLog  $processingLog  The log record for the run to start
+     *
+     * @throws \InvalidArgumentException If the processing pipeline profile is unrecognized
+     */
     public function start(MediaProcessingLog $processingLog): void
     {
         match ($processingLog->processingPipelineProfile()) {
@@ -51,6 +70,16 @@ class ProcessingRunOrchestrator
         };
     }
 
+    /**
+     * Resume a processing run that was paused for manual sermon segment confirmation.
+     *
+     * Only applicable to 'livestream' and 'video_auto_trim' profiles which
+     * utilize the segmentation-based pipeline.
+     *
+     * @param  MediaProcessingLog  $processingLog  The log record awaiting resumption
+     *
+     * @throws \InvalidArgumentException If manual review is not supported for this profile
+     */
     public function resumeAfterManualReview(MediaProcessingLog $processingLog): void
     {
         match ($processingLog->processingPipelineProfile()) {
@@ -70,6 +99,14 @@ class ProcessingRunOrchestrator
         };
     }
 
+    /**
+     * Re-run the classification and structural analysis for an existing livestream run.
+     *
+     * Used when the original source media is still available to refresh
+     * sermon-derived outputs or correct manual classification errors.
+     *
+     * @param  MediaProcessingLog  $processingLog  The log record to reclassify
+     */
     public function reclassify(MediaProcessingLog $processingLog): void
     {
         $this->dispatchChain(
@@ -80,6 +117,18 @@ class ProcessingRunOrchestrator
         );
     }
 
+    /**
+     * Attempt to retry a failed or cancelled processing run.
+     *
+     * Consults the PhaseRegistry to determine a surgical retry plan (either
+     * resuming from a specific job offset, targeted reset, or full restart)
+     * based on the run's last successful state.
+     *
+     * @param  MediaProcessingLog  $processingLog  The failed or cancelled log
+     * @return ProcessingResult The outcome of the retry initiation attempt
+     *
+     * @throws \Throwable For unexpected orchestration failures
+     */
     public function retry(MediaProcessingLog $processingLog): ProcessingResult
     {
         try {
@@ -117,6 +166,15 @@ class ProcessingRunOrchestrator
         }
     }
 
+    /**
+     * Terminate an active processing run.
+     *
+     * Marks the run as cancelled and, for segmentation-style pipelines,
+     * triggers a cleanup of associated temporary files.
+     *
+     * @param  MediaProcessingLog  $processingLog  The log record for the run to cancel
+     * @return bool True if the cancellation transition was successful
+     */
     public function cancel(MediaProcessingLog $processingLog): bool
     {
         if ($processingLog->status === ProcessingStatus::Completed) {


### PR DESCRIPTION
### 💡 What: Documentation added to ProcessingRunOrchestrator

Added comprehensive PHPDoc blocks and type annotations to the `App\Services\Processing\ProcessingRunOrchestrator` class and its public methods.

### 🎯 Why: What was unclear and how this helps

The `ProcessingRunOrchestrator` is a critical coordination layer that manages complex job chains and parallel processing for different media types (audio, video, livestream). Previously, it lacked documentation on its public API surface, making it difficult for developers to understand the expected inputs, return types, and potential exceptions.

This documentation:
- Clarifies the dispatching logic for different pipeline profiles.
- Explains the surgical retry strategy based on phase registry offsets.
- Documents the requirements for resuming runs after manual review.
- Helps PHPStan with more precise type analysis.

### 🔄 Behavior: Explicitly state changes

No functional changes — documentation only.


---
*PR created automatically by Jules for task [8317626535611516885](https://jules.google.com/task/8317626535611516885) started by @GarethClarridge*