### PR TITLE
R6: Extract Sermon query scopes to a dedicated SermonBuilder

### DIFF
--- a/app/Models/Builders/SermonBuilder.php
+++ b/app/Models/Builders/SermonBuilder.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Builders;
+
+use App\Enums\ProcessingStatus;
+use App\Enums\SermonContentType;
+use App\Enums\SermonService;
+use App\Enums\SermonSourceType;
+use App\Models\Preacher;
+use App\Models\Sermon;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Dedicated query builder for the Sermon model.
+ *
+ * Holds every reusable Sermon query constraint so the model stays focused on
+ * attributes, casts, and relationships. Attached via the #[UseEloquentBuilder]
+ * attribute on the model, so `Sermon::query()` and static forwarding
+ * (`Sermon::forPodcast()`) both return this builder.
+ *
+ * @extends Builder<Sermon>
+ */
+class SermonBuilder extends Builder
+{
+    public function last12Months(): self
+    {
+        return $this->where('date', '>=', now()->subMonths(12)->startOfDay());
+    }
+
+    public function forService(SermonService $serviceType): self
+    {
+        return $this->where('service', $serviceType);
+    }
+
+    public function inSeries(string $seriesTitle): self
+    {
+        return $this->where('series', $seriesTitle);
+    }
+
+    public function byPreacher(string $preacherName): self
+    {
+        return $this->where(function (Builder $builder) use ($preacherName): void {
+            $builder->where('preacher', $preacherName)
+                ->orWhereHas('preacherProfile', fn (Builder $preacherQuery): Builder => $preacherQuery->where('name', $preacherName));
+        });
+    }
+
+    public function needsPreacherReview(): self
+    {
+        return $this->where('needs_preacher_review', true);
+    }
+
+    public function whereSermon(): self
+    {
+        return $this->where($this->qualifyColumn('content_type'), SermonContentType::Sermon);
+    }
+
+    public function whereChildrensTalk(): self
+    {
+        return $this->where($this->qualifyColumn('content_type'), SermonContentType::ChildrensTalk);
+    }
+
+    /**
+     * Constrain to sermons visible in the public sitemap.
+     */
+    public function whereVisibleInSitemap(): self
+    {
+        // A sermon's canonical URL is keyed on its slug, so a record without one
+        // has no public page to point to and must never reach URL generation.
+        $this->whereNotNull($this->qualifyColumn('slug'))
+            ->where($this->qualifyColumn('slug'), '!=', '');
+
+        if ((bool) config('sermons.childrens_talks.public', false)) {
+            return $this;
+        }
+
+        return $this->whereSermon();
+    }
+
+    /**
+     * Constrain to sermons created through automated processing.
+     */
+    public function automated(): self
+    {
+        return $this->where(function (Builder $q): void {
+            $q->whereNotNull('transcript_file_path')
+                ->orWhereHas('processingLogs');
+        });
+    }
+
+    /**
+     * Constrain to manually created sermons.
+     */
+    public function manual(): self
+    {
+        return $this->where(function (Builder $q): void {
+            $q->whereNull('transcript_file_path')
+                ->whereDoesntHave('processingLogs');
+        });
+    }
+
+    public function processingCompleted(): self
+    {
+        return $this->whereHas('processingLogs', function (Builder $q): void {
+            $q->where('status', ProcessingStatus::Completed);
+        });
+    }
+
+    public function processingFailed(): self
+    {
+        return $this->whereHas('processingLogs', function (Builder $q): void {
+            $q->where('status', ProcessingStatus::Failed);
+        });
+    }
+
+    public function processingInProgress(): self
+    {
+        return $this->whereHas('processingLogs', function (Builder $q): void {
+            $q->where('status', ProcessingStatus::Processing);
+        });
+    }
+
+    public function fromLivestream(): self
+    {
+        return $this->where('source_type', SermonSourceType::Livestream);
+    }
+
+    public function withVideo(): self
+    {
+        return $this->whereNotNull('video_file_path');
+    }
+
+    public function bySourceType(SermonSourceType $sourceType): self
+    {
+        return $this->where('source_type', $sourceType);
+    }
+
+    public function withThumbnail(): self
+    {
+        return $this->whereNotNull('thumbnail_file_path');
+    }
+
+    public function orderByPreacherName(string $direction = 'asc'): self
+    {
+        $direction = $direction === 'desc' ? 'desc' : 'asc';
+
+        return $this
+            ->orderBy(
+                Preacher::query()
+                    ->select('name')
+                    ->whereColumn('preachers.id', 'sermons.preacher_id')
+                    ->limit(1),
+                $direction
+            )
+            ->orderBy('preacher', $direction);
+    }
+
+    /**
+     * Constrain to podcast-ready sermons (must have an audio file), newest first.
+     */
+    public function forPodcast(): self
+    {
+        return $this->whereNotNull('audio_file_path')
+            ->where('audio_file_path', '!=', '')
+            ->orderBy('date', 'desc');
+    }
+}

