### PR TITLE
Adopt spatie/laravel-backup for nightly encrypted DB + local-file backups (Phase P2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,12 @@ LIVESTREAM_NOTIFY_FAILURE=true
 # DO_SPACES_ENDPOINT=
 # DO_SPACES_CDN_ENDPOINT=
 
+# Backups (spatie/laravel-backup; nightly backup:run is production-only).
+# Encrypts the backup zip (AES-256). Required in production — without it the
+# archive is stored unencrypted. Keep a copy of this password OUTSIDE the
+# backups themselves, or the archives are unrecoverable.
+# BACKUP_ARCHIVE_PASSWORD=
+
 # Speaker Identification (disabled by default)
 SPEAKER_IDENTIFICATION_ENABLED=false
 SPEAKER_IDENTIFICATION_MODE=shadow

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -42,6 +42,21 @@ return Application::configure(basePath: dirname(__DIR__))
             ->everyFiveMinutes()
             ->withoutOverlapping()
             ->environments(['production']);
+        $schedule->command('backup:clean')
+            ->dailyAt('01:00')
+            ->withoutOverlapping(60)
+            ->onOneServer()
+            ->environments(['production']);
+        $schedule->command('backup:run')
+            ->dailyAt('01:30')
+            ->withoutOverlapping(120)
+            ->onOneServer()
+            ->environments(['production']);
+        $schedule->command('backup:monitor')
+            ->dailyAt('08:00')
+            ->withoutOverlapping(30)
+            ->onOneServer()
+            ->environments(['production']);
     })
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->append(SecurityHeaders::class);

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "owen-oj/laravel-getid3": "^2.2",
         "php-ffmpeg/php-ffmpeg": "^1.3",
         "predis/predis": "^3.1",
+        "spatie/laravel-backup": "^10.3",
         "spatie/laravel-data": "^4.17",
         "spatie/laravel-google-calendar": "^3.8",
         "spatie/laravel-medialibrary": "^11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4492b93b29c99650ecc3918249745001",
+    "content-hash": "603cdab5aec4121320aba8b4d66208ff",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -5640,6 +5640,70 @@
             "time": "2026-02-21T22:52:37+00:00"
         },
         {
+            "name": "spatie/db-dumper",
+            "version": "4.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/db-dumper.git",
+                "reference": "f8f2785574de84aa4642a4df8b59a6dd578dd5d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/f8f2785574de84aa4642a4df8b59a6dd578dd5d3",
+                "reference": "f8f2785574de84aa4642a4df8b59a6dd578dd5d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.3",
+                "symfony/process": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^4.0",
+                "phpstan/phpstan": "^2.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\DbDumper\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Dump databases",
+            "homepage": "https://github.com/spatie/db-dumper",
+            "keywords": [
+                "database",
+                "db-dumper",
+                "dump",
+                "mysqldump",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/db-dumper/tree/4.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-04T11:43:33+00:00"
+        },
+        {
             "name": "spatie/image",
             "version": "3.9.4",
             "source": {
@@ -5766,6 +5830,106 @@
                 "source": "https://github.com/spatie/image-optimizer/tree/1.8.1"
             },
             "time": "2025-11-26T10:57:19+00:00"
+        },
+        {
+            "name": "spatie/laravel-backup",
+            "version": "10.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-backup.git",
+                "reference": "c026344f7e26321d6e1d214cd3e566ce5c54715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/c026344f7e26321d6e1d214cd3e566ce5c54715d",
+                "reference": "c026344f7e26321d6e1d214cd3e566ce5c54715d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zip": "^1.14.0",
+                "illuminate/console": "^12.40|^13.0",
+                "illuminate/contracts": "^12.40|^13.0",
+                "illuminate/events": "^12.40|^13.0",
+                "illuminate/filesystem": "^12.40|^13.0",
+                "illuminate/notifications": "^12.40|^13.0",
+                "illuminate/support": "^12.40|^13.0",
+                "league/flysystem": "^3.30.2",
+                "php": "^8.3",
+                "spatie/db-dumper": "^4.0",
+                "spatie/laravel-package-tools": "^1.92.7",
+                "spatie/laravel-signal-aware-command": "^2.1",
+                "spatie/temporary-directory": "^2.3",
+                "symfony/console": "^7.3.6|^8.0",
+                "symfony/finder": "^7.3.5|^8.0"
+            },
+            "require-dev": {
+                "composer-runtime-api": "^2.0",
+                "ext-pcntl": "*",
+                "larastan/larastan": "^3.8",
+                "laravel/slack-notification-channel": "^3.7",
+                "league/flysystem-aws-s3-v3": "^3.30.1",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.8|^11.0",
+                "pestphp/pest": "^4.1.5",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpstan/phpstan-phpunit": "^2.0.8",
+                "rector/rector": "^2.2.8"
+            },
+            "suggest": {
+                "laravel/slack-notification-channel": "Required for sending notifications via Slack"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Backup\\BackupServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Helpers/functions.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Backup\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A Laravel package to backup your application",
+            "homepage": "https://github.com/spatie/laravel-backup",
+            "keywords": [
+                "backup",
+                "database",
+                "laravel-backup",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-backup/issues",
+                "source": "https://github.com/spatie/laravel-backup/tree/10.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/spatie",
+                    "type": "github"
+                },
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-06-10T08:25:59+00:00"
         },
         {
             "name": "spatie/laravel-data",
@@ -6095,6 +6259,81 @@
                 }
             ],
             "time": "2026-02-21T12:49:54+00:00"
