### PR TITLE
📜 Herald: Add PHPDoc to AudioChunkingService

### DIFF
--- a/.Jules/herald.md
+++ b/.Jules/herald.md
@@ -13,3 +13,7 @@
 ## 2026-06-05 - Enhancing Type Safety and Business Context
 **Learning:** Added precise array shapes to `SermonAnalysis` DTO and its interface, and documented a magic number in `SermonCandidateConfidenceService`. Explicit array shapes are particularly useful for DTOs that interact with AI services or database attributes, as they clarify the expected keys and types which might otherwise be opaque. Documenting magic numbers like the 20-minute sermon threshold provides essential business context for why specific values were chosen.
 **Action:** Continue to prioritize array shape documentation for DTOs and services that return or consume complex associative arrays. Always look for magic numbers in business logic and provide a "why" comment explaining their calibration or rationale.
+
+## 2026-06-08 - Documenting Fuzzy Reassembly Logic
+**Learning:** Documentation for reassembly and deduplication logic (like in `AudioChunkingService`) must explicitly bridge the gap between technical implementation (85% similarity threshold) and domain impact (Whisper transcription variations across chunk boundaries). Precise `list<array{...}>` shapes for multi-segment data are essential for ensuring callers provide the necessary metadata (indices, timestamps) for correct ordering and overlap handling.
+**Action:** When documenting fuzzy matching or deduplication, always explain the calibration rationale for similarity thresholds to prevent arbitrary adjustments that might break edge-case handling.