--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -14,11 +14,12 @@ use App\Enums\SermonService;
 use App\Enums\SermonSourceType;
 use App\Enums\SermonVideoQualityStatus;
 use App\Enums\SermonVideoVisibilityOverride;
+use App\Models\Builders\SermonBuilder;
 use App\Rules\NotEmptyString;
 use App\Rules\SermonPointElement;
 use App\Sitemap\SermonSitemapPresenter;
 use Database\Factories\SermonFactory;
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -97,26 +98,13 @@ use Spatie\Sitemap\Tags\Url;
  * @property-read Collection<int, SermonScriptureFilter> $scriptureFilters
  *
  * @method static \Database\Factories\SermonFactory factory(...$parameters)
- * @method static Builder|Sermon newModelQuery()
- * @method static Builder|Sermon newQuery()
- * @method static Builder|Sermon query()
- * @method static Builder|Sermon last12Months()
- * @method static Builder|Sermon forService(\App\Enums\SermonService $serviceType)
- * @method static Builder|Sermon inSeries(string $seriesTitle)
- * @method static Builder|Sermon byPreacher(string $preacherName)
- * @method static Builder|Sermon automated()
- * @method static Builder|Sermon manual()
- * @method static Builder|Sermon processingCompleted()
- * @method static Builder|Sermon processingFailed()
- * @method static Builder|Sermon processingInProgress()
- * @method static Builder|Sermon withThumbnail()
- * @method static Builder|Sermon forPodcast()
- * @method static Builder|Sermon needsPreacherReview()
- * @method static Builder|Sermon whereSermon()
- * @method static Builder|Sermon whereChildrensTalk()
+ * @method static SermonBuilder newModelQuery()
+ * @method static SermonBuilder newQuery()
+ * @method static SermonBuilder query()
  *
  * @mixin \Eloquent
  */
+#[UseEloquentBuilder(SermonBuilder::class)]
 class Sermon extends Model implements Sitemapable
 {
     /** @use HasFactory<SermonFactory> */
@@ -362,92 +350,6 @@ class Sermon extends Model implements Sitemapable
     }
 
     /**
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeLast12Months(Builder $query): Builder
-    {
-        return $query->where('date', '>=', now()->subMonths(12)->startOfDay());
-    }
-
-    /**
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeForService(Builder $query, SermonService $serviceType): Builder
-    {
-        return $query->where('service', $serviceType);
-    }
-
-    /**
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeInSeries(Builder $query, string $seriesTitle): Builder
-    {
-        return $query->where('series', $seriesTitle);
-    }
-
-    /**
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeByPreacher(Builder $query, string $preacherName): Builder
-    {
-        return $query->where(function (Builder $builder) use ($preacherName): void {
-            $builder->where('preacher', $preacherName)
-                ->orWhereHas('preacherProfile', fn (Builder $preacherQuery): Builder => $preacherQuery->where('name', $preacherName));
-        });
-    }
-
-    /**
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeNeedsPreacherReview(Builder $query): Builder
-    {
-        return $query->where('needs_preacher_review', true);
-    }
-
-    /**
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeWhereSermon(Builder $query): Builder
-    {
-        return $query->where($query->qualifyColumn('content_type'), SermonContentType::Sermon);
-    }
-
-    /**
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeWhereChildrensTalk(Builder $query): Builder
-    {
-        return $query->where($query->qualifyColumn('content_type'), SermonContentType::ChildrensTalk);
-    }
-
-    /**
-     * Scope to filter sermons visible in the public sitemap.
-     *
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeWhereVisibleInSitemap(Builder $query): Builder
-    {
-        // A sermon's canonical URL is keyed on its slug, so a record without one
-        // has no public page to point to and must never reach URL generation.
-        $query->whereNotNull($query->qualifyColumn('slug'))
-            ->where($query->qualifyColumn('slug'), '!=', '');
-
-        if ((bool) config('sermons.childrens_talks.public', false)) {
-            return $query;
-        }
-
-        return $query->whereSermon();
-    }
-
-    /**
      * @return BelongsTo<ScripturePassage, $this>
      */
     public function scripturePassage(): BelongsTo