+        },
+        {
+            "name": "spatie/laravel-signal-aware-command",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-signal-aware-command.git",
+                "reference": "54dcc1efd152bfb3eb0faf56a5fc28569b864b5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-signal-aware-command/zipball/54dcc1efd152bfb3eb0faf56a5fc28569b864b5d",
+                "reference": "54dcc1efd152bfb3eb0faf56a5fc28569b864b5d",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "spatie/laravel-package-tools": "^1.4.3",
+                "symfony/console": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "brianium/paratest": "^6.2|^7.0",
+                "ext-pcntl": "*",
+                "nunomaduro/collision": "^5.3|^6.0|^7.0|^8.0",
+                "orchestra/testbench": "^9.0|^10.0",
+                "pestphp/pest-plugin-laravel": "^1.3|^2.0|^3.0",
+                "phpunit/phpunit": "^9.5|^10|^11",
+                "spatie/laravel-ray": "^1.17"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Signal": "Spatie\\SignalAwareCommand\\Facades\\Signal"
+                    },
+                    "providers": [
+                        "Spatie\\SignalAwareCommand\\SignalAwareCommandServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\SignalAwareCommand\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Handle signals in artisan commands",
+            "homepage": "https://github.com/spatie/laravel-signal-aware-command",
+            "keywords": [
+                "laravel",
+                "laravel-signal-aware-command",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-signal-aware-command/issues",
+                "source": "https://github.com/spatie/laravel-signal-aware-command/tree/2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-22T08:16:31+00:00"
         },
         {
             "name": "spatie/laravel-sitemap",

--- a/config/backup.php
+++ b/config/backup.php
@@ -1,0 +1,405 @@
+<?php
+
+use Spatie\Backup\Notifications\Notifiable;
+use Spatie\Backup\Notifications\Notifications\BackupHasFailedNotification;
+use Spatie\Backup\Notifications\Notifications\BackupWasSuccessfulNotification;
+use Spatie\Backup\Notifications\Notifications\CleanupHasFailedNotification;
+use Spatie\Backup\Notifications\Notifications\CleanupWasSuccessfulNotification;
+use Spatie\Backup\Notifications\Notifications\HealthyBackupWasFoundNotification;
+use Spatie\Backup\Notifications\Notifications\UnhealthyBackupWasFoundNotification;
+use Spatie\Backup\Tasks\Cleanup\Strategies\DefaultStrategy;
+use Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays;
+use Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes;
+use Spatie\DbDumper\Compressors\GzipCompressor;
+
+return [
+
+    'backup' => [
+        /*
+         * The name of this application. You can use this name to monitor
+         * the backups.
+         */
+        'name' => env('APP_NAME', 'laravel-backup'),
+
+        'source' => [
+            'files' => [
+                /*
+                 * The list of directories and files that will be included in the backup.
+                 *
+                 * Only local *persistent* storage is included. Application code lives in
+                 * git; sermon media lives in Spaces (sermon_disk) and must not be
+                 * re-uploaded (~200 GB); temp/livewire-tmp/extracted/services are
+                 * processing scratch space.
+                 */
+                'include' => [
+                    // Medialibrary-managed files and site assets (local-only).
+                    storage_path('app/public'),
+                    // Member-only sermon assets moved OFF Spaces by
+                    // MoveSermonToPrivateStorage — the local copy is the only copy.
+                    storage_path('app/private'),
+                    // Google service-account credentials for calendar sync.
+                    storage_path('app/google-calendar'),
+                    // BritishEnglishConverter external word list.
+                    storage_path('app/spelling'),
+                ],
+
+                /*
+                 * These directories and files will be excluded from the backup.
+                 *
+                 * Directories used by the backup process will automatically be excluded.
+                 */
+                'exclude' => [
+                    // Transient thumbnails/uploads inside the public disk.
+                    storage_path('app/public/temp'),
+                    // Publication candidates; purged after 48 h by
+                    // media:cleanup-unpublished-section-assets.
+                    storage_path('app/private/section-publications'),
+                ],
+
+                /*
+                 * Determines if symlinks should be followed.
+                 */
+                'follow_links' => false,
+
+                /*
+                 * Determines if it should avoid unreadable folders.
+                 */
+                'ignore_unreadable_directories' => false,
+
+                /*
+                 * This path is used to make directories in resulting zip-file relative
+                 * Set to `null` to include complete absolute path
+                 * Example: base_path()
+                 */
+                'relative_path' => null,
+            ],
+
+            /*
+             * The names of the connections to the databases that should be backed up
+             * MySQL, PostgreSQL, SQLite and Mongo databases are supported.
+             *
+             * The content of the database dump may be customized for each connection
+             * by adding a 'dump' key to the connection settings in config/database.php.
+             * E.g.
+             * 'mysql' => [
+             *       ...
+             *      'dump' => [
+             *           'exclude_tables' => [
+             *                'table_to_exclude_from_backup',
+             *                'another_table_to_exclude'
+             *            ]
+             *       ],
+             * ],
+             *
+             * If you are using only InnoDB tables on a MySQL server, you can
+             * also supply the useSingleTransaction option to avoid table locking.
+             *
+             * E.g.
+             * 'mysql' => [
+             *       ...
+             *      'dump' => [
+             *           'useSingleTransaction' => true,
+             *       ],
+             * ],
+             *
+             * For a complete list of available customization options, see https://github.com/spatie/db-dumper
+             */
+            'databases' => [
+                env('DB_CONNECTION', 'mysql'),
+            ],
+        ],
+
+        /*
+         * The database dump can be compressed to decrease disk space usage.
+         *
+         * Out of the box Laravel-backup supplies
+         * Spatie\DbDumper\Compressors\GzipCompressor::class.
+         *
+         * You can also create custom compressor. More info on that here:
+         * https://github.com/spatie/db-dumper#using-compression
+         *
+         * If you do not want any compressor at all, set it to null.
+         */
+        'database_dump_compressor' => GzipCompressor::class,
+
+        /*
+         * If specified, the database dumped file name will contain a timestamp (e.g.: 'Y-m-d-H-i-s').
+         */
+        'database_dump_file_timestamp_format' => null,
+
+        /*
+         * The base of the dump filename, either 'database' or 'connection'
+         *
+         * If 'database' (default), the dumped filename will contain the database name.
+         * If 'connection', the dumped filename will contain the connection name.
+         */
+        'database_dump_filename_base' => 'database',
+
+        /*
+         * The file extension used for the database dump files.
+         *
+         * If not specified, the file extension will be .archive for MongoDB and .sql for all other databases
+         * The file extension should be specified without a leading .
+         */
+        'database_dump_file_extension' => '',
+
+        'destination' => [
+            /*
+             * The compression algorithm to be used for creating the zip archive.
+             *
+             * If backing up only database, you may choose gzip compression for db dump and no compression at zip.
+             *
+             * Some common algorithms are listed below:
+             * ZipArchive::CM_STORE (no compression at all; set 0 as compression level)
+             * ZipArchive::CM_DEFAULT
+             * ZipArchive::CM_DEFLATE
+             * ZipArchive::CM_BZIP2
+             * ZipArchive::CM_XZ
+             *
+             * For more check https://www.php.net/manual/zip.constants.php and confirm it's supported by your system.
+             */
+            'compression_method' => ZipArchive::CM_DEFAULT,
+
+            /*
+             * The compression level corresponding to the used algorithm; an integer between 0 and 9.
+             *
+             * Check supported levels for the chosen algorithm, usually 1 means the fastest and weakest compression,
+             * while 9 the slowest and strongest one.
+             *
+             * Setting of 0 for some algorithms may switch to the strongest compression.
+             */
+            'compression_level' => 9,
+
+            /*
+             * The filename prefix used for the backup zip file.
+             */
+            'filename_prefix' => '',
+
+            /*
+             * The disk names on which the backups will be stored.
+             */
+            'disks' => [
+                'do_spaces_backups',
+            ],
+
+            /*
+             * Determines whether to allow backups to continue when some targets fail instead of failing completely.
+             */
+            'continue_on_failure' => false,
+        ],
+
+        /*
+         * The directory where the temporary files will be stored.
+         */
+        'temporary_directory' => storage_path('app/backup-temp'),
+
+        /*
+         * The password to be used for archive encryption.
+         * Set to `null` to disable encryption.
+         */
+        'password' => env('BACKUP_ARCHIVE_PASSWORD'),
+
+        /*
+         * The encryption algorithm to be used for archive encryption.
+         * Set to 'none' to disable encryption.
+         *
+         * Supported: 'none', 'default', 'aes128', 'aes192', 'aes256'
+         *
+         * When set to 'default', we'll use AES-256 if available on your system.
+         */
+        'encryption' => 'default',
+
+        /*
+         * After creating the zip, verify it can be opened and contains files.
+         * Recommended for critical backups but adds a small overhead.
+         */
+        'verify_backup' => false,
+
+        /*
+         * The number of attempts, in case the backup command encounters an exception
+         */
+        'tries' => 1,
+
+        /*
+         * The number of seconds to wait before attempting a new backup if the previous try failed
+         * Set to `0` for none
+         */
+        'retry_delay' => 0,
+    ],
+
+    /*
+     * You can get notified when specific events occur. Out of the box you can use 'mail' and 'slack'.
+     * For Slack you need to install laravel/slack-notification-channel.
+     *
+     * You can also use your own notification classes, just make sure the class is named after one of
+     * the `Spatie\Backup\Notifications\Notifications` classes.
+     */
+    'notifications' => [
+        /*
+         * Failures alert the admin mailbox; routine successes are logged only,
+         * so the alert address stays high-signal.
+         */
+        'notifications' => [
+            BackupHasFailedNotification::class => ['mail'],
+            UnhealthyBackupWasFoundNotification::class => ['mail'],
+            CleanupHasFailedNotification::class => ['mail'],
+            BackupWasSuccessfulNotification::class => [],
+            HealthyBackupWasFoundNotification::class => [],
+            CleanupWasSuccessfulNotification::class => [],
+        ],
+
+        /*
+         * Here you can specify the notifiable to which the notifications should be sent. The default
+         * notifiable will use the variables specified in this config file.
+         */
+        'notifiable' => Notifiable::class,
+
+        'mail' => [
+            // Falls back through the same chain as media-processing.admin_email;
+            // the package rejects a null/invalid address at boot, so the final
+            // literal keeps non-production environments bootable.
+            'to' => env('LIVESTREAM_ADMIN_EMAIL', env('MAIL_FROM_ADDRESS', 'hello@example.com')),
+
+            'from' => [
+                'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
+                'name' => env('MAIL_FROM_NAME', 'Example'),
+            ],
+        ],
+
+        'slack' => [
+            'webhook_url' => '',
+
+            /*
+             * If this is set to null the default channel of the webhook will be used.
+             */
+            'channel' => null,
+
+            'username' => null,
+
+            'icon' => null,
+        ],
+
+        'discord' => [
+            'webhook_url' => '',
+
+            /*
+             * If this is an empty string, the name field on the webhook will be used.
+             */
+            'username' => '',
+
+            /*
+             * If this is an empty string, the avatar on the webhook will be used.
+             */
+            'avatar_url' => '',
+        ],
+
+        /*
+         * A generic webhook channel that POSTs JSON to a URL.
+         * Useful for Mattermost, Microsoft Teams, or custom integrations.
+         */
+        'webhook' => [
+            'url' => '',
+        ],
+    ],
+
+    /*
+     * The log channel used for backup activity messages.
+     *
+     * Set to a channel name defined in config/logging.php to use that channel.
+     * Set to false to disable backup logging entirely.
+     * Set to null to use the default log channel.
+     */
+    'log_channel' => null,
+
+    /*
+     * Here you can specify which backups should be monitored.
+     * If a backup does not meet the specified requirements the
+     * UnHealthyBackupWasFound event will be fired.
+     */
+    'monitor_backups' => [
+        [
+            'name' => env('APP_NAME', 'laravel-backup'),
+            'disks' => ['do_spaces_backups'],
+            'health_checks' => [
+                MaximumAgeInDays::class => 1,
+                MaximumStorageInMegabytes::class => 5000,
+            ],
+        ],
+
+        /*
+        [
+            'name' => 'name of the second app',
+            'disks' => ['local', 's3'],
+            'health_checks' => [
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 1,
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes::class => 5000,
+            ],
+        ],
+        */
+    ],
+
+    'cleanup' => [
+        /*
+         * The strategy that will be used to cleanup old backups. The default strategy
+         * will keep all backups for a certain amount of days. After that period only
+         * a daily backup will be kept. After that period only weekly backups will
+         * be kept and so on.
+         *
+         * No matter how you configure it the default strategy will never
+         * delete the newest backup.
+         */
+        'strategy' => DefaultStrategy::class,
+
+        'default_strategy' => [
+            /*
+             * The number of days for which backups must be kept.
+             */
+            'keep_all_backups_for_days' => 7,
+
+            /*
+             * After the "keep_all_backups_for_days" period is over, the most recent backup
+             * of that day will be kept. Older backups within the same day will be removed.
+             * If you create backups only once a day, no backups will be removed yet.
+             */
+            'keep_daily_backups_for_days' => 7,
+
+            /*
+             * After the "keep_daily_backups_for_days" period is over, the most recent backup
+             * of that week will be kept. Older backups within the same week will be removed.
+             * If you create backups only once a week, no backups will be removed yet.
+             */
+            'keep_weekly_backups_for_weeks' => 4,
+
+            /*
+             * After the "keep_weekly_backups_for_weeks" period is over, the most recent backup
+             * of that month will be kept. Older backups within the same month will be removed.
+             */
+            'keep_monthly_backups_for_months' => 3,
+
+            /*
+             * After the "keep_monthly_backups_for_months" period is over, the most recent backup
+             * of that year will be kept. Older backups within the same year will be removed.
+             */
+            'keep_yearly_backups_for_years' => 0,
+
+            /*
+             * After cleaning up the backups remove the oldest backup until
+             * this amount of megabytes has been reached.
+             * Set null for unlimited size.
+             */
+            'delete_oldest_backups_when_using_more_megabytes_than' => 5000,
+        ],
+
+        /*
+         * The number of attempts, in case the cleanup command encounters an exception
+         */
+        'tries' => 1,
+
+        /*
+         * The number of seconds to wait before attempting a new cleanup if the previous try failed
+         * Set to `0` for none
+         */
+        'retry_delay' => 0,
+    ],
+
+];

--- a/config/database.php
+++ b/config/database.php
@@ -51,6 +51,12 @@ return [
             'prefix' => '',
             'strict' => true,
             'engine' => null,
+            // Read by spatie/laravel-backup's db-dumper: all tables are InnoDB,
+            // so a single-transaction dump avoids locking the live site's tables
+            // during the nightly backup:run.
+            'dump' => [
+                'useSingleTransaction' => true,
+            ],
         ],
 
         'pgsql' => [

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -88,6 +88,25 @@ return [
             'cdn_endpoint' => env('DO_SPACES_CDN_ENDPOINT'),
         ],
 
+        // Same Spaces bucket/credentials as do_spaces, but private visibility and
+        // a dedicated prefix. Backup archives must never inherit the public-read
+        // visibility (or CDN exposure) the sermon-serving disk requires, and
+        // throw=true lets a failed upload surface as a BackupHasFailed alert
+        // instead of a silent false return.
+        'do_spaces_backups' => [
+            'driver' => 's3',
+            'key' => env('DO_SPACES_KEY', env('DO_SPACES_ACCESS_KEY_ID')),
+            'secret' => env('DO_SPACES_SECRET', env('DO_SPACES_SECRET_ACCESS_KEY')),
+            'region' => env('DO_SPACES_REGION', env('DO_SPACES_DEFAULT_REGION', 'nyc3')),
+            'bucket' => env('DO_SPACES_BUCKET'),
+            'endpoint' => env('DO_SPACES_ENDPOINT', 'https://nyc3.digitaloceanspaces.com'),
+            'root' => 'backups',
+            'use_path_style_endpoint' => false,
+            'throw' => true,
+            'visibility' => 'private',
+            'bucket_endpoint' => true,
+        ],
+
     ],
 
 ];

--- a/docs/plans/JUNE-2026-REVIEW-IMPLEMENTATION-2026-06-03.md
+++ b/docs/plans/JUNE-2026-REVIEW-IMPLEMENTATION-2026-06-03.md
@@ -288,7 +288,7 @@ and do not wait for any approval):
 
 | Phase | Package | Verdict | One-line rationale |
 |-------|---------|---------|--------------------|