--- a/app/Services/Media/Audio/AudioChunkingService.php
+++ b/app/Services/Media/Audio/AudioChunkingService.php
@@ -27,7 +27,14 @@ class AudioChunkingService
     ) {}
 
     /**
-     * Determine if an audio file needs chunking based on duration
+     * Determine if an audio file needs chunking based on duration.
+     *
+     * Chunking is required for files exceeding the Whisper API's 25MB limit.
+     * While this check is duration-based, it targets files that would likely
+     * exceed the size limit even after standard compression.
+     *
+     * @param  float  $duration  Audio duration in seconds
+     * @return bool True if the file should be chunked
      */
     public function needsChunking(float $duration): bool
     {
@@ -35,9 +42,12 @@ class AudioChunkingService
     }
 
     /**
-     * Get audio duration in seconds using FFprobe
+     * Get audio duration in seconds using FFprobe.
      *
-     * @throws TranscriptionException When duration cannot be determined
+     * @param  string  $filePath  Full path to the audio file
+     * @return float Duration in seconds
+     *
+     * @throws TranscriptionException When duration cannot be determined or FFprobe fails
      */
     public function getAudioDuration(string $filePath): float
     {
@@ -64,14 +74,18 @@ class AudioChunkingService
     }
 
     /**
-     * Create audio chunks from the original file
+     * Create audio chunks from the original file.
+     *
+     * Splits a long audio file into smaller segments of approximately 6 minutes,
+     * with a 15-second overlap to ensure no content is lost at the boundaries.
+     * Chunks are saved as low-bitrate mono MP3s to minimize transcription costs.
      *
      * @param  string  $filePath  Full path to the original audio file
      * @param  string  $processingId  Processing ID for logging
      * @param  float  $duration  Total duration in seconds
-     * @return array<int, string> Array of chunk file paths
+     * @return list<string> Array of absolute paths to the created chunk files
      *
-     * @throws TranscriptionException When chunk creation fails
+     * @throws TranscriptionException When FFmpeg fails to create a chunk or directory
      */
     public function createAudioChunks(string $filePath, string $processingId, float $duration): array
     {
@@ -145,11 +159,15 @@ class AudioChunkingService
     }
 
     /**
-     * Reassemble transcripts from chunks with overlap deduplication
+     * Reassemble individual chunk transcripts into a single coherent text.
      *
-     * @param  array<int, array<string, mixed>>  $transcripts  Array of transcript data with indices and content
+     * Orders chunks by their original index and removes overlapping content
+     * at the boundaries using fuzzy sentence matching to handle transcription
+     * variations between chunks.
+     *
+     * @param  list<array{index: int, transcript: string, start_time: float}>  $transcripts  Ordered transcript segments
      * @param  string  $processingId  Processing ID for logging
-     * @return string The reassembled transcript
+     * @return string The complete reassembled and deduplicated transcript
      */
     public function reassembleTranscripts(array $transcripts, string $processingId): string
     {
@@ -189,7 +207,15 @@ class AudioChunkingService
     }
 
     /**
-     * Remove overlapping content from the beginning of a transcript
+     * Remove overlapping content from the start of a transcript segment.
+     *
+     * Compares the end of the previous segment with the start of the current
+     * segment. If matching sentences are found (up to 3), they are stripped
+     * from the current segment to prevent repetition in the final output.
+     *
+     * @param  string  $currentTranscript  The new transcript segment to be appended
+     * @param  string  $previousTranscript  The transcript segment immediately preceding it
+     * @return string The current transcript with leading overlap removed
      */
     public function removeOverlapFromTranscript(string $currentTranscript, string $previousTranscript): string
     {
@@ -226,10 +252,15 @@ class AudioChunkingService
     }
 
     /**
-     * Check if two arrays of sentences match with some tolerance
+     * Check if two sequences of sentences match with a defined similarity tolerance.
      *
-     * @param  array<int, string>  $sentences1
-     * @param  array<int, string>  $sentences2
+     * Uses a similarity threshold of 85% to account for slight variations in
+     * Whisper's output across chunk boundaries (e.g., minor punctuation or
+     * word confidence differences).
+     *
+     * @param  list<string>  $sentences1  First sequence of sentences (typically the end of a chunk)
+     * @param  list<string>  $sentences2  Second sequence of sentences (typically the start of the next chunk)
+     * @return bool True if the sequences are considered equivalent
      */
     public function sentencesMatch(array $sentences1, array $sentences2): bool
     {
@@ -255,7 +286,13 @@ class AudioChunkingService
     }
 
     /**
-     * Normalize sentence for comparison by removing punctuation and extra spaces
+     * Normalize a sentence to its canonical form for fuzzy comparison.
+     *
+     * Converts to lowercase, strips all non-alphanumeric characters, and
+     * collapses multiple spaces into one.
+     *
+     * @param  string  $sentence  The raw sentence text
+     * @return string The normalized alphanumeric string
      */
     public function normalizeSentenceForComparison(string $sentence): string
     {
@@ -266,9 +303,10 @@ class AudioChunkingService
     }
 
     /**
-     * Clean up temporary chunk files
+     * Clean up temporary chunk files from the filesystem.
      *
-     * @param  array<int, string>  $chunkPaths
+     * @param  list<string>  $chunkPaths  Array of absolute paths to delete
+     * @param  string  $processingId  Processing ID for logging
      */
     public function cleanupChunkFiles(array $chunkPaths, string $processingId): void
     {
@@ -287,9 +325,17 @@ class AudioChunkingService
     }
 
     /**
-     * Compress audio file for transcription service
+     * Compress an audio file to satisfy Whisper API's size constraints.
      *
-     * @throws TranscriptionException When compression fails
+     * Produces a mono MP3 at the configured bitrate (default 32kbps) which
+     * significantly reduces file size while maintaining enough quality for
+     * speech-to-text accuracy.
+     *
+     * @param  string  $inputPath  Absolute path to the source audio file
+     * @param  string  $processingId  Processing ID for logging
+     * @return string Absolute path to the compressed file
+     *
+     * @throws TranscriptionException When FFmpeg fails or produced file is empty
      */
     public function compressAudioForTranscription(string $inputPath, string $processingId): string
     {
@@ -350,7 +396,9 @@ class AudioChunkingService
     }
 
     /**
-     * Get the chunk duration in minutes
+     * Get the configured chunk duration in minutes.
+     *
+     * Used by transcription services to calculate expected segment offsets.
      */
     public function getChunkDurationMinutes(): int
     {
@@ -358,7 +406,9 @@ class AudioChunkingService
     }
 
     /**
-     * Get the chunk overlap in seconds
+     * Get the configured chunk overlap in seconds.
+     *
+     * Used to ensure overlapping regions are correctly handled during reassembly.
      */
     public function getChunkOverlapSeconds(): int
     {


### PR DESCRIPTION
💡 **What:** Added comprehensive PHPDoc blocks to `AudioChunkingService`.
🎯 **Why:** Clarified the "why" behind fuzzy matching thresholds (85% similarity) and the 25MB Whisper limit. Added precise array shapes for transcript reassembly data to improve IDE support and static analysis.
🔄 **Behavior:** No functional changes — documentation only.

---
*PR created automatically by Jules for task [15621040682831022500](https://jules.google.com/task/15621040682831022500) started by @GarethClarridge*