### PR TITLE
🏛️ Warden: Add index to media_processing_logs.job_id

### DIFF
--- a/database/migrations/2026_06_10_072047_add_job_id_index_to_media_processing_logs_table.php
+++ b/database/migrations/2026_06_10_072047_add_job_id_index_to_media_processing_logs_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('media_processing_logs', function (Blueprint $table) {
+            $table->index('job_id', 'media_processing_logs_job_id_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('media_processing_logs', function (Blueprint $table) {
+            $table->dropIndex('media_processing_logs_job_id_index');
+        });
+    }
+};


### PR DESCRIPTION
💡 **What:** Added a missing index to the `job_id` column of the `media_processing_logs` table.
🎯 **Why:** This column is used for correlation with background queue jobs. Adding an index improves lookup performance during monitoring and status updates.
🗄️ **Migration:** `2026_06_10_072047_add_job_id_index_to_media_processing_logs_table.php`
✅ **Verification:** Verified index existence via `SHOW INDEX` after migration and confirmed reversibility via rollback.
⚠️ **Rollback:** `php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [2456599962562945572](https://jules.google.com/task/2456599962562945572) started by @GarethClarridge*