-| **P2** | `spatie/laravel-backup` | ✅ **Adopt — do first** | Lowest risk, purely additive. `mysqldump` is already in the image — prerequisite resolved. |
+| **P2** | `spatie/laravel-backup` | ✅ **Done** (2026-06-10) | Lowest risk, purely additive. `mysqldump` is already in the image — prerequisite resolved. |
 | **P1** | `laravel/horizon` | ✅ **Adopt** | Queue observability; its boot check also enforces the Phase 0.1 invariant permanently. |
 | **P3** | `spatie/laravel-health` (+ `schedule-monitor`) | ✅ **Adopt — re-premised** | Now must also decide how it relates to the bespoke route-canary system added since 2026-06-03. |
 | **P4** | `spatie/laravel-model-states` | ⏸️ **Defer** | Unchanged verdict; references updated to post-R3 paths. |
@@ -337,9 +337,29 @@ Rollback: revert the supervisord block to `queue:work`, remove the package. No d
 Exit criteria: Redis queues run under Horizon with an admin-gated dashboard; no raw `queue:work`
 worker remains in production; admin-gate test green.
 
-### Phase P2 — `spatie/laravel-backup` (automated DB + file backups) · ✅ Adopt (do first)
+### Phase P2 — `spatie/laravel-backup` (automated DB + file backups) · ✅ Done
 
