### PR TITLE
Fix console noise: Permissions-Policy warning and unused pattern.svg preload

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -38,8 +38,10 @@ class SecurityHeaders
         }
 
         // Security Header: Permissions Policy
-        // Restricts sensitive browser features that this application does not use
-        $response->headers->set('Permissions-Policy', 'accelerometer=(), ambient-light-sensor=(), camera=(), display-capture=(), gamepad=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()');
+        // Restricts sensitive browser features that this application does not use.
+        // ambient-light-sensor is deliberately absent: Chrome never shipped it as a
+        // Permissions-Policy feature and logs "Unrecognized feature" on every page.
+        $response->headers->set('Permissions-Policy', 'accelerometer=(), camera=(), display-capture=(), gamepad=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()');
 
         // Security Header: Content Security Policy (CSP)
         // Provides an additional layer of security by restricting where resources can be loaded from.

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -52,7 +52,7 @@
   @endif
 
   {{-- Preload hints for critical resources --}}
-  <link rel="preload" as="image" href="/svg/pattern.svg">
+  <link rel="preload" as="image" href="{{ Vite::asset('resources/svg/pattern.svg') }}">
   @yield('preload')
 
   <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png?v=GvJNbAA7Wv">

--- a/tests/Feature/BladeShellRenderingTest.php
+++ b/tests/Feature/BladeShellRenderingTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature;
 use App\Models\Page;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Vite;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -131,6 +132,21 @@ class BladeShellRenderingTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('<title>Calendar Patterns | Crockenhill Baptist Church</title>', false);
+    }
+
+    #[Test]
+    public function layout_preloads_the_vite_built_pattern_asset(): void
+    {
+        $response = $this->get('/login');
+
+        $response->assertOk();
+        $response->assertSee(
+            '<link rel="preload" as="image" href="'.Vite::asset('resources/svg/pattern.svg').'">',
+            false
+        );
+        // The unhashed public copy is never referenced by the built CSS; preloading
+        // it downloads the pattern twice and logs an unused-preload warning.
+        $response->assertDontSee('href="/svg/pattern.svg"', false);
     }
 
     #[Test]

--- a/tests/Feature/Security/SecurityHeadersTest.php
+++ b/tests/Feature/Security/SecurityHeadersTest.php
@@ -18,7 +18,7 @@ class SecurityHeadersTest extends TestCase
         $response->assertHeader('X-Frame-Options', 'SAMEORIGIN');
         $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
         $response->assertHeader('X-XSS-Protection', '0');
-        $response->assertHeader('Permissions-Policy', 'accelerometer=(), ambient-light-sensor=(), camera=(), display-capture=(), gamepad=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()');
+        $response->assertHeader('Permissions-Policy', 'accelerometer=(), camera=(), display-capture=(), gamepad=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()');
         $response->assertHeader('Content-Security-Policy');
     }
 
@@ -31,7 +31,7 @@ class SecurityHeadersTest extends TestCase
         $response->assertHeader('X-Frame-Options', 'SAMEORIGIN');
         $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
         $response->assertHeader('X-XSS-Protection', '0');
-        $response->assertHeader('Permissions-Policy', 'accelerometer=(), ambient-light-sensor=(), camera=(), display-capture=(), gamepad=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()');
+        $response->assertHeader('Permissions-Policy', 'accelerometer=(), camera=(), display-capture=(), gamepad=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()');
         $response->assertHeader('Content-Security-Policy');
     }
 


### PR DESCRIPTION
## Summary
Removes the two console messages logged on every page load:

- **`Error with Permissions-Policy header: Unrecognized feature: 'ambient-light-sensor'`** — Chrome never shipped `ambient-light-sensor` as a Permissions-Policy feature, so the directive was a no-op that logged a warning. Removed it from `SecurityHeaders`; all other restrictions are unchanged.
- **`The resource /svg/pattern.svg was preloaded ... but not used`** — the built CSS references the Vite-hashed `/build/assets/pattern-*.svg`, so the layout's preload of the unhashed `/svg/pattern.svg` fetched a second copy of the pattern that nothing ever used. The preload now resolves the real URL via `Vite::asset('resources/svg/pattern.svg')`, keeping the early-fetch benefit for the header/footer background.

## Test plan
- [x] Updated `SecurityHeadersTest` expectations for the new header value
- [x] New `BladeShellRenderingTest` assertion: layout preloads the manifest-resolved pattern URL and no longer references `/svg/pattern.svg`
- [x] `vendor/bin/sail bin pint --dirty` / `vendor/bin/sail composer phpstan` (clean)
- [x] Full parallel suite: 5,462 passed
- [x] Full Dusk suite: 42 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)