@@ -487,73 +389,6 @@ class Sermon extends Model implements Sitemapable
     public function latestProcessingLog(): HasOne
     {
         return $this->hasOne(MediaProcessingLog::class, 'sermon_id')->latestOfMany();
-    }
-
-    /**
-     * Scope to get only automated sermons
-     *
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeAutomated(Builder $query): Builder
-    {
-        return $query->where(function (Builder $q): void {
-            $q->whereNotNull('transcript_file_path')
-                ->orWhereHas('processingLogs');
-        });
-    }
-
-    /**
-     * Scope to get only manually created sermons
-     *
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeManual(Builder $query): Builder
-    {
-        return $query->where(function (Builder $q): void {
-            $q->whereNull('transcript_file_path')
-                ->whereDoesntHave('processingLogs');
-        });
-    }
-
-    /**
-     * Scope to get sermons with completed processing
-     *
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeProcessingCompleted(Builder $query): Builder
-    {
-        return $query->whereHas('processingLogs', function (Builder $q): void {
-            $q->where('status', ProcessingStatus::Completed);
-        });
-    }
-
-    /**
-     * Scope to get sermons with failed processing
-     *
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeProcessingFailed(Builder $query): Builder
-    {
-        return $query->whereHas('processingLogs', function (Builder $q): void {
-            $q->where('status', ProcessingStatus::Failed);
-        });
-    }
-
-    /**
-     * Scope to get sermons currently being processed
-     *
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeProcessingInProgress(Builder $query): Builder
-    {
-        return $query->whereHas('processingLogs', function (Builder $q): void {
-            $q->where('status', ProcessingStatus::Processing);
-        });
     }
 
     /**
@@ -662,7 +497,7 @@ class Sermon extends Model implements Sitemapable
 
     /**
      * Check if this sermon was created through automated processing.
-     * Logic aligned with scopeAutomated() criteria.
+     * Logic aligned with SermonBuilder::automated() criteria.
      *
      * @return bool True if sermon was automatically processed
      */
@@ -788,69 +623,6 @@ class Sermon extends Model implements Sitemapable
     }
 
     /**
-     * Scope to get only livestream sermons
-     *
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeFromLivestream(Builder $query): Builder
-    {
-        return $query->where('source_type', SermonSourceType::Livestream);
-    }
-
-    /**
-     * Scope to get sermons with video files
-     *
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeWithVideo(Builder $query): Builder
-    {
-        return $query->whereNotNull('video_file_path');
-    }
-
-    /**
-     * Scope to get sermons by source type
-     *
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeBySourceType(Builder $query, SermonSourceType $sourceType): Builder
-    {
-        return $query->where('source_type', $sourceType);
-    }
-
-    /**
-     * Scope to get sermons with thumbnails
-     *
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeWithThumbnail(Builder $query): Builder
-    {
-        return $query->whereNotNull('thumbnail_file_path');
-    }
-
-    /**
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeOrderByPreacherName(Builder $query, string $direction = 'asc'): Builder
-    {
-        $direction = $direction === 'desc' ? 'desc' : 'asc';
-
-        return $query
-            ->orderBy(
-                Preacher::query()
-                    ->select('name')
-                    ->whereColumn('preachers.id', 'sermons.preacher_id')
-                    ->limit(1),
-                $direction
-            )
-            ->orderBy('preacher', $direction);
-    }
-
-    /**
      * Convert the sermon to a sitemap tag.
      *
      * @return Url|string|array<string, mixed>
@@ -858,18 +630,5 @@ class Sermon extends Model implements Sitemapable
     public function toSitemapTag(): Url|string|array
     {
         return app(SermonSitemapPresenter::class)->toSitemapTag($this);
-    }
-
-    /**
-     * Scope for podcast-ready sermons (must have audio file)
-     *
-     * @param  Builder<Sermon>  $query
-     * @return Builder<Sermon>
-     */
-    public function scopeForPodcast(Builder $query): Builder
-    {
-        return $query->whereNotNull('audio_file_path')
-            ->where('audio_file_path', '!=', '')
-            ->orderBy('date', 'desc');
     }
 }