-**Status: Pending approval.** Lowest-risk option in Track 3 — purely additive, fully reversible.
+**Status: ✅ Done** (approved and implemented 2026-06-10).
+
+Execution note: `spatie/laravel-backup` v10.3 is installed with `config/backup.php` committed
+(`mysqldump` 8.0.45 verified in the container). **One deliberate deviation from the plan:** backups
+land on a new `do_spaces_backups` disk in [config/filesystems.php](../../config/filesystems.php) —
+same bucket/credentials as `do_spaces`, but `private` visibility, a `backups/` root prefix, and
+`throw => true` — because the sermon-serving disk is public-visibility/CDN-fronted and backup
+archives must not inherit that. Scope: `storage/app/public`, `storage/app/private` (the *only*
+copy of member-only sermon assets once `MoveSermonToPrivateStorage` pulls them off Spaces),
+`google-calendar` credentials, and the spelling word list; `public/temp` and
+`private/section-publications` (48 h-transient) excluded; DB dump gzipped with
+`useSingleTransaction` so the nightly run does not lock live tables. Retention 7 all / 7 daily /
+4 weekly / 3 monthly; AES encryption via `BACKUP_ARCHIVE_PASSWORD` (declared in `.env.example`);
+failure-only mail to `LIVESTREAM_ADMIN_EMAIL`. Scheduled production-only with `onOneServer()`:
+`backup:clean` 01:00, `backup:run` 01:30 `withoutOverlapping(120)`, `backup:monitor` 08:00.
+Tests: [tests/Feature/Console/BackupRunCommandTest.php](../../tests/Feature/Console/BackupRunCommandTest.php)
+(a real `backup:run --only-db` lands an **encrypted** zip on the backups disk; a failed run sends
+`BackupHasFailedNotification`) plus a `SchedulerRegistrationTest` case for the three commands.
+`GenerateProdSermonPatchCommand` untouched. **Remaining manual steps:** set
+`BACKUP_ARCHIVE_PASSWORD` in production (and store a copy outside the backups), then restore-test
+one dump from Spaces before trusting the schedule.
 
 Refresh notes: the original "add default-mysql-client to the Dockerfile" task is **already done** —
 [docker/8.4/Dockerfile](../../docker/8.4/Dockerfile) declares `ARG MYSQL_CLIENT="mysql-client"` (l.7)
