### PR TITLE
Fix contacttus typo in redirects

### DIFF
--- a/config/redirects.php
+++ b/config/redirects.php
@@ -24,6 +24,7 @@ return [
     'whats-on/sunday' => '/community/sunday-mornings',
 
     'aboutus' => '/church',
+    'contactus' => '/',
     'contacttus' => '/',
     'links' => '/church/links',
     'whatson' => '/community',

--- a/tests/Feature/RedirectsTest.php
+++ b/tests/Feature/RedirectsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class RedirectsTest extends TestCase
+{
+    #[Test]
+    public function it_redirects_legacy_contactus_url(): void
+    {
+        $response = $this->get('/contactus');
+        $response->assertRedirect('/');
+        $response->assertStatus(301);
+    }
+
+    #[Test]
+    public function it_redirects_typoed_contacttus_url(): void
+    {
+        $response = $this->get('/contacttus');
+        $response->assertRedirect('/');
+        $response->assertStatus(301);
+    }
+
+    #[Test]
+    public function it_redirects_legacy_aboutus_url(): void
+    {
+        $response = $this->get('/aboutus');
+        $response->assertRedirect('/church');
+        $response->assertStatus(301);
+    }
+}


### PR DESCRIPTION
This change fixes a typo in the permanent redirects configuration where 'contacttus' was used instead of 'contactus'. 

To maintain backward compatibility and follow the "safest path" for the Mortician agent, I have:
1. Kept the 'contacttus' redirect (aliasing it to the homepage).
2. Added a new 'contactus' redirect to the homepage.
3. Introduced `tests/Feature/RedirectsTest.php` to ensure both paths are correctly handled and return a 301 status.

The changes were verified using:
- `php artisan test tests/Feature/RedirectsTest.php`
- `vendor/bin/pint --dirty`
- `composer phpstan`

---
*PR created automatically by Jules for task [16336957227216186350](https://jules.google.com/task/16336957227216186350) started by @GarethClarridge*