### PR TITLE
📜 Herald: Add PHPDoc to ApiBibleClient

### DIFF
--- a/app/Services/Scripture/ApiBibleClient.php
+++ b/app/Services/Scripture/ApiBibleClient.php
@@ -47,6 +47,8 @@ class ApiBibleClient
     /**
      * Returns true if there is remaining quota in today's daily API budget.
      * Checked before every outbound call regardless of caller.
+     *
+     * @return bool
      */
     public function hasDailyBudget(): bool
     {
@@ -93,6 +95,13 @@ class ApiBibleClient
      * Search for a passage by normalized reference text and return the resolved passage.
      * Uses a single search call which returns content in the response.
      * Returns null if not found or if the API call fails.
+     *
+     * @param  string  $normalizedReference  Normalized Bible reference
+     * @return ApiBiblePassageResult|null The resolved passage or null if not found
+     *
+     * @throws ApiBibleBudgetExhaustedException If the daily API budget is exhausted
+     * @throws \RuntimeException If the API call fails due to rate-limiting or server errors
+     * @throws ConnectionException If a network connection error occurs
      */
     public function searchPassage(string $normalizedReference): ?ApiBiblePassageResult
     {
@@ -184,6 +193,13 @@ class ApiBibleClient
      * Refresh an existing passage by its stored passage ID.
      * Used for scheduled cache refreshes to avoid re-searching by text.
      * Returns null if the passage is no longer available.
+     *
+     * @param  string  $passageId  The unique API.Bible passage ID
+     * @return ApiBiblePassageResult|null The resolved passage or null if not found
+     *
+     * @throws ApiBibleBudgetExhaustedException If the daily API budget is exhausted
+     * @throws \RuntimeException If the API call fails due to rate-limiting or server errors
+     * @throws ConnectionException If a network connection error occurs
      */
     public function fetchPassageById(string $passageId): ?ApiBiblePassageResult
     {


### PR DESCRIPTION
This change improves the inline documentation for the `ApiBibleClient` service. 

Key improvements:
- Added missing `@return` type hints.
- Added `@param` and `@return` annotations to public methods to clarify expected data shapes.
- Added explicit `@throws` annotations for all documented exceptions that can be raised or bubbled up by the API client (budget exhaustion, network errors, and transient API failures).

These changes improve developer experience and help static analysis tools like PHPStan verify correctness. 

No functional changes were made.

---
*PR created automatically by Jules for task [17007479885154570935](https://jules.google.com/task/17007479885154570935) started by @GarethClarridge*