@@ -499,8 +519,8 @@ thumbnail pipeline, voice fingerprinting, or vector search (MySQL, no pgvector).
 4. **Phase R6** (hotspot decomposition + DTOs) — opportunistic, whenever those files are next touched.
 5. **Track 3**: P2 → P1 → P3 after approval. P4/P5 deferred with named triggers; P6 is decisions-only.
 
-R1–R3, R5, R6, D1, and D2 are done (R6's importer target deferred behind SIMPLIFICATION-PLAN
-Phase 25); R4 is deferred indefinitely. Only Track 3 (approval-gated package adoptions) remains.
+R1–R3, R5, R6, D1, D2, and P2 are done (R6's importer target deferred behind SIMPLIFICATION-PLAN
+Phase 25); R4 is deferred indefinitely. Of Track 3, only P1 and P3 (approval-gated) remain active.
 
 ## Definition of Done
 

--- a/tests/Feature/Console/BackupRunCommandTest.php
+++ b/tests/Feature/Console/BackupRunCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Backup\Config\Config;
+use Spatie\Backup\Notifications\Notifiable;
+use Spatie\Backup\Notifications\Notifications\BackupHasFailedNotification;
+use Tests\TestCase;
+use ZipArchive;
+
+/**
+ * Exercises the spatie/laravel-backup adoption (June 2026 review, Phase P2):
+ * a real `backup:run --only-db` shells out to mysqldump against the test
+ * database and must land an encrypted zip on the backups disk, and a failed
+ * run must notify the admin mailbox.
+ */
+class BackupRunCommandTest extends TestCase
+{
+    #[Test]
+    public function backup_run_writes_an_encrypted_database_backup_to_the_backups_disk(): void
+    {
+        Notification::fake();
+        Storage::fake('do_spaces_backups');
+        config(['backup.backup.password' => 'test-archive-password']);
+
+        // The package resolves its scoped Config object during application
+        // boot and the zip writer re-fetches it from the container, so the
+        // runtime password override only applies after the stale instance is
+        // forgotten; --config does the same for the command's own copy.
+        $this->app->forgetInstance(Config::class);
+
+        $this->artisan('backup:run', ['--only-db' => true, '--config' => 'backup'])
+            ->assertSuccessful();
+
+        $zips = array_values(array_filter(
+            Storage::disk('do_spaces_backups')->allFiles(),
+            fn (string $file): bool => str_ends_with($file, '.zip'),
+        ));
+
+        $this->assertCount(1, $zips, 'Expected exactly one backup zip on the backups disk.');
+
+        $zip = new ZipArchive;
+        $this->assertTrue($zip->open(Storage::disk('do_spaces_backups')->path($zips[0])));
+
+        $dumpIndex = null;
+
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            if (str_ends_with((string) $zip->getNameIndex($i), '.sql.gz')) {
+                $dumpIndex = $i;
+
+                break;
+            }
+        }
+
+        $this->assertNotNull($dumpIndex, 'Backup zip should contain a gzipped database dump.');
+
+        $stat = $zip->statIndex($dumpIndex);
+        $this->assertIsArray($stat);
+        $this->assertNotSame(
+            ZipArchive::EM_NONE,
+            $stat['encryption_method'],
+            'The database dump entry should be encrypted inside the archive.',
+        );
+
+        $zip->setPassword('test-archive-password');
+        $this->assertNotFalse($zip->getFromIndex($dumpIndex), 'The dump should extract with the archive password.');
+
+        $zip->close();
+    }
+
+    #[Test]
+    public function a_failed_backup_notifies_the_admin_mailbox(): void
+    {
+        Notification::fake();
+        Storage::fake('do_spaces_backups');
+        config(['backup.backup.source.databases' => ['nonexistent-connection']]);
+
+        $this->artisan('backup:run', ['--only-db' => true, '--config' => 'backup'])->assertFailed();
+
+        Notification::assertSentTo(new Notifiable, BackupHasFailedNotification::class);
+    }
+}

