### PR TITLE
Adopt laravel/horizon for queue observability (Phase P1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -428,6 +428,14 @@ jobs:
             docker compose -f docker-compose.prod.yml --env-file .env.production run --rm app \
               php artisan migrate --force
 
+            # Ask the outgoing release's Horizon to finish in-flight jobs and
+            # stop consuming before the container swap below kills it. The swap
+            # itself picks up the new code (fresh image), so this only narrows
+            # the window where a mid-flight job dies and waits out retry_after.
+            # `|| true`: tolerate an old image that predates Horizon.
+            docker compose -f docker-compose.prod.yml --env-file .env.production exec -T app \
+              php artisan horizon:terminate || true
+
             docker compose -f docker-compose.prod.yml --env-file .env.production up -d
 
             # Flush the application data cache so values written by the previous

--- a/app/Providers/HorizonServiceProvider.php
+++ b/app/Providers/HorizonServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Horizon\HorizonApplicationServiceProvider;
+
+class HorizonServiceProvider extends HorizonApplicationServiceProvider
+{
+    /**
+     * Register the Horizon gate.
+     *
+     * This gate determines who can access Horizon in non-local environments.
+     * Reuses the same admin check as the EnsureUserIsAdmin middleware.
+     */
+    protected function gate(): void
+    {
+        Gate::define('viewHorizon', function (?User $user = null): bool {
+            return $user?->canAccessAdmin() === true;
+        });
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -42,6 +42,9 @@ return Application::configure(basePath: dirname(__DIR__))
             ->everyFiveMinutes()
             ->withoutOverlapping()
             ->environments(['production']);
+        $schedule->command('horizon:snapshot')
+            ->everyFiveMinutes()
+            ->environments(['production']);
     })
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->append(SecurityHeaders::class);

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -4,6 +4,7 @@ use App\Providers\AiServiceProvider;
 use App\Providers\AppServiceProvider;
 use App\Providers\AuthServiceProvider;
 use App\Providers\ChurchServiceDomainServiceProvider;
+use App\Providers\HorizonServiceProvider;
 use App\Providers\MediaProcessingServiceProvider;
 use App\Providers\ModelObserverServiceProvider;
 use App\Providers\RateLimitServiceProvider;
@@ -20,4 +21,5 @@ return [
     ModelObserverServiceProvider::class,
     RateLimitServiceProvider::class,
     MediaProcessingServiceProvider::class,
+    HorizonServiceProvider::class,
 ];

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "blade-ui-kit/blade-heroicons": "^2.6",
         "intervention/image-laravel": "^4.0",
         "laravel/framework": "^13.0",
+        "laravel/horizon": "^5.47",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^3.0",
         "league/commonmark": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4492b93b29c99650ecc3918249745001",
+    "content-hash": "42a2e5a5adc26c1355632ed8ac319a9c",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2292,6 +2292,86 @@
             "time": "2026-06-04T18:46:35+00:00"
         },
         {
+            "name": "laravel/horizon",
+            "version": "v5.47.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/horizon.git",
+                "reference": "a6ac142293ad02db4d7cccb961dd32f56ef1462d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/horizon/zipball/a6ac142293ad02db4d7cccb961dd32f56ef1462d",
+                "reference": "a6ac142293ad02db4d7cccb961dd32f56ef1462d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcntl": "*",
+                "ext-posix": "*",
+                "illuminate/contracts": "^9.21|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/queue": "^9.21|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^9.21|^10.0|^11.0|^12.0|^13.0",
+                "laravel/sentinel": "^1.0",
+                "nesbot/carbon": "^2.17|^3.0",
+                "php": "^8.0",
+                "ramsey/uuid": "^4.0",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/error-handler": "^6.0|^7.0|^8.0",
+                "symfony/polyfill-php83": "^1.28",
+                "symfony/process": "^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^7.56|^8.37|^9.16|^10.9|^11.0",
+                "phpstan/phpstan": "^1.10|^2.0",
+                "predis/predis": "^1.1|^2.0|^3.0"
+            },
+            "suggest": {
+                "ext-redis": "Required to use the Redis PHP driver.",
+                "predis/predis": "Required when not using the Redis PHP driver (^1.1|^2.0|^3.0)."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Horizon": "Laravel\\Horizon\\Horizon"
+                    },
+                    "providers": [
+                        "Laravel\\Horizon\\HorizonServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Horizon\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Dashboard and code-driven configuration for Laravel queues.",
+            "keywords": [
+                "laravel",
+                "queue"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/horizon/issues",
+                "source": "https://github.com/laravel/horizon/tree/v5.47.2"
+            },
+            "time": "2026-06-03T15:11:37+00:00"
+        },
+        {
             "name": "laravel/prompts",
             "version": "v0.3.18",
             "source": {
@@ -2412,6 +2492,62 @@
                 "source": "https://github.com/laravel/sanctum"
             },
             "time": "2026-04-30T11:46:25+00:00"
+        },
+        {
+            "name": "laravel/sentinel",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sentinel.git",
+                "reference": "972d9885d9d14312a118e9565c4e6ecc5e751ea1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sentinel/zipball/972d9885d9d14312a118e9565c4e6ecc5e751ea1",
+                "reference": "972d9885d9d14312a118e9565c4e6ecc5e751ea1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/container": "^8.37|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.27",
+                "orchestra/testbench": "^6.47.1|^7.56|^8.37|^9.16|^10.9|^11.0",
+                "phpstan/phpstan": "^2.1.33"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sentinel\\SentinelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sentinel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "mior@laravel.com"
+                }
+            ],
+            "support": {
+                "source": "https://github.com/laravel/sentinel/tree/v1.1.0"
+            },
+            "time": "2026-03-24T14:03:38+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -1,0 +1,268 @@
+<?php
+
+use Illuminate\Support\Str;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Name
+    |--------------------------------------------------------------------------
+    |
+    | This name appears in notifications and in the Horizon UI. Unique names
+    | can be useful while running multiple instances of Horizon within an
+    | application, allowing you to identify the Horizon you're viewing.
+    |
+    */
+
+    'name' => env('HORIZON_NAME'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Domain
+    |--------------------------------------------------------------------------
+    |
+    | This is the subdomain where Horizon will be accessible from. If this
+    | setting is null, Horizon will reside under the same domain as the
+    | application. Otherwise, this value will serve as the subdomain.
+    |
+    */
+
+    'domain' => env('HORIZON_DOMAIN'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Path
+    |--------------------------------------------------------------------------
+    |
+    | This is the URI path where Horizon will be accessible from. Feel free
+    | to change this path to anything you like. Note that the URI will not
+    | affect the paths of its internal API that aren't exposed to users.
+    |
+    */
+
+    'path' => env('HORIZON_PATH', 'horizon'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Redis Connection
+    |--------------------------------------------------------------------------
+    |
+    | This is the name of the Redis connection where Horizon will store the
+    | meta information required for it to function. It includes the list
+    | of supervisors, failed jobs, job metrics, and other information.
+    |
+    */
+
+    'use' => 'default',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Redis Prefix
+    |--------------------------------------------------------------------------
+    |
+    | This prefix will be used when storing all Horizon data in Redis. You
+    | may modify the prefix when you are running multiple installations
+    | of Horizon on the same server so that they don't have problems.
+    |
+    */
+
+    'prefix' => env(
+        'HORIZON_PREFIX',
+        Str::slug(env('APP_NAME', 'laravel'), '_').'_horizon:'
+    ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Route Middleware
+    |--------------------------------------------------------------------------
+    |
+    | These middleware will get attached onto each Horizon route, giving you
+    | the chance to add your own middleware to this list or change any of
+    | the existing middleware. Or, you can simply stick with this list.
+    |
+    */
+
+    'middleware' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Wait Time Thresholds
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to configure when the LongWaitDetected event
+    | will be fired. Every connection / queue combination may have its
+    | own, unique threshold (in seconds) before this event is fired.
+    |
+    */
+
+    'waits' => [
+        'redis:default' => 60,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Job Trimming Times
+    |--------------------------------------------------------------------------
+    |
+    | Here you can configure for how long (in minutes) you desire Horizon to
+    | persist the recent and failed jobs. Typically, recent jobs are kept
+    | for one hour while all failed jobs are stored for an entire week.
+    |
+    */
+
+    'trim' => [
+        'recent' => 60,
+        'pending' => 60,
+        'completed' => 60,
+        'recent_failed' => 10080,
+        'failed' => 10080,
+        'monitored' => 10080,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Silenced Jobs
+    |--------------------------------------------------------------------------
+    |
+    | Silencing a job will instruct Horizon to not place the job in the list
+    | of completed jobs within the Horizon dashboard. This setting may be
+    | used to fully remove any noisy jobs from the completed jobs list.
+    |
+    */
+
+    'silenced' => [
+        // App\Jobs\ExampleJob::class,
+    ],
+
+    'silenced_tags' => [
+        // 'notifications',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Metrics
+    |--------------------------------------------------------------------------
+    |
+    | Here you can configure how many snapshots should be kept to display in
+    | the metrics graph. This will get used in combination with Horizon's
+    | `horizon:snapshot` schedule to define how long to retain metrics.
+    |
+    */
+
+    'metrics' => [
+        'trim_snapshots' => [
+            'job' => 24,
+            'queue' => 24,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Fast Termination
+    |--------------------------------------------------------------------------
+    |
+    | When this option is enabled, Horizon's "terminate" command will not
+    | wait on all of the workers to terminate unless the --wait option
+    | is provided. Fast termination can shorten deployment delay by
+    | allowing a new instance of Horizon to start while the last
+    | instance will continue to terminate each of its workers.
+    |
+    */
+
+    'fast_termination' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Memory Limit (MB)
+    |--------------------------------------------------------------------------
+    |
+    | This value describes the maximum amount of memory the Horizon master
+    | supervisor may consume before it is terminated and restarted. For
+    | configuring these limits on your workers, see the next section.
+    |
+    */
+
+    'memory_limit' => 64,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Worker Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define the queue worker settings used by your application
+    | in all environments. These supervisors and settings handle all your
+    | queued jobs and will be provisioned by Horizon during deployment.
+    |
+    */
+
+    'defaults' => [
+        // Mirrors the pre-Horizon `queue:work redis` supervisord worker exactly.
+        // `balance => false` is the only strategy that passes the full queue list
+        // to each worker in strict priority order (like `--queue=a,b,c`); the
+        // `simple` strategy instead splits the fixed process count evenly across
+        // queues, which with 6 queues and 2 processes would assign 0 per queue.
+        // Pinning minProcesses = maxProcesses disables autoscaling.
+        // INVARIANT: `timeout` must stay below queue.connections.redis.retry_after
+        // (REDIS_QUEUE_RETRY_AFTER=7260) or jobs can be processed twice; Horizon
+        // refuses to boot when this is violated.
+        'supervisor-media' => [
+            'connection' => 'redis',
+            'queue' => [
+                'video-processing',
+                'audio-processing',
+                'sermon-processing',
+                'livestream-processing',
+                'speaker-identification',
+                'default',
+            ],
+            'balance' => false,
+            'minProcesses' => 1,
+            'maxProcesses' => 1,
+            'maxTime' => 86400,
+            'maxJobs' => 500,
+            'memory' => 512,
+            'tries' => 3,
+            'timeout' => 7200,
+            'sleep' => 3,
+            'nice' => 0,
+        ],
+    ],
+
+    'environments' => [
+        'production' => [
+            'supervisor-media' => [
+                'minProcesses' => 2,
+                'maxProcesses' => 2,
+            ],
+        ],
+
+        'local' => [
+            'supervisor-media' => [],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | File Watcher Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The following list of directories and files will be watched when using
+    | the `horizon:listen` command. Whenever any directories or files are
+    | changed, Horizon will automatically restart to apply all changes.
+    |
+    */
+
+    'watch' => [
+        'app',
+        'bootstrap',
+        'config/**/*.php',
+        'database/**/*.php',
+        'public/**/*.php',
+        'resources/**/*.php',
+        'routes',
+        'composer.lock',
+        'composer.json',
+        '.env',
+    ],
+];

--- a/docker/production/supervisord.conf
+++ b/docker/production/supervisord.conf
@@ -46,23 +46,21 @@ redirect_stderr=true
 stdout_logfile=/var/www/html/storage/logs/scheduler.log
 stopwaitsecs=5
 
-[program:queue-worker]
+; Horizon manages its own worker children (supervisor + queue config lives in
+; config/horizon.php), so no numprocs/process_name here. stopwaitsecs must stay
+; >= 7260 (above the 7200s job timeout) with stopasgroup=true so supervisord-
+; initiated stops/restarts let an in-flight 2 h media job drain. Note this does
+; not cover deploys: a container swap is bounded by Docker's stop grace period,
+; so a job still running at swap time is killed and re-released after
+; retry_after (7260 s).
+[program:horizon]
 directory=/var/www/html
-command=php /var/www/html/artisan queue:work redis
-    --queue=video-processing,audio-processing,sermon-processing,livestream-processing,speaker-identification,default
-    --sleep=3
-    --tries=3
-    --timeout=7200
-    --max-time=86400
-    --max-jobs=500
-    --memory=512
-process_name=%(program_name)s_%(process_num)02d
-numprocs=2
+command=php /var/www/html/artisan horizon
 autostart=true
 autorestart=true
 stopasgroup=true
 killasgroup=true
 user=www
 redirect_stderr=true
-stdout_logfile=/var/www/html/storage/logs/queue-worker.log
+stdout_logfile=/var/www/html/storage/logs/horizon.log
 stopwaitsecs=7260

--- a/docs/plans/JUNE-2026-REVIEW-IMPLEMENTATION-2026-06-03.md
+++ b/docs/plans/JUNE-2026-REVIEW-IMPLEMENTATION-2026-06-03.md
@@ -298,9 +298,20 @@ and do not wait for any approval):
 
 ### Phase P1 — `laravel/horizon` (queue observability) · ✅ Adopt
 
-**Status: Pending approval.** Reversible (Horizon stores metrics in Redis only — no schema).
+**Status: Implemented 2026-06-10** (Horizon 5.47); the staging smoke test below is still
+outstanding. Reversible (Horizon stores metrics in Redis only — no schema).
 **Precondition: Phase 0.1 (`retry_after`) must land first** — Horizon refuses to boot when
 `retry_after` ≤ `timeout`, so doing 0.1 independently keeps the deploy of this phase boring.
+
+> **Execution note (2026-06-10):** the supervisor uses `balance => false` with
+> `minProcesses = maxProcesses`, **not** `balance => 'simple'` as originally sketched. Current
+> Horizon docs/source confirm `simple` splits the fixed process count evenly across queues
+> (one pool per queue — `floor(2/6) = 0` workers each), while `false` passes the full queue
+> list to every worker in strict priority order, exactly like the old
+> `queue:work --queue=a,b,…`. Pinning min = max disables autoscaling. Also added
+> `horizon:snapshot` every five minutes (production-only) so the metrics graphs populate, and
+> re-pointed the `QueueWorkerCoverageTest` / `QueueRetryAfterInvariantTest` guards at
+> `config/horizon.php` instead of parsing `queue:work` flags out of `supervisord.conf`.
 
 The production worker is the `[program:queue-worker]` block in
 [docker/production/supervisord.conf](../../docker/production/supervisord.conf):
@@ -312,7 +323,8 @@ Tasks:
 - [x] **Approval gate.**
 - [x] `composer require laravel/horizon`; `php artisan horizon:install`; commit `config/horizon.php`.
 - [x] Define **one supervisor** mirroring the current worker exactly (connection `redis`, the six
-      queues in priority order, `balance => 'simple'`, `processes => 2`, `tries => 3`,
+      queues in priority order, `balance => false` + `minProcesses = maxProcesses = 2` — see
+      execution note above, `tries => 3`,
       `timeout => 7200`, `memory => 512`, `sleep => 3`, `maxTime => 86400`, `maxJobs => 500`) so
       runtime behaviour does not change. Local dev currently splits video/livestream onto a second
       worker in `docker-compose.yml`; mirror that with a second supervisor later if wanted — start
@@ -329,7 +341,7 @@ Tasks:
 Tests / verification:
 
 - [x] Feature test: `/horizon` is 403 for guest/non-admin, 200 for admin.
-- [x] Staging smoke test: one media-processing job end to end — appears in the dashboard, completes
+- [ ] Staging smoke test: one media-processing job end to end — appears in the dashboard, completes
       **once**, and a deliberately-failed job lands in Failed Jobs and is retryable from the UI.
 
 Rollback: revert the supervisord block to `queue:work`, remove the package. No data/schema changes.

--- a/tests/Feature/Config/QueueRetryAfterInvariantTest.php
+++ b/tests/Feature/Config/QueueRetryAfterInvariantTest.php
@@ -9,45 +9,44 @@ use Tests\TestCase;
 
 /**
  * Guards the cross-file invariant that the redis queue's `retry_after` always
- * exceeds the production worker's `--timeout`. The two values live in files no
- * single runtime reads together (config/queue.php and the supervisord config),
- * so only a test makes the relationship visible. If TRANSCRIPTION_JOB_TIMEOUT
- * (or any other long job) forces the worker `--timeout` up, this fails the build
- * until `retry_after` is raised with it — which is the point.
+ * exceeds every production Horizon supervisor's job `timeout`. Horizon also
+ * enforces this at boot (it refuses to start when violated), but that only
+ * surfaces at deploy time — this test fails the build instead. If
+ * TRANSCRIPTION_JOB_TIMEOUT (or any other long job) forces a supervisor
+ * timeout up, this fails until `retry_after` is raised with it — which is the
+ * point.
  */
 class QueueRetryAfterInvariantTest extends TestCase
 {
     #[Test]
-    public function redis_retry_after_exceeds_the_production_worker_timeout(): void
+    public function redis_retry_after_exceeds_every_production_horizon_supervisor_timeout(): void
     {
-        $supervisordPath = base_path('docker/production/supervisord.conf');
+        $defaults = (array) config('horizon.defaults');
+        $production = (array) config('horizon.environments.production');
 
-        $this->assertFileExists(
-            $supervisordPath,
-            'Expected the production supervisord config to exist so the invariant can be checked.',
-        );
+        $this->assertNotEmpty($production, 'No Horizon supervisors are configured for production.');
 
-        $supervisord = (string) file_get_contents($supervisordPath);
-
-        $this->assertSame(
-            1,
-            preg_match('/--timeout=(\d+)/', $supervisord, $matches),
-            'Could not find the queue worker --timeout value in supervisord.conf.',
-        );
-
-        $workerTimeout = (int) $matches[1];
         $retryAfter = (int) config('queue.connections.redis.retry_after');
 
-        $this->assertGreaterThan(
-            $workerTimeout,
-            $retryAfter,
-            sprintf(
-                'queue.connections.redis.retry_after (%d) must exceed the worker --timeout (%d), '
-                .'or a long-running job can be released and re-delivered while still running. '
-                .'Raise REDIS_QUEUE_RETRY_AFTER (and its default in config/queue.php) above the worker timeout.',
+        foreach ($production as $supervisor => $overrides) {
+            $options = array_merge((array) ($defaults[$supervisor] ?? []), (array) $overrides);
+
+            $this->assertArrayHasKey('timeout', $options, "Horizon supervisor [{$supervisor}] does not define a timeout.");
+
+            $timeout = (int) $options['timeout'];
+
+            $this->assertGreaterThan(
+                $timeout,
                 $retryAfter,
-                $workerTimeout,
-            ),
-        );
+                sprintf(
+                    'queue.connections.redis.retry_after (%d) must exceed the [%s] supervisor timeout (%d), '
+                    .'or a long-running job can be released and re-delivered while still running. '
+                    .'Raise REDIS_QUEUE_RETRY_AFTER (and its default in config/queue.php) above the supervisor timeout.',
+                    $retryAfter,
+                    $supervisor,
+                    $timeout,
+                ),
+            );
+        }
     }
 }

--- a/tests/Feature/HorizonDashboardTest.php
+++ b/tests/Feature/HorizonDashboardTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class HorizonDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function guest_cannot_view_horizon_dashboard(): void
+    {
+        $this->get('/horizon')->assertForbidden();
+    }
+
+    #[Test]
+    public function non_admin_user_cannot_view_horizon_dashboard(): void
+    {
+        $user = User::factory()->create([
+            'is_admin' => false,
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user)->get('/horizon')->assertForbidden();
+    }
+
+    #[Test]
+    public function unverified_admin_cannot_view_horizon_dashboard(): void
+    {
+        $unverifiedAdmin = User::factory()->create([
+            'is_admin' => true,
+            'email_verified_at' => null,
+        ]);
+
+        $this->actingAs($unverifiedAdmin)->get('/horizon')->assertForbidden();
+    }
+
+    #[Test]
+    public function verified_admin_can_view_horizon_dashboard(): void
+    {
+        $admin = User::factory()->crockenhillAdmin()->create();
+
+        $this->actingAs($admin)->get('/horizon')->assertOk();
+    }
+}

--- a/tests/Unit/Config/QueueWorkerCoverageTest.php
+++ b/tests/Unit/Config/QueueWorkerCoverageTest.php
@@ -26,17 +26,35 @@ class QueueWorkerCoverageTest extends TestCase
     }
 
     #[Test]
-    public function production_supervisor_worker_consumes_all_required_processing_queues(): void
+    public function production_horizon_supervisors_consume_all_required_processing_queues(): void
     {
-        $queues = $this->extractQueuesFromFile(base_path('docker/production/supervisord.conf'));
+        $queues = $this->productionHorizonQueues();
 
         foreach ($this->requiredQueues() as $requiredQueue) {
             $this->assertContains(
                 $requiredQueue,
                 $queues,
-                "production supervisor worker is missing required queue [{$requiredQueue}]"
+                "production Horizon supervisors are missing required queue [{$requiredQueue}]"
             );
         }
+    }
+
+    #[Test]
+    public function production_supervisord_runs_horizon(): void
+    {
+        $supervisord = file_get_contents(base_path('docker/production/supervisord.conf'));
+
+        $this->assertNotFalse($supervisord);
+        $this->assertStringContainsString(
+            'artisan horizon',
+            $supervisord,
+            'Production supervisord must run Horizon — otherwise the queues guarded by this test are never consumed.'
+        );
+        $this->assertStringNotContainsString(
+            'queue:work',
+            $supervisord,
+            'Raw queue:work workers must not run alongside Horizon in production.'
+        );
     }
 
     #[Test]
@@ -62,6 +80,30 @@ class QueueWorkerCoverageTest extends TestCase
         ];
 
         return array_values(array_unique(array_filter($required)));
+    }
+
+    /**
+     * Queues consumed in production: each supervisor listed for the production
+     * environment, with its options merged over the Horizon defaults.
+     *
+     * @return array<int, string>
+     */
+    private function productionHorizonQueues(): array
+    {
+        $defaults = (array) config('horizon.defaults');
+        $production = (array) config('horizon.environments.production');
+
+        $this->assertNotEmpty($production, 'No Horizon supervisors are configured for production.');
+
+        $queues = [];
+
+        foreach ($production as $supervisor => $overrides) {
+            $options = array_merge((array) ($defaults[$supervisor] ?? []), (array) $overrides);
+
+            $queues = array_merge($queues, (array) ($options['queue'] ?? []));
+        }
+
+        return array_values(array_unique($queues));
     }
 
     /**


### PR DESCRIPTION
## Summary

Implements **Track 3 Phase P1** of the [June 2026 review plan](docs/plans/JUNE-2026-REVIEW-IMPLEMENTATION-2026-06-03.md): replaces the raw supervisord `queue:work` worker with **Horizon 5.47**, mirroring the previous runtime exactly, with an admin-gated dashboard at `/horizon`.

- `config/horizon.php`: one `supervisor-media` supervisor on the `redis` connection consuming the six queues in priority order — 2 pinned processes in production, 1 locally (`tries 3 / timeout 7200 / memory 512 / sleep 3 / maxTime 86400 / maxJobs 500`).
- `HorizonServiceProvider::gate()` reuses the existing `canAccessAdmin()` check (`is_admin` + verified email). Not added to any navigation.
- `docker/production/supervisord.conf`: `queue:work` block replaced by a single `artisan horizon` program (`stopwaitsecs=7260`, `stopasgroup=true` kept).
- Deploy workflow runs `horizon:terminate` before the container swap (`|| true` tolerates the first deploy, whose outgoing image predates Horizon).
- `horizon:snapshot` scheduled every five minutes, production-only, so the metrics graphs populate.
- Guard tests (`QueueWorkerCoverageTest`, `QueueRetryAfterInvariantTest`) re-pointed at `config/horizon.php`; they now also assert production supervisord runs Horizon and contains no raw `queue:work` worker.
- Plan doc updated: P1 marked implemented, the erroneously pre-ticked staging smoke test unticked.

## Deliberate deviations from the plan sketch

1. **`balance => false` + `minProcesses = maxProcesses = 2`, not `balance => 'simple'`.** Horizon's `simple` strategy creates a pool *per queue* and divides the fixed process count evenly — with six queues and two processes that is `floor(2/6) = 0` workers per queue. `false` passes the full queue list to every worker in strict priority order, the true `queue:work --queue=a,b,…` mirror, and pinning min = max disables autoscaling.
2. **No deploy-time 2 h drain.** Deploys swap the app container under Docker's 10 s stop grace, so `stopwaitsecs` only protects supervisord-initiated restarts. Adding `stop_grace_period: 7260s` would turn a deploy during a long transcription into an up-to-2 h site outage (web + workers share the container), so it was deliberately not added — a job killed at swap time re-releases after `retry_after` (7260 s) and retries, now visibly in the dashboard.

Rollback: revert the supervisord block to `queue:work`, remove the package — Horizon stores metrics in Redis only, no schema changes.

## Verification

- Pint clean; PHPStan 0 errors (515 files).
- Full parallel suite: **5443 passed**. Dusk: **41 passed**.
- New `HorizonDashboardTest`: guest / non-admin / unverified admin → 403, verified admin → 200.
- Horizon boot-verified locally: `horizon:status` and `horizon:supervisor-status supervisor-media` both report running (also proves the `retry_after` invariant check passes).

## Outstanding

- [ ] Staging smoke test: one media-processing job end to end — appears in the dashboard, completes **once**, and a deliberately-failed job lands in Failed Jobs and is retryable from the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)