--- a/app/Services/Public/SermonRepository.php
+++ b/app/Services/Public/SermonRepository.php
@@ -6,6 +6,7 @@ namespace App\Services\Public;
 
 use App\Enums\SermonContentType;
 use App\Enums\SermonService;
+use App\Models\Builders\SermonBuilder;
 use App\Models\Preacher;
 use App\Models\Sermon;
 use App\Models\SermonScriptureFilter;
@@ -36,10 +37,8 @@ class SermonRepository
      * Performance Optimization: Limits retrieved columns to the set required by
      * SermonViewPresenter and SermonExposurePolicy to minimize memory usage and
      * prevent N+1 lazy-loading of media metadata or related profile images.
-     *
-     * @return Builder<Sermon>
      */
-    public function basePublicSermonQuery(?SermonContentType $contentType = null): Builder
+    public function basePublicSermonQuery(?SermonContentType $contentType = null): SermonBuilder
     {
         return Sermon::query()
             ->when($contentType, fn (Builder $q) => $q->where('content_type', $contentType))
@@ -79,25 +78,21 @@ class SermonRepository
 
     /**
      * Build the base query for public sermon listings (ContentType::Sermon).
-     *
-     * @return Builder<Sermon>
      */
-    public function publicSermonQuery(): Builder
+    public function publicSermonQuery(): SermonBuilder
     {
         return $this->basePublicSermonQuery(SermonContentType::Sermon);
     }
 
     /**
      * Build the ordered public sermon query for the canonical archive page.
-     *
-     * @return Builder<Sermon>
      */
     public function publicBrowseQuery(
         ?string $book = null,
         ?int $chapter = null,
         ?int $preacherId = null,
         ?string $series = null,
-    ): Builder {
+    ): SermonBuilder {
         $query = $this->publicSermonQuery()
             ->when($preacherId, fn (Builder $builder): Builder => $builder->where('preacher_id', $preacherId))
             ->when($series, fn (Builder $builder): Builder => $builder->where('series', $series));

--- a/tests/Integration/Models/SermonTest.php
+++ b/tests/Integration/Models/SermonTest.php
@@ -6,6 +6,7 @@ namespace Tests\Integration\Models;
 
 use App\Enums\SermonContentType;
 use App\Enums\SermonService;
+use App\Models\Builders\SermonBuilder;
 use App\Models\Preacher;
 use App\Models\Sermon;
 use App\Presenters\SermonViewPresenter;
@@ -21,6 +22,13 @@ use Tests\TestCase;
 class SermonTest extends TestCase
 {
     use RefreshDatabase;
+
+    #[Test]
+    public function sermon_queries_use_the_dedicated_builder(): void
+    {
+        $this->assertInstanceOf(SermonBuilder::class, Sermon::query());
+        $this->assertInstanceOf(SermonBuilder::class, Sermon::forPodcast());
+    }
 
     #[Test]
     public function sermon_relationships()


### PR DESCRIPTION
## Summary
- Introduces `app/Models/Builders/SermonBuilder` (the project's first dedicated Eloquent builder) holding all 19 Sermon query scopes, attached with Laravel 13's `#[UseEloquentBuilder]` attribute.
- `Sermon` drops from 875 to 634 lines and now holds only attributes, casts, relationships, validation rules, and instance helpers.
- Call sites need no changes: `Sermon::forPodcast()`, `Sermon::query()->whereSermon()`, etc. resolve to the builder via static forwarding. `SermonRepository` query factories now return the concrete `SermonBuilder` type (this is what lets PHPStan keep checking chained scope calls).
- Adds a wiring test asserting `Sermon::query()` returns the dedicated builder; the existing scope behaviour tests (SermonProcessingScopesTest, SermonStatusAndMediaTest, SermonTest, SermonThumbnailTest) exercise every moved method unchanged.

Part of June 2026 review **Phase R6** (Finding 2) — see `docs/plans/JUNE-2026-REVIEW-IMPLEMENTATION-2026-06-03.md`.

## Verification
- Pint clean, PHPStan (larastan 3.9.6 understands the attribute) 0 errors
- Full parallel suite: 5426 passed (one unrelated storage-fake teardown flake in SermonThumbnailTest passed on isolation and re-run)
- Dusk: 41 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)