### PR TITLE
📖 Editor: Standardise admin action buttons for better clarity

### DIFF
--- a/resources/views/livewire/admin/calendar-events/edit-calendar-event.blade.php
+++ b/resources/views/livewire/admin/calendar-events/edit-calendar-event.blade.php
@@ -7,7 +7,7 @@
             Cancel
         </x-button>
         <x-form-button variant="primary" wire:click="save" icon="check">
-            Save
+            Save event
         </x-form-button>
     </x-slot:actions>
 

--- a/resources/views/livewire/admin/meetings/meeting-form.blade.php
+++ b/resources/views/livewire/admin/meetings/meeting-form.blade.php
@@ -4,7 +4,7 @@
             Cancel
         </x-button>
         <x-form-button variant="primary" wire:click="save" icon="check">
-            Save
+            Save meeting
         </x-form-button>
     </x-slot:actions>
 

--- a/resources/views/livewire/admin/pages/page-form.blade.php
+++ b/resources/views/livewire/admin/pages/page-form.blade.php
@@ -4,7 +4,7 @@
             Cancel
         </x-button>
         <x-form-button variant="primary" wire:click="save" icon="check">
-            Save
+            Save page
         </x-form-button>
     </x-slot:actions>
 

--- a/resources/views/livewire/admin/preachers/preacher-form.blade.php
+++ b/resources/views/livewire/admin/preachers/preacher-form.blade.php
@@ -4,7 +4,7 @@
             Cancel
         </x-button>
         <x-form-button variant="primary" wire:click="save" icon="check">
-            Save
+            Save preacher
         </x-form-button>
     </x-slot:actions>
 

--- a/resources/views/livewire/admin/sermons/edit-sermon.blade.php
+++ b/resources/views/livewire/admin/sermons/edit-sermon.blade.php
@@ -1,7 +1,7 @@
 <x-admin.form-shell
     :title="'Edit ' . $contentTypeLabel"
     :description="$isChildrensTalk
-        ? 'Update the published children\'s-talk details. Sermon-only fields stay hidden on this form.'
+        ? 'Update the published children\'s talk details. Sermon-only fields stay hidden on this form.'
         : 'Update sermon details, metadata, and any AI-assisted content shown publicly.'"
     save-action="save"
 >
@@ -19,7 +19,7 @@
             Cancel
         </x-button>
         <x-form-button variant="primary" wire:click="save" icon="check">
-            Save
+            Save {{ strtolower($contentTypeLabel) }}
         </x-form-button>
     </x-slot:actions>
 
@@ -78,7 +78,7 @@
         <x-slot:footer>
             <div class="flex justify-end gap-2">
                 <x-form-button variant="primary" wire:click="save" icon="check">
-                    Save details
+                    Save {{ strtolower($contentTypeLabel) }} details
                 </x-form-button>
             </div>
         </x-slot:footer>
@@ -125,7 +125,7 @@
                         Add point
                     </x-form-button>
                     <x-form-button variant="primary" wire:click="save" icon="check">
-                        Save all
+                        Save all content
                     </x-form-button>
                 </div>
             </x-slot:footer>

--- a/resources/views/livewire/admin/users/user-form.blade.php
+++ b/resources/views/livewire/admin/users/user-form.blade.php
@@ -4,7 +4,7 @@
             Cancel
         </x-button>
         <x-form-button variant="primary" wire:click="save" icon="check">
-            Save
+            Save user
         </x-form-button>
     </x-slot:actions>
 


### PR DESCRIPTION
This change improves the administrative user experience by standardising microcopy on action buttons. 

Key changes:
- Updated "Save" to "Save meeting", "Save page", "Save preacher", "Save user", and "Save event" in their respective forms.
- Implemented dynamic "Save {{ strtolower($contentTypeLabel) }}" labels in the sermon editor to correctly handle both Sermons and Children's Talks.
- Fixed hyphenation of "children's talk" to match domain standards.
- No functional or behavioural changes; copy only.

---
*PR created automatically by Jules for task [1041003695631599366](https://jules.google.com/task/1041003695631599366) started by @GarethClarridge*