### PR TITLE
🔦 Lighthouse: Enhanced Breadcrumb Hierarchy for Sermons

### DIFF
--- a/app/Presenters/BreadcrumbPresenter.php
+++ b/app/Presenters/BreadcrumbPresenter.php
@@ -4,13 +4,20 @@ declare(strict_types=1);
 
 namespace App\Presenters;
 
-use App\Models\Preacher;
+use App\Seo\SermonArchiveSeoPresenter;
+use App\Services\Public\SermonRepository;
+use App\Support\BibleCanon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
 class BreadcrumbPresenter
 {
-    public function __construct(private readonly Request $request) {}
+    public function __construct(
+        private readonly Request $request,
+        private readonly SermonRepository $sermonRepository,
+        private readonly BibleCanon $bibleCanon,
+        private readonly SermonArchiveSeoPresenter $seoPresenter,
+    ) {}
 
     /**
      * Build the ordered breadcrumb items for the current request.
@@ -109,7 +116,6 @@ class BreadcrumbPresenter
                 $items[] = ['name' => 'Series', 'item' => url('christ/sermons/series')];
             }
 
-            // Enhanced deep hierarchy for filtered archives
             if ($this->request->routeIs('sermons.index')) {
                 $items = array_merge($items, $this->buildSermonFilterItems());
             }
@@ -128,43 +134,56 @@ class BreadcrumbPresenter
     }
 
     /**
-     * Build breadcrumb items for filtered sermon archive.
+     * Build breadcrumb items for a filtered sermon archive.
+     *
+     * Filters are normalized through the same repository method the controller
+     * uses, so the trail can never assert a book, chapter, or preacher the page
+     * itself rejected. The preacher name resolves via the SEO presenter's cached,
+     * memoized lookup, keeping the leaf in step with the page title.
      *
      * @return list<array{name: string, item: string}>
      */
     private function buildSermonFilterItems(): array
     {
+        $filters = $this->sermonRepository->normalizeArchiveFilters(
+            $this->bibleCanon,
+            $this->request->query('book'),
+            $this->request->query('chapter'),
+            $this->request->query('preacher'),
+            $this->request->query('series'),
+        );
+
         $items = [];
 
-        if ($book = $this->request->query('book')) {
+        if ($filters['book'] !== null) {
             $items[] = [
-                'name' => (string) $book,
-                'item' => route('sermons.index', ['book' => $book]),
+                'name' => $filters['book'],
+                'item' => route('sermons.index', ['book' => $filters['book']]),
             ];
 
-            if ($chapter = $this->request->query('chapter')) {
+            if ($filters['chapter'] !== null) {
                 $items[] = [
-                    'name' => "Chapter {$chapter}",
-                    'item' => route('sermons.index', ['book' => $book, 'chapter' => $chapter]),
+                    'name' => "Chapter {$filters['chapter']}",
+                    'item' => route('sermons.index', ['book' => $filters['book'], 'chapter' => $filters['chapter']]),
                 ];
             }
         }
 
-        if ($preacherId = $this->request->query('preacher')) {
-            $preacher = Preacher::query()->find($preacherId);
-            $preacherName = ($preacher instanceof Preacher) ? $preacher->name : null;
-            if ($preacherName) {
+        if ($filters['preacherId'] !== null) {
+            $preacherName = $this->seoPresenter->preacherName($filters['preacherId']);
+
+            if ($preacherName !== null) {
                 $items[] = [
                     'name' => $preacherName,
-                    'item' => route('sermons.index', ['preacher' => $preacherId]),
+                    'item' => route('sermons.index', ['preacher' => $filters['preacherId']]),
                 ];
             }
         }
 
-        if ($series = $this->request->query('series')) {
+        if ($filters['series'] !== null) {
             $items[] = [
-                'name' => (string) $series,
-                'item' => route('sermons.index', ['series' => $series]),
+                'name' => $filters['series'],
+                'item' => route('sermons.index', ['series' => $filters['series']]),
             ];
         }
 
@@ -182,7 +201,7 @@ class BreadcrumbPresenter
         return [
             '@context' => 'https://schema.org',
             '@type' => 'BreadcrumbList',
-            '@id' => url()->current().'#breadcrumb',
+            '@id' => $this->request->fullUrl().'#breadcrumb',
             'itemListElement' => array_map(
                 static fn (array $item, int $index): array => [
                     '@type' => 'ListItem',

--- a/app/Presenters/BreadcrumbPresenter.php
+++ b/app/Presenters/BreadcrumbPresenter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Presenters;
 
+use App\Models\Preacher;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
@@ -26,8 +27,8 @@ class BreadcrumbPresenter
             $items = array_merge($items, $this->buildPublicItems($area));
         }
 
-        if (end($items)['item'] !== url()->current()) {
-            $items[] = ['name' => $heading, 'item' => url()->current()];
+        if (end($items)['item'] !== $this->request->fullUrl()) {
+            $items[] = ['name' => $heading, 'item' => $this->request->fullUrl()];
         }
 
         return $items;
@@ -107,6 +108,11 @@ class BreadcrumbPresenter
             } elseif ($segment3 === 'series' && $this->request->segment(4) !== null) {
                 $items[] = ['name' => 'Series', 'item' => url('christ/sermons/series')];
             }
+
+            // Enhanced deep hierarchy for filtered archives
+            if ($this->request->routeIs('sermons.index')) {
+                $items = array_merge($items, $this->buildSermonFilterItems());
+            }
         } elseif ($segment2 === 'members') {
             $items[] = ['name' => 'Members', 'item' => url('church/members')];
         } elseif ($segment2 === 'childrens-corner') {
@@ -116,6 +122,50 @@ class BreadcrumbPresenter
         } elseif ($this->request->segment(1) === 'meetings' && $this->request->segment(3) === 'events') {
             $meetingSlug = (string) $segment2;
             $items[] = ['name' => Str::title(str_replace('-', ' ', $meetingSlug)), 'item' => url('community/'.$meetingSlug)];
+        }
+
+        return $items;
+    }
+
+    /**
+     * Build breadcrumb items for filtered sermon archive.
+     *
+     * @return list<array{name: string, item: string}>
+     */
+    private function buildSermonFilterItems(): array
+    {
+        $items = [];
+
+        if ($book = $this->request->query('book')) {
+            $items[] = [
+                'name' => (string) $book,
+                'item' => route('sermons.index', ['book' => $book]),
+            ];
+
+            if ($chapter = $this->request->query('chapter')) {
+                $items[] = [
+                    'name' => "Chapter {$chapter}",
+                    'item' => route('sermons.index', ['book' => $book, 'chapter' => $chapter]),
+                ];
+            }
+        }
+
+        if ($preacherId = $this->request->query('preacher')) {
+            $preacher = Preacher::query()->find($preacherId);
+            $preacherName = ($preacher instanceof Preacher) ? $preacher->name : null;
+            if ($preacherName) {
+                $items[] = [
+                    'name' => $preacherName,
+                    'item' => route('sermons.index', ['preacher' => $preacherId]),
+                ];
+            }
+        }
+
+        if ($series = $this->request->query('series')) {
+            $items[] = [
+                'name' => (string) $series,
+                'item' => route('sermons.index', ['series' => $series]),
+            ];
         }
 
         return $items;

--- a/app/Seo/SermonArchiveSeoPresenter.php
+++ b/app/Seo/SermonArchiveSeoPresenter.php
@@ -112,6 +112,17 @@ class SermonArchiveSeoPresenter
     }
 
     /**
+     * Resolve a preacher's display name from their ID, or null if not found.
+     *
+     * Shared with the breadcrumb presenter so the filtered-archive trail and the
+     * page title resolve the same name through one cached, memoized lookup.
+     */
+    public function preacherName(int $preacherId): ?string
+    {
+        return $this->resolvePreacherName($preacherId);
+    }
+
+    /**
      * Resolve a preacher name from ID, utilizing identity-based request-level memoization
      * and the cached public preacher collection to avoid redundant DB queries.
      *

--- a/tests/Feature/BreadcrumbRenderingTest.php
+++ b/tests/Feature/BreadcrumbRenderingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Models\Preacher;
 use App\Presenters\BreadcrumbPresenter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Blade;
@@ -238,5 +239,82 @@ class BreadcrumbRenderingTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSee('BreadcrumbList', false);
+    }
+
+    #[Test]
+    public function presenter_builds_deep_hierarchy_for_book_filtered_archive(): void
+    {
+        $this->get('/christ/sermons?book=Genesis');
+
+        $presenter = app(BreadcrumbPresenter::class);
+        $items = $presenter->items('christ', 'Genesis | Sermons');
+
+        $names = array_column($items, 'name');
+        $this->assertContains('Home', $names);
+        $this->assertContains('Christ', $names);
+        $this->assertContains('Sermons', $names);
+        $this->assertContains('Genesis', $names);
+
+        $genesisItem = collect($items)->firstWhere('name', 'Genesis');
+        $this->assertStringContainsString('book=Genesis', $genesisItem['item']);
+    }
+
+    #[Test]
+    public function presenter_builds_deeper_hierarchy_for_book_and_chapter_filtered_archive(): void
+    {
+        $this->get('/christ/sermons?book=Genesis&chapter=1');
+
+        $presenter = app(BreadcrumbPresenter::class);
+        $items = $presenter->items('christ', 'Genesis 1 | Sermons');
+
+        $names = array_column($items, 'name');
+        $this->assertContains('Sermons', $names);
+        $this->assertContains('Genesis', $names);
+        $this->assertContains('Chapter 1', $names);
+
+        $genesisItem = collect($items)->firstWhere('name', 'Genesis');
+        $this->assertStringContainsString('book=Genesis', $genesisItem['item']);
+        $this->assertStringNotContainsString('chapter=1', $genesisItem['item']);
+
+        $chapterItem = collect($items)->firstWhere('name', 'Chapter 1');
+        $this->assertStringContainsString('book=Genesis', $chapterItem['item']);
+        $this->assertStringContainsString('chapter=1', $chapterItem['item']);
+    }
+
+    #[Test]
+    public function presenter_builds_hierarchy_for_preacher_filtered_archive(): void
+    {
+        // Mock a preacher for resolution
+        Preacher::factory()->create(['id' => 1, 'name' => 'Mark Davies', 'slug' => 'mark-davies']);
+
+        $this->get('/christ/sermons?preacher=1');
+
+        $presenter = app(BreadcrumbPresenter::class);
+        $items = $presenter->items('christ', 'Mark Davies | Sermons');
+
+        $names = array_column($items, 'name');
+        $this->assertContains('Sermons', $names);
+        $this->assertContains('Mark Davies', $names);
+
+        $preacherItem = collect($items)->firstWhere('name', 'Mark Davies');
+        $this->assertStringContainsString('preacher=1', $preacherItem['item']);
+    }
+
+    #[Test]
+    public function presenter_builds_hierarchy_for_series_filtered_archive(): void
+    {
+        $this->get('/christ/sermons?series=The+Gospel+of+Mark');
+
+        $presenter = app(BreadcrumbPresenter::class);
+        $items = $presenter->items('christ', 'The Gospel of Mark | Sermons');
+
+        $names = array_column($items, 'name');
+        $this->assertContains('Sermons', $names);
+        $this->assertContains('The Gospel of Mark', $names);
+
+        $seriesItem = collect($items)->firstWhere('name', 'The Gospel of Mark');
+        $this->assertStringContainsString('series=The', $seriesItem['item']);
+        $this->assertStringContainsString('Gospel', $seriesItem['item']);
+        $this->assertStringContainsString('Mark', $seriesItem['item']);
     }
 }

--- a/tests/Feature/BreadcrumbRenderingTest.php
+++ b/tests/Feature/BreadcrumbRenderingTest.php
@@ -284,10 +284,9 @@ class BreadcrumbRenderingTest extends TestCase
     #[Test]
     public function presenter_builds_hierarchy_for_preacher_filtered_archive(): void
     {
-        // Mock a preacher for resolution
-        Preacher::factory()->create(['id' => 1, 'name' => 'Mark Davies', 'slug' => 'mark-davies']);
+        $preacher = Preacher::factory()->create(['name' => 'Mark Davies', 'slug' => 'mark-davies']);
 
-        $this->get('/christ/sermons?preacher=1');
+        $this->get('/christ/sermons?preacher='.$preacher->id);
 
         $presenter = app(BreadcrumbPresenter::class);
         $items = $presenter->items('christ', 'Mark Davies | Sermons');
@@ -297,7 +296,7 @@ class BreadcrumbRenderingTest extends TestCase
         $this->assertContains('Mark Davies', $names);
 
         $preacherItem = collect($items)->firstWhere('name', 'Mark Davies');
-        $this->assertStringContainsString('preacher=1', $preacherItem['item']);
+        $this->assertStringContainsString('preacher='.$preacher->id, $preacherItem['item']);
     }
 
     #[Test]
@@ -313,8 +312,22 @@ class BreadcrumbRenderingTest extends TestCase
         $this->assertContains('The Gospel of Mark', $names);
 
         $seriesItem = collect($items)->firstWhere('name', 'The Gospel of Mark');
-        $this->assertStringContainsString('series=The', $seriesItem['item']);
-        $this->assertStringContainsString('Gospel', $seriesItem['item']);
-        $this->assertStringContainsString('Mark', $seriesItem['item']);
+        $this->assertSame(route('sermons.index', ['series' => 'The Gospel of Mark']), $seriesItem['item']);
+    }
+
+    #[Test]
+    public function presenter_drops_invalid_filters_so_trail_matches_the_page(): void
+    {
+        // A book outside the Bible canon and an unknown preacher are rejected by
+        // the archive controller; the breadcrumb must not assert them either.
+        $this->get('/christ/sermons?book=Narnia&chapter=99&preacher=999999');
+
+        $presenter = app(BreadcrumbPresenter::class);
+        $items = $presenter->items('christ', 'Sermons');
+
+        $names = array_column($items, 'name');
+        $this->assertContains('Sermons', $names);
+        $this->assertNotContains('Narnia', $names);
+        $this->assertNotContains('Chapter 99', $names);
     }
 }


### PR DESCRIPTION
I have enhanced the site's breadcrumb navigation to better support filtered sermon archives. Previously, filtering by a Bible book or preacher resulted in a flat breadcrumb trail. Now, the `BreadcrumbPresenter` dynamically generates a structured hierarchy based on active query parameters.

For example, navigating to `/christ/sermons?book=Genesis&chapter=1` now produces a trail: `Home > Christ > Sermons > Genesis > Chapter 1`.

This improvement benefits:
1. **Search Engines**: Provides a clearer internal linking structure and more accurate `BreadcrumbList` JSON-LD data.
2. **Users**: Offers semantic navigation back through the filtered archive levels.

I also updated the presenter to use `$request->fullUrl()` for the final breadcrumb segment, ensuring that search engines see the exact filtered URL as the current location in the hierarchy. Comprehensive tests have been added to verify these new deep trails.

---
*PR created automatically by Jules for task [10171153297167534827](https://jules.google.com/task/10171153297167534827) started by @GarethClarridge*