### PR TITLE
Fix typo in contactus redirect configuration

### DIFF
--- a/.Jules/editor.md
+++ b/.Jules/editor.md
@@ -1,0 +1,5 @@
+# Editor Journal
+
+## 2026-06-11 - Typo in config/redirects.php
+**Learning:** Found a typo in `config/redirects.php` where `'contacttus' => '/'` was defined. This typo was also previously identified in a Mortician audit.
+**Action:** Corrected `'contacttus'` to `'contactus'` to ensure the intended redirect works for users typing the correct URL. Added a feature test `tests/Feature/RedirectTest.php` to verify the fix.

--- a/config/redirects.php
+++ b/config/redirects.php
@@ -24,7 +24,7 @@ return [
     'whats-on/sunday' => '/community/sunday-mornings',
 
     'aboutus' => '/church',
-    'contacttus' => '/',
+    'contactus' => '/',
     'links' => '/church/links',
     'whatson' => '/community',
     'whats-on' => '/community',

--- a/tests/Feature/RedirectTest.php
+++ b/tests/Feature/RedirectTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class RedirectTest extends TestCase
+{
+    public function test_contactus_redirect(): void
+    {
+        $response = $this->get('/contactus');
+        $response->assertStatus(301);
+        $response->assertRedirect('/');
+    }
+
+    public function test_aboutus_redirect(): void
+    {
+        $response = $this->get('/aboutus');
+        $response->assertStatus(301);
+        $response->assertRedirect('/church');
+    }
+}


### PR DESCRIPTION
I have fixed a typo in the `config/redirects.php` file where `'contacttus'` was incorrectly used instead of `'contactus'`. This ensures that the legacy redirect for the contact page works as intended for users using the correct spelling.

I also added a new feature test `tests/Feature/RedirectTest.php` to verify that the redirect is correctly loaded and returns the expected 301 status.

**Changes:**
- Modified `config/redirects.php`: Changed `'contacttus' => '/'` to `'contactus' => '/'`.
- Created `tests/Feature/RedirectTest.php`: Added tests for the corrected redirect and one existing redirect to ensure stability.

No functional changes were made to the application logic, only a correction to the static configuration data.

---
*PR created automatically by Jules for task [18346808287677183876](https://jules.google.com/task/18346808287677183876) started by @GarethClarridge*