### PR TITLE
Fix Alpine x-init syntax error on autofocus inputs with wire:model

### DIFF
--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -25,7 +25,7 @@ $clearLabel = 'Clear ' . ($label ?: ($attributes->get('placeholder') ?: 'input')
 <div x-data="{ count: 0, limit: {{ $maxlength ?? 'null' }}, focused: false, showPassword: false }"
      x-init="
         count = $refs.input.value.length;
-        @if($autofocus) $nextTick(() => $refs.input.focus()) @endif
+        @if($autofocus) $nextTick(() => $refs.input.focus()); @endif
         @if($modelName)
             $watch('$wire.{{ $modelName }}', value => {
                 count = (value ?? '').toString().length;

--- a/tests/Browser/LivewireHydrationTest.php
+++ b/tests/Browser/LivewireHydrationTest.php
@@ -56,4 +56,37 @@ class LivewireHydrationTest extends DuskTestCase
             }, 'Livewire update roundtrip failed — the component could not re-render via the update endpoint.');
         });
     }
+
+    /**
+     * Alpine evaluates x-init/x-data expressions at boot; a malformed expression
+     * (e.g. Blade conditionals concatenating two statements without a separator)
+     * logs a SEVERE console error but leaves hydration intact, so the roundtrip
+     * test above stays green. This catches that failure mode.
+     */
+    public function test_login_page_boots_without_severe_javascript_console_errors(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->driver->manage()->getLog('browser');
+
+            $browser->visit('/login');
+
+            $browser->waitUsing(10, 100, function () use ($browser) {
+                return $browser->script(
+                    'return typeof window.Livewire !== "undefined" && window.Livewire.all().length > 0'
+                )[0];
+            }, 'Livewire JS runtime never booted on the login page.');
+
+            $severeEntries = array_values(array_filter(
+                $browser->driver->manage()->getLog('browser'),
+                fn (array $entry): bool => $entry['level'] === 'SEVERE'
+                    && in_array($entry['source'], ['javascript', 'console-api'], true)
+            ));
+
+            $this->assertSame(
+                [],
+                array_column($severeEntries, 'message'),
+                'JavaScript errors were logged while booting the login page.'
+            );
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- The `@if($autofocus)` branch of `x-input`'s `x-init` expression was missing a trailing semicolon, so on inputs that also have a `wire:model` (the login email field) the rendered JS concatenated `$nextTick(...)` and `$watch(...)` into one invalid statement: `Uncaught SyntaxError: Unexpected identifier '$watch'`. The error killed the entire `x-init` — no autofocus, no character-count sync.
- Adds a Dusk regression test to `LivewireHydrationTest` that asserts the login page boots without SEVERE `javascript`/`console-api` console entries. Alpine expression errors don't block Livewire hydration, so the existing roundtrip smoke test stayed green through this bug.

## Test plan
- [x] New test fails against the unfixed component with exactly the reported error, passes with the fix
- [x] `vendor/bin/sail artisan dusk --filter=LivewireHydrationTest` (2 passed)
- [x] `vendor/bin/sail artisan dusk tests/Browser/Auth/LoginTest.php` (5 passed)
- [x] `vendor/bin/sail bin pint --dirty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)