### PR TITLE
Fix Pint formatting on ApiBibleClient lost in #742 squash

### DIFF
--- a/app/Services/Scripture/ApiBibleClient.php
+++ b/app/Services/Scripture/ApiBibleClient.php
@@ -47,8 +47,6 @@ class ApiBibleClient
     /**
      * Returns true if there is remaining quota in today's daily API budget.
      * Checked before every outbound call regardless of caller.
-     *
-     * @return bool
      */
     public function hasDailyBudget(): bool
     {


### PR DESCRIPTION
## Why

The squash merge of #742 captured a pre-Pint commit (`f11c6886f`) instead of the branch tip that contained the formatting fix. As a result, `master` landed with a redundant `@return bool` docblock on `ApiBibleClient::hasDailyBudget()`, and the Laravel Quality Gate's **Formatting (Pint)** step fails on master.

## What

Removes the redundant `@return bool` tag (Pint `no_superfluous_phpdoc_tags`) to restore Pint compliance.

## Verification

- `pint --test` — passes
- `composer phpstan` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)