### PR TITLE
📖 Editor: improve "Save service" button label clarity

### DIFF
--- a/resources/views/livewire/admin/church-services/manage-church-service.blade.php
+++ b/resources/views/livewire/admin/church-services/manage-church-service.blade.php
@@ -13,7 +13,7 @@
             </x-button>
         @endif
         <x-form-button variant="primary" wire:click="save" icon="check">
-            {{ $isEditing ? 'Save changes' : 'Create service' }}
+            {{ $isEditing ? 'Save service' : 'Create service' }}
         </x-form-button>
     </x-slot:actions>
 


### PR DESCRIPTION
### 💡 What:
Improved the "Save changes" button label in the Church Service management form.

### 🎯 Why:
To improve microcopy clarity and ensure consistency across the admin panel. The project's copy standards prefer specific verbs and objects (e.g., "Save service") over generic ones like "Save changes".

### 🔄 Behavior:
No functional changes — copy only.

### 📍 Where:
`resources/views/livewire/admin/church-services/manage-church-service.blade.php`

---
*PR created automatically by Jules for task [13600846471230418916](https://jules.google.com/task/13600846471230418916) started by @GarethClarridge*