### PR TITLE
🔗 Pathfinder: Document broken contact redirect typo

### DIFF
--- a/.Jules/pathfinder.md
+++ b/.Jules/pathfinder.md
@@ -9,3 +9,8 @@
 **Pattern:** `config/redirects.php` entry pointing to a non-existent slug.
 **Cause:** `about-us/privacy-policy` redirects to `/church/privacy-policy`, but the page slug in the database is `privacy-notice`.
 **Action:** Cross-reference redirect targets against the `pages` table and `route:list`.
+
+## 2026-06-10 - Redirect typo causing 404
+**Pattern:** Typo in redirect configuration key (e.g. `'contacttus'` instead of `'contactus'`).
+**Cause:** Manual entry error in `config/redirects.php`.
+**Action:** Verify redirect keys by hitting both the intended and spelled-in-config URLs with `curl -I`.

--- a/docs/issues/2026-06-10-broken-contact-redirect.md
+++ b/docs/issues/2026-06-10-broken-contact-redirect.md
@@ -1,0 +1,39 @@
+# 🔗 Pathfinder: Broken redirect and typo in `config/redirects.php`
+
+## Summary
+The redirect for `/contactus` is currently returning a 404 because of a typo in the configuration key within `config/redirects.php`.
+
+## Affected items
+- `http://localhost:8000/contactus` returns **404 Not Found**.
+- `http://localhost:8000/contacttus` returns **301 Moved Permanently** to `/`.
+
+## Verification
+I discovered this by checking for hardcoded internal paths and cross-referencing them with the `config/redirects.php` file and live route responses.
+
+```bash
+# Verification results:
+$ curl -I http://localhost:8000/contactus
+HTTP/1.1 404 Not Found
+...
+
+$ curl -I http://localhost:8000/contacttus
+HTTP/1.1 301 Moved Permanently
+Location: /
+...
+```
+
+## Likely cause
+A typo in `config/redirects.php` on line 27:
+```php
+'contacttus' => '/',
+```
+
+## Suggested action
+Correct the key in `config/redirects.php` from `'contacttus'` to `'contactus'`.
+
+```php
+'contactus' => '/',
+```
+
+## Risk note
+Minimal. This is a fix for a broken legacy redirect.


### PR DESCRIPTION
I have completed my diagnostic mission as Pathfinder. 

I crawled the application's public surfaces, including sitemap entries and hardcoded links in Blade templates. I identified a broken redirect for `/contactus` which returns a 404 error. Upon investigation, I found a typo in `config/redirects.php` where the key is misspelled as `'contacttus'`.

Following the Pathfinder persona's mission to default to issues for non-Blade template changes, I have created a diagnostic report in `docs/issues/2026-06-10-broken-contact-redirect.md` with full evidence and suggested fix. I also updated the Pathfinder journal in `.Jules/pathfinder.md` to record this pattern of breakage.

Summary of changes:
- Created `docs/issues/2026-06-10-broken-contact-redirect.md` with diagnostic evidence.
- Updated `.Jules/pathfinder.md` with the new redirect typo pattern.
- Verified system stability by running relevant tests.

---
*PR created automatically by Jules for task [14862077600541471674](https://jules.google.com/task/14862077600541471674) started by @GarethClarridge*