### PR TITLE
♿ Aria: Add accessible name to event categorisation select

### DIFF
--- a/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
+++ b/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
@@ -71,6 +71,7 @@
                                     Uncategorised
                                 </span>
                                 <select wire:change="categorize({{ $event->id }}, $event.target.value)"
+                                    aria-label="Categorise event: {{ $event->title }}"
                                     class="text-xs rounded-md border-gray-300 shadow-sm focus:border-cbc-teal focus:ring-cbc-teal w-40">
                                     <option value="">Categorise...</option>
                                     @foreach($meetings as $slug => $name)

--- a/tests/Feature/Livewire/Admin/CalendarEvents/ListCalendarEventsTest.php
+++ b/tests/Feature/Livewire/Admin/CalendarEvents/ListCalendarEventsTest.php
@@ -35,7 +35,7 @@ class ListCalendarEventsTest extends TestCase
         CalendarEvent::factory()->create([
             'title' => 'Specific Event',
             'meeting_slug' => null,
-            'start_datetime' => now()->addDay()
+            'start_datetime' => now()->addDay(),
         ]);
 
         Livewire::test(ListCalendarEvents::class)

--- a/tests/Feature/Livewire/Admin/CalendarEvents/ListCalendarEventsTest.php
+++ b/tests/Feature/Livewire/Admin/CalendarEvents/ListCalendarEventsTest.php
@@ -28,6 +28,21 @@ class ListCalendarEventsTest extends TestCase
     }
 
     #[Test]
+    public function it_has_aria_label_on_categorize_select(): void
+    {
+        $this->actingAs($this->admin);
+
+        CalendarEvent::factory()->create([
+            'title' => 'Specific Event',
+            'meeting_slug' => null,
+            'start_datetime' => now()->addDay()
+        ]);
+
+        Livewire::test(ListCalendarEvents::class)
+            ->assertSeeHtml('aria-label="Categorise event: Specific Event"');
+    }
+
+    #[Test]
     public function it_renders_successfully_for_admin(): void
     {
         $this->actingAs($this->admin);


### PR DESCRIPTION
I have fixed an accessibility issue where the categorisation dropdown in the admin calendar events list lacked an accessible name. This made it difficult for screen reader users to understand which event they were categorising.

Changes:
- Added `aria-label="Categorise event: {{ $event->title }}"` to the `<select>` element in `resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php`.
- Added a new test `it_has_aria_label_on_categorize_select` to `tests/Feature/Livewire/Admin/CalendarEvents/ListCalendarEventsTest.php` to ensure this remains fixed.

Verification:
- Ran `php artisan test tests/Feature/Livewire/Admin/CalendarEvents/ListCalendarEventsTest.php` and all tests passed.
- Manually verified that the `aria-label` is correctly rendered with the event title.

---
*PR created automatically by Jules for task [14335675460010382304](https://jules.google.com/task/14335675460010382304) started by @GarethClarridge*