### PR TITLE
Remove unused inspire console command

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Foundation\Inspiring;
-
 /*
 |--------------------------------------------------------------------------
 | Console Routes
@@ -12,7 +10,3 @@ use Illuminate\Foundation\Inspiring;
 | simple approach to interacting with each command's IO methods.
 |
 */
-
-Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
-})->describe('Display an inspiring quote');


### PR DESCRIPTION
Removed the default Laravel 'inspire' command and its associated 'Illuminate\Foundation\Inspiring' import from 'routes/console.php'. This boilerplate code was not used by the application and its removal helps reduce technical debt and maintain a cleaner codebase, as per the Mortician persona's objectives.

---
*PR created automatically by Jules for task [15956320071995022842](https://jules.google.com/task/15956320071995022842) started by @GarethClarridge*