### PR TITLE
Record E2E division-of-labour and Livewire SFC stances in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,12 @@ vendor/bin/sail bin pint --dirty       # Auto-fix formatting on changed files
 - Cover happy path, failure paths, and edge cases.
 - You must not remove existing tests without approval.
 
+### Browser-test division of labour: Dusk vs Playwright
+- **Dusk verifies interaction; Playwright verifies visual output.** This is a deliberate boundary, not an accident of history.
+- New browser tests that assert *behaviour* — clicks, navigation, form flows, Livewire actions, auth journeys — belong in `tests/Browser/` (Dusk).
+- Playwright specs (`tests/Playwright/`) exist solely for pixel-level visual regression against committed baselines. Do not add functional assertions there beyond the minimal preconditions/waits a stable screenshot needs (e.g. waiting for a menu to be open before capturing it).
+- If a check could live in either suite, it goes in Dusk; Playwright only gets a spec when the thing being protected is *how the page looks*.
+
 ### Diagnosing test failures without re-running
 The parallel suite output is often truncated before the failure summary. Pipe through `tee` so the full output is on disk:
 ```bash
@@ -200,6 +206,10 @@ Never re-run the full suite just to discover which test failed.
 - Livewire components keep server-side state and validate/authorise actions.
 - Use `wire:navigate` for in-app SPA navigation; verify behaviour on link changes.
 - Use `@once` for scripts/styles included in repeated components.
+
+### Livewire component format (deliberate stance)
+- Existing components stay in the **class + Blade view** format (`app/Livewire/` + `resources/views/livewire/`). Do **not** migrate them to Livewire 4 single-file components — mass conversion is high churn for no behavioural payoff.
+- Livewire 4 single-file components are permitted only for **new, small leaf components** where the format genuinely simplifies things. Anything with non-trivial logic, or any admin component (which must `use WithAdminAuthorization` — see below), defaults to the class + view format.
 
 ### Image Processing
 - This project uses `intervention/image-laravel` (v4.x) via the `Image` facade — use `Image::read()`, not `Image::make()` (the legacy `intervention/image` v2 API).

--- a/docs/plans/JUNE-2026-REVIEW-IMPLEMENTATION-2026-06-03.md
+++ b/docs/plans/JUNE-2026-REVIEW-IMPLEMENTATION-2026-06-03.md
@@ -239,13 +239,20 @@ shapes are typed DTOs; 0 PHPStan errors; full suite green.
 
 ## Track 2 — Tooling & decision-only items
 
-### Phase D1: E2E framework strategy — mostly decided; one residual task
+### Phase D1: E2E framework strategy — ✅ Done
 
-Finding 6. **Status: Decided in practice — needs writing up.**
+Finding 6. **Status: Complete** (implemented 2026-06-10).
 
 The division of labour already exists in
 [tests/Playwright/README.md](../../tests/Playwright/README.md): *"Dusk verifies interaction,
 Playwright verifies visual output"* — option (a) from the original plan, chosen.
+
+Execution note: the stance is now a "Browser-test division of labour: Dusk vs Playwright"
+subsection under Testing Rules in `AGENTS.md`. **Trim audit result: nothing to trim.** All five
+Playwright specs were reviewed against the Dusk suite; their only non-screenshot assertions are
+navigation preconditions (finding a seeded link to capture) and the `aria-expanded` check in
+`mobile-nav.spec.ts`, which doubles as the synchronisation wait before the screenshot — removing
+it would just mean replacing it with an equivalent wait. No maintenance-costing duplication exists.
 
 - [x] Copy that stance into `AGENTS.md` (testing section) so future UI tests have one obvious home
       without reading the Playwright README.
@@ -254,9 +261,14 @@ Playwright verifies visual output"* — option (a) from the original plan, chose
 
 Exit criteria: the stance is in `AGENTS.md`; no duplicated functional coverage that hurts.
 
-### Phase D2: Livewire SFC stance — Pending (decision-only, unchanged)
+### Phase D2: Livewire SFC stance — ✅ Done
 
-Finding 13. **Priority: Low.** Verified 2026-06-10: no SFC stance exists in `AGENTS.md` yet.
+Finding 13. **Status: Complete** (implemented 2026-06-10).
+
+Execution note: the stance is now a "Livewire component format (deliberate stance)" subsection
+under Frontend Conventions in `AGENTS.md` — existing components stay class + view; SFCs only for
+new small leaf components; admin components default to class + view because of the
+`WithAdminAuthorization` requirement.
 
 - [x] Record an explicit stance in `AGENTS.md`: keep the existing class+view components as-is; adopt
       Livewire 4 single-file components only for **new small leaf components** if desired.
@@ -487,8 +499,8 @@ thumbnail pipeline, voice fingerprinting, or vector search (MySQL, no pgvector).
 4. **Phase R6** (hotspot decomposition + DTOs) — opportunistic, whenever those files are next touched.
 5. **Track 3**: P2 → P1 → P3 after approval. P4/P5 deferred with named triggers; P6 is decisions-only.
 
-R1–R3, R5, and R6 are done (R6's importer target deferred behind SIMPLIFICATION-PLAN Phase 25);
-R4 is deferred indefinitely.
+R1–R3, R5, R6, D1, and D2 are done (R6's importer target deferred behind SIMPLIFICATION-PLAN
+Phase 25); R4 is deferred indefinitely. Only Track 3 (approval-gated package adoptions) remains.
 
 ## Definition of Done
 


### PR DESCRIPTION
## Summary

Completes **Track 2 (Phases D1 + D2)** of [docs/plans/JUNE-2026-REVIEW-IMPLEMENTATION-2026-06-03.md](docs/plans/JUNE-2026-REVIEW-IMPLEMENTATION-2026-06-03.md). Both are decision-recording tasks — documentation only, no PHP touched.

- **D1 — E2E framework stance**: new "Browser-test division of labour: Dusk vs Playwright" subsection under Testing Rules in `AGENTS.md`, codifying the stance already stated in `tests/Playwright/README.md` (Dusk verifies interaction, Playwright verifies visual output) plus a tiebreaker: ambiguous checks go to Dusk.
- **D1 — trim audit: nothing to trim.** All five Playwright specs reviewed against the Dusk suite. Their only non-screenshot assertions are navigation preconditions and the `aria-expanded` check in `mobile-nav.spec.ts`, which doubles as the synchronisation wait before the screenshot — removing it would just substitute an equivalent wait. The no-trim verdict is documented in the plan.
- **D2 — Livewire SFC stance**: new "Livewire component format (deliberate stance)" subsection under Frontend Conventions — existing class + view components stay as-is (no mass migration); Livewire 4 single-file components only for new small leaf components; admin components default to class + view because of the `WithAdminAuthorization` requirement.
- Plan updated: D1/D2 marked done with execution notes; closing summary now shows only Track 3 (approval-gated package adoptions) remaining.

## Test plan

- Documentation-only change (two markdown files) — the plan's quality gates apply only to phases that touch PHP, so no suite run is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)