### PR TITLE
♿ Aria: Standardise focus indicators across form components

### DIFF
--- a/resources/views/components/checkbox.blade.php
+++ b/resources/views/components/checkbox.blade.php
@@ -18,7 +18,7 @@ $describedBy = implode(' ', $describedBy);
         <input
             type="checkbox"
             {{ $attributes->merge([
-                'class' => 'h-4 w-4 rounded border-gray-300 text-cbc-teal focus:ring-cbc-teal focus-visible:ring-2' . ($hasError ? ' border-red-300' : ''),
+                'class' => 'h-4 w-4 rounded border-gray-300 text-cbc-teal focus:ring-cbc-teal focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2' . ($hasError ? ' border-red-300' : ''),
                 'id' => $id
             ]) }}
             @checked($checked)

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -8,7 +8,7 @@ $hasError = $modelName && $errors->has($modelName);
 $type = $attributes->get('type', 'text');
 $isPassword = $type === 'password';
 
-$inputClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2 disabled:opacity-50 disabled:bg-gray-50 disabled:cursor-not-allowed'
+$inputClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 disabled:opacity-50 disabled:bg-gray-50 disabled:cursor-not-allowed'
     . ($icon ? ' pl-10' : '')
     . ($hasError ? ' border-red-300' : ' border-gray-300')
     . ($clearable || $isPassword || $modelName ? ' pr-10' : '');

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -4,7 +4,7 @@
 $modelName = $attributes->wire('model')?->value();
 $id = $attributes->get('id', $modelName ? str_replace(['.', ' ', '[', ']'], '-', $modelName) : ($label ? \Illuminate\Support\Str::slug($label) : null));
 $hasError = $modelName && $errors->has($modelName);
-$selectClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2 disabled:opacity-50 disabled:bg-gray-50 disabled:cursor-not-allowed'
+$selectClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 disabled:opacity-50 disabled:bg-gray-50 disabled:cursor-not-allowed'
     . ($hasError ? ' border-red-300' : ' border-gray-300');
 
 $describedBy = [];

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -4,7 +4,7 @@
 $modelName = $attributes->wire('model')?->value();
 $id = $attributes->get('id', $modelName ? str_replace(['.', ' ', '[', ']'], '-', $modelName) : ($label ? \Illuminate\Support\Str::slug($label) : null));
 $hasError = $modelName && $errors->has($modelName);
-$textareaClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2 disabled:opacity-50 disabled:bg-gray-50 disabled:cursor-not-allowed'
+$textareaClasses = 'block w-full rounded-md shadow-sm sm:text-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 disabled:opacity-50 disabled:bg-gray-50 disabled:cursor-not-allowed'
     . ($hasError ? ' border-red-300' : ' border-gray-300')
     . ($modelName ? ' pr-10' : '')
     . ($autogrow ? ' resize-none overflow-hidden' : '');

--- a/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
+++ b/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
@@ -72,7 +72,7 @@
                                 </span>
                                 <select wire:change="categorize({{ $event->id }}, $event.target.value)"
                                     aria-label="Categorise event: {{ $event->title }}"
-                                    class="text-xs rounded-md border-gray-300 shadow-sm focus:border-cbc-teal focus:ring-cbc-teal w-40">
+                                    class="text-xs rounded-md border-gray-300 shadow-sm focus:border-cbc-teal focus:ring-cbc-teal focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 w-40">
                                     <option value="">Categorise...</option>
                                     @foreach($meetings as $slug => $name)
                                         <option value="{{ $slug }}">{{ $name }}</option>

--- a/resources/views/livewire/processing-logs-viewer.blade.php
+++ b/resources/views/livewire/processing-logs-viewer.blade.php
@@ -19,7 +19,7 @@
                 <input
                     type="checkbox"
                     wire:model.live="autoRefresh"
-                    class="rounded border-gray-300 text-cbc-teal focus:ring-cbc-teal"
+                    class="rounded border-gray-300 text-cbc-teal focus:ring-cbc-teal focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
                 >
                 <span class="ml-1">Auto-refresh</span>
             </label>

--- a/tests/Feature/View/Components/FormAccessibilityTest.php
+++ b/tests/Feature/View/Components/FormAccessibilityTest.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Feature\View\Components;
 
+use App\Actions\GetMediaProcessingStatus;
+use App\Data\StandardProcessingResponse;
+use App\Livewire\ProcessingLogsViewer;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\ViewErrorBag;
+use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -117,5 +121,31 @@ class FormAccessibilityTest extends TestCase
         $this->blade('<x-textarea wire:model="field" />')->assertSee('<span class="sr-only">Loading...</span>', false);
         $this->blade('<x-select wire:model="field" :options="[]" />')->assertSee('<span class="sr-only">Loading...</span>', false);
         $this->blade('<x-toggle wire:model="field" />')->assertSee('<span class="sr-only">Loading...</span>', false);
+    }
+
+    #[Test]
+    public function form_controls_render_visible_keyboard_focus_colour_and_offset(): void
+    {
+        $expectedFocusClasses = 'focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2';
+
+        $this->blade('<x-input wire:model="field" />')->assertSee($expectedFocusClasses, false);
+        $this->blade('<x-textarea wire:model="field" />')->assertSee($expectedFocusClasses, false);
+        $this->blade('<x-select wire:model="field" :options="[]" />')->assertSee($expectedFocusClasses, false);
+        $this->blade('<x-checkbox wire:model="field" />')->assertSee($expectedFocusClasses, false);
+    }
+
+    #[Test]
+    public function processing_logs_auto_refresh_checkbox_renders_visible_keyboard_focus_colour_and_offset(): void
+    {
+        $this->mock(GetMediaProcessingStatus::class, function ($mock): void {
+            $mock
+                ->shouldReceive('getWithLogs')
+                ->once()
+                ->with('processing-123', 20)
+                ->andReturn(StandardProcessingResponse::notFound());
+        });
+
+        Livewire::test(ProcessingLogsViewer::class, ['processingId' => 'processing-123'])
+            ->assertSeeHtml('class="rounded border-gray-300 text-cbc-teal focus:ring-cbc-teal focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"');
     }
 }


### PR DESCRIPTION
This PR standardises focus indicators across the application's base form components and key administrative views. 

💡 **What:** 
- Added `focus-visible:ring-cbc-teal` and `focus-visible:ring-offset-2` to `x-input`, `x-select`, `x-textarea`, and `x-checkbox` components.
- Manually applied the same focus pattern to raw HTML `<select>` and `<input type="checkbox">` elements in the calendar events list and processing logs viewer.

🎯 **Who:** 
- Keyboard-only users: Provides a clear, high-contrast visual indication of which element is currently focused.
- Low-vision users: Enhances visibility of interactive elements during navigation.

🧪 **How to verify:** 
- Tab through the public sermons search/filters or any admin form.
- Use the Playwright screenshot `focused_select.png` generated during verification.

🔄 **Behavior:** 
- Visual improvement for keyboard navigation only. Same visible behavior for mouse users unless they interact with keyboard focus styles. accessibility metadata only.

---
*PR created automatically by Jules for task [4658977579095744991](https://jules.google.com/task/4658977579095744991) started by @GarethClarridge*