--- a/tests/Feature/Console/SchedulerRegistrationTest.php
+++ b/tests/Feature/Console/SchedulerRegistrationTest.php
@@ -93,4 +93,17 @@ class SchedulerRegistrationTest extends TestCase
         $this->assertTrue($event->withoutOverlapping);
         $this->assertContains('production', $event->environments);
     }
+
+    #[Test]
+    public function backup_commands_are_scheduled_with_overlap_protection_on_one_server_and_gated_to_production(): void
+    {
+        foreach (['backup:clean', 'backup:run', 'backup:monitor'] as $command) {
+            $event = $this->findEvent($command);
+
+            $this->assertNotNull($event, "{$command} should be registered in the scheduler");
+            $this->assertTrue($event->withoutOverlapping, "{$command} should have withoutOverlapping enabled");
+            $this->assertTrue($event->onOneServer, "{$command} should run on one server only");
+            $this->assertContains('production', $event->environments);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Implements **Track 3 Phase P2** of [docs/plans/JUNE-2026-REVIEW-IMPLEMENTATION-2026-06-03.md](docs/plans/JUNE-2026-REVIEW-IMPLEMENTATION-2026-06-03.md): automated, encrypted database + local-file backups via `spatie/laravel-backup` v10.3 (approval gate signed off by maintainer instruction to implement the phase).

### Destination — one deliberate deviation from the plan

The plan named the existing `do_spaces` disk, but that disk is **public-visibility and CDN-fronted** — backup archives must not inherit that. Backups instead land on a new `do_spaces_backups` disk: same bucket/credentials, `private` visibility, `backups/` root prefix, and `throw => true` so a failed upload raises (and alerts) instead of returning a silent `false`.

### What gets backed up

Database plus **local-persistent** storage only — sermon media already in Spaces (~200 GB) is not re-uploaded:

- `storage/app/public` — medialibrary-managed files and site assets
- `storage/app/private` — member-only sermon assets that `MoveSermonToPrivateStorage` pulls **off** Spaces; the local copy is the *only* copy
- `storage/app/google-calendar` — service-account credentials
- `storage/app/spelling` — external word list

Excluded: `public/temp` and `private/section-publications` (48 h-transient, purged by `media:cleanup-unpublished-section-assets`).

### Details

- DB dump is gzipped; mysql connection gains `'dump' => ['useSingleTransaction' => true]` so the nightly run never locks live tables
- Archives AES-encrypted via `BACKUP_ARCHIVE_PASSWORD` (declared in `.env.example`)
- Failure-only notifications to `LIVESTREAM_ADMIN_EMAIL` (falls back through `MAIL_FROM_ADDRESS` — the package rejects a null address at boot)
- Retention: 7 all / 7 daily / 4 weekly / 3 monthly
- Schedule (production-only, `onOneServer()`, overlap-protected): `backup:clean` 01:00, `backup:run` 01:30, `backup:monitor` 08:00
- `GenerateProdSermonPatchCommand` untouched, per the plan (different format, different purpose)

## Tests

- **`BackupRunCommandTest`** — a real `backup:run --only-db` shells out to mysqldump and must land an **encrypted** zip on the backups disk (asserted via the entry's `encryption_method`); a failed run must send `BackupHasFailedNotification`
- **`SchedulerRegistrationTest`** — the three backup commands are registered with overlap protection, `onOneServer`, and the production gate

Quality gates: Pint clean · PHPStan 0 errors · 5,441 tests green (parallel, recreated DBs) · 41 Dusk tests green

## Remaining manual steps (recorded in the plan's execution note)

1. Set `BACKUP_ARCHIVE_PASSWORD` in production — and store a copy *outside* the backups, or the archives are unrecoverable
2. Restore-test one dump from Spaces before trusting the schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)