### PR TITLE
Fix missing admin layout on the service show page

### DIFF
--- a/app/Livewire/Admin/ChurchServices/ShowChurchService.php
+++ b/app/Livewire/Admin/ChurchServices/ShowChurchService.php
@@ -43,7 +43,13 @@ class ShowChurchService extends Component
     {
         $readModel = app(ChurchServiceShowPresenter::class)->present($this->churchService);
 
-        return view('livewire.admin.church-services.show-church-service', $readModel->toViewData());
+        $label = $this->churchService->date->format('j M Y').' '.$this->churchService->service->label();
+
+        return view('livewire.admin.church-services.show-church-service', $readModel->toViewData())
+            ->layout('layouts.admin', [
+                'title' => $label,
+                'heading' => $label,
+            ]);
     }
 
     public function reclassify(int $processingLogId): void

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -30,15 +30,17 @@ return [
 
     /*
     |---------------------------------------------------------------------------
-    | Layout
+    | Page Layout
     |---------------------------------------------------------------------------
     | The view that will be used as the layout when rendering a single component
     | as an entire page via `Route::get('/post/create', CreatePost::class);`.
     | In this case, the view returned by CreatePost will render into $slot.
+    | All current full-page components are admin pages, so the admin layout is
+    | the safe fallback when a component omits an explicit ->layout() call.
     |
     */
 
-    'layout' => 'components.layouts.app',
+    'component_layout' => 'layouts.admin',
 
     /*
     |---------------------------------------------------------------------------

--- a/tests/Feature/Admin/AdminLivewireAuthorizationTest.php
+++ b/tests/Feature/Admin/AdminLivewireAuthorizationTest.php
@@ -28,6 +28,8 @@ class AdminLivewireAuthorizationTest extends TestCase
 
     protected User $unverifiedAdmin;
 
+    protected User $verifiedAdmin;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -45,6 +47,11 @@ class AdminLivewireAuthorizationTest extends TestCase
         $this->unverifiedAdmin = User::factory()->create([
             'is_admin' => true,
             'email_verified_at' => null,
+        ]);
+
+        $this->verifiedAdmin = User::factory()->create([
+            'is_admin' => true,
+            'email_verified_at' => now(),
         ]);
     }
 
@@ -126,6 +133,27 @@ class AdminLivewireAuthorizationTest extends TestCase
         foreach ($this->adminLivewireRouteScenarios() as [$routeName, $parameters]) {
             $this->get(route($routeName, $parameters))
                 ->assertRedirect(route('verification.notice'));
+        }
+    }
+
+    #[Test]
+    public function verified_admin_users_can_render_routed_admin_livewire_components(): void
+    {
+        $this->actingAs($this->verifiedAdmin);
+
+        foreach ($this->adminLivewireRouteScenarios() as [$routeName, $parameters]) {
+            $response = $this->get(route($routeName, $parameters));
+
+            $this->assertSame(
+                200,
+                $response->getStatusCode(),
+                sprintf(
+                    '[%s] expected to render for a verified admin but returned %d: %s',
+                    $routeName,
+                    $response->getStatusCode(),
+                    $response->exception?->getMessage() ?? 'no exception',
+                ),
+            );
         }
     }
 


### PR DESCRIPTION
## Problem

Visiting `/admin/services/{id}` as an admin 500s with **"View [app] not found"** — hit in practice straight after uploading a service record, since the show page is the upload's landing destination.

Two causes stacked:

1. Commit `7de897678` ("April review 3.9") removed `->layout('layouts.admin', [...])` from `ShowChurchService::render()`. The `<x-admin.page>` wrapper it moved to is a page-header component, not an HTML document layout, so nothing replaced the call.
2. With no explicit layout, Livewire v4 falls back to `config('livewire.component_layout')`. Our published `config/livewire.php` was still the v3 file — its `'layout'` key is silently ignored by v4 — so the vendor default `layouts::app` applied, and `resources/views/layouts/app.blade.php` does not exist (only `admin` and `main`). The view finder reports just the leaf name of a namespaced view, hence the cryptic `[app]`.

## Why tests never caught it

- Happy-path coverage uses `Livewire::test()`, which renders the component in isolation — the page-layout wrapper only runs on full-page route dispatch.
- The HTTP tests for this route (`AdminLivewireAuthorizationTest`) only asserted the denied paths (guest redirect, non-admin 403, unverified redirect), all short-circuited by middleware before render.
- Action tests assert `assertRedirect(...)` to this route but never follow the redirect.

## Changes

- **`ShowChurchService::render()`** — restore `->layout('layouts.admin', [...])` with the service date + slot label as title/heading, matching `ShowSong`/`ManageChurchService`.
- **`config/livewire.php`** — replace the dead v3 `'layout'` key with `'component_layout' => 'layouts.admin'`, so a future forgotten `->layout()` renders correct admin chrome instead of a 500.
- **`AdminLivewireAuthorizationTest`** — new `verified_admin_users_can_render_routed_admin_livewire_components` test: GETs all 29 routed admin Livewire pages as a verified admin and asserts 200, with route-name + exception detail in the failure message.

## Verification

- Stashing the first two changes makes the new test fail at `admin.services.show` with the exact production error; restoring them turns it green — the test demonstrably catches this class of regression.
- Pint passed, PHPStan clean, full parallel suite 5,461 tests OK, Dusk 41 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)