### PR TITLE
Add Dusk smoke test for Livewire frontend hydration

### DIFF
--- a/tests/Browser/LivewireHydrationTest.php
+++ b/tests/Browser/LivewireHydrationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Browser;
+
+use Illuminate\Foundation\Testing\DatabaseTruncation;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+/**
+ * Smoke test that Livewire's JavaScript runtime actually boots and hydrates
+ * components in a real browser.
+ *
+ * Server-side tests (Livewire::test(), HTTP feature tests) never execute
+ * JavaScript, so a frontend/backend version mismatch — e.g. stale published
+ * assets in public/vendor/livewire shadowing the dynamic asset route — breaks
+ * every Livewire page while the whole PHPUnit suite stays green. This test
+ * closes that gap for any failure mode where livewire.js loads but cannot
+ * hydrate the server-rendered snapshots.
+ */
+class LivewireHydrationTest extends DuskTestCase
+{
+    use DatabaseTruncation;
+
+    public function test_livewire_runtime_hydrates_components_and_completes_an_update_roundtrip(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/login');
+
+            $browser->waitUsing(10, 100, function () use ($browser) {
+                return $browser->script(
+                    'return typeof window.Livewire !== "undefined" && window.Livewire.all().length > 0'
+                )[0];
+            }, 'Livewire JS runtime never registered any components — frontend assets may be stale, missing, or incompatible with the installed Livewire version.');
+
+            $unhydratedCount = $browser->script(
+                'return Array.from(document.querySelectorAll("*")).filter((el) => el.hasAttribute("wire:id") && ! el.__livewire).length'
+            )[0];
+
+            $this->assertSame(
+                0,
+                $unhydratedCount,
+                'Some server-rendered Livewire components were never hydrated client-side (e.g. "Snapshot missing" errors from mismatched frontend assets).'
+            );
+
+            $browser->script(<<<'JS'
+                window.__livewireRefreshResult = 'pending';
+                window.Livewire.all()[0].$wire.$refresh()
+                    .then(() => { window.__livewireRefreshResult = 'ok'; })
+                    .catch((error) => { window.__livewireRefreshResult = 'failed: ' + error; });
+            JS);
+
+            $browser->waitUsing(10, 100, function () use ($browser) {
+                return $browser->script('return window.__livewireRefreshResult')[0] === 'ok';
+            }, 'Livewire update roundtrip failed — the component could not re-render via the update endpoint.');
+        });
+    }
+}


### PR DESCRIPTION
## Why

Uploading a livestream broke locally with `Snapshot missing` / `Could not find Livewire component in DOM tree` console errors. Root cause: `public/vendor/livewire/` held assets published under Livewire 3 (June 2025) that silently shadowed the dynamic asset route after the Livewire 4 upgrade (`fece4d51c`, 2026-05-18). No test caught it because:

- PHPUnit/`Livewire::test()` never executes JavaScript — the frontend asset version is invisible to it.
- Dusk and Playwright run in CI on clean checkouts, where the gitignored stale directory doesn't exist.
- No existing browser test touched a Livewire component at all (zero `wire:` selectors in `tests/Browser/`).

The stale directory has been deleted locally (it was untracked; nothing in the repo or CI references it — Livewire 4 serves assets from its hashed dynamic route). This PR adds the missing guard.

## What

`tests/Browser/LivewireHydrationTest` visits `/login` (public page mounting a Livewire component, no fixtures needed) and asserts, in escalating order:

1. `window.Livewire` boots and registers at least one component.
2. Every server-rendered `wire:id` element is actually hydrated client-side (`el.__livewire` attached) — exactly what "Snapshot missing" prevents.
3. A `$wire.$refresh()` roundtrip through the update endpoint succeeds.

This catches the whole class of "Livewire JS loads but can't drive the page" failures: stale published assets, snapshot-format drift after upgrades, double Alpine/Livewire instances, blocked update endpoints.

## Validation

- Test fails correctly against deliberately sabotaged published assets, with a descriptive timeout message. (Gotcha found while validating: with `APP_DEBUG=false` — the Dusk env — Livewire serves `livewire.min.js`, not `livewire.js`, so both variants must be considered.)
- Pint passed, PHPStan clean, full parallel suite 5,460 tests OK, full Dusk suite 42 passed (54s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)