### PR TITLE
🧹 Tidy: Refactor ProcessingResult to readonly class

### DIFF
--- a/app/Data/ProcessingResult.php
+++ b/app/Data/ProcessingResult.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-class ProcessingResult
+readonly class ProcessingResult
 {
     /**
      * @param  array<string, mixed>|null  $details
      */
     public function __construct(
-        public readonly bool $success,
-        public readonly string $processingId,
-        public readonly string $message,
-        public readonly ?string $statusUrl = null,
-        public readonly ?string $errorCode = null,
-        public readonly ?array $details = null
+        public bool $success,
+        public string $processingId,
+        public string $message,
+        public ?string $statusUrl = null,
+        public ?string $errorCode = null,
+        public ?array $details = null
     ) {}
 
     /**


### PR DESCRIPTION
💡 **What:** Refactored the `ProcessingResult` DTO to use a `readonly class` declaration and removed redundant `readonly` modifiers from its promoted constructor properties.
🎯 **Why:** Improves code consistency and maintainability by adhering to the project's preferred pattern for immutable DTOs and reducing visual clutter.
🔄 **Behavior:** No functional changes.
✅ **Tests:** All relevant integration tests passed, and PHPStan reports 0 errors.

---
*PR created automatically by Jules for task [11893632560561061611](https://jules.google.com/task/11893632560561061611) started by @GarethClarridge*