### PR TITLE
Harden SermonPagesTest layout assertions

### DIFF
--- a/tests/Feature/SermonPagesTest.php
+++ b/tests/Feature/SermonPagesTest.php
@@ -162,7 +162,7 @@ class SermonPagesTest extends TestCase
         $response = $this->get('/christ/sermons');
 
         $response->assertStatus(200);
-        $response->assertSee('<div class="mx-auto mt-6 mb-6 grid max-w-2xl items-start justify-center gap-4 px-6 [grid-template-columns:repeat(auto-fit,minmax(min(100%,19rem),19rem))] lg:max-w-5xl xl:max-w-7xl">', false);
+        $response->assertSee('[grid-template-columns:repeat(auto-fit,minmax(min(100%,19rem),19rem))]');
         $response->assertDontSee('<h2 id=', false);
     }
 
@@ -179,7 +179,7 @@ class SermonPagesTest extends TestCase
         $response = $this->get('/christ/sermons?preacher='.$preacher->id);
 
         $response->assertStatus(200);
-        $response->assertSee('<div class="mx-auto mt-6 mb-6 grid max-w-2xl items-start justify-center gap-4 px-6 [grid-template-columns:repeat(auto-fit,minmax(min(100%,19rem),19rem))] lg:max-w-5xl xl:max-w-7xl">', false);
+        $response->assertSee('[grid-template-columns:repeat(auto-fit,minmax(min(100%,19rem),19rem))]');
         $response->assertDontSee('<h2 id=', false);
     }
 


### PR DESCRIPTION
This PR hardens `SermonPagesTest` by replacing brittle exact HTML markup assertions with robust assertions targeting unique layout-defining CSS classes. Specifically, assertions that matched a long list of Tailwind classes on a `div` tag were refactored to check only for the distinctive arbitrary-value grid class. This ensures the tests verify the structural layout while remaining resilient to cosmetic CSS changes like margins or padding.

---
*PR created automatically by Jules for task [2506355648961513649](https://jules.google.com/task/2506355648961513649) started by @GarethClarridge*