### PR TITLE
R6: Decompose SongCatalogSyncService + typed sync report DTO

### DIFF
--- a/app/Console/Commands/SyncSongsCommand.php
+++ b/app/Console/Commands/SyncSongsCommand.php
@@ -19,7 +19,7 @@ class SyncSongsCommand extends Command
     public function handle(SongCatalogSyncService $syncService): int
     {
         try {
-            $metrics = $syncService->sync(
+            $report = $syncService->sync(
                 path: $this->option('path'),
                 dryRun: (bool) $this->option('dry-run')
             );
@@ -30,28 +30,28 @@ class SyncSongsCommand extends Command
         }
 
         $this->info('Song catalogue sync completed.');
-        $this->line('Path: '.$metrics['path']);
+        $this->line('Path: '.$report->path);
 
-        if ($metrics['dry_run']) {
+        if ($report->dryRun) {
             $this->warn('Dry run enabled. No database changes were written.');
         }
 
         $this->table(
             ['Metric', 'Value'],
             [
-                ['Source songs', (string) $metrics['source_songs']],
-                ['Canonical groups', (string) $metrics['canonical_groups']],
-                ['Duplicate groups', (string) $metrics['duplicate_groups']],
-                ['Duplicate rows merged', (string) $metrics['duplicate_rows']],
-                ['Songs upserted', (string) $metrics['songs_upserted']],
-                ['Songs created', (string) $metrics['songs_created']],
-                ['Songs updated', (string) $metrics['songs_updated']],
-                ['Songs restored', (string) $metrics['songs_restored']],
-                ['Song authors upserted', (string) $metrics['song_authors_upserted']],
-                ['Song books upserted', (string) $metrics['song_books_upserted']],
-                ['Song-author links synced', (string) $metrics['song_author_links_synced']],
-                ['Song-book links synced', (string) $metrics['song_book_links_synced']],
-                ['Groups with parse warnings', (string) $metrics['groups_with_parse_warnings']],
+                ['Source songs', (string) $report->sourceSongs],
+                ['Canonical groups', (string) $report->canonicalGroups],
+                ['Duplicate groups', (string) $report->duplicateGroups],
+                ['Duplicate rows merged', (string) $report->duplicateRows],
+                ['Songs upserted', (string) $report->songsUpserted],
+                ['Songs created', (string) $report->songsCreated],
+                ['Songs updated', (string) $report->songsUpdated],
+                ['Songs restored', (string) $report->songsRestored],
+                ['Song authors upserted', (string) $report->songAuthorsUpserted],
+                ['Song books upserted', (string) $report->songBooksUpserted],
+                ['Song-author links synced', (string) $report->songAuthorLinksSynced],
+                ['Song-book links synced', (string) $report->songBookLinksSynced],
+                ['Groups with parse warnings', (string) $report->groupsWithParseWarnings],
             ]
         );
 

--- a/app/Data/OpenLpSongSourceData.php
+++ b/app/Data/OpenLpSongSourceData.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+/**
+ * Raw rows read from an OpenLP songs SQLite database.
+ *
+ * Row arrays keep the source column names; consumers normalise individual
+ * values via OpenLpRowValue.
+ */
+readonly class OpenLpSongSourceData
+{
+    /**
+     * @param  list<array<string, mixed>>  $songs
+     * @param  list<array<string, mixed>>  $authors
+     * @param  list<array<string, mixed>>  $authorLinks
+     * @param  list<array<string, mixed>>  $books
+     * @param  list<array<string, mixed>>  $bookLinks
+     */
+    public function __construct(
+        public array $songs,
+        public array $authors,
+        public array $authorLinks,
+        public array $books,
+        public array $bookLinks,
+    ) {}
+}

--- a/app/Data/SongCatalogSyncReport.php
+++ b/app/Data/SongCatalogSyncReport.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use Spatie\LaravelData\Data;
+
+/**
+ * Outcome metrics for one OpenLP song-catalogue sync run.
+ *
+ * Counters are mutable: the sync coordinator increments them as it walks the
+ * canonical song groups, then hands the finished report to callers.
+ */
+class SongCatalogSyncReport extends Data
+{
+    public function __construct(
+        public string $path,
+        public bool $dryRun,
+        public int $sourceSongs = 0,
+        public int $canonicalGroups = 0,
+        public int $duplicateGroups = 0,
+        public int $duplicateRows = 0,
+        public int $songsUpserted = 0,
+        public int $songsCreated = 0,
+        public int $songsUpdated = 0,
+        public int $songsRestored = 0,
+        public int $songAuthorsUpserted = 0,
+        public int $songBooksUpserted = 0,
+        public int $songAuthorLinksSynced = 0,
+        public int $songBookLinksSynced = 0,
+        public int $groupsWithParseWarnings = 0,
+    ) {}
+}

--- a/app/Services/Song/SongCatalogSyncService.php
+++ b/app/Services/Song/SongCatalogSyncService.php
@@ -4,342 +4,248 @@ declare(strict_types=1);
 
 namespace App\Services\Song;
 
+use App\Data\OpenLpSongSourceData;
+use App\Data\SongCatalogSyncReport;
 use App\Models\Song;
-use App\Models\SongAuthor;
-use App\Models\SongBook;
+use App\Services\Song\Sync\LegacySongReconciler;
+use App\Services\Song\Sync\OpenLpRowValue;
+use App\Services\Song\Sync\OpenLpSongSourceReader;
+use App\Services\Song\Sync\SongAuthorBookSyncer;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use PDO;
-use PDOException;
-use RuntimeException;
 
+/**
+ * Coordinates the OpenLP songs SQLite → canonical catalogue sync.
+ *
+ * Collaborators own the distinct responsibilities: OpenLpSongSourceReader
+ * reads the SQLite source, LegacySongReconciler matches pre-import rows,
+ * and SongAuthorBookSyncer handles authors/books and pivot links. This
+ * service groups source rows into canonical songs, upserts them, and
+ * assembles the run report. Dry-run and real mode share the same pipeline;
+ * dry-run substitutes preview (identity) ID maps and skips all writes.
+ */
 class SongCatalogSyncService
 {
     public function __construct(
         private readonly OpenLpLyricsParser $lyricsParser,
+        private readonly OpenLpSongSourceReader $sourceReader,
+        private readonly LegacySongReconciler $reconciler,
+        private readonly SongAuthorBookSyncer $syncer,
     ) {}
 
-    /**
-     * @return array{
-     *     path:string,
-     *     dry_run:bool,
-     *     source_songs:int,
-     *     canonical_groups:int,
-     *     duplicate_groups:int,
-     *     duplicate_rows:int,
-     *     songs_upserted:int,
-     *     songs_created:int,
-     *     songs_updated:int,
-     *     songs_restored:int,
-     *     song_authors_upserted:int,
-     *     song_books_upserted:int,
-     *     song_author_links_synced:int,
-     *     song_book_links_synced:int,
-     *     groups_with_parse_warnings:int
-     * }
-     */
-    public function sync(?string $path = null, bool $dryRun = false): array
+    public function sync(?string $path = null, bool $dryRun = false): SongCatalogSyncReport
     {
-        $state = $this->prepareSyncState($path);
-        $metrics = $this->initializeMetrics($state['resolvedPath'], $dryRun, $state['sourceData'], $state['songGroups']);
+        [$resolvedPath, $sourceData] = $this->sourceReader->read($path);
+
+        $songGroups = $this->groupSongsByCanonicalKey($sourceData->songs);
+        $existingSongs = $this->existingSongsByCanonicalKey(array_keys($songGroups));
+        $legacyReconciliationMap = $this->reconciler->buildReconciliationMap($songGroups, $existingSongs);
+
+        $report = $this->initializeReport($resolvedPath, $dryRun, $sourceData, $songGroups);
 
         if ($dryRun) {
-            return $this->buildDryRunMetrics(
-                $metrics,
-                $state['sourceData'],
-                $state['songGroups'],
-                $state['existingSongs'],
-                $state['legacyReconciliationMap']
-            );
+            return $this->previewSync($report, $sourceData, $songGroups, $existingSongs, $legacyReconciliationMap);
         }
 
-        DB::transaction(function () use (&$metrics, $state): void {
-            $sourceData = $state['sourceData'];
-            $songGroups = $state['songGroups'];
-            $legacyReconciliationMap = $state['legacyReconciliationMap'];
+        return $this->applySync($report, $sourceData, $songGroups, $legacyReconciliationMap);
+    }
 
-            [$authorIdMap, $authorUpsertedCount] = $this->upsertSongAuthors($sourceData['authors']);
-            $metrics['song_authors_upserted'] = $authorUpsertedCount;
+    /**
+     * @param  array<string, list<array<string, mixed>>>  $songGroups
+     */
+    private function initializeReport(string $path, bool $dryRun, OpenLpSongSourceData $sourceData, array $songGroups): SongCatalogSyncReport
+    {
+        $report = new SongCatalogSyncReport(
+            path: $path,
+            dryRun: $dryRun,
+            sourceSongs: count($sourceData->songs),
+            canonicalGroups: count($songGroups),
+        );
 
-            [$bookIdMap, $bookUpsertedCount] = $this->upsertSongBooks($sourceData['books']);
-            $metrics['song_books_upserted'] = $bookUpsertedCount;
+        foreach ($songGroups as $groupRows) {
+            if (count($groupRows) > 1) {
+                $report->duplicateGroups++;
+                $report->duplicateRows += count($groupRows) - 1;
+            }
+        }
+
+        return $report;
+    }
+
+    /**
+     * Apply the sync inside one transaction.
+     *
+     * @param  array<string, list<array<string, mixed>>>  $songGroups
+     * @param  array<string, array{song_id: int, deleted: bool}>  $legacyReconciliationMap
+     */
+    private function applySync(
+        SongCatalogSyncReport $report,
+        OpenLpSongSourceData $sourceData,
+        array $songGroups,
+        array $legacyReconciliationMap
+    ): SongCatalogSyncReport {
+        DB::transaction(function () use ($report, $sourceData, $songGroups, $legacyReconciliationMap): void {
+            [$authorIdMap, $authorUpsertedCount] = $this->syncer->upsertAuthors($sourceData->authors);
+            $report->songAuthorsUpserted = $authorUpsertedCount;
+
+            [$bookIdMap, $bookUpsertedCount] = $this->syncer->upsertBooks($sourceData->books);
+            $report->songBooksUpserted = $bookUpsertedCount;
+
+            $authorLinksBySourceSongId = $this->syncer->groupLinksBySourceSongId($sourceData->authorLinks);
+            $bookLinksBySourceSongId = $this->syncer->groupLinksBySourceSongId($sourceData->bookLinks);
 
             foreach ($songGroups as $canonicalKey => $groupRows) {
                 $this->processSongGroup(
                     $canonicalKey,
                     $groupRows,
-                    $sourceData,
+                    $authorLinksBySourceSongId,
+                    $bookLinksBySourceSongId,
                     $authorIdMap,
                     $bookIdMap,
-                    $legacyReconciliationMap,
-                    $metrics
+                    $legacyReconciliationMap[$canonicalKey]['song_id'] ?? null,
+                    $report,
                 );
             }
         });
 
-        /** @var array{path:string,dry_run:bool,source_songs:int,canonical_groups:int,duplicate_groups:int,duplicate_rows:int,songs_upserted:int,songs_created:int,songs_updated:int,songs_restored:int,song_authors_upserted:int,song_books_upserted:int,song_author_links_synced:int,song_book_links_synced:int,groups_with_parse_warnings:int} $metrics */
-        return $metrics;
+        return $report;
     }
 
     /**
-     * Prepare source data and existing state for synchronization.
+     * Walk the same pipeline as applySync without writing anything: preview
+     * (identity) ID maps stand in for the post-upsert lookups, so the link
+     * counts dedupe on source IDs exactly as the dry-run metrics always have.
      *
-     * @return array{
-     *     resolvedPath: string,
-     *     sourceData: array{
-     *         songs: list<array<string, mixed>>,
-     *         authors: list<array<string, mixed>>,
-     *         author_links: list<array<string, mixed>>,
-     *         books: list<array<string, mixed>>,
-     *         book_links: list<array<string, mixed>>
-     *     },
-     *     songGroups: array<string, list<array<string, mixed>>>,
-     *     existingSongs: array<string, array{song_id: int, deleted: bool}>,
-     *     legacyReconciliationMap: array<string, array{song_id: int, deleted: bool}>
-     * }
-     */
-    private function prepareSyncState(?string $path): array
-    {
-        $resolvedPath = $this->resolvePath($path);
-        $sourceData = $this->loadSourceData($resolvedPath);
-        $songGroups = $this->groupSongsByCanonicalKey($sourceData['songs']);
-        $existingSongs = $this->existingSongsByCanonicalKey(array_keys($songGroups));
-        $legacyReconciliationMap = $this->buildLegacyReconciliationMap($songGroups, $existingSongs);
-
-        return [
-            'resolvedPath' => $resolvedPath,
-            'sourceData' => $sourceData,
-            'songGroups' => $songGroups,
-            'existingSongs' => $existingSongs,
-            'legacyReconciliationMap' => $legacyReconciliationMap,
-        ];
-    }
-
-    /**
-     * Process a single song group during synchronization.
-     *
-     * @param  list<array<string, mixed>>  $groupRows
-     * @param  array{
-     *     songs: list<array<string, mixed>>,
-     *     authors: list<array<string, mixed>>,
-     *     author_links: list<array<string, mixed>>,
-     *     books: list<array<string, mixed>>,
-     *     book_links: list<array<string, mixed>>
-     * }  $sourceData
-     * @param  array<int, int>  $authorIdMap
-     * @param  array<int, int>  $bookIdMap
+     * @param  array<string, list<array<string, mixed>>>  $songGroups
+     * @param  array<string, array{song_id: int, deleted: bool}>  $existingSongs
      * @param  array<string, array{song_id: int, deleted: bool}>  $legacyReconciliationMap
-     * @param  array<string, mixed>  $metrics
      */
-    private function processSongGroup(
-        string $canonicalKey,
-        array $groupRows,
-        array $sourceData,
-        array $authorIdMap,
-        array $bookIdMap,
-        array $legacyReconciliationMap,
-        array &$metrics
-    ): void {
-        [$song, $created, $restored, $parseWarnings] = $this->upsertSongFromGroup(
-            $canonicalKey,
-            $groupRows,
-            $legacyReconciliationMap[$canonicalKey]['song_id'] ?? null
-        );
-
-        $metrics['songs_upserted']++;
-
-        if ($created) {
-            $metrics['songs_created']++;
-        } else {
-            $metrics['songs_updated']++;
-        }
-
-        if ($restored) {
-            $metrics['songs_restored']++;
-        }
-
-        if ($parseWarnings > 0) {
-            $metrics['groups_with_parse_warnings']++;
-        }
-
-        $authorPivotRows = $this->buildAuthorPivotRows($song->id, $groupRows, $sourceData['author_links'], $authorIdMap);
-        DB::table('song_author_song')->where('song_id', $song->id)->delete();
-        if ($authorPivotRows !== []) {
-            DB::table('song_author_song')->insert($authorPivotRows);
-        }
-        $metrics['song_author_links_synced'] += count($authorPivotRows);
-
-        $bookPivotRows = $this->buildBookPivotRows($song->id, $groupRows, $sourceData['book_links'], $bookIdMap);
-        DB::table('song_book_song')->where('song_id', $song->id)->delete();
-        if ($bookPivotRows !== []) {
-            DB::table('song_book_song')->insert($bookPivotRows);
-        }
-        $metrics['song_book_links_synced'] += count($bookPivotRows);
-    }
-
-    /**
-     * @param  array{
-     *     songs:list<array<string,mixed>>,
-     *     authors:list<array<string,mixed>>,
-     *     author_links:list<array<string,mixed>>,
-     *     books:list<array<string,mixed>>,
-     *     book_links:list<array<string,mixed>>
-     * }  $sourceData
-     * @param  array<string, list<array<string,mixed>>>  $songGroups
-     * @return array{
-     *     path:string,
-     *     dry_run:bool,
-     *     source_songs:int,
-     *     canonical_groups:int,
-     *     duplicate_groups:int,
-     *     duplicate_rows:int,
-     *     songs_upserted:int,
-     *     songs_created:int,
-     *     songs_updated:int,
-     *     songs_restored:int,
-     *     song_authors_upserted:int,
-     *     song_books_upserted:int,
-     *     song_author_links_synced:int,
-     *     song_book_links_synced:int,
-     *     groups_with_parse_warnings:int
-     * }
-     */
-    private function initializeMetrics(string $path, bool $dryRun, array $sourceData, array $songGroups): array
-    {
-        $metrics = [
-            'path' => $path,
-            'dry_run' => $dryRun,
-            'source_songs' => count($sourceData['songs']),
-            'canonical_groups' => count($songGroups),
-            'duplicate_groups' => 0,
-            'duplicate_rows' => 0,
-            'songs_upserted' => 0,
-            'songs_created' => 0,
-            'songs_updated' => 0,
-            'songs_restored' => 0,
-            'song_authors_upserted' => 0,
-            'song_books_upserted' => 0,
-            'song_author_links_synced' => 0,
-            'song_book_links_synced' => 0,
-            'groups_with_parse_warnings' => 0,
-        ];
-
-        foreach ($songGroups as $groupRows) {
-            if (count($groupRows) > 1) {
-                $metrics['duplicate_groups']++;
-                $metrics['duplicate_rows'] += count($groupRows) - 1;
-            }
-        }
-
-        return $metrics;
-    }
-
-    /**
-     * @param  array{
-     *     path:string,
-     *     dry_run:bool,
-     *     source_songs:int,
-     *     canonical_groups:int,
-     *     duplicate_groups:int,
-     *     duplicate_rows:int,
-     *     songs_upserted:int,
-     *     songs_created:int,
-     *     songs_updated:int,
-     *     songs_restored:int,
-     *     song_authors_upserted:int,
-     *     song_books_upserted:int,
-     *     song_author_links_synced:int,
-     *     song_book_links_synced:int,
-     *     groups_with_parse_warnings:int
-     * }  $metrics
-     * @param  array{
-     *     songs:list<array<string,mixed>>,
-     *     authors:list<array<string,mixed>>,
-     *     author_links:list<array<string,mixed>>,
-     *     books:list<array<string,mixed>>,
-     *     book_links:list<array<string,mixed>>
-     * }  $sourceData
-     * @param  array<string, list<array<string,mixed>>>  $songGroups
-     * @param  array<string, array{song_id:int, deleted:bool}>  $existingSongs
-     * @param  array<string, array{song_id:int, deleted:bool}>  $legacyReconciliationMap
-     * @return array{
-     *     path:string,
-     *     dry_run:bool,
-     *     source_songs:int,
-     *     canonical_groups:int,
-     *     duplicate_groups:int,
-     *     duplicate_rows:int,
-     *     songs_upserted:int,
-     *     songs_created:int,
-     *     songs_updated:int,
-     *     songs_restored:int,
-     *     song_authors_upserted:int,
-     *     song_books_upserted:int,
-     *     song_author_links_synced:int,
-     *     song_book_links_synced:int,
-     *     groups_with_parse_warnings:int
-     * }
-     */
-    private function buildDryRunMetrics(
-        array $metrics,
-        array $sourceData,
+    private function previewSync(
+        SongCatalogSyncReport $report,
+        OpenLpSongSourceData $sourceData,
         array $songGroups,
         array $existingSongs,
         array $legacyReconciliationMap
-    ): array {
-        [$validAuthorIds, $authorUpsertedCount] = $this->previewSongAuthorUpserts($sourceData['authors']);
-        $metrics['song_authors_upserted'] = $authorUpsertedCount;
+    ): SongCatalogSyncReport {
+        [$authorIdMap, $authorUpsertedCount] = $this->syncer->previewAuthorUpserts($sourceData->authors);
+        $report->songAuthorsUpserted = $authorUpsertedCount;
 
-        [$validBookIds, $bookUpsertedCount] = $this->previewSongBookUpserts($sourceData['books']);
-        $metrics['song_books_upserted'] = $bookUpsertedCount;
+        [$bookIdMap, $bookUpsertedCount] = $this->syncer->previewBookUpserts($sourceData->books);
+        $report->songBooksUpserted = $bookUpsertedCount;
 
-        $authorLinksBySourceSongId = $this->groupLinksBySourceSongId($sourceData['author_links']);
-        $bookLinksBySourceSongId = $this->groupLinksBySourceSongId($sourceData['book_links']);
+        $authorLinksBySourceSongId = $this->syncer->groupLinksBySourceSongId($sourceData->authorLinks);
+        $bookLinksBySourceSongId = $this->syncer->groupLinksBySourceSongId($sourceData->bookLinks);
 
         foreach ($songGroups as $canonicalKey => $groupRows) {
-            $metrics['songs_upserted']++;
+            $report->songsUpserted++;
 
             $existingSong = $existingSongs[$canonicalKey] ?? $legacyReconciliationMap[$canonicalKey] ?? null;
 
             if ($existingSong !== null) {
-                $metrics['songs_updated']++;
+                $report->songsUpdated++;
 
                 if ($existingSong['deleted'] === true) {
-                    $metrics['songs_restored']++;
+                    $report->songsRestored++;
                 }
             } else {
-                $metrics['songs_created']++;
+                $report->songsCreated++;
             }
 
             $representative = $this->selectRepresentativeSong($groupRows);
             $parsedLyrics = $this->lyricsParser->parse(
                 (string) ($representative['lyrics'] ?? ''),
-                $this->stringOrNull($representative['verse_order'] ?? null),
+                OpenLpRowValue::stringOrNull($representative['verse_order'] ?? null),
             );
             if ($parsedLyrics['warnings'] !== []) {
-                $metrics['groups_with_parse_warnings']++;
+                $report->groupsWithParseWarnings++;
             }
 
-            $metrics['song_author_links_synced'] += $this->countDryRunAuthorLinks(
-                $groupRows,
-                $authorLinksBySourceSongId,
-                $validAuthorIds
-            );
+            $sourceSongIds = OpenLpRowValue::sourceSongIds($groupRows);
 
-            $metrics['song_book_links_synced'] += $this->countDryRunBookLinks(
-                $groupRows,
-                $bookLinksBySourceSongId,
-                $validBookIds
+            $report->songAuthorLinksSynced += count(
+                $this->syncer->authorPivotRows(0, $sourceSongIds, $authorLinksBySourceSongId, $authorIdMap)
+            );
+            $report->songBookLinksSynced += count(
+                $this->syncer->bookPivotRows(0, $sourceSongIds, $bookLinksBySourceSongId, $bookIdMap)
             );
         }
 
-        return $metrics;
+        return $report;
+    }
+
+    /**
+     * Upsert one canonical song group and replace its author/book links.
+     *
+     * @param  list<array<string, mixed>>  $groupRows
+     * @param  array<int, list<array<string, mixed>>>  $authorLinksBySourceSongId
+     * @param  array<int, list<array<string, mixed>>>  $bookLinksBySourceSongId
+     * @param  array<int, int>  $authorIdMap
+     * @param  array<int, int>  $bookIdMap
+     */
+    private function processSongGroup(
+        string $canonicalKey,
+        array $groupRows,
+        array $authorLinksBySourceSongId,
+        array $bookLinksBySourceSongId,
+        array $authorIdMap,
+        array $bookIdMap,
+        ?int $reconciledSongId,
+        SongCatalogSyncReport $report,
+    ): void {
+        [$song, $created, $restored, $parseWarnings] = $this->upsertSongFromGroup($canonicalKey, $groupRows, $reconciledSongId);
+
+        $report->songsUpserted++;
+
+        if ($created) {
+            $report->songsCreated++;
+        } else {
+            $report->songsUpdated++;
+        }
+
+        if ($restored) {
+            $report->songsRestored++;
+        }
+
+        if ($parseWarnings > 0) {
+            $report->groupsWithParseWarnings++;
+        }
+
+        $sourceSongIds = OpenLpRowValue::sourceSongIds($groupRows);
+
+        $authorPivotRows = $this->syncer->authorPivotRows($song->id, $sourceSongIds, $authorLinksBySourceSongId, $authorIdMap);
+        $this->syncer->replaceAuthorLinks($song->id, $authorPivotRows);
+        $report->songAuthorLinksSynced += count($authorPivotRows);
+
+        $bookPivotRows = $this->syncer->bookPivotRows($song->id, $sourceSongIds, $bookLinksBySourceSongId, $bookIdMap);
+        $this->syncer->replaceBookLinks($song->id, $bookPivotRows);
+        $report->songBookLinksSynced += count($bookPivotRows);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, list<array<string, mixed>>>
+     */
+    private function groupSongsByCanonicalKey(array $rows): array
+    {
+        $groups = [];
+
+        foreach ($rows as $row) {
+            $searchTitle = is_string($row['search_title'] ?? null) ? $row['search_title'] : '';
+            $canonicalKey = Song::canonicalizeKey($searchTitle);
+
+            if ($canonicalKey === '') {
+                continue;
+            }
+
+            $groups[$canonicalKey][] = $row;
+        }
+
+        return $groups;
     }
 
     /**
      * @param  list<string>  $canonicalKeys
-     * @return array<string, array{song_id:int, deleted:bool}>
+     * @return array<string, array{song_id: int, deleted: bool}>
      */
     private function existingSongsByCanonicalKey(array $canonicalKeys): array
     {
@@ -347,7 +253,7 @@ class SongCatalogSyncService
             return [];
         }
 
-        /** @var array<string, array{song_id:int, deleted:bool}> $songs */
+        /** @var array<string, array{song_id: int, deleted: bool}> $songs */
         $songs = Song::query()
             ->withTrashed()
             ->whereIn('canonical_key', $canonicalKeys)
@@ -363,217 +269,27 @@ class SongCatalogSyncService
         return $songs;
     }
 
-    private function resolvePath(?string $path): string
-    {
-        $configuredPath = $path ?? config('service-tracking.songs.sqlite_path');
-
-        if (! is_string($configuredPath) || trim($configuredPath) === '') {
-            throw new RuntimeException('No songs SQLite path configured. Set OPENLP_SONGS_DB_PATH or pass --path.');
-        }
-
-        $resolvedPath = trim($configuredPath);
-
-        if (! is_file($resolvedPath)) {
-            throw new RuntimeException("Songs SQLite file does not exist at [{$resolvedPath}].");
-        }
-
-        if (! is_readable($resolvedPath)) {
-            throw new RuntimeException("Songs SQLite file is not readable at [{$resolvedPath}].");
-        }
-
-        return $resolvedPath;
-    }
-
     /**
-     * @return array{
-     *     songs:list<array<string,mixed>>,
-     *     authors:list<array<string,mixed>>,
-     *     author_links:list<array<string,mixed>>,
-     *     books:list<array<string,mixed>>,
-     *     book_links:list<array<string,mixed>>
-     * }
-     */
-    private function loadSourceData(string $path): array
-    {
-        try {
-            $pdo = new PDO('sqlite:'.$path);
-            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        } catch (PDOException $exception) {
-            throw new RuntimeException('Unable to open songs SQLite database: '.$exception->getMessage(), previous: $exception);
-        }
-
-        $requiredTables = [
-            'songs',
-            'authors',
-            'authors_songs',
-            'song_books',
-            'songs_songbooks',
-        ];
-
-        $existingTables = $this->fetchTableNames($pdo);
-        foreach ($requiredTables as $requiredTable) {
-            if (! in_array($requiredTable, $existingTables, true)) {
-                throw new RuntimeException("Songs SQLite database is missing required table [{$requiredTable}].");
-            }
-        }
-
-        return [
-            'songs' => $this->fetchAll($pdo, 'SELECT id, title, alternate_title, lyrics, verse_order, copyright, comments, ccli_number, search_title, last_modified FROM songs'),
-            'authors' => $this->fetchAll($pdo, 'SELECT id, display_name, first_name, last_name FROM authors'),
-            'author_links' => $this->fetchAll($pdo, 'SELECT song_id, author_id, author_type FROM authors_songs'),
-            'books' => $this->fetchAll($pdo, 'SELECT id, name, publisher FROM song_books'),
-            'book_links' => $this->fetchAll($pdo, 'SELECT song_id, songbook_id, entry FROM songs_songbooks'),
-        ];
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $rows
-     * @return array<string, list<array<string,mixed>>>
-     */
-    private function groupSongsByCanonicalKey(array $rows): array
-    {
-        $groups = [];
-
-        foreach ($rows as $row) {
-            $searchTitle = is_string($row['search_title'] ?? null) ? $row['search_title'] : '';
-            $canonicalKey = Song::canonicalizeKey($searchTitle);
-
-            if ($canonicalKey === '') {
-                continue;
-            }
-
-            if (! array_key_exists($canonicalKey, $groups)) {
-                $groups[$canonicalKey] = [];
-            }
-
-            $groups[$canonicalKey][] = $row;
-        }
-
-        return $groups;
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $authorRows
-     * @return array{0: array<int, int>, 1: int}
-     */
-    private function upsertSongAuthors(array $authorRows): array
-    {
-        $payloads = [];
-
-        foreach ($authorRows as $authorRow) {
-            $displayName = $this->stringOrNull($authorRow['display_name'] ?? null);
-            if ($displayName === null) {
-                continue;
-            }
-
-            $payloads[] = [
-                'display_name' => $displayName,
-                'first_name' => $this->stringOrNull($authorRow['first_name'] ?? null),
-                'last_name' => $this->stringOrNull($authorRow['last_name'] ?? null),
-                'created_at' => now(),
-                'updated_at' => now(),
-            ];
-        }
-
-        if ($payloads !== []) {
-            SongAuthor::query()->upsert(
-                $payloads,
-                ['display_name'],
-                ['first_name', 'last_name', 'updated_at']
-            );
-        }
-
-        /** @var array<string, int> $lookup */
-        $lookup = SongAuthor::query()
-            ->pluck('id', 'display_name')
-            ->mapWithKeys(static fn ($id, $displayName): array => [(string) $displayName => (int) $id])
-            ->all();
-
-        $sourceAuthorIdToLocalId = [];
-
-        foreach ($authorRows as $authorRow) {
-            $displayName = $this->stringOrNull($authorRow['display_name'] ?? null);
-            $sourceAuthorId = $this->intOrNull($authorRow['id'] ?? null);
-
-            if ($displayName === null || $sourceAuthorId === null) {
-                continue;
-            }
-
-            $localId = $lookup[$displayName] ?? null;
-            if ($localId !== null) {
-                $sourceAuthorIdToLocalId[$sourceAuthorId] = $localId;
-            }
-        }
-
-        return [$sourceAuthorIdToLocalId, count($payloads)];
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $bookRows
-     * @return array{0: array<int, int>, 1: int}
-     */
-    private function upsertSongBooks(array $bookRows): array
-    {
-        $payloads = [];
-
-        foreach ($bookRows as $bookRow) {
-            $sourceBookId = $this->intOrNull($bookRow['id'] ?? null);
-            $bookName = $this->stringOrNull($bookRow['name'] ?? null);
-
-            if ($sourceBookId === null || $bookName === null) {
-                continue;
-            }
-
-            $payloads[] = [
-                'source_book_id' => $sourceBookId,
-                'name' => $bookName,
-                'publisher' => $this->stringOrNull($bookRow['publisher'] ?? null),
-                'created_at' => now(),
-                'updated_at' => now(),
-            ];
-        }
-
-        if ($payloads !== []) {
-            SongBook::query()->upsert(
-                $payloads,
-                ['source_book_id'],
-                ['name', 'publisher', 'updated_at']
-            );
-        }
-
-        /** @var array<int, int> $lookup */
-        $lookup = SongBook::query()
-            ->pluck('id', 'source_book_id')
-            ->mapWithKeys(static fn ($id, $sourceBookId): array => [(int) $sourceBookId => (int) $id])
-            ->all();
-
-        return [$lookup, count($payloads)];
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $groupRows
+     * @param  list<array<string, mixed>>  $groupRows
      * @return array{0: Song, 1: bool, 2: bool, 3: int}
      */
     private function upsertSongFromGroup(string $canonicalKey, array $groupRows, ?int $reconciledSongId = null): array
     {
         $representative = $this->selectRepresentativeSong($groupRows);
 
-        $sourceSongIds = array_values(array_filter(
-            array_map(fn (array $row): ?int => $this->intOrNull($row['id'] ?? null), $groupRows),
-            static fn (?int $songId): bool => $songId !== null
-        ));
+        $sourceSongIds = OpenLpRowValue::sourceSongIds($groupRows);
         sort($sourceSongIds);
 
         $parsedLyrics = $this->lyricsParser->parse(
             (string) ($representative['lyrics'] ?? ''),
-            $this->stringOrNull($representative['verse_order'] ?? null),
+            OpenLpRowValue::stringOrNull($representative['verse_order'] ?? null),
         );
         $warnings = $parsedLyrics['warnings'];
 
         $importMetadata = [
             'source_song_ids' => $sourceSongIds,
-            'source_representative_song_id' => $this->intOrNull($representative['id'] ?? null),
-            'source_last_modified' => $this->stringOrNull($representative['last_modified'] ?? null),
+            'source_representative_song_id' => OpenLpRowValue::intOrNull($representative['id'] ?? null),
+            'source_last_modified' => OpenLpRowValue::stringOrNull($representative['last_modified'] ?? null),
             'duplicate_count' => max(0, count($sourceSongIds) - 1),
         ];
 
@@ -581,7 +297,7 @@ class SongCatalogSyncService
             $importMetadata['lyrics_parse_warnings'] = $warnings;
         }
 
-        $title = $this->stringOrNull($representative['title'] ?? null) ?? 'Untitled';
+        $title = OpenLpRowValue::stringOrNull($representative['title'] ?? null) ?? 'Untitled';
         $lyricsXml = (string) ($representative['lyrics'] ?? '');
 
         if ($lyricsXml === '') {
@@ -591,13 +307,13 @@ class SongCatalogSyncService
         $attributes = [
             'canonical_key' => $canonicalKey,
             'title' => $title,
-            'alternate_title' => $this->stringOrNull($representative['alternate_title'] ?? null),
+            'alternate_title' => OpenLpRowValue::stringOrNull($representative['alternate_title'] ?? null),
             'lyrics_xml' => $lyricsXml,
             'lyrics_plain' => $parsedLyrics['lyrics_plain'],
-            'verse_order' => $this->stringOrNull($representative['verse_order'] ?? null),
-            'copyright' => $this->stringOrNull($representative['copyright'] ?? null),
-            'comments' => $this->stringOrNull($representative['comments'] ?? null),
-            'ccli_number' => $this->stringOrNull($representative['ccli_number'] ?? null),
+            'verse_order' => OpenLpRowValue::stringOrNull($representative['verse_order'] ?? null),
+            'copyright' => OpenLpRowValue::stringOrNull($representative['copyright'] ?? null),
+            'comments' => OpenLpRowValue::stringOrNull($representative['comments'] ?? null),
+            'ccli_number' => OpenLpRowValue::stringOrNull($representative['ccli_number'] ?? null),
             'import_metadata' => $importMetadata,
         ];
 
@@ -640,416 +356,21 @@ class SongCatalogSyncService
     }
 
     /**
-     * @param  array<string, list<array<string,mixed>>>  $songGroups
-     * @param  array<string, array{song_id:int, deleted:bool}>  $existingSongs
-     * @return array<string, array{song_id:int, deleted:bool}>
-     */
-    private function buildLegacyReconciliationMap(array $songGroups, array $existingSongs): array
-    {
-        $legacySongs = $this->fetchLegacySongsForReconciliation();
-        if ($legacySongs === []) {
-            return [];
-        }
-
-        $lookupState = $this->prepareLegacyLookupState($legacySongs);
-
-        $acceptedMatches = [];
-        $reservedLegacyIds = [];
-
-        // Phase 1: Match by Praise number AND Title
-        $this->matchLegacySongsByPraiseAndTitle(
-            $songGroups,
-            $existingSongs,
-            $lookupState,
-            $acceptedMatches,
-            $reservedLegacyIds
-        );
-
-        // Phase 2: Match by Title only (excluding already matched)
-        $this->matchLegacySongsByTitleOnly(
-            $songGroups,
-            $existingSongs,
-            $lookupState,
-            $acceptedMatches,
-            $reservedLegacyIds
-        );
-
-        return $acceptedMatches;
-    }
-
-    /**
-     * Prepare lookups for legacy song reconciliation.
+     * Pick the most recently modified row of a canonical group (highest source
+     * ID breaks ties) as the source of truth for the song's attributes.
      *
-     * @param  list<Song>  $legacySongs
-     * @return array{
-     *     byPraiseAndTitle: array<string, list<int>>,
-     *     byTitle: array<string, list<int>>,
-     *     stateById: array<int, array{song_id: int, deleted: bool}>
-     * }
-     */
-    private function prepareLegacyLookupState(array $legacySongs): array
-    {
-        $byPraiseAndTitle = [];
-        $byTitle = [];
-        $stateById = [];
-
-        foreach ($legacySongs as $legacySong) {
-            $stateById[$legacySong->id] = [
-                'song_id' => $legacySong->id,
-                'deleted' => $legacySong->deleted_at !== null,
-            ];
-
-            $titleVariants = $this->legacyTitleVariants($legacySong);
-            $praiseNumber = $this->normalizedPraiseNumber($legacySong->getAttribute('praise_number'));
-
-            foreach ($titleVariants as $titleVariant) {
-                $byTitle[$titleVariant][] = $legacySong->id;
-
-                if ($praiseNumber !== null) {
-                    $byPraiseAndTitle[$praiseNumber.'|'.$titleVariant][] = $legacySong->id;
-                }
-            }
-        }
-
-        return [
-            'byPraiseAndTitle' => $byPraiseAndTitle,
-            'byTitle' => $byTitle,
-            'stateById' => $stateById,
-        ];
-    }
-
-    /**
-     * Match legacy songs using both praise number and title.
-     *
-     * @param  array<string, list<array<string, mixed>>>  $songGroups
-     * @param  array<string, array{song_id: int, deleted: bool}>  $existingSongs
-     * @param  array{
-     *     byPraiseAndTitle: array<string, list<int>>,
-     *     byTitle: array<string, list<int>>,
-     *     stateById: array<int, array{song_id: int, deleted: bool}>
-     * }  $lookupState
-     * @param  array<string, array{song_id: int, deleted: bool}>  $acceptedMatches
-     * @param  array<int, bool>  $reservedLegacyIds
-     */
-    private function matchLegacySongsByPraiseAndTitle(
-        array $songGroups,
-        array $existingSongs,
-        array $lookupState,
-        array &$acceptedMatches,
-        array &$reservedLegacyIds
-    ): void {
-        $praiseCandidates = [];
-
-        foreach ($songGroups as $canonicalKey => $groupRows) {
-            if (array_key_exists($canonicalKey, $existingSongs)) {
-                continue;
-            }
-
-            $candidateIds = $this->candidateLegacySongIdsByPraiseAndTitle($groupRows, $lookupState['byPraiseAndTitle']);
-
-            if (count($candidateIds) === 1) {
-                $praiseCandidates[$canonicalKey] = $candidateIds[0];
-            }
-        }
-
-        foreach ($this->acceptUniqueCandidateMatches($praiseCandidates) as $canonicalKey => $legacySongId) {
-            $acceptedMatches[$canonicalKey] = $lookupState['stateById'][$legacySongId];
-            $reservedLegacyIds[$legacySongId] = true;
-        }
-    }
-
-    /**
-     * Match legacy songs using title only.
-     *
-     * @param  array<string, list<array<string, mixed>>>  $songGroups
-     * @param  array<string, array{song_id: int, deleted: bool}>  $existingSongs
-     * @param  array{
-     *     byPraiseAndTitle: array<string, list<int>>,
-     *     byTitle: array<string, list<int>>,
-     *     stateById: array<int, array{song_id: int, deleted: bool}>
-     * }  $lookupState
-     * @param  array<string, array{song_id: int, deleted: bool}>  $acceptedMatches
-     * @param  array<int, bool>  $reservedLegacyIds
-     */
-    private function matchLegacySongsByTitleOnly(
-        array $songGroups,
-        array $existingSongs,
-        array $lookupState,
-        array &$acceptedMatches,
-        array &$reservedLegacyIds
-    ): void {
-        $titleCandidates = [];
-
-        foreach ($songGroups as $canonicalKey => $groupRows) {
-            if (array_key_exists($canonicalKey, $existingSongs) || array_key_exists($canonicalKey, $acceptedMatches)) {
-                continue;
-            }
-
-            $candidateIds = $this->candidateLegacySongIdsByTitle($groupRows, $lookupState['byTitle'], $reservedLegacyIds);
-
-            if (count($candidateIds) === 1) {
-                $titleCandidates[$canonicalKey] = $candidateIds[0];
-            }
-        }
-
-        foreach ($this->acceptUniqueCandidateMatches($titleCandidates) as $canonicalKey => $legacySongId) {
-            $acceptedMatches[$canonicalKey] = $lookupState['stateById'][$legacySongId];
-        }
-    }
-
-    /**
-     * @return list<Song>
-     */
-    private function fetchLegacySongsForReconciliation(): array
-    {
-        $selectColumns = ['id', 'canonical_key', 'title', 'deleted_at'];
-
-        if (Schema::hasColumn('songs', 'praise_number')) {
-            $selectColumns[] = 'praise_number';
-        }
-
-        if (Schema::hasColumn('songs', 'alternative_title')) {
-            $selectColumns[] = 'alternative_title';
-        }
-
-        if (Schema::hasColumn('songs', 'alternate_title')) {
-            $selectColumns[] = 'alternate_title';
-        }
-
-        /** @var list<Song> $legacySongs */
-        $legacySongs = Song::query()
-            ->withTrashed()
-            ->where(function ($query): void {
-                $query->whereNull('canonical_key')
-                    ->orWhere('canonical_key', '')
-                    ->orWhere('canonical_key', 'like', 'legacy-song-%');
-            })
-            ->get($selectColumns)
-            ->all();
-
-        return $legacySongs;
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function legacyTitleVariants(Song $song): array
-    {
-        $variants = [];
-
-        foreach (['title', 'alternative_title', 'alternate_title'] as $attribute) {
-            $normalizedTitle = $this->normalizedSongTitle($song->getAttribute($attribute));
-
-            if ($normalizedTitle === null || in_array($normalizedTitle, $variants, true)) {
-                continue;
-            }
-
-            $variants[] = $normalizedTitle;
-        }
-
-        return $variants;
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $groupRows
-     * @param  array<string, list<int>>  $legacyByPraiseAndTitle
-     * @return list<int>
-     */
-    private function candidateLegacySongIdsByPraiseAndTitle(array $groupRows, array $legacyByPraiseAndTitle): array
-    {
-        $candidateIds = [];
-
-        foreach ($this->sourcePraiseNumbers($groupRows) as $praiseNumber) {
-            foreach ($this->sourceTitleVariants($groupRows) as $titleVariant) {
-                foreach ($legacyByPraiseAndTitle[$praiseNumber.'|'.$titleVariant] ?? [] as $legacySongId) {
-                    $candidateIds[$legacySongId] = true;
-                }
-            }
-        }
-
-        return array_map('intval', array_keys($candidateIds));
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $groupRows
-     * @param  array<string, list<int>>  $legacyByTitle
-     * @param  array<int, bool>  $reservedLegacyIds
-     * @return list<int>
-     */
-    private function candidateLegacySongIdsByTitle(array $groupRows, array $legacyByTitle, array $reservedLegacyIds): array
-    {
-        $candidateIds = [];
-
-        foreach ($this->sourceTitleVariants($groupRows) as $titleVariant) {
-            foreach ($legacyByTitle[$titleVariant] ?? [] as $legacySongId) {
-                if (array_key_exists($legacySongId, $reservedLegacyIds)) {
-                    continue;
-                }
-
-                $candidateIds[$legacySongId] = true;
-            }
-        }
-
-        return array_map('intval', array_keys($candidateIds));
-    }
-
-    /**
-     * @param  array<string, int>  $candidates
-     * @return array<string, int>
-     */
-    private function acceptUniqueCandidateMatches(array $candidates): array
-    {
-        $countsByLegacySongId = [];
-
-        foreach ($candidates as $legacySongId) {
-            $countsByLegacySongId[$legacySongId] = ($countsByLegacySongId[$legacySongId] ?? 0) + 1;
-        }
-
-        $accepted = [];
-
-        foreach ($candidates as $canonicalKey => $legacySongId) {
-            if (($countsByLegacySongId[$legacySongId] ?? 0) !== 1) {
-                continue;
-            }
-
-            $accepted[$canonicalKey] = $legacySongId;
-        }
-
-        return $accepted;
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $groupRows
-     * @return list<string>
-     */
-    private function sourceTitleVariants(array $groupRows): array
-    {
-        $variants = [];
-
-        foreach ($groupRows as $groupRow) {
-            foreach (['title', 'alternate_title'] as $field) {
-                $normalizedTitle = $this->normalizedSongTitle($groupRow[$field] ?? null);
-
-                if ($normalizedTitle === null || in_array($normalizedTitle, $variants, true)) {
-                    continue;
-                }
-
-                $variants[] = $normalizedTitle;
-            }
-        }
-
-        return $variants;
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $groupRows
-     * @return list<string>
-     */
-    private function sourcePraiseNumbers(array $groupRows): array
-    {
-        $praiseNumbers = [];
-
-        foreach ($groupRows as $groupRow) {
-            $praiseNumber = $this->sourcePraiseNumber($groupRow);
-
-            if ($praiseNumber === null || in_array($praiseNumber, $praiseNumbers, true)) {
-                continue;
-            }
-
-            $praiseNumbers[] = $praiseNumber;
-        }
-
-        return $praiseNumbers;
-    }
-
-    /**
-     * @param  array<string,mixed>  $sourceRow
-     */
-    private function sourcePraiseNumber(array $sourceRow): ?string
-    {
-        $title = $this->stringOrNull($sourceRow['title'] ?? null);
-
-        if ($title !== null && preg_match('/#\s*([A-Za-z0-9]+)\s*$/u', $title, $matches) === 1) {
-            return $this->normalizedPraiseNumber($matches[1]);
-        }
-
-        $searchTitle = $this->stringOrNull($sourceRow['search_title'] ?? null);
-
-        if ($searchTitle === null) {
-            return null;
-        }
-
-        $primarySearchTitle = trim((string) strtok($searchTitle, '@'));
-
-        if (preg_match('/\b([0-9]+[A-Za-z]?)$/u', $primarySearchTitle, $matches) === 1) {
-            return $this->normalizedPraiseNumber($matches[1]);
-        }
-
-        if (preg_match('/^([0-9]+[A-Za-z]?)\b/u', $primarySearchTitle, $matches) === 1) {
-            return $this->normalizedPraiseNumber($matches[1]);
-        }
-
-        return null;
-    }
-
-    private function normalizedSongTitle(mixed $value): ?string
-    {
-        if (! is_string($value)) {
-            return null;
-        }
-
-        $normalized = trim(Str::lower($value));
-
-        if ($normalized === '') {
-            return null;
-        }
-
-        $normalized = (string) preg_replace('/\s*#\s*[a-z0-9]+$/u', '', $normalized);
-        $normalized = (string) preg_replace('/[^a-z0-9]+/u', ' ', $normalized);
-        $normalized = (string) preg_replace('/\s+/u', ' ', $normalized);
-        $normalized = trim($normalized);
-
-        return $normalized === '' ? null : $normalized;
-    }
-
-    private function normalizedPraiseNumber(mixed $value): ?string
-    {
-        if (! is_string($value)) {
-            return null;
-        }
-
-        $normalized = strtoupper(trim($value));
-
-        if ($normalized === '') {
-            return null;
-        }
-
-        if (preg_match('/^(\d+)([A-Z]?)$/', $normalized, $matches) !== 1) {
-            return $normalized;
-        }
-
-        $number = ltrim($matches[1], '0');
-
-        if ($number === '') {
-            $number = '0';
-        }
-
-        return $number.$matches[2];
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $groupRows
-     * @return array<string,mixed>
+     * @param  list<array<string, mixed>>  $groupRows
+     * @return array<string, mixed>
      */
     private function selectRepresentativeSong(array $groupRows): array
     {
         usort($groupRows, function (array $left, array $right): int {
-            $leftTimestamp = $this->parseTimestamp($left['last_modified'] ?? null);
-            $rightTimestamp = $this->parseTimestamp($right['last_modified'] ?? null);
+            $leftTimestamp = OpenLpRowValue::parseTimestamp($left['last_modified'] ?? null);
+            $rightTimestamp = OpenLpRowValue::parseTimestamp($right['last_modified'] ?? null);
 
             if ($leftTimestamp === $rightTimestamp) {
-                $leftId = $this->intOrNull($left['id'] ?? null) ?? 0;
-                $rightId = $this->intOrNull($right['id'] ?? null) ?? 0;
+                $leftId = OpenLpRowValue::intOrNull($left['id'] ?? null) ?? 0;
+                $rightId = OpenLpRowValue::intOrNull($right['id'] ?? null) ?? 0;
 
                 return $rightId <=> $leftId;
             }
@@ -1058,353 +379,6 @@ class SongCatalogSyncService
         });
 
         return $groupRows[0];
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $groupRows
-     * @param  list<array<string,mixed>>  $authorLinks
-     * @param  array<int, int>  $authorIdMap
-     * @return list<array{song_id:int,song_author_id:int,author_type:string}>
-     */
-    private function buildAuthorPivotRows(int $songId, array $groupRows, array $authorLinks, array $authorIdMap): array
-    {
-        $sourceSongIds = array_values(array_filter(
-            array_map(fn (array $row): ?int => $this->intOrNull($row['id'] ?? null), $groupRows),
-            static fn (?int $id): bool => $id !== null
-        ));
-
-        $linksBySong = [];
-        foreach ($authorLinks as $link) {
-            $sourceSongId = $this->intOrNull($link['song_id'] ?? null);
-            if ($sourceSongId === null) {
-                continue;
-            }
-
-            if (! array_key_exists($sourceSongId, $linksBySong)) {
-                $linksBySong[$sourceSongId] = [];
-            }
-
-            $linksBySong[$sourceSongId][] = $link;
-        }
-
-        $rows = [];
-        $seen = [];
-
-        foreach ($sourceSongIds as $sourceSongId) {
-            $links = $linksBySong[$sourceSongId] ?? [];
-
-            foreach ($links as $link) {
-                $sourceAuthorId = $this->intOrNull($link['author_id'] ?? null);
-                if ($sourceAuthorId === null) {
-                    continue;
-                }
-
-                $localAuthorId = $authorIdMap[$sourceAuthorId] ?? null;
-                if ($localAuthorId === null) {
-                    continue;
-                }
-
-                $authorType = $this->stringOrNull($link['author_type'] ?? null) ?? '';
-                $dedupeKey = $localAuthorId.'|'.$authorType;
-
-                if (array_key_exists($dedupeKey, $seen)) {
-                    continue;
-                }
-
-                $rows[] = [
-                    'song_id' => $songId,
-                    'song_author_id' => $localAuthorId,
-                    'author_type' => $authorType,
-                ];
-                $seen[$dedupeKey] = true;
-            }
-        }
-
-        return $rows;
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $authorRows
-     * @return array{0: array<int, bool>, 1: int}
-     */
-    private function previewSongAuthorUpserts(array $authorRows): array
-    {
-        $validAuthorIds = [];
-        $upsertCount = 0;
-
-        foreach ($authorRows as $authorRow) {
-            $displayName = $this->stringOrNull($authorRow['display_name'] ?? null);
-            $sourceAuthorId = $this->intOrNull($authorRow['id'] ?? null);
-
-            if ($displayName === null || $sourceAuthorId === null) {
-                continue;
-            }
-
-            $validAuthorIds[$sourceAuthorId] = true;
-            $upsertCount++;
-        }
-
-        return [$validAuthorIds, $upsertCount];
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $bookRows
-     * @return array{0: array<int, bool>, 1: int}
-     */
-    private function previewSongBookUpserts(array $bookRows): array
-    {
-        $validBookIds = [];
-        $upsertCount = 0;
-
-        foreach ($bookRows as $bookRow) {
-            $sourceBookId = $this->intOrNull($bookRow['id'] ?? null);
-            $bookName = $this->stringOrNull($bookRow['name'] ?? null);
-
-            if ($sourceBookId === null || $bookName === null) {
-                continue;
-            }
-
-            $validBookIds[$sourceBookId] = true;
-            $upsertCount++;
-        }
-
-        return [$validBookIds, $upsertCount];
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $links
-     * @return array<int, list<array<string,mixed>>>
-     */
-    private function groupLinksBySourceSongId(array $links): array
-    {
-        $linksBySourceSongId = [];
-
-        foreach ($links as $link) {
-            $sourceSongId = $this->intOrNull($link['song_id'] ?? null);
-            if ($sourceSongId === null) {
-                continue;
-            }
-
-            if (! array_key_exists($sourceSongId, $linksBySourceSongId)) {
-                $linksBySourceSongId[$sourceSongId] = [];
-            }
-
-            $linksBySourceSongId[$sourceSongId][] = $link;
-        }
-
-        return $linksBySourceSongId;
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $groupRows
-     * @param  array<int, list<array<string,mixed>>>  $authorLinksBySourceSongId
-     * @param  array<int, bool>  $validAuthorIds
-     */
-    private function countDryRunAuthorLinks(array $groupRows, array $authorLinksBySourceSongId, array $validAuthorIds): int
-    {
-        $sourceSongIds = array_values(array_filter(
-            array_map(fn (array $row): ?int => $this->intOrNull($row['id'] ?? null), $groupRows),
-            static fn (?int $id): bool => $id !== null
-        ));
-
-        $count = 0;
-        $seen = [];
-
-        foreach ($sourceSongIds as $sourceSongId) {
-            $authorLinks = $authorLinksBySourceSongId[$sourceSongId] ?? [];
-
-            foreach ($authorLinks as $authorLink) {
-                $sourceAuthorId = $this->intOrNull($authorLink['author_id'] ?? null);
-                if ($sourceAuthorId === null || ! array_key_exists($sourceAuthorId, $validAuthorIds)) {
-                    continue;
-                }
-
-                $authorType = $this->stringOrNull($authorLink['author_type'] ?? null) ?? '';
-                $dedupeKey = $sourceAuthorId.'|'.$authorType;
-
-                if (array_key_exists($dedupeKey, $seen)) {
-                    continue;
-                }
-
-                $seen[$dedupeKey] = true;
-                $count++;
-            }
-        }
-
-        return $count;
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $groupRows
-     * @param  array<int, list<array<string,mixed>>>  $bookLinksBySourceSongId
-     * @param  array<int, bool>  $validBookIds
-     */
-    private function countDryRunBookLinks(array $groupRows, array $bookLinksBySourceSongId, array $validBookIds): int
-    {
-        $sourceSongIds = array_values(array_filter(
-            array_map(fn (array $row): ?int => $this->intOrNull($row['id'] ?? null), $groupRows),
-            static fn (?int $id): bool => $id !== null
-        ));
-
-        $count = 0;
-        $seen = [];
-
-        foreach ($sourceSongIds as $sourceSongId) {
-            $bookLinks = $bookLinksBySourceSongId[$sourceSongId] ?? [];
-
-            foreach ($bookLinks as $bookLink) {
-                $sourceBookId = $this->intOrNull($bookLink['songbook_id'] ?? null);
-                if ($sourceBookId === null || ! array_key_exists($sourceBookId, $validBookIds)) {
-                    continue;
-                }
-
-                $entry = (string) ($bookLink['entry'] ?? '');
-                $dedupeKey = $sourceBookId.'|'.$entry;
-
-                if (array_key_exists($dedupeKey, $seen)) {
-                    continue;
-                }
-
-                $seen[$dedupeKey] = true;
-                $count++;
-            }
-        }
-
-        return $count;
-    }
-
-    /**
-     * @param  list<array<string,mixed>>  $groupRows
-     * @param  list<array<string,mixed>>  $bookLinks
-     * @param  array<int, int>  $bookIdMap
-     * @return list<array{song_id:int,song_book_id:int,entry:string}>
-     */
-    private function buildBookPivotRows(int $songId, array $groupRows, array $bookLinks, array $bookIdMap): array
-    {
-        $sourceSongIds = array_values(array_filter(
-            array_map(fn (array $row): ?int => $this->intOrNull($row['id'] ?? null), $groupRows),
-            static fn (?int $id): bool => $id !== null
-        ));
-
-        $linksBySong = [];
-        foreach ($bookLinks as $link) {
-            $sourceSongId = $this->intOrNull($link['song_id'] ?? null);
-            if ($sourceSongId === null) {
-                continue;
-            }
-
-            if (! array_key_exists($sourceSongId, $linksBySong)) {
-                $linksBySong[$sourceSongId] = [];
-            }
-
-            $linksBySong[$sourceSongId][] = $link;
-        }
-
-        $rows = [];
-        $seen = [];
-
-        foreach ($sourceSongIds as $sourceSongId) {
-            $links = $linksBySong[$sourceSongId] ?? [];
-
-            foreach ($links as $link) {
-                $sourceBookId = $this->intOrNull($link['songbook_id'] ?? null);
-                if ($sourceBookId === null) {
-                    continue;
-                }
-
-                $localBookId = $bookIdMap[$sourceBookId] ?? null;
-                if ($localBookId === null) {
-                    continue;
-                }
-
-                $entry = (string) ($link['entry'] ?? '');
-                $dedupeKey = $localBookId.'|'.$entry;
-
-                if (array_key_exists($dedupeKey, $seen)) {
-                    continue;
-                }
-
-                $rows[] = [
-                    'song_id' => $songId,
-                    'song_book_id' => $localBookId,
-                    'entry' => $entry,
-                ];
-                $seen[$dedupeKey] = true;
-            }
-        }
-
-        return $rows;
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function fetchTableNames(PDO $pdo): array
-    {
-        $rows = $this->fetchAll($pdo, "SELECT name FROM sqlite_master WHERE type='table'");
-
-        return array_values(array_filter(
-            array_map(
-                fn (array $row): ?string => $this->stringOrNull($row['name'] ?? null),
-                $rows
-            ),
-            static fn (?string $name): bool => $name !== null
-        ));
-    }
-
-    /**
-     * @return list<array<string,mixed>>
-     */
-    private function fetchAll(PDO $pdo, string $sql): array
-    {
-        try {
-            $statement = $pdo->query($sql);
-            if ($statement === false) {
-                return [];
-            }
-
-            /** @var list<array<string, mixed>> $rows */
-            $rows = array_values($statement->fetchAll(PDO::FETCH_ASSOC));
-
-            return $rows;
-        } catch (PDOException $exception) {
-            throw new RuntimeException('Failed running source SQLite query: '.$exception->getMessage(), previous: $exception);
-        }
-    }
-
-    private function parseTimestamp(mixed $value): int
-    {
-        if (! is_string($value) || trim($value) === '') {
-            return 0;
-        }
-
-        $timestamp = strtotime($value);
-
-        return $timestamp === false ? 0 : $timestamp;
-    }
-
-    private function stringOrNull(mixed $value): ?string
-    {
-        if (! is_string($value)) {
-            return null;
-        }
-
-        $trimmed = trim($value);
-
-        return $trimmed === '' ? null : $trimmed;
-    }
-
-    private function intOrNull(mixed $value): ?int
-    {
-        if (is_int($value)) {
-            return $value;
-        }
-
-        if (! is_numeric($value)) {
-            return null;
-        }
-
-        return (int) $value;
     }
 
     private function generateUniqueSlug(string $title, ?int $excludeId = null): string

--- a/app/Services/Song/Sync/LegacySongReconciler.php
+++ b/app/Services/Song/Sync/LegacySongReconciler.php
@@ -1,0 +1,419 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Song\Sync;
+
+use App\Models\Song;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+/**
+ * Matches incoming OpenLP song groups against pre-import "legacy" song rows
+ * (rows whose canonical_key is missing or still carries a legacy placeholder),
+ * so a re-import updates the existing record instead of creating a duplicate.
+ *
+ * Matching runs in two phases — praise number + title, then title only — and
+ * only accepts a match when it is unambiguous in both directions (one legacy
+ * candidate for the group, one group claiming the legacy row).
+ */
+class LegacySongReconciler
+{
+    /**
+     * @param  array<string, list<array<string, mixed>>>  $songGroups
+     * @param  array<string, array{song_id: int, deleted: bool}>  $existingSongs
+     * @return array<string, array{song_id: int, deleted: bool}>
+     */
+    public function buildReconciliationMap(array $songGroups, array $existingSongs): array
+    {
+        $legacySongs = $this->fetchLegacySongsForReconciliation();
+        if ($legacySongs === []) {
+            return [];
+        }
+
+        $lookupState = $this->prepareLegacyLookupState($legacySongs);
+
+        $acceptedMatches = [];
+        $reservedLegacyIds = [];
+
+        // Phase 1: Match by Praise number AND Title
+        $this->matchLegacySongsByPraiseAndTitle(
+            $songGroups,
+            $existingSongs,
+            $lookupState,
+            $acceptedMatches,
+            $reservedLegacyIds
+        );
+
+        // Phase 2: Match by Title only (excluding already matched)
+        $this->matchLegacySongsByTitleOnly(
+            $songGroups,
+            $existingSongs,
+            $lookupState,
+            $acceptedMatches,
+            $reservedLegacyIds
+        );
+
+        return $acceptedMatches;
+    }
+
+    /**
+     * Prepare lookups for legacy song reconciliation.
+     *
+     * @param  list<Song>  $legacySongs
+     * @return array{
+     *     byPraiseAndTitle: array<string, list<int>>,
+     *     byTitle: array<string, list<int>>,
+     *     stateById: array<int, array{song_id: int, deleted: bool}>
+     * }
+     */
+    private function prepareLegacyLookupState(array $legacySongs): array
+    {
+        $byPraiseAndTitle = [];
+        $byTitle = [];
+        $stateById = [];
+
+        foreach ($legacySongs as $legacySong) {
+            $stateById[$legacySong->id] = [
+                'song_id' => $legacySong->id,
+                'deleted' => $legacySong->deleted_at !== null,
+            ];
+
+            $titleVariants = $this->legacyTitleVariants($legacySong);
+            $praiseNumber = $this->normalizedPraiseNumber($legacySong->getAttribute('praise_number'));
+
+            foreach ($titleVariants as $titleVariant) {
+                $byTitle[$titleVariant][] = $legacySong->id;
+
+                if ($praiseNumber !== null) {
+                    $byPraiseAndTitle[$praiseNumber.'|'.$titleVariant][] = $legacySong->id;
+                }
+            }
+        }
+
+        return [
+            'byPraiseAndTitle' => $byPraiseAndTitle,
+            'byTitle' => $byTitle,
+            'stateById' => $stateById,
+        ];
+    }
+
+    /**
+     * Match legacy songs using both praise number and title.
+     *
+     * @param  array<string, list<array<string, mixed>>>  $songGroups
+     * @param  array<string, array{song_id: int, deleted: bool}>  $existingSongs
+     * @param  array{
+     *     byPraiseAndTitle: array<string, list<int>>,
+     *     byTitle: array<string, list<int>>,
+     *     stateById: array<int, array{song_id: int, deleted: bool}>
+     * }  $lookupState
+     * @param  array<string, array{song_id: int, deleted: bool}>  $acceptedMatches
+     * @param  array<int, bool>  $reservedLegacyIds
+     */
+    private function matchLegacySongsByPraiseAndTitle(
+        array $songGroups,
+        array $existingSongs,
+        array $lookupState,
+        array &$acceptedMatches,
+        array &$reservedLegacyIds
+    ): void {
+        $praiseCandidates = [];
+
+        foreach ($songGroups as $canonicalKey => $groupRows) {
+            if (array_key_exists($canonicalKey, $existingSongs)) {
+                continue;
+            }
+
+            $candidateIds = $this->candidateLegacySongIdsByPraiseAndTitle($groupRows, $lookupState['byPraiseAndTitle']);
+
+            if (count($candidateIds) === 1) {
+                $praiseCandidates[$canonicalKey] = $candidateIds[0];
+            }
+        }
+
+        foreach ($this->acceptUniqueCandidateMatches($praiseCandidates) as $canonicalKey => $legacySongId) {
+            $acceptedMatches[$canonicalKey] = $lookupState['stateById'][$legacySongId];
+            $reservedLegacyIds[$legacySongId] = true;
+        }
+    }
+
+    /**
+     * Match legacy songs using title only.
+     *
+     * @param  array<string, list<array<string, mixed>>>  $songGroups
+     * @param  array<string, array{song_id: int, deleted: bool}>  $existingSongs
+     * @param  array{
+     *     byPraiseAndTitle: array<string, list<int>>,
+     *     byTitle: array<string, list<int>>,
+     *     stateById: array<int, array{song_id: int, deleted: bool}>
+     * }  $lookupState
+     * @param  array<string, array{song_id: int, deleted: bool}>  $acceptedMatches
+     * @param  array<int, bool>  $reservedLegacyIds
+     */
+    private function matchLegacySongsByTitleOnly(
+        array $songGroups,
+        array $existingSongs,
+        array $lookupState,
+        array &$acceptedMatches,
+        array &$reservedLegacyIds
+    ): void {
+        $titleCandidates = [];
+
+        foreach ($songGroups as $canonicalKey => $groupRows) {
+            if (array_key_exists($canonicalKey, $existingSongs) || array_key_exists($canonicalKey, $acceptedMatches)) {
+                continue;
+            }
+
+            $candidateIds = $this->candidateLegacySongIdsByTitle($groupRows, $lookupState['byTitle'], $reservedLegacyIds);
+
+            if (count($candidateIds) === 1) {
+                $titleCandidates[$canonicalKey] = $candidateIds[0];
+            }
+        }
+
+        foreach ($this->acceptUniqueCandidateMatches($titleCandidates) as $canonicalKey => $legacySongId) {
+            $acceptedMatches[$canonicalKey] = $lookupState['stateById'][$legacySongId];
+        }
+    }
+
+    /**
+     * @return list<Song>
+     */
+    private function fetchLegacySongsForReconciliation(): array
+    {
+        $selectColumns = ['id', 'canonical_key', 'title', 'deleted_at'];
+
+        if (Schema::hasColumn('songs', 'praise_number')) {
+            $selectColumns[] = 'praise_number';
+        }
+
+        if (Schema::hasColumn('songs', 'alternative_title')) {
+            $selectColumns[] = 'alternative_title';
+        }
+
+        if (Schema::hasColumn('songs', 'alternate_title')) {
+            $selectColumns[] = 'alternate_title';
+        }
+
+        /** @var list<Song> $legacySongs */
+        $legacySongs = Song::query()
+            ->withTrashed()
+            ->where(function ($query): void {
+                $query->whereNull('canonical_key')
+                    ->orWhere('canonical_key', '')
+                    ->orWhere('canonical_key', 'like', 'legacy-song-%');
+            })
+            ->get($selectColumns)
+            ->all();
+
+        return $legacySongs;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function legacyTitleVariants(Song $song): array
+    {
+        $variants = [];
+
+        foreach (['title', 'alternative_title', 'alternate_title'] as $attribute) {
+            $normalizedTitle = $this->normalizedSongTitle($song->getAttribute($attribute));
+
+            if ($normalizedTitle === null || in_array($normalizedTitle, $variants, true)) {
+                continue;
+            }
+
+            $variants[] = $normalizedTitle;
+        }
+
+        return $variants;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $groupRows
+     * @param  array<string, list<int>>  $legacyByPraiseAndTitle
+     * @return list<int>
+     */
+    private function candidateLegacySongIdsByPraiseAndTitle(array $groupRows, array $legacyByPraiseAndTitle): array
+    {
+        $candidateIds = [];
+
+        foreach ($this->sourcePraiseNumbers($groupRows) as $praiseNumber) {
+            foreach ($this->sourceTitleVariants($groupRows) as $titleVariant) {
+                foreach ($legacyByPraiseAndTitle[$praiseNumber.'|'.$titleVariant] ?? [] as $legacySongId) {
+                    $candidateIds[$legacySongId] = true;
+                }
+            }
+        }
+
+        return array_map('intval', array_keys($candidateIds));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $groupRows
+     * @param  array<string, list<int>>  $legacyByTitle
+     * @param  array<int, bool>  $reservedLegacyIds
+     * @return list<int>
+     */
+    private function candidateLegacySongIdsByTitle(array $groupRows, array $legacyByTitle, array $reservedLegacyIds): array
+    {
+        $candidateIds = [];
+
+        foreach ($this->sourceTitleVariants($groupRows) as $titleVariant) {
+            foreach ($legacyByTitle[$titleVariant] ?? [] as $legacySongId) {
+                if (array_key_exists($legacySongId, $reservedLegacyIds)) {
+                    continue;
+                }
+
+                $candidateIds[$legacySongId] = true;
+            }
+        }
+
+        return array_map('intval', array_keys($candidateIds));
+    }
+
+    /**
+     * @param  array<string, int>  $candidates
+     * @return array<string, int>
+     */
+    private function acceptUniqueCandidateMatches(array $candidates): array
+    {
+        $countsByLegacySongId = [];
+
+        foreach ($candidates as $legacySongId) {
+            $countsByLegacySongId[$legacySongId] = ($countsByLegacySongId[$legacySongId] ?? 0) + 1;
+        }
+
+        $accepted = [];
+
+        foreach ($candidates as $canonicalKey => $legacySongId) {
+            if (($countsByLegacySongId[$legacySongId] ?? 0) !== 1) {
+                continue;
+            }
+
+            $accepted[$canonicalKey] = $legacySongId;
+        }
+
+        return $accepted;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $groupRows
+     * @return list<string>
+     */
+    private function sourceTitleVariants(array $groupRows): array
+    {
+        $variants = [];
+
+        foreach ($groupRows as $groupRow) {
+            foreach (['title', 'alternate_title'] as $field) {
+                $normalizedTitle = $this->normalizedSongTitle($groupRow[$field] ?? null);
+
+                if ($normalizedTitle === null || in_array($normalizedTitle, $variants, true)) {
+                    continue;
+                }
+
+                $variants[] = $normalizedTitle;
+            }
+        }
+
+        return $variants;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $groupRows
+     * @return list<string>
+     */
+    private function sourcePraiseNumbers(array $groupRows): array
+    {
+        $praiseNumbers = [];
+
+        foreach ($groupRows as $groupRow) {
+            $praiseNumber = $this->sourcePraiseNumber($groupRow);
+
+            if ($praiseNumber === null || in_array($praiseNumber, $praiseNumbers, true)) {
+                continue;
+            }
+
+            $praiseNumbers[] = $praiseNumber;
+        }
+
+        return $praiseNumbers;
+    }
+
+    /**
+     * @param  array<string, mixed>  $sourceRow
+     */
+    private function sourcePraiseNumber(array $sourceRow): ?string
+    {
+        $title = OpenLpRowValue::stringOrNull($sourceRow['title'] ?? null);
+
+        if ($title !== null && preg_match('/#\s*([A-Za-z0-9]+)\s*$/u', $title, $matches) === 1) {
+            return $this->normalizedPraiseNumber($matches[1]);
+        }
+
+        $searchTitle = OpenLpRowValue::stringOrNull($sourceRow['search_title'] ?? null);
+
+        if ($searchTitle === null) {
+            return null;
+        }
+
+        $primarySearchTitle = trim((string) strtok($searchTitle, '@'));
+
+        if (preg_match('/\b([0-9]+[A-Za-z]?)$/u', $primarySearchTitle, $matches) === 1) {
+            return $this->normalizedPraiseNumber($matches[1]);
+        }
+
+        if (preg_match('/^([0-9]+[A-Za-z]?)\b/u', $primarySearchTitle, $matches) === 1) {
+            return $this->normalizedPraiseNumber($matches[1]);
+        }
+
+        return null;
+    }
+
+    private function normalizedSongTitle(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim(Str::lower($value));
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        $normalized = (string) preg_replace('/\s*#\s*[a-z0-9]+$/u', '', $normalized);
+        $normalized = (string) preg_replace('/[^a-z0-9]+/u', ' ', $normalized);
+        $normalized = (string) preg_replace('/\s+/u', ' ', $normalized);
+        $normalized = trim($normalized);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function normalizedPraiseNumber(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = strtoupper(trim($value));
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (preg_match('/^(\d+)([A-Z]?)$/', $normalized, $matches) !== 1) {
+            return $normalized;
+        }
+
+        $number = ltrim($matches[1], '0');
+
+        if ($number === '') {
+            $number = '0';
+        }
+
+        return $number.$matches[2];
+    }
+}

--- a/app/Services/Song/Sync/OpenLpRowValue.php
+++ b/app/Services/Song/Sync/OpenLpRowValue.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Song\Sync;
+
+/**
+ * Scalar normalisation for raw OpenLP SQLite row values, shared by the
+ * source reader, reconciler, syncer, and sync coordinator.
+ */
+final class OpenLpRowValue
+{
+    public static function stringOrNull(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    public static function intOrNull(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (! is_numeric($value)) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    public static function parseTimestamp(mixed $value): int
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return 0;
+        }
+
+        $timestamp = strtotime($value);
+
+        return $timestamp === false ? 0 : $timestamp;
+    }
+
+    /**
+     * Extract the source song IDs present in a canonical group's rows.
+     *
+     * @param  list<array<string, mixed>>  $groupRows
+     * @return list<int>
+     */
+    public static function sourceSongIds(array $groupRows): array
+    {
+        return array_values(array_filter(
+            array_map(static fn (array $row): ?int => self::intOrNull($row['id'] ?? null), $groupRows),
+            static fn (?int $songId): bool => $songId !== null
+        ));
+    }
+}

--- a/app/Services/Song/Sync/OpenLpSongSourceReader.php
+++ b/app/Services/Song/Sync/OpenLpSongSourceReader.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Song\Sync;
+
+use App\Data\OpenLpSongSourceData;
+use PDO;
+use PDOException;
+use RuntimeException;
+
+/**
+ * Reads the OpenLP songs SQLite database into memory.
+ *
+ * Owns path resolution/validation and all PDO access; the sync pipeline
+ * never touches SQLite directly.
+ */
+class OpenLpSongSourceReader
+{
+    private const REQUIRED_TABLES = [
+        'songs',
+        'authors',
+        'authors_songs',
+        'song_books',
+        'songs_songbooks',
+    ];
+
+    /**
+     * Resolve the source path (explicit argument or configured default) and
+     * load every table the sync needs.
+     *
+     * @return array{0: string, 1: OpenLpSongSourceData} The resolved path and the loaded rows.
+     */
+    public function read(?string $path = null): array
+    {
+        $resolvedPath = $this->resolvePath($path);
+
+        return [$resolvedPath, $this->loadSourceData($resolvedPath)];
+    }
+
+    private function resolvePath(?string $path): string
+    {
+        $configuredPath = $path ?? config('service-tracking.songs.sqlite_path');
+
+        if (! is_string($configuredPath) || trim($configuredPath) === '') {
+            throw new RuntimeException('No songs SQLite path configured. Set OPENLP_SONGS_DB_PATH or pass --path.');
+        }
+
+        $resolvedPath = trim($configuredPath);
+
+        if (! is_file($resolvedPath)) {
+            throw new RuntimeException("Songs SQLite file does not exist at [{$resolvedPath}].");
+        }
+
+        if (! is_readable($resolvedPath)) {
+            throw new RuntimeException("Songs SQLite file is not readable at [{$resolvedPath}].");
+        }
+
+        return $resolvedPath;
+    }
+
+    private function loadSourceData(string $path): OpenLpSongSourceData
+    {
+        try {
+            $pdo = new PDO('sqlite:'.$path);
+            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        } catch (PDOException $exception) {
+            throw new RuntimeException('Unable to open songs SQLite database: '.$exception->getMessage(), previous: $exception);
+        }
+
+        $existingTables = $this->fetchTableNames($pdo);
+        foreach (self::REQUIRED_TABLES as $requiredTable) {
+            if (! in_array($requiredTable, $existingTables, true)) {
+                throw new RuntimeException("Songs SQLite database is missing required table [{$requiredTable}].");
+            }
+        }
+
+        return new OpenLpSongSourceData(
+            songs: $this->fetchAll($pdo, 'SELECT id, title, alternate_title, lyrics, verse_order, copyright, comments, ccli_number, search_title, last_modified FROM songs'),
+            authors: $this->fetchAll($pdo, 'SELECT id, display_name, first_name, last_name FROM authors'),
+            authorLinks: $this->fetchAll($pdo, 'SELECT song_id, author_id, author_type FROM authors_songs'),
+            books: $this->fetchAll($pdo, 'SELECT id, name, publisher FROM song_books'),
+            bookLinks: $this->fetchAll($pdo, 'SELECT song_id, songbook_id, entry FROM songs_songbooks'),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function fetchTableNames(PDO $pdo): array
+    {
+        $rows = $this->fetchAll($pdo, "SELECT name FROM sqlite_master WHERE type='table'");
+
+        return array_values(array_filter(
+            array_map(
+                static fn (array $row): ?string => OpenLpRowValue::stringOrNull($row['name'] ?? null),
+                $rows
+            ),
+            static fn (?string $name): bool => $name !== null
+        ));
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function fetchAll(PDO $pdo, string $sql): array
+    {
+        try {
+            $statement = $pdo->query($sql);
+            if ($statement === false) {
+                return [];
+            }
+
+            /** @var list<array<string, mixed>> $rows */
+            $rows = array_values($statement->fetchAll(PDO::FETCH_ASSOC));
+
+            return $rows;
+        } catch (PDOException $exception) {
+            throw new RuntimeException('Failed running source SQLite query: '.$exception->getMessage(), previous: $exception);
+        }
+    }
+}

--- a/app/Services/Song/Sync/SongAuthorBookSyncer.php
+++ b/app/Services/Song/Sync/SongAuthorBookSyncer.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Song\Sync;
+
+use App\Models\SongAuthor;
+use App\Models\SongBook;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Syncs song authors, song books, and their pivot links from OpenLP rows.
+ *
+ * Real and dry-run modes share one pivot-row path: the upsert methods return a
+ * source-ID → local-ID map, the preview methods return an identity map over the
+ * same valid source IDs, and the pivot builders are agnostic about which they
+ * receive. Dedupe therefore happens on local IDs in real mode and on source IDs
+ * in preview mode, exactly as the metrics have always counted.
+ */
+class SongAuthorBookSyncer
+{
+    /**
+     * Upsert authors and map each source author ID to its local SongAuthor ID.
+     *
+     * @param  list<array<string, mixed>>  $authorRows
+     * @return array{0: array<int, int>, 1: int} The source→local ID map and the upserted-payload count.
+     */
+    public function upsertAuthors(array $authorRows): array
+    {
+        $payloads = [];
+
+        foreach ($authorRows as $authorRow) {
+            $displayName = OpenLpRowValue::stringOrNull($authorRow['display_name'] ?? null);
+            if ($displayName === null) {
+                continue;
+            }
+
+            $payloads[] = [
+                'display_name' => $displayName,
+                'first_name' => OpenLpRowValue::stringOrNull($authorRow['first_name'] ?? null),
+                'last_name' => OpenLpRowValue::stringOrNull($authorRow['last_name'] ?? null),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ];
+        }
+
+        if ($payloads !== []) {
+            SongAuthor::query()->upsert(
+                $payloads,
+                ['display_name'],
+                ['first_name', 'last_name', 'updated_at']
+            );
+        }
+
+        /** @var array<string, int> $lookup */
+        $lookup = SongAuthor::query()
+            ->pluck('id', 'display_name')
+            ->mapWithKeys(static fn ($id, $displayName): array => [(string) $displayName => (int) $id])
+            ->all();
+
+        $sourceAuthorIdToLocalId = [];
+
+        foreach ($authorRows as $authorRow) {
+            $displayName = OpenLpRowValue::stringOrNull($authorRow['display_name'] ?? null);
+            $sourceAuthorId = OpenLpRowValue::intOrNull($authorRow['id'] ?? null);
+
+            if ($displayName === null || $sourceAuthorId === null) {
+                continue;
+            }
+
+            $localId = $lookup[$displayName] ?? null;
+            if ($localId !== null) {
+                $sourceAuthorIdToLocalId[$sourceAuthorId] = $localId;
+            }
+        }
+
+        return [$sourceAuthorIdToLocalId, count($payloads)];
+    }
+
+    /**
+     * Upsert books and map each source book ID to its local SongBook ID.
+     *
+     * @param  list<array<string, mixed>>  $bookRows
+     * @return array{0: array<int, int>, 1: int} The source→local ID map and the upserted-payload count.
+     */
+    public function upsertBooks(array $bookRows): array
+    {
+        $payloads = [];
+
+        foreach ($bookRows as $bookRow) {
+            $sourceBookId = OpenLpRowValue::intOrNull($bookRow['id'] ?? null);
+            $bookName = OpenLpRowValue::stringOrNull($bookRow['name'] ?? null);
+
+            if ($sourceBookId === null || $bookName === null) {
+                continue;
+            }
+
+            $payloads[] = [
+                'source_book_id' => $sourceBookId,
+                'name' => $bookName,
+                'publisher' => OpenLpRowValue::stringOrNull($bookRow['publisher'] ?? null),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ];
+        }
+
+        if ($payloads !== []) {
+            SongBook::query()->upsert(
+                $payloads,
+                ['source_book_id'],
+                ['name', 'publisher', 'updated_at']
+            );
+        }
+
+        /** @var array<int, int> $lookup */
+        $lookup = SongBook::query()
+            ->pluck('id', 'source_book_id')
+            ->mapWithKeys(static fn ($id, $sourceBookId): array => [(int) $sourceBookId => (int) $id])
+            ->all();
+
+        return [$lookup, count($payloads)];
+    }
+
+    /**
+     * Preview the author upsert without writing: an identity map over the valid
+     * source author IDs, plus the count an upsert would have processed.
+     *
+     * @param  list<array<string, mixed>>  $authorRows
+     * @return array{0: array<int, int>, 1: int}
+     */
+    public function previewAuthorUpserts(array $authorRows): array
+    {
+        $identityMap = [];
+        $upsertCount = 0;
+
+        foreach ($authorRows as $authorRow) {
+            $displayName = OpenLpRowValue::stringOrNull($authorRow['display_name'] ?? null);
+            $sourceAuthorId = OpenLpRowValue::intOrNull($authorRow['id'] ?? null);
+
+            if ($displayName === null || $sourceAuthorId === null) {
+                continue;
+            }
+
+            $identityMap[$sourceAuthorId] = $sourceAuthorId;
+            $upsertCount++;
+        }
+
+        return [$identityMap, $upsertCount];
+    }
+
+    /**
+     * Preview the book upsert without writing: an identity map over the valid
+     * source book IDs, plus the count an upsert would have processed.
+     *
+     * @param  list<array<string, mixed>>  $bookRows
+     * @return array{0: array<int, int>, 1: int}
+     */
+    public function previewBookUpserts(array $bookRows): array
+    {
+        $identityMap = [];
+        $upsertCount = 0;
+
+        foreach ($bookRows as $bookRow) {
+            $sourceBookId = OpenLpRowValue::intOrNull($bookRow['id'] ?? null);
+            $bookName = OpenLpRowValue::stringOrNull($bookRow['name'] ?? null);
+
+            if ($sourceBookId === null || $bookName === null) {
+                continue;
+            }
+
+            $identityMap[$sourceBookId] = $sourceBookId;
+            $upsertCount++;
+        }
+
+        return [$identityMap, $upsertCount];
+    }
+
+    /**
+     * Group flat link rows by their source song ID.
+     *
+     * @param  list<array<string, mixed>>  $links
+     * @return array<int, list<array<string, mixed>>>
+     */
+    public function groupLinksBySourceSongId(array $links): array
+    {
+        $linksBySourceSongId = [];
+
+        foreach ($links as $link) {
+            $sourceSongId = OpenLpRowValue::intOrNull($link['song_id'] ?? null);
+            if ($sourceSongId === null) {
+                continue;
+            }
+
+            $linksBySourceSongId[$sourceSongId][] = $link;
+        }
+
+        return $linksBySourceSongId;
+    }
+
+    /**
+     * Build the deduplicated author pivot rows for one canonical song group.
+     *
+     * @param  list<int>  $sourceSongIds
+     * @param  array<int, list<array<string, mixed>>>  $authorLinksBySourceSongId
+     * @param  array<int, int>  $authorIdMap
+     * @return list<array{song_id: int, song_author_id: int, author_type: string}>
+     */
+    public function authorPivotRows(int $songId, array $sourceSongIds, array $authorLinksBySourceSongId, array $authorIdMap): array
+    {
+        $rows = [];
+        $seen = [];
+
+        foreach ($sourceSongIds as $sourceSongId) {
+            foreach ($authorLinksBySourceSongId[$sourceSongId] ?? [] as $link) {
+                $sourceAuthorId = OpenLpRowValue::intOrNull($link['author_id'] ?? null);
+                if ($sourceAuthorId === null) {
+                    continue;
+                }
+
+                $localAuthorId = $authorIdMap[$sourceAuthorId] ?? null;
+                if ($localAuthorId === null) {
+                    continue;
+                }
+
+                $authorType = OpenLpRowValue::stringOrNull($link['author_type'] ?? null) ?? '';
+                $dedupeKey = $localAuthorId.'|'.$authorType;
+
+                if (array_key_exists($dedupeKey, $seen)) {
+                    continue;
+                }
+
+                $rows[] = [
+                    'song_id' => $songId,
+                    'song_author_id' => $localAuthorId,
+                    'author_type' => $authorType,
+                ];
+                $seen[$dedupeKey] = true;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Build the deduplicated book pivot rows for one canonical song group.
+     *
+     * @param  list<int>  $sourceSongIds
+     * @param  array<int, list<array<string, mixed>>>  $bookLinksBySourceSongId
+     * @param  array<int, int>  $bookIdMap
+     * @return list<array{song_id: int, song_book_id: int, entry: string}>
+     */
+    public function bookPivotRows(int $songId, array $sourceSongIds, array $bookLinksBySourceSongId, array $bookIdMap): array
+    {
+        $rows = [];
+        $seen = [];
+
+        foreach ($sourceSongIds as $sourceSongId) {
+            foreach ($bookLinksBySourceSongId[$sourceSongId] ?? [] as $link) {
+                $sourceBookId = OpenLpRowValue::intOrNull($link['songbook_id'] ?? null);
+                if ($sourceBookId === null) {
+                    continue;
+                }
+
+                $localBookId = $bookIdMap[$sourceBookId] ?? null;
+                if ($localBookId === null) {
+                    continue;
+                }
+
+                $entry = (string) ($link['entry'] ?? '');
+                $dedupeKey = $localBookId.'|'.$entry;
+
+                if (array_key_exists($dedupeKey, $seen)) {
+                    continue;
+                }
+
+                $rows[] = [
+                    'song_id' => $songId,
+                    'song_book_id' => $localBookId,
+                    'entry' => $entry,
+                ];
+                $seen[$dedupeKey] = true;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Replace a song's author links with the given pivot rows.
+     *
+     * @param  list<array{song_id: int, song_author_id: int, author_type: string}>  $pivotRows
+     */
+    public function replaceAuthorLinks(int $songId, array $pivotRows): void
+    {
+        DB::table('song_author_song')->where('song_id', $songId)->delete();
+
+        if ($pivotRows !== []) {
+            DB::table('song_author_song')->insert($pivotRows);
+        }
+    }
+
+    /**
+     * Replace a song's book links with the given pivot rows.
+     *
+     * @param  list<array{song_id: int, song_book_id: int, entry: string}>  $pivotRows
+     */
+    public function replaceBookLinks(int $songId, array $pivotRows): void
+    {
+        DB::table('song_book_song')->where('song_id', $songId)->delete();
+
+        if ($pivotRows !== []) {
+            DB::table('song_book_song')->insert($pivotRows);
+        }
+    }
+}

--- a/tests/Feature/Console/SyncSongsCommandTest.php
+++ b/tests/Feature/Console/SyncSongsCommandTest.php
@@ -268,17 +268,17 @@ class SyncSongsCommandTest extends TestCase
             'canonical_key' => 'stand up stand up for jesus',
         ]);
 
-        $metrics = app(SongCatalogSyncService::class)->sync(path: $path, dryRun: true);
+        $report = app(SongCatalogSyncService::class)->sync(path: $path, dryRun: true);
 
-        $this->assertSame(3, $metrics['songs_upserted']);
-        $this->assertSame(2, $metrics['songs_created']);
-        $this->assertSame(1, $metrics['songs_updated']);
-        $this->assertSame(0, $metrics['songs_restored']);
-        $this->assertSame(1, $metrics['groups_with_parse_warnings']);
-        $this->assertSame(3, $metrics['song_authors_upserted']);
-        $this->assertSame(2, $metrics['song_books_upserted']);
-        $this->assertSame(3, $metrics['song_author_links_synced']);
-        $this->assertSame(3, $metrics['song_book_links_synced']);
+        $this->assertSame(3, $report->songsUpserted);
+        $this->assertSame(2, $report->songsCreated);
+        $this->assertSame(1, $report->songsUpdated);
+        $this->assertSame(0, $report->songsRestored);
+        $this->assertSame(1, $report->groupsWithParseWarnings);
+        $this->assertSame(3, $report->songAuthorsUpserted);
+        $this->assertSame(2, $report->songBooksUpserted);
+        $this->assertSame(3, $report->songAuthorLinksSynced);
+        $this->assertSame(3, $report->songBookLinksSynced);
 
         $this->assertDatabaseCount('songs', 1);
         $this->assertDatabaseCount('song_authors', 0);
@@ -295,9 +295,9 @@ class SyncSongsCommandTest extends TestCase
         ]);
         $trashedSong->delete();
 
-        $metrics = app(SongCatalogSyncService::class)->sync(path: $path, dryRun: true);
+        $report = app(SongCatalogSyncService::class)->sync(path: $path, dryRun: true);
 
-        $this->assertSame(1, $metrics['songs_restored']);
+        $this->assertSame(1, $report->songsRestored);
         $this->assertTrue($trashedSong->fresh()?->trashed() ?? false);
     }
 

--- a/tests/Integration/Services/Song/Sync/LegacySongReconcilerTest.php
+++ b/tests/Integration/Services/Song/Sync/LegacySongReconcilerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Services\Song\Sync;
+
+use App\Models\Song;
+use App\Services\Song\Sync\LegacySongReconciler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class LegacySongReconcilerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private LegacySongReconciler $reconciler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->reconciler = app(LegacySongReconciler::class);
+    }
+
+    #[Test]
+    public function it_matches_a_legacy_song_by_title(): void
+    {
+        $legacySong = Song::factory()->create([
+            'canonical_key' => 'legacy-song-1001',
+            'title' => 'A New Commandment',
+        ]);
+
+        $map = $this->reconciler->buildReconciliationMap(
+            ['a new commandment' => [['id' => 1, 'title' => 'A New Commandment', 'search_title' => 'a new commandment@']]],
+            []
+        );
+
+        $this->assertSame(
+            ['a new commandment' => ['song_id' => $legacySong->id, 'deleted' => false]],
+            $map
+        );
+    }
+
+    #[Test]
+    public function it_skips_groups_that_already_match_an_existing_canonical_key(): void
+    {
+        Song::factory()->create([
+            'canonical_key' => 'legacy-song-1001',
+            'title' => 'A New Commandment',
+        ]);
+
+        $map = $this->reconciler->buildReconciliationMap(
+            ['a new commandment' => [['id' => 1, 'title' => 'A New Commandment', 'search_title' => 'a new commandment@']]],
+            ['a new commandment' => ['song_id' => 99, 'deleted' => false]]
+        );
+
+        $this->assertSame([], $map);
+    }
+
+    #[Test]
+    public function it_rejects_an_ambiguous_title_match(): void
+    {
+        Song::factory()->create(['canonical_key' => 'legacy-song-1', 'title' => 'Amazing Grace']);
+        Song::factory()->create(['canonical_key' => 'legacy-song-2', 'title' => 'Amazing Grace']);
+
+        $map = $this->reconciler->buildReconciliationMap(
+            ['amazing grace' => [['id' => 1, 'title' => 'Amazing Grace', 'search_title' => 'amazing grace@']]],
+            []
+        );
+
+        $this->assertSame([], $map);
+    }
+
+    #[Test]
+    public function it_marks_soft_deleted_legacy_matches_as_deleted(): void
+    {
+        $legacySong = Song::factory()->create([
+            'canonical_key' => 'legacy-song-1001',
+            'title' => 'Be Thou My Vision',
+        ]);
+        $legacySong->delete();
+
+        $map = $this->reconciler->buildReconciliationMap(
+            ['be thou my vision' => [['id' => 1, 'title' => 'Be Thou My Vision', 'search_title' => 'be thou my vision@']]],
+            []
+        );
+
+        $this->assertTrue($map['be thou my vision']['deleted']);
+        $this->assertSame($legacySong->id, $map['be thou my vision']['song_id']);
+    }
+}

--- a/tests/Integration/Services/Song/Sync/SongAuthorBookSyncerTest.php
+++ b/tests/Integration/Services/Song/Sync/SongAuthorBookSyncerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Services\Song\Sync;
+
+use App\Models\SongAuthor;
+use App\Services\Song\Sync\SongAuthorBookSyncer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SongAuthorBookSyncerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private SongAuthorBookSyncer $syncer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->syncer = app(SongAuthorBookSyncer::class);
+    }
+
+    #[Test]
+    public function upsert_authors_maps_source_ids_to_local_ids(): void
+    {
+        [$idMap, $upsertedCount] = $this->syncer->upsertAuthors([
+            ['id' => 10, 'display_name' => 'Writer One', 'first_name' => 'Writer', 'last_name' => 'One'],
+            ['id' => 20, 'display_name' => 'Writer Two', 'first_name' => null, 'last_name' => null],
+            ['id' => 30, 'display_name' => null],
+        ]);
+
+        $this->assertSame(2, $upsertedCount);
+        $this->assertDatabaseCount('song_authors', 2);
+
+        $writerOne = SongAuthor::query()->where('display_name', 'Writer One')->firstOrFail();
+        $this->assertSame($writerOne->id, $idMap[10]);
+        $this->assertArrayNotHasKey(30, $idMap);
+    }
+
+    #[Test]
+    public function author_pivot_rows_dedupe_on_local_author_and_role(): void
+    {
+        $links = $this->syncer->groupLinksBySourceSongId([
+            ['song_id' => 1, 'author_id' => 10, 'author_type' => 'words'],
+            ['song_id' => 2, 'author_id' => 10, 'author_type' => 'words'], // duplicate via merged group row
+            ['song_id' => 1, 'author_id' => 10, 'author_type' => 'music'], // same author, different role
+            ['song_id' => 1, 'author_id' => 99, 'author_type' => 'words'], // unknown author — dropped
+        ]);
+
+        $rows = $this->syncer->authorPivotRows(7, [1, 2], $links, [10 => 555]);
+
+        $this->assertSame([
+            ['song_id' => 7, 'song_author_id' => 555, 'author_type' => 'words'],
+            ['song_id' => 7, 'song_author_id' => 555, 'author_type' => 'music'],
+        ], $rows);
+    }
+
+    #[Test]
+    public function preview_maps_are_identity_maps_over_valid_source_ids(): void
+    {
+        [$authorMap, $authorCount] = $this->syncer->previewAuthorUpserts([
+            ['id' => 10, 'display_name' => 'Writer One'],
+            ['id' => null, 'display_name' => 'No Source Id'],
+        ]);
+
+        $this->assertSame([10 => 10], $authorMap);
+        $this->assertSame(1, $authorCount);
+
+        [$bookMap, $bookCount] = $this->syncer->previewBookUpserts([
+            ['id' => 3, 'name' => 'Classic Hymns', 'publisher' => null],
+            ['id' => 4, 'name' => null],
+        ]);
+
+        $this->assertSame([3 => 3], $bookMap);
+        $this->assertSame(1, $bookCount);
+
+        $this->assertDatabaseCount('song_authors', 0);
+        $this->assertDatabaseCount('song_books', 0);
+    }
+
+    #[Test]
+    public function book_pivot_rows_dedupe_on_local_book_and_entry(): void
+    {
+        $links = $this->syncer->groupLinksBySourceSongId([
+            ['song_id' => 1, 'songbook_id' => 3, 'entry' => '10'],
+            ['song_id' => 2, 'songbook_id' => 3, 'entry' => '10'], // duplicate entry across merged rows
+            ['song_id' => 2, 'songbook_id' => 3, 'entry' => '11'], // distinct entry
+        ]);
+
+        $rows = $this->syncer->bookPivotRows(7, [1, 2], $links, [3 => 42]);
+
+        $this->assertSame([
+            ['song_id' => 7, 'song_book_id' => 42, 'entry' => '10'],
+            ['song_id' => 7, 'song_book_id' => 42, 'entry' => '11'],
+        ], $rows);
+    }
+}

--- a/tests/Integration/Services/SongCatalogSyncServiceTest.php
+++ b/tests/Integration/Services/SongCatalogSyncServiceTest.php
@@ -79,13 +79,13 @@ class SongCatalogSyncServiceTest extends TestCase
         $path = $this->createSqliteWithOneSong('Amazing Grace', 'amazing grace how sweet the sound');
         $songCountBeforeSync = Song::query()->count();
 
-        $metrics = $this->service->sync($path, dryRun: true);
+        $report = $this->service->sync($path, dryRun: true);
 
-        $this->assertTrue($metrics['dry_run']);
-        $this->assertSame(1, $metrics['source_songs']);
-        $this->assertSame(1, $metrics['canonical_groups']);
-        $this->assertSame(1, $metrics['songs_upserted']);
-        $this->assertSame(1, $metrics['songs_created']);
+        $this->assertTrue($report->dryRun);
+        $this->assertSame(1, $report->sourceSongs);
+        $this->assertSame(1, $report->canonicalGroups);
+        $this->assertSame(1, $report->songsUpserted);
+        $this->assertSame(1, $report->songsCreated);
 
         // No actual DB writes
         $this->assertSame($songCountBeforeSync, Song::query()->count());
@@ -99,11 +99,11 @@ class SongCatalogSyncServiceTest extends TestCase
     {
         $path = $this->createSqliteWithOneSong('How Great Thou Art', 'how great thou art');
 
-        $metrics = $this->service->sync($path, dryRun: false);
+        $report = $this->service->sync($path, dryRun: false);
 
-        $this->assertFalse($metrics['dry_run']);
-        $this->assertSame(1, $metrics['songs_created']);
-        $this->assertSame(0, $metrics['songs_updated']);
+        $this->assertFalse($report->dryRun);
+        $this->assertSame(1, $report->songsCreated);
+        $this->assertSame(0, $report->songsUpdated);
 
         $this->assertDatabaseHas('songs', ['title' => 'How Great Thou Art']);
     }
@@ -116,11 +116,11 @@ class SongCatalogSyncServiceTest extends TestCase
         $this->service->sync($path, dryRun: false);
 
         // Sync again — same canonical key, should update
-        $metrics = $this->service->sync($path, dryRun: false);
+        $report = $this->service->sync($path, dryRun: false);
 
-        $this->assertSame(0, $metrics['songs_created']);
-        $this->assertSame(1, $metrics['songs_updated']);
-        $this->assertSame(1, $metrics['songs_upserted']);
+        $this->assertSame(0, $report->songsCreated);
+        $this->assertSame(1, $report->songsUpdated);
+        $this->assertSame(1, $report->songsUpserted);
     }
 
     #[Test]
@@ -131,13 +131,13 @@ class SongCatalogSyncServiceTest extends TestCase
             ['title' => 'To God Be the Glory (alt)', 'search_title' => 'to god be the glory'],
         );
 
-        $metrics = $this->service->sync($path, dryRun: true);
+        $report = $this->service->sync($path, dryRun: true);
 
-        $this->assertSame(2, $metrics['source_songs']);
-        $this->assertSame(1, $metrics['canonical_groups']);
-        $this->assertSame(1, $metrics['duplicate_groups']);
-        $this->assertSame(1, $metrics['duplicate_rows']);
-        $this->assertSame(1, $metrics['songs_upserted']);
+        $this->assertSame(2, $report->sourceSongs);
+        $this->assertSame(1, $report->canonicalGroups);
+        $this->assertSame(1, $report->duplicateGroups);
+        $this->assertSame(1, $report->duplicateRows);
+        $this->assertSame(1, $report->songsUpserted);
     }
 
     #[Test]
@@ -150,9 +150,9 @@ class SongCatalogSyncServiceTest extends TestCase
         Song::query()->where('title', 'Great Is Thy Faithfulness')->delete();
         $this->assertSoftDeleted('songs', ['title' => 'Great Is Thy Faithfulness']);
 
-        $metrics = $this->service->sync($path, dryRun: false);
+        $report = $this->service->sync($path, dryRun: false);
 
-        $this->assertSame(1, $metrics['songs_restored']);
+        $this->assertSame(1, $report->songsRestored);
         $this->assertDatabaseHas('songs', ['title' => 'Great Is Thy Faithfulness', 'deleted_at' => null]);
     }
 
@@ -161,9 +161,9 @@ class SongCatalogSyncServiceTest extends TestCase
     {
         $path = $this->createSqliteWithMultiRoleAuthor('In Christ Alone', 'in christ alone');
 
-        $metrics = $this->service->sync($path, dryRun: false);
+        $report = $this->service->sync($path, dryRun: false);
 
-        $this->assertSame(2, $metrics['song_author_links_synced']);
+        $this->assertSame(2, $report->songAuthorLinksSynced);
 
         $song = Song::query()->where('title', 'In Christ Alone')->firstOrFail();
         $this->assertCount(2, $song->authors);


### PR DESCRIPTION
## Summary
- Splits the 1,436-line `SongCatalogSyncService` into collaborators under `App\Services\Song\Sync`:
  - **`OpenLpSongSourceReader`** — SQLite path resolution, required-table validation, PDO reads.
  - **`LegacySongReconciler`** — the two-phase (praise number + title, then title-only) legacy-row matching.
  - **`SongAuthorBookSyncer`** — author/book upserts, pivot-row building, link replacement.
  - **`OpenLpRowValue`** — shared scalar normalisation for raw source rows.
- `SongCatalogSyncService` remains a ~430-line coordinator (grouping, song upserts, report assembly).
- **Real/dry-run duplication collapsed**: the four `countDryRun*`/`buildPivotRows*` methods become two. Preview mode passes identity ID maps (source ID → source ID) through the same pivot builders, which reproduces the historical dry-run dedupe-on-source-ID counts exactly — verified by the untouched `dry_run_reports_projected_sync_metrics_without_writing_changes` assertions.
- **Finding 3 (typed DTOs)**: the 15-key metrics `array{...}` shape (repeated four times in PHPDoc) is now the `SongCatalogSyncReport` spatie/laravel-data object; the five-table source shape is now `OpenLpSongSourceData`. `SyncSongsCommand` and the tests use typed properties.
- Adds focused integration tests for the reconciler (title match, ambiguity rejection, soft-delete state) and the syncer (ID mapping, pivot dedupe, identity-map previews). The reader's validation paths stay covered by the existing service tests.

Part of June 2026 review **Phase R6** (Findings 2 & 3) — see `docs/plans/JUNE-2026-REVIEW-IMPLEMENTATION-2026-06-03.md`.

## Verification
- Pint clean, PHPStan 0 errors
- Song-sync suites: 26 passed; full parallel suite: 5433 passed (first run had 5 unrelated calendar-event Livewire flakes that pass in isolation and on re-run)
- Dusk: 41 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)