### PR TITLE
Services hub: attention strip, pipeline rollup, This Sunday hero, and Add menu (consolidation P1)

### DIFF
--- a/app/Enums/ChurchServiceRollupStatus.php
+++ b/app/Enums/ChurchServiceRollupStatus.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Rolled-up pipeline status for a ChurchService, shown as a single chip on
+ * the services hub. Derived by ChurchServiceRollupQuery; precedence (first
+ * match wins): Processing, NeedsReview, Published, Ready. When no livestream
+ * run matches the service and nothing needs attention, the date decides:
+ * today or future = PlanOnly (nothing expected yet), past = AwaitingRecording
+ * (a recording is overdue).
+ *
+ * Colour discipline: amber = needs a human, teal = done/ready, sky = machine
+ * working, slate = inert (plan-only).
+ */
+enum ChurchServiceRollupStatus: string
+{
+    case PlanOnly = 'plan_only';
+    case AwaitingRecording = 'awaiting_recording';
+    case Processing = 'processing';
+    case NeedsReview = 'needs_review';
+    case Ready = 'ready';
+    case Published = 'published';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::PlanOnly => 'Plan only',
+            self::AwaitingRecording => 'Awaiting recording',
+            self::Processing => 'Processing',
+            self::NeedsReview => 'Needs review',
+            self::Ready => 'Ready',
+            self::Published => 'Published',
+        };
+    }
+
+    public function badgeClasses(): string
+    {
+        return match ($this) {
+            self::PlanOnly => 'bg-slate-200 text-slate-800',
+            self::AwaitingRecording => 'bg-slate-200 text-slate-700',
+            self::Processing => 'bg-sky-100 text-sky-800',
+            self::NeedsReview => 'bg-amber-100 text-amber-800',
+            self::Ready => 'bg-cbc-teal-light/15 text-cbc-teal-dark',
+            self::Published => 'bg-cbc-teal text-white',
+        };
+    }
+
+    public function needsAttention(): bool
+    {
+        return $this === self::NeedsReview;
+    }
+}

--- a/app/Http/Controllers/MemberController.php
+++ b/app/Http/Controllers/MemberController.php
@@ -4,36 +4,21 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use App\Enums\InboundEmailStatus;
-use App\Models\InboundEmail;
-use App\Models\MediaProcessingLog;
+use App\Queries\AdminAttentionCounts;
 use Illuminate\Contracts\View\View;
 
 class MemberController extends Controller
 {
-    public function __invoke(): View
+    public function __invoke(AdminAttentionCounts $attentionCounts): View
     {
         $isAdmin = auth()->user()?->canAccessAdmin() === true;
 
-        $pendingInboundEmailCount = $isAdmin
-            ? InboundEmail::query()
-                ->whereIn('status', [
-                    InboundEmailStatus::Pending->value,
-                    InboundEmailStatus::Failed->value,
-                ])
-                ->count()
-            : 0;
-
-        $pendingSermonReviewCount = $isAdmin
-            ? MediaProcessingLog::query()
-                ->awaitingManualSermonReview()
-                ->count()
-            : 0;
+        $counts = $isAdmin ? $attentionCounts->cached() : null;
 
         return view('members.home', [
             'heading' => 'Members',
-            'pendingInboundEmailCount' => $pendingInboundEmailCount,
-            'pendingSermonReviewCount' => $pendingSermonReviewCount,
+            'pendingInboundEmailCount' => $counts['pending_emails'] ?? 0,
+            'pendingSermonReviewCount' => $counts['awaiting_segment_runs'] ?? 0,
         ]);
     }
 }

--- a/app/Livewire/Admin/ChurchServices/ListChurchServices.php
+++ b/app/Livewire/Admin/ChurchServices/ListChurchServices.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace App\Livewire\Admin\ChurchServices;
 
+use App\Enums\ChurchServiceRollupStatus;
 use App\Enums\SermonService;
 use App\Livewire\Traits\WithAdminAuthorization;
 use App\Livewire\Traits\WithSortableListing;
 use App\Models\ChurchService;
+use App\Queries\AdminAttentionCounts;
+use App\Queries\ChurchServiceRollupQuery;
 use App\Traits\EscapesLikeWildcards;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\View\View;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -31,6 +35,18 @@ class ListChurchServices extends Component
         'created_at',
         'updated_at',
     ];
+
+    /**
+     * Columns the hub needs per row. `import_metadata` is included because the
+     * run matcher harvests fallback processing ids from it (contract C2).
+     */
+    protected const LIST_COLUMNS = [
+        'id', 'date', 'service', 'source', 'original_filename', 'needs_review', 'updated_at',
+        'pending_structure_merge_source', 'import_metadata',
+    ];
+
+    /** Days either side of today considered for the "This Sunday" hero. */
+    protected const HERO_WINDOW_DAYS = 7;
 
     #[Url(except: '')]
     public string $search = '';
@@ -73,7 +89,7 @@ class ListChurchServices extends Component
         $this->resetPage();
     }
 
-    public function render(): View
+    public function render(ChurchServiceRollupQuery $rollupQuery, AdminAttentionCounts $attentionCounts): View
     {
         $this->sanitizeSorting();
 
@@ -89,10 +105,7 @@ class ListChurchServices extends Component
          * to reduce memory usage and DB I/O. Search terms are escaped to prevent LIKE injection.
          */
         $churchServices = ChurchService::query()
-            ->select([
-                'id', 'date', 'service', 'source', 'original_filename', 'needs_review', 'updated_at',
-                'pending_structure_merge_source',
-            ])
+            ->select(self::LIST_COLUMNS)
             ->withCount('items')
             ->when($search !== '', function (Builder $query) use ($search, $escapedSearch): void {
                 $query->where(function (Builder $searchQuery) use ($search, $escapedSearch): void {
@@ -116,11 +129,23 @@ class ListChurchServices extends Component
             ->orderBy($this->sortBy, $this->sortDirection === 'desc' ? 'desc' : 'asc')
             ->paginate(20);
 
+        /** @var EloquentCollection<int, ChurchService> $pageServices */
+        $pageServices = $churchServices->getCollection();
+
+        $heroCandidates = $this->heroCandidates();
+
+        /** @var EloquentCollection<int, ChurchService> $rollupInput */
+        $rollupInput = $pageServices->concat($heroCandidates)->unique('id')->values();
+
+        $rollups = $rollupQuery->forServices($rollupInput);
+
+        $heroService = $this->selectHeroService($heroCandidates, $rollups);
+
         $headers = [
             ['key' => 'date', 'label' => 'Service', 'sortable' => true],
             ['key' => 'items', 'label' => 'Items', 'sortable' => false],
             ['key' => 'source', 'label' => 'Source', 'sortable' => true],
-            ['key' => 'needs_review', 'label' => 'Review', 'sortable' => true],
+            ['key' => 'needs_review', 'label' => 'Status', 'sortable' => true],
             ['key' => 'updated_at', 'label' => 'Uploaded', 'sortable' => true],
         ];
 
@@ -128,7 +153,96 @@ class ListChurchServices extends Component
             'churchServices' => $churchServices,
             'services' => SermonService::cases(),
             'headers' => $headers,
+            'rollups' => $rollups,
+            'attentionChips' => $this->attentionChips($attentionCounts->counts()),
+            'heroService' => $heroService,
+            'heroRollup' => $heroService !== null ? ($rollups[$heroService->id] ?? null) : null,
+            'heroIsCurrent' => $heroService !== null && $this->isWithinHeroWindow($heroService),
         ])->layout('layouts.admin', ['title' => 'Services', 'heading' => 'Services']);
+    }
+
+    /**
+     * @param  array{pending_emails: int, awaiting_segment_runs: int, flagged_sections: int, pending_merges: int, services_needing_review: int}  $counts
+     * @return list<array{label: string, count: int, href: string}>
+     */
+    private function attentionChips(array $counts): array
+    {
+        return [
+            ['label' => 'Inbound emails', 'count' => $counts['pending_emails'], 'href' => route('admin.services.inbound-emails')],
+            ['label' => 'Sermon segments', 'count' => $counts['awaiting_segment_runs'], 'href' => route('admin.services.processing.review.index')],
+            ['label' => 'Flagged sections', 'count' => $counts['flagged_sections'], 'href' => route('admin.services.review')],
+            ['label' => 'Pending merges', 'count' => $counts['pending_merges'], 'href' => route('admin.services.review')],
+            ['label' => 'Services needing review', 'count' => $counts['services_needing_review'], 'href' => route('admin.services.index', ['needsReviewFilter' => 1])],
+        ];
+    }
+
+    /**
+     * Hero candidates: services dated within ±7 days of today, or failing
+     * that the most recent past service.
+     *
+     * @return EloquentCollection<int, ChurchService>
+     */
+    private function heroCandidates(): EloquentCollection
+    {
+        $window = ChurchService::query()
+            ->select(self::LIST_COLUMNS)
+            ->withCount('items')
+            ->whereBetween('date', [
+                now()->subDays(self::HERO_WINDOW_DAYS)->toDateString(),
+                now()->addDays(self::HERO_WINDOW_DAYS)->toDateString(),
+            ])
+            ->get();
+
+        if ($window->isNotEmpty()) {
+            return $window;
+        }
+
+        return ChurchService::query()
+            ->select(self::LIST_COLUMNS)
+            ->withCount('items')
+            ->whereDate('date', '<=', now()->toDateString())
+            ->orderByDesc('date')
+            ->orderBy('service')
+            ->limit(1)
+            ->get();
+    }
+
+    /**
+     * Pick the hero: closest to today, tie-breaking on needs-attention
+     * (non-zero rollup attention count) first, then most recent date.
+     *
+     * @param  EloquentCollection<int, ChurchService>  $candidates
+     * @param  array<int, array{status: ChurchServiceRollupStatus, attention_count: int, run_count: int, steps: list<array{label: string, state: string}>}>  $rollups
+     */
+    private function selectHeroService(EloquentCollection $candidates, array $rollups): ?ChurchService
+    {
+        if ($candidates->isEmpty()) {
+            return null;
+        }
+
+        $today = now()->startOfDay();
+
+        return $candidates
+            ->sort(function (ChurchService $left, ChurchService $right) use ($rollups, $today): int {
+                $distance = (int) abs($today->diffInDays($left->date)) <=> (int) abs($today->diffInDays($right->date));
+                if ($distance !== 0) {
+                    return $distance;
+                }
+
+                $leftAttention = ($rollups[$left->id]['attention_count'] ?? 0) > 0;
+                $rightAttention = ($rollups[$right->id]['attention_count'] ?? 0) > 0;
+                if ($leftAttention !== $rightAttention) {
+                    return $rightAttention <=> $leftAttention;
+                }
+
+                return $right->date <=> $left->date;
+            })
+            ->first();
+    }
+
+    private function isWithinHeroWindow(ChurchService $service): bool
+    {
+        return (int) abs(now()->startOfDay()->diffInDays($service->date)) <= self::HERO_WINDOW_DAYS;
     }
 
     private function abortIfDisabled(): void

--- a/app/Queries/AdminAttentionCounts.php
+++ b/app/Queries/AdminAttentionCounts.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Enums\InboundEmailStatus;
+use App\Models\ChurchService;
+use App\Models\InboundEmail;
+use App\Models\MediaProcessingLog;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Shared attention counts for the services hub strip and the members-home
+ * badge. Every count is computed from the same code path that produces the
+ * corresponding queue rows (contract C1) — in particular, flagged sections
+ * use the dashboard query's seven-reason review-candidate predicate, not a
+ * raw pending_approval count.
+ *
+ * The hub computes fresh via counts(); the high-traffic members home reads
+ * the briefly cached copy via cached() — a stale badge is acceptable, a
+ * wrong predicate is not.
+ */
+class AdminAttentionCounts
+{
+    private const CACHE_KEY = 'admin-attention-counts';
+
+    private const CACHE_SECONDS = 60;
+
+    public function __construct(
+        private readonly ServiceReviewDashboardQuery $dashboardQuery,
+    ) {}
+
+    /**
+     * @return array{
+     *     pending_emails: int,
+     *     awaiting_segment_runs: int,
+     *     flagged_sections: int,
+     *     pending_merges: int,
+     *     services_needing_review: int
+     * }
+     */
+    public function counts(): array
+    {
+        if (! (bool) config('service-tracking.enabled', true)) {
+            return [
+                'pending_emails' => 0,
+                'awaiting_segment_runs' => 0,
+                'flagged_sections' => 0,
+                'pending_merges' => 0,
+                'services_needing_review' => 0,
+            ];
+        }
+
+        return [
+            'pending_emails' => InboundEmail::query()
+                ->whereIn('status', [
+                    InboundEmailStatus::Pending->value,
+                    InboundEmailStatus::Failed->value,
+                ])
+                ->count(),
+            'awaiting_segment_runs' => MediaProcessingLog::query()
+                ->awaitingManualSermonReview()
+                ->count(),
+            'flagged_sections' => $this->flaggedSectionCount(),
+            'pending_merges' => $this->dashboardQuery->pendingMergeCount(),
+            'services_needing_review' => ChurchService::query()
+                ->where('needs_review', true)
+                ->count(),
+        ];
+    }
+
+    /**
+     * Briefly cached copy for the members-home badge call site only.
+     *
+     * @return array{
+     *     pending_emails: int,
+     *     awaiting_segment_runs: int,
+     *     flagged_sections: int,
+     *     pending_merges: int,
+     *     services_needing_review: int
+     * }
+     */
+    public function cached(): array
+    {
+        return Cache::remember(self::CACHE_KEY, self::CACHE_SECONDS, fn (): array => $this->counts());
+    }
+
+    /**
+     * @param  array{pending_emails: int, awaiting_segment_runs: int, flagged_sections: int, pending_merges: int, services_needing_review: int}|null  $counts
+     */
+    public function total(?array $counts = null): int
+    {
+        return array_sum($counts ?? $this->counts());
+    }
+
+    private function flaggedSectionCount(): int
+    {
+        if (! (bool) config('media-processing.section_publishing.enabled', true)) {
+            return 0;
+        }
+
+        return $this->dashboardQuery->reviewCandidateSectionCount();
+    }
+}

--- a/app/Queries/ChurchServiceProcessingRunQuery.php
+++ b/app/Queries/ChurchServiceProcessingRunQuery.php
@@ -6,15 +6,14 @@ namespace App\Queries;
 
 use App\Models\ChurchService;
 use App\Models\MediaProcessingLog;
-use App\Services\Processing\MediaProcessingIdentityResolver;
 use App\Support\ChurchServiceProcessingTimeline;
-use Illuminate\Database\Eloquent\Builder;
+use App\Support\ChurchServiceRunMatcher;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 class ChurchServiceProcessingRunQuery
 {
     public function __construct(
-        private readonly MediaProcessingIdentityResolver $identityResolver,
+        private readonly ChurchServiceRunMatcher $runMatcher,
     ) {}
 
     /**
@@ -22,9 +21,7 @@ class ChurchServiceProcessingRunQuery
      */
     public function forService(ChurchService $churchService): EloquentCollection
     {
-        $serviceDate = $churchService->date->toDateString();
-        $serviceType = $churchService->service;
-        $fallbackProcessingIds = $this->fallbackProcessingIdsForService($churchService);
+        $fallbackProcessingIds = $this->runMatcher->fallbackProcessingIdsForService($churchService);
 
         return MediaProcessingLog::query()
             ->livestream()
@@ -41,56 +38,13 @@ class ChurchServiceProcessingRunQuery
                     ->orderBy('started_at')
                     ->orderBy('id'),
             ])
-            ->where(function (Builder $query) use ($churchService, $fallbackProcessingIds, $serviceDate, $serviceType): void {
-                $this->identityResolver->scopeMatchesIdentity($query, $serviceDate, $serviceType);
-
-                $query->orWhere('church_service_id', $churchService->id);
-
-                if ($fallbackProcessingIds !== []) {
-                    $query->orWhereIn('processing_id', $fallbackProcessingIds);
-                }
-            })
+            ->tap(fn ($query) => $this->runMatcher->applyMatchClauses($query, $churchService, $fallbackProcessingIds))
             ->orderByDesc('created_at')
             ->get();
     }
 
     public function matchesService(MediaProcessingLog $processingLog, ChurchService $churchService): bool
     {
-        $serviceDate = $churchService->date->toDateString();
-        $serviceType = $churchService->service;
-
-        if ($this->identityResolver->matchesService($processingLog, $serviceDate, $serviceType)) {
-            return true;
-        }
-
-        if ($processingLog->church_service_id === $churchService->id) {
-            return true;
-        }
-
-        return in_array($processingLog->processing_id, $this->fallbackProcessingIdsForService($churchService), true);
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function fallbackProcessingIdsForService(ChurchService $churchService): array
-    {
-        $churchService->loadMissing('items');
-
-        $processingIds = [];
-
-        foreach ($churchService->items as $item) {
-            if (is_string($item->livestream_processing_id) && trim($item->livestream_processing_id) !== '') {
-                $processingIds[] = $item->livestream_processing_id;
-            }
-        }
-
-        $serviceMetadata = $churchService->import_metadata?->toArray() ?? [];
-        $serviceProjection = $serviceMetadata['livestream_projection'] ?? [];
-        if (is_string($serviceProjection['processing_id'] ?? null) && trim($serviceProjection['processing_id']) !== '') {
-            $processingIds[] = $serviceProjection['processing_id'];
-        }
-
-        return array_values(array_unique($processingIds));
+        return $this->runMatcher->matches($processingLog, $churchService);
     }
 }

--- a/app/Queries/ChurchServiceRollupQuery.php
+++ b/app/Queries/ChurchServiceRollupQuery.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Enums\ChurchServiceRollupStatus;
+use App\Enums\ProcessingStatus;
+use App\Enums\ServiceSectionPublicationStatus;
+use App\Models\ChurchService;
+use App\Models\MediaProcessingLog;
+use App\Models\ServiceSection;
+use App\Support\ChurchServiceRunMatcher;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
+
+/**
+ * Bulk pipeline rollup for the services hub: one run query for a whole page
+ * of services (no N+1), aggregated into a single ChurchServiceRollupStatus
+ * chip plus pipeline-stepper states per service.
+ */
+class ChurchServiceRollupQuery
+{
+    /**
+     * Safe column list for media_processing_logs (TD-004B): the table carries
+     * oversized JSON blobs (visual_samples, song_clusters, rms_stats,
+     * ai_analysis) that must never be hydrated for list/rollup rendering.
+     *
+     * @var list<string>
+     */
+    private const RUN_COLUMNS = [
+        'id',
+        'processing_id',
+        'processing_type',
+        'status',
+        'current_step',
+        'error_message',
+        'original_filename',
+        'extracted_date',
+        'extracted_service',
+        'processing_metadata',
+        'sermon_id',
+        'church_service_id',
+        'created_at',
+        'updated_at',
+    ];
+
+    public function __construct(
+        private readonly ChurchServiceRunMatcher $runMatcher,
+        private readonly ServiceReviewDashboardQuery $dashboardQuery,
+    ) {}
+
+    /**
+     * @param  EloquentCollection<int, ChurchService>  $services
+     * @return array<int, array{
+     *     status: ChurchServiceRollupStatus,
+     *     attention_count: int,
+     *     run_count: int,
+     *     steps: list<array{label: string, state: string}>
+     * }>
+     */
+    public function forServices(EloquentCollection $services): array
+    {
+        if ($services->isEmpty()) {
+            return [];
+        }
+
+        $services->loadMissing('items');
+
+        /** @var array<int, list<string>> $fallbackProcessingIds */
+        $fallbackProcessingIds = $services
+            ->mapWithKeys(fn (ChurchService $service): array => [
+                $service->id => $this->runMatcher->fallbackProcessingIdsForService($service),
+            ])
+            ->all();
+
+        $runs = $this->matchingRuns($services, $fallbackProcessingIds);
+
+        $rollups = [];
+
+        foreach ($services as $service) {
+            $serviceRuns = $runs->filter(
+                fn (MediaProcessingLog $run): bool => $this->runMatcher->matches($run, $service, $fallbackProcessingIds[$service->id])
+            )->values();
+
+            $rollups[$service->id] = $this->rollup($service, $serviceRuns);
+        }
+
+        return $rollups;
+    }
+
+    /**
+     * @param  EloquentCollection<int, ChurchService>  $services
+     * @param  array<int, list<string>>  $fallbackProcessingIds
+     * @return EloquentCollection<int, MediaProcessingLog>
+     */
+    private function matchingRuns(EloquentCollection $services, array $fallbackProcessingIds): EloquentCollection
+    {
+        return MediaProcessingLog::query()
+            ->select(self::RUN_COLUMNS)
+            ->livestream()
+            ->with([
+                'serviceSections' => fn ($query) => $query
+                    ->orderBy('section_order')
+                    ->orderBy('id'),
+            ])
+            ->where(function (Builder $query) use ($services, $fallbackProcessingIds): void {
+                foreach ($services as $service) {
+                    $query->orWhere(function (Builder $query) use ($service, $fallbackProcessingIds): void {
+                        $this->runMatcher->applyMatchClauses($query, $service, $fallbackProcessingIds[$service->id]);
+                    });
+                }
+            })
+            ->get();
+    }
+
+    /**
+     * @param  Collection<int, MediaProcessingLog>  $serviceRuns
+     * @return array{
+     *     status: ChurchServiceRollupStatus,
+     *     attention_count: int,
+     *     run_count: int,
+     *     steps: list<array{label: string, state: string}>
+     * }
+     */
+    private function rollup(ChurchService $service, Collection $serviceRuns): array
+    {
+        /** @var Collection<int, ServiceSection> $sections */
+        $sections = $serviceRuns->flatMap(fn (MediaProcessingLog $run) => $run->serviceSections);
+
+        $flaggedSectionCount = $this->sectionPublishingEnabled()
+            ? $sections->filter(fn (ServiceSection $section): bool => $this->dashboardQuery->isReviewCandidate($section))->count()
+            : 0;
+
+        $awaitingSegmentRunCount = $serviceRuns
+            ->filter(fn (MediaProcessingLog $run): bool => $run->requiresManualSermonReview())
+            ->count();
+
+        $attentionCount = $flaggedSectionCount
+            + $awaitingSegmentRunCount
+            + ($service->needs_review ? 1 : 0)
+            + ($service->pending_structure_merge_source !== null ? 1 : 0);
+
+        $isProcessing = $serviceRuns->contains(
+            fn (MediaProcessingLog $run): bool => in_array($run->status, [
+                ProcessingStatus::Pending,
+                ProcessingStatus::Started,
+                ProcessingStatus::Processing,
+            ], true)
+        );
+
+        $hasCompletedRun = $serviceRuns->contains(
+            fn (MediaProcessingLog $run): bool => $run->status === ProcessingStatus::Completed
+        );
+
+        $hasSermon = $serviceRuns->contains(fn (MediaProcessingLog $run): bool => $run->sermon_id !== null)
+            || $sections->contains(fn (ServiceSection $section): bool => $section->published_sermon_id !== null);
+
+        $allSectionsResolved = $sections->isNotEmpty() && $sections->every(
+            fn (ServiceSection $section): bool => in_array($section->publication_status, [
+                ServiceSectionPublicationStatus::Published,
+                ServiceSectionPublicationStatus::NotApplicable,
+            ], true)
+        );
+
+        $status = match (true) {
+            $isProcessing => ChurchServiceRollupStatus::Processing,
+            $attentionCount > 0 => ChurchServiceRollupStatus::NeedsReview,
+            $serviceRuns->isEmpty() => $service->date->isPast() && ! $service->date->isToday()
+                ? ChurchServiceRollupStatus::AwaitingRecording
+                : ChurchServiceRollupStatus::PlanOnly,
+            $allSectionsResolved && $hasSermon => ChurchServiceRollupStatus::Published,
+            default => ChurchServiceRollupStatus::Ready,
+        };
+
+        return [
+            'status' => $status,
+            'attention_count' => $attentionCount,
+            'run_count' => $serviceRuns->count(),
+            'steps' => $this->steps($service, $status, $serviceRuns->isNotEmpty(), $hasCompletedRun, $attentionCount),
+        ];
+    }
+
+    /**
+     * Stepper states for x-admin.pipeline-steps: done|active|blocked|todo.
+     *
+     * @return list<array{label: string, state: string}>
+     */
+    private function steps(
+        ChurchService $service,
+        ChurchServiceRollupStatus $status,
+        bool $hasRuns,
+        bool $hasCompletedRun,
+        int $attentionCount
+    ): array {
+        $reviewState = match (true) {
+            $attentionCount > 0 => 'blocked',
+            $hasCompletedRun => 'done',
+            default => 'todo',
+        };
+
+        return [
+            ['label' => 'Plan', 'state' => $service->items->isNotEmpty() ? 'done' : 'todo'],
+            ['label' => 'Recording', 'state' => $hasRuns ? 'done' : 'todo'],
+            ['label' => 'Processed', 'state' => match (true) {
+                $status === ChurchServiceRollupStatus::Processing => 'active',
+                $hasCompletedRun => 'done',
+                default => 'todo',
+            }],
+            ['label' => 'Review', 'state' => $reviewState],
+            ['label' => 'Published', 'state' => $status === ChurchServiceRollupStatus::Published ? 'done' : 'todo'],
+        ];
+    }
+
+    private function sectionPublishingEnabled(): bool
+    {
+        return (bool) config('media-processing.section_publishing.enabled', true);
+    }
+}

--- a/app/Queries/ServiceReviewDashboardQuery.php
+++ b/app/Queries/ServiceReviewDashboardQuery.php
@@ -181,6 +181,17 @@ class ServiceReviewDashboardQuery
         ];
     }
 
+    /**
+     * Count of review-candidate sections, derived from the same seven-reason
+     * predicate that builds reviewGroups() — never a cheaper SQL approximation,
+     * so the hub strip, review inbox, and members-home badge cannot disagree.
+     */
+    public function reviewCandidateSectionCount(): int
+    {
+        return collect($this->reviewGroups())
+            ->sum(fn (array $group): int => count($group['sections']));
+    }
+
     public function pendingMergeCount(): int
     {
         return ChurchService::query()

--- a/app/Support/ChurchServiceRunMatcher.php
+++ b/app/Support/ChurchServiceRunMatcher.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Models\ChurchService;
+use App\Models\MediaProcessingLog;
+use App\Services\Processing\MediaProcessingIdentityResolver;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Single source of truth for deciding whether a MediaProcessingLog belongs to
+ * a ChurchService. A run matches when ANY of three paths hit:
+ *
+ *  (a) extracted date + service slot identity match,
+ *  (b) explicit `church_service_id` foreign key,
+ *  (c) fallback processing ids harvested from `items.livestream_processing_id`
+ *      and `import_metadata.livestream_projection.processing_id` (repaired runs).
+ *
+ * Both ChurchServiceProcessingRunQuery (per-service detail page) and
+ * ChurchServiceRollupQuery (bulk hub rollup) consume this class so the
+ * repaired-run regression coverage keeps one implementation honest.
+ */
+class ChurchServiceRunMatcher
+{
+    public function __construct(
+        private readonly MediaProcessingIdentityResolver $identityResolver,
+    ) {}
+
+    /**
+     * Add the three-path match clauses as a nested where group.
+     *
+     * Callers resolve the fallback ids up front so bulk consumers can harvest
+     * them from an already eager-loaded `items` relation without per-row queries.
+     *
+     * @param  Builder<MediaProcessingLog>  $query
+     * @param  list<string>  $fallbackProcessingIds
+     */
+    public function applyMatchClauses(Builder $query, ChurchService $churchService, array $fallbackProcessingIds): void
+    {
+        $serviceDate = $churchService->date->toDateString();
+        $serviceType = $churchService->service;
+
+        $query->where(function (Builder $query) use ($churchService, $fallbackProcessingIds, $serviceDate, $serviceType): void {
+            $this->identityResolver->scopeMatchesIdentity($query, $serviceDate, $serviceType);
+
+            $query->orWhere('church_service_id', $churchService->id);
+
+            if ($fallbackProcessingIds !== []) {
+                $query->orWhereIn('processing_id', $fallbackProcessingIds);
+            }
+        });
+    }
+
+    /**
+     * @param  list<string>|null  $fallbackProcessingIds  pass pre-harvested ids in bulk paths
+     */
+    public function matches(MediaProcessingLog $processingLog, ChurchService $churchService, ?array $fallbackProcessingIds = null): bool
+    {
+        $fallbackProcessingIds ??= $this->fallbackProcessingIdsForService($churchService);
+
+        if ($this->identityResolver->matchesService($processingLog, $churchService->date->toDateString(), $churchService->service)) {
+            return true;
+        }
+
+        if ($processingLog->church_service_id === $churchService->id) {
+            return true;
+        }
+
+        return in_array($processingLog->processing_id, $fallbackProcessingIds, true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function fallbackProcessingIdsForService(ChurchService $churchService): array
+    {
+        $churchService->loadMissing('items');
+
+        $processingIds = [];
+
+        foreach ($churchService->items as $item) {
+            if (is_string($item->livestream_processing_id) && trim($item->livestream_processing_id) !== '') {
+                $processingIds[] = $item->livestream_processing_id;
+            }
+        }
+
+        $serviceMetadata = $churchService->import_metadata?->toArray() ?? [];
+        $serviceProjection = $serviceMetadata['livestream_projection'] ?? [];
+        if (is_string($serviceProjection['processing_id'] ?? null) && trim($serviceProjection['processing_id']) !== '') {
+            $processingIds[] = $serviceProjection['processing_id'];
+        }
+
+        return array_values(array_unique($processingIds));
+    }
+}

--- a/docs/plans/SERVICE-UI-CONSOLIDATION-2026-06-10.md
+++ b/docs/plans/SERVICE-UI-CONSOLIDATION-2026-06-10.md
@@ -1,0 +1,507 @@
+# Service & Livestream UI Consolidation — Implementation Plan
+
+Created 2026-06-10. **Amended same day after a Codex review** — the amendments tighten the
+read-model contracts (single-source-of-truth counts, three-path run matching, blob-column
+safety, per-action authorization, config-gate matrix) so the consolidation cannot silently lose
+the existing matching/counting/performance semantics. Approved direction: reorganise the
+service/livestream admin UI around **the service** (the Sunday) instead of around pipeline
+tables, consolidating 13 surfaces into 6.
+
+## Background
+
+The service/media admin area has grown one page per pipeline table. Today an admin juggles:
+
+| # | Route | Component | Role |
+|---|-------|-----------|------|
+| 1 | `/admin/sermon-upload` | [MediaUpload](../../app/Livewire/MediaUpload.php) | Upload recording (audio/video/livestream) |
+| 2 | `/admin/services/upload` | [UploadChurchService](../../app/Livewire/Admin/ChurchServices/UploadChurchService.php) | Upload OpenLP `.osz` plan |
+| 3 | `/admin/services/submit-email` | [SubmitEmailText](../../app/Livewire/Admin/ChurchServices/SubmitEmailText.php) | Paste order-of-service email |
+| 4 | `/admin/services/create`, `/{id}/edit` | [ManageChurchService](../../app/Livewire/Admin/ChurchServices/ManageChurchService.php) | Manual plan entry / item editing |
+| 5 | `/admin/services/inbound-emails` | [ReviewInboundEmails](../../app/Livewire/Admin/ChurchServices/ReviewInboundEmails.php) | Approve low-confidence email parses |
+| 6 | `/admin/services/review` | [ServiceReviewDashboard](../../app/Livewire/Admin/ChurchServices/ServiceReviewDashboard.php) | Flagged sections grouped by service; edit/approve/merge |
+| 7 | `/admin/services/section-publications` | [ListSectionPublications](../../app/Livewire/Admin/ChurchServices/ListSectionPublications.php) | The same sections, by publication status |
+| 8 | `/admin/services/processing/review` | [ProcessingReviewList](../../app/Livewire/Admin/ChurchServices/ProcessingReviewList.php) | Runs paused for sermon-segment confirmation |
+| 9 | `/admin/services/processing/{log}/review` | [ProcessingReview](../../app/Livewire/Admin/ChurchServices/ProcessingReview.php) | Pick the correct sermon segment |
+| 10 | `/admin/services` | [ListChurchServices](../../app/Livewire/Admin/ChurchServices/ListChurchServices.php) | Services table |
+| 11 | `/admin/services/{id}` | [ShowChurchService](../../app/Livewire/Admin/ChurchServices/ShowChurchService.php) | Planned-vs-detected timeline, run cards, merge resolution |
+| 12 | `/admin/services/songs` (+ `/{song}`) | ListSongs / ShowSong | Song catalogue (reference data) |
+| 13 | `/church/members` | [members/home.blade.php](../../resources/views/members/home.blade.php) | 7-button entry grid |
+
+Diagnosis (from the 2026-06-10 UI review):
+
+- **Pages mirror tables, not tasks.** The admin's mental model is *plan + recording in → sermon,
+  songs, children's talk out*; no page represents that journey.
+- **The same entity is reviewable in three places.** A pending section has Approve buttons on
+  pages 6, 7, and links from 11. A paused run appears on 8, 11, and the members grid.
+- **Navigation is a mesh.** Every page header carries 3–6 sibling-page buttons because no page is
+  *home*.
+- **Two input pages, two visual languages.** MediaUpload is hand-rolled legacy markup
+  ([form.blade.php](../../resources/views/livewire/media-upload/form.blade.php)); the plan upload
+  uses `x-admin.form-shell`.
+- **No pipeline visibility.** Plan → recording → processing → review → published state is
+  fragmented across four badge systems.
+
+The backend is already well-factored for this consolidation: actions
+(`App\Actions\ServiceReview\*`, `App\Actions\Publication\*`, `App\Actions\InboundEmail\*`,
+[ConfirmLivestreamSermonSegment](../../app/Actions/ConfirmLivestreamSermonSegment.php)), queries
+([ServiceReviewDashboardQuery](../../app/Queries/ServiceReviewDashboardQuery.php),
+[ChurchServiceProcessingRunQuery](../../app/Queries/ChurchServiceProcessingRunQuery.php)), the
+[ManagesSectionPublication](../../app/Livewire/Admin/ChurchServices/Concerns/ManagesSectionPublication.php)
+trait, and the `awaitingManualSermonReview` scope are all reusable as-is. This is a UI/IA
+refactor, not a domain change.
+
+## Goal — target information architecture
+
+Three core pages, one hierarchy:
+
+1. **Services hub** (`/admin/services`) — attention strip, "This Sunday" hero card with pipeline
+   stepper, services table with one rolled-up status column, single `+ Add` menu.
+2. **Service workbench** (`/admin/services/{id}`) — the existing detail page absorbs *all*
+   in-context review: inline section approve/reject/edit/merge/speaker, embedded sermon-segment
+   confirmation, pipeline stepper header.
+3. **Review inbox** (`/admin/services/inbox`) — one queue replacing four: emails, flagged
+   sections, segment confirmations, merges and service flags, grouped by service, with inline
+   quick actions and filter chips.
+
+Unchanged: Songs catalogue, Sermons list, ManageChurchService edit form.
+
+### Page disposition
+
+| Current | Fate |
+|---|---|
+| ListChurchServices | Becomes the **hub** (Phase 1) |
+| ShowChurchService | Becomes the **workbench** (Phase 3) |
+| ReviewInboundEmails | Retired → inbox `Emails` filter (Phase 2/5) |
+| ServiceReviewDashboard | Retired → inbox (triage) + workbench (editing) (Phase 3/5) |
+| ListSectionPublications | Retired → inbox `Sections` filter (Phase 2/5) |
+| ProcessingReviewList | Retired → inbox `Segments` filter (Phase 2/5) |
+| ProcessingReview | Embedded in workbench; standalone route kept as fallback for orphan runs (Phase 3) |
+| SubmitEmailText | Reached only via the Add menu; page survives unchanged (Phase 4) |
+| UploadChurchService / MediaUpload | Both restyled/reached via Add menu; MediaUpload modernised (Phase 4) |
+| members/home grid | Shrinks to Services · Review inbox (badge) · Sermons · Song catalogue (Phase 2) |
+
+## Non-Goals
+
+- No changes to the processing pipeline, actions, jobs, or models' write paths.
+- No changes to public-facing pages (sermon archive, children's corner, podcasts).
+- No new packages.
+- The Songs catalogue and Sermons admin pages keep their current design.
+- Mobile-first redesign of tables is out of scope (existing `overflow-x-auto` pattern stays).
+
+## Design rules (apply to every phase)
+
+- Follow [docs/design-style-guide.md](../design-style-guide.md) and the `frontend-design` skill.
+  Admin pages: neutral, fast-scanning, `x-admin.*` shells, shared form components.
+- **Colour discipline:** amber = needs a human, teal = done/ready, sky = machine working,
+  rose = error/rejected, slate = inert (plan-only). Service-type chips (Morning/Evening) lose
+  their green/amber fills — use neutral `bg-gray-100 text-gray-700` so amber regains meaning.
+- Internal links use `wire:navigate`; icon-only actions get `aria-label`; loading states via
+  `wire:loading`; empty states for every list.
+- Config gates carry over: every new surface respects `service-tracking.enabled`; section
+  entries also respect `media-processing.section_publishing.enabled`
+  (see `abortIfDisabled()` in the existing components).
+
+## Read-model contracts (binding for every phase)
+
+These invariants exist in the current code as deliberate decisions, several pinned by
+regression tests. The consolidation must not re-derive them loosely.
+
+**C1 — Counts and lists share predicates.** Any attention count shown on the hub strip or
+members-home badge MUST be computed from the same code path that produces the corresponding
+inbox/workbench rows — never a parallel SQL approximation. Specifically: "flagged sections" is
+*not* `publication_status = pending_approval`; a section is a review candidate when
+[ServiceReviewDashboardQuery::reviewReasons()](../../app/Queries/ServiceReviewDashboardQuery.php)
+is non-empty (manual review, speaker review, pending approval, low confidence, inferred/unmatched
+song, heuristic demotion — seven reasons, partly PHP-evaluated). A cheap count that only sees
+`pending_approval` would show "All caught up" while the inbox still has work. Where the exact
+count is too expensive for a high-traffic page (members home), cache it briefly
+(`Cache::remember`, ≤60 s) rather than substituting a weaker predicate — a stale badge is
+acceptable, a wrong predicate is not.
+
+**C2 — Run↔service matching has three paths.** A `MediaProcessingLog` belongs to a service when
+*any* of: (a) extracted date+slot identity match, (b) `church_service_id` FK, or (c) fallback
+processing-ids harvested from `items.livestream_processing_id` and
+`import_metadata.livestream_projection.processing_id` (repaired runs) — see
+[ChurchServiceProcessingRunQuery::fallbackProcessingIdsForService()](../../app/Queries/ChurchServiceProcessingRunQuery.php),
+pinned by `it_shows_repaired_runs_found_via_item_projection_columns` in
+[ShowChurchServiceTest](../../tests/Feature/Livewire/Admin/ChurchServices/ShowChurchServiceTest.php).
+Any new bulk/rollup query MUST reuse this matching via a shared, extracted scope — not reimplement
+paths (a)+(b) and drop (c).
+
+**C3 — No blob columns in `MediaProcessingLog` lists.** Every list/aggregate query over
+`media_processing_logs` selects an explicit safe column list (TD-004B): the table carries
+oversized JSON blobs (`visual_samples`, `song_clusters`, `rms_stats`, `ai_analysis`, …) that must
+never be hydrated for queue rendering. Pinned by
+[ProcessingReviewListTest](../../tests/Feature/Livewire/Admin/ChurchServices/ProcessingReviewListTest.php);
+copy the column list from [ProcessingReviewList](../../app/Livewire/Admin/ChurchServices/ProcessingReviewList.php).
+The inbox and rollup queries inherit this rule.
+
+**C4 — Admin authorization is per-component *and* per-action.** Every new Livewire component
+under `App\Livewire\Admin` must use `WithAdminAuthorization` (pinned by
+[AdminLivewireComponentsUseTraitTest](../../tests/Integration/Livewire/Traits/AdminLivewireComponentsUseTraitTest.php)),
+and every state-mutating action method calls `$this->authorizeAdmin()` first. When porting
+dashboard actions in Phase 3, note the **existing gap**: `confirmMerge()` in
+[ServiceReviewDashboard](../../app/Livewire/Admin/ChurchServices/ServiceReviewDashboard.php)
+mutates without a per-action authorize call — fix it during the port, don't copy it.
+
+**C5 — Config-gate matrix.** `service-tracking.enabled = false` ⇒ all service surfaces
+(hub, workbench, inbox, upload pages) 404 as today, `AdminAttentionCounts` returns **all zeros**,
+and members home hides the Services/Review-inbox buttons (the Sermons and recording-upload
+entries are *not* gated — `MediaUpload` is gated only by the Sermon create Gate).
+`media-processing.section_publishing.enabled = false` ⇒ section counts contribute zero, the
+inbox omits the Sections chip and section entries, and the workbench hides
+publication/approval affordances (matching today's
+[ListSectionPublications](../../app/Livewire/Admin/ChurchServices/ListSectionPublications.php) gate).
+Every new query/component gets explicit tests for both gates.
+
+## Quality gates
+
+Run for every phase before finalising (per project policy):
+
+- `vendor/bin/sail bin pint --dirty`
+- `vendor/bin/sail composer phpstan` — 0 errors
+- `vendor/bin/sail artisan test --compact --parallel`
+- `vendor/bin/sail artisan dusk`
+
+---
+
+## Phase 1 — Services hub (no route changes)
+
+**Goal:** `/admin/services` answers "does anything need me?" and "where is each Sunday in the
+pipeline?" at a glance. Pure addition; nothing retired.
+
+### 1.1 Attention-counts read model
+
+- [ ] New `App\Queries\AdminAttentionCounts` returning
+      `{pending_emails, awaiting_segment_runs, flagged_sections, pending_merges, services_needing_review}`:
+      - emails: `InboundEmail` whereIn status `Pending|Failed` (the logic currently inlined in
+        [MemberController](../../app/Http/Controllers/MemberController.php));
+      - runs: `MediaProcessingLog::awaitingManualSermonReview()->count()` (also in MemberController),
+        selecting safe columns only (contract C3);
+      - **flagged sections: per contract C1**, derived from the dashboard-query review-candidate
+        path (`reviewGroups()` + `summary()` sections count — the seven-reason predicate), NOT a
+        raw `pending_approval` SQL count. Expose the count from
+        [ServiceReviewDashboardQuery](../../app/Queries/ServiceReviewDashboardQuery.php) so the
+        strip, the inbox, and the badge cannot disagree. Returns zero when section publishing is
+        disabled (contract C5);
+      - merges: reuse [ServiceReviewDashboardQuery::pendingMergeCount()](../../app/Queries/ServiceReviewDashboardQuery.php);
+      - services: `ChurchService` where `needs_review = true`.
+- [ ] `total()` helper for the members-home badge; the whole result is `Cache::remember`-ed
+      (≤60 s) for the members-home call site only — the hub computes fresh (C1).
+- [ ] All counts return zero when `service-tracking.enabled` is false (contract C5).
+- [ ] Refactor `MemberController` to consume this query (removes the duplicated count logic).
+- [ ] Unit/feature test for the query covering each count, the flagged-vs-pending distinction
+      (a section flagged for *low confidence only* must appear in the count), and both config
+      gates.
+
+### 1.2 Rolled-up service status
+
+- [ ] New `App\Enums\ChurchServiceRollupStatus`:
+      `PlanOnly | AwaitingRecording | Processing | NeedsReview | Ready | Published`
+      with `label()` and badge-class mapping following the colour rules above.
+      (`PlanOnly` = no matching run and service date is in the future or recent;
+      `AwaitingRecording` = no matching run, past date — implementation may merge these two if
+      the distinction proves noisy; decide during build and document in the enum.)
+- [ ] New `App\Queries\ChurchServiceRollupQuery` with a **bulk** method
+      `forServices(EloquentCollection $services): array` (keyed by service id) so the paginated
+      list (20 rows) computes statuses without N+1:
+      - one query for `MediaProcessingLog` livestream runs matching the page's services via
+        **all three match paths of contract C2** — (date, service) identity pairs,
+        `church_service_id`, *and* fallback processing-ids from item/import-metadata projection
+        columns. Extract the matching logic from
+        [ChurchServiceProcessingRunQuery](../../app/Queries/ChurchServiceProcessingRunQuery.php)
+        into a shared collaborator (e.g. `App\Support\ChurchServiceRunMatcher`) consumed by both
+        the existing per-service query and the new bulk query, so the repaired-run regression
+        test keeps one implementation honest. Bulk note: the page's services must eager-load
+        `items` once for the fallback-id harvest (no per-row `loadMissing`). Select safe columns
+        only (contract C3);
+      - aggregate per service: any run in `Pending|Started|Processing` → `Processing`; any
+        flagged section / awaiting-segment run / `needs_review` / pending merge →
+        `NeedsReview` (with count); all sections `Published|NotApplicable` and a sermon exists →
+        `Published`; else `Ready`.
+- [ ] Replace the `needs_review` badge column in
+      [list-church-services.blade.php](../../resources/views/livewire/admin/church-services/list-church-services.blade.php)
+      with the rollup chip (`Needs review (n)` shows the count). Keep the `needsReviewFilter`
+      URL param working; add a `status` filter option only if it falls out naturally —
+      otherwise defer to Phase 5 polish.
+
+### 1.3 Attention strip + "This Sunday" hero
+
+- [ ] New Blade partial (or `x-admin.attention-strip` component) rendered above the filters on
+      the hub: one chip per non-zero attention count, deep-linking (Phase 1 targets = the four
+      existing queue pages; re-pointed to the inbox in Phase 2). All-zero state renders a single
+      quiet "All caught up" line, not five zeros.
+- [ ] Hero card for "This Sunday", defined precisely (date-desc alone would surface a
+      far-future imported plan): among services dated within **±7 days of today**, pick the one
+      closest to today, tie-breaking first on *needs attention* (non-Ready rollup), then most
+      recent. If none in the window, fall back to the most recent past service. Card shows
+      date/slot heading, item count, run summary, rollup chip, `Open service →`. Implemented
+      with data already loaded for the table (no extra queries beyond the rollup bulk call —
+      the hero's service is fetched alongside the page or reuses a row already present).
+- [ ] Pipeline stepper visual: new `x-admin.pipeline-steps` component taking
+      `[{label, state: done|active|blocked|todo}]`; used by the hero now, reused by the
+      workbench in Phase 3. States derive from the rollup query.
+
+### 1.4 `+ Add` menu
+
+- [ ] Check `resources/views/components/` for an existing dropdown/menu component before
+      writing one (per component-reuse rule). If none fits, add `x-admin.action-menu`
+      (Alpine, keyboard-operable, `x-cloak`).
+- [ ] Hub header gains one primary `+ Add` button with items: *Upload recording* →
+      `admin.sermon-upload.create`; *Upload order of service* → `admin.services.upload`;
+      *Paste email text* → `admin.services.submit-email`; *Create manually* →
+      `admin.services.create`. The existing row of header buttons shrinks to the Add menu +
+      `Song catalogue`.
+
+### 1.5 Tests
+
+- [ ] Extend [AdminChurchServiceTest](../../tests/Feature/Livewire/AdminChurchServiceTest.php)
+      (hub renders strip, rollup chips, hero, Add menu; gates respected).
+- [ ] New query tests: `AdminAttentionCountsTest`, `ChurchServiceRollupQueryTest`
+      (cover every rollup state, the bulk no-N+1 shape via `expectsDatabaseQueryCount` or
+      similar, **and a repaired-run case** — a log matched only via
+      `items.livestream_processing_id` must roll up, mirroring the ShowChurchServiceTest
+      regression).
+- [ ] Hero-selection tests: future-only plans, ±7-day window tie-breaks, past-only fallback.
+
+**Exit criteria:** hub shows attention strip, hero with stepper, one rollup status per row, and a
+single Add menu; MemberController consumes the shared counts query; all gates green.
+
+---
+
+## Phase 2 — Review inbox
+
+**Goal:** one chronological "Monday-morning sweep" queue. Old queue pages remain functional but
+de-emphasised; deep links for *editing* still target the old pages until Phase 3.
+
+### 2.1 Read model
+
+- [ ] New `App\Queries\ReviewInboxQuery` returning service-grouped entries:
+      `{group: {service|null, date_label, service_label}, items: [{kind, payload, actions}]}`
+      where `kind ∈ {email, section, segment, merge, service_flag}`:
+      - **email** — `InboundEmail` Pending/Failed + preview via
+        [InboundEmailPreviewFactory](../../app/Actions/InboundEmail/InboundEmailPreviewFactory.php);
+        attributed to a (date, slot) group when the parse resolved one, else an
+        "Unattributed" group pinned first;
+      - **section** — reuse [ServiceReviewDashboardQuery::reviewGroups()](../../app/Queries/ServiceReviewDashboardQuery.php)
+        review-candidate logic + reasons (do not re-derive the flagging rules);
+      - **segment** — `MediaProcessingLog::awaitingManualSermonReview()` with the **explicit
+        safe-column select copied from
+        [ProcessingReviewList](../../app/Livewire/Admin/ChurchServices/ProcessingReviewList.php)**
+        (contract C3 / TD-004B) — extend the existing blob-column regression test to cover the
+        inbox query;
+      - **merge / service_flag** — `pending_structure_merge_source` / `needs_review` services.
+      - Cap each source (e.g. 50) and order groups by service date desc;
+        `reviewGroups()` currently loads unbounded — apply the cap here, not by
+        rewriting that query.
+      - Counts shown on chips come from the same result set (contract C1).
+- [ ] Feature tests for the query: grouping, attribution fallback, caps, both config gates
+      (sections omitted when publishing disabled; whole page 404 when service-tracking disabled).
+
+### 2.2 Component and route
+
+- [ ] New `App\Livewire\Admin\ChurchServices\ReviewInbox` at `/admin/services/inbox`
+      (`admin.services.inbox`), registered **before** the `/{churchService}` catch-all in
+      [routes/web.php](../../routes/web.php) (same constraint that bit the existing routes).
+      Uses `WithAdminAuthorization`; **every mutating action calls `$this->authorizeAdmin()`**
+      (contract C4 — the trait test enforces the trait automatically since the component lives
+      under `App\Livewire\Admin`).
+- [ ] Filter chips `All | Emails | Sections | Segments | Services` as a `#[Url]` param —
+      the `Services` chip is the explicit home for merge and service-flag items (they also
+      appear under `All`). Chips with a zero count render disabled/hidden. Layout:
+      `x-admin.page`, one card per service group, rows per item.
+- [ ] Inline quick actions, all reusing existing actions/traits:
+      - email: Approve / Edit & approve (→ `services.create?inboundEmailId=`) / Re-parse /
+        Reject — port handlers from
+        [ReviewInboundEmails](../../app/Livewire/Admin/ChurchServices/ReviewInboundEmails.php);
+      - section: Approve / Reject / Requeue via
+        [ManagesSectionPublication](../../app/Livewire/Admin/ChurchServices/Concerns/ManagesSectionPublication.php);
+        an `Edit ↗` link to the Review Dashboard (re-pointed to the workbench in Phase 3);
+      - segment: `Choose segment →` link (Phase 2 target: existing
+        `admin.services.processing.review` detail page);
+      - merge: `Resolve →` link to the service page (resolution UI already lives there);
+      - service_flag: `Mark reviewed` via
+        [MarkServiceReviewed](../../app/Actions/ServiceReview/MarkServiceReviewed.php).
+- [ ] Empty state: "All caught up — nothing needs review." with a link back to the hub.
+
+### 2.3 Re-point navigation
+
+- [ ] Hub attention strip deep-links → inbox filters.
+- [ ] [members/home.blade.php](../../resources/views/members/home.blade.php) "Services, sermons
+      and songs" card shrinks to four buttons: **Services**, **Review inbox** (badge = total
+      attention count from `AdminAttentionCounts`, cached per contract C1), **Manage sermons**,
+      **Song catalogue**. (Upload actions live behind the hub's Add menu now.) When
+      `service-tracking.enabled` is false, the Services and Review-inbox buttons are hidden and
+      the sermon-recording upload remains reachable (contract C5) — today's grid silently links
+      to 404s in that state; this fixes that.
+- [ ] Old queue pages stay routable (bookmarks, mid-flight habits) but lose their members-home
+      entries. Their header buttons gain a single `Review inbox` link; the rest of the
+      cross-link mesh on those pages is removed.
+
+### 2.4 Tests
+
+- [ ] New `ReviewInboxTest` covering: rendering of each kind, each quick action (assert it
+      delegates to the existing action and refreshes the list), filter chips (including the
+      `Services` chip for merges/flags), empty state, per-action authorization (non-admin user
+      rejected on every mutating method, per C4), config gates, and the blob-column guard for
+      the segment source (extend the TD-004B pattern).
+- [ ] Update [MembersTest](../../tests/Browser/MembersTest.php) (Dusk) for the new button set.
+- [ ] Keep `AdminInboundEmailReviewTest`, `AdminSectionPublicationQueueTest`,
+      `ProcessingReviewListTest` passing untouched (pages still live until Phase 5).
+
+**Exit criteria:** every reviewable item type appears in one inbox with working quick actions;
+members home and the hub route attention through it; legacy queue pages still pass their tests.
+
+---
+
+## Phase 3 — Service workbench
+
+**Goal:** the service detail page becomes the single in-context review surface. Largest phase —
+land as several PRs in the listed order.
+
+### 3.1 Pipeline stepper header (small, independent)
+
+- [ ] Extend [ChurchServiceShowPresenter](../../app/Presenters/ChurchServiceShowPresenter.php)
+      to emit stepper states (`Plan / Recording / Processed / Review / Published`) from data the
+      page already loads; render `x-admin.pipeline-steps` under the title. Test in
+      [ShowChurchServiceTest](../../tests/Feature/Livewire/Admin/ChurchServices/ShowChurchServiceTest.php).
+
+### 3.2 Inline section review on the timeline
+
+- [ ] Move the Review Dashboard's per-section panel into the expandable area of
+      [service-flow-row.blade.php](../../resources/views/livewire/admin/church-services/partials/service-flow-row.blade.php)
+      (rows already have an Alpine `expanded` toggle): review-reason chips, type/title edits,
+      children's-talk speaker picker, audio/video preview players, Approve/Reject/Requeue,
+      merge-adjacent affordance between sibling rows.
+- [ ] Port the supporting state/actions from
+      [ServiceReviewDashboard](../../app/Livewire/Admin/ChurchServices/ServiceReviewDashboard.php)
+      into [ShowChurchService](../../app/Livewire/Admin/ChurchServices/ShowChurchService.php):
+      `sectionEdits`/`speakerEdits` seeding (**candidates only** — seeding every section of every
+      run would balloon the Livewire payload), `saveSection`, `approvePendingPublications`
+      (batch approve stays — per-service header button), `initiateMerge/confirmMerge/cancelMerge`,
+      plus `ManagesSectionPublication`. **Fix during the port (contract C4):** `confirmMerge()`
+      currently mutates without `$this->authorizeAdmin()` — add the call and a test; do not
+      copy the gap. Keep the component lean by extracting a `Concerns\ReviewsServiceSections`
+      trait if it grows past ~300 lines.
+- [ ] Candidate-media preview URLs come from the existing
+      `services.section-publications.preview-{audio,video}` routes — these routes **stay**
+      (only the list page around them retires).
+- [ ] Migrate the relevant tests from
+      [AdminServiceReviewDashboardTest](../../tests/Feature/Livewire/AdminServiceReviewDashboardTest.php)
+      to `ShowChurchServiceTest` as each behaviour moves.
+
+### 3.3 Embedded segment confirmation
+
+- [ ] Extract the segment-selection UI from
+      [processing-review.blade.php](../../resources/views/livewire/admin/church-services/processing-review.blade.php)
+      into a shared partial; render it on the workbench inside the run card when that run
+      `requiresManualSermonReview()`. Confirm action reuses
+      [ConfirmLivestreamSermonSegment](../../app/Actions/ConfirmLivestreamSermonSegment.php).
+- [ ] The standalone `processing/{log}/review` page **stays** as the fallback for orphan runs
+      (a paused run whose extracted date/slot matches no `ChurchService` — possible with bad
+      filename parses) and renders the same shared partial. Inbox segment links prefer the
+      workbench when a service match exists, else the standalone page.
+
+### 3.4 Retire the Review Dashboard
+
+- [ ] Re-point the inbox `Edit ↗` links (2.2) at workbench rows (`#section-{id}` anchors).
+- [ ] `admin.services.review` → 302 to `admin.services.inbox`. Delete the component + view;
+      keep [ServiceReviewDashboardQuery](../../app/Queries/ServiceReviewDashboardQuery.php)
+      (the inbox and workbench consume it).
+- [ ] Migrate remaining dashboard tests (summary cards → inbox; batch approve → workbench);
+      add a redirect test.
+
+**Exit criteria:** a flagged section or paused segment is fully resolvable on the service page;
+the Review Dashboard URL redirects to the inbox; no review capability lost (test-mapped).
+
+---
+
+## Phase 4 — Inputs
+
+**Goal:** both inputs share the admin visual language and one entry point (the Add menu).
+
+- [ ] Restyle the MediaUpload form
+      ([form.blade.php](../../resources/views/livewire/media-upload/form.blade.php)) to
+      `x-admin.form-shell`: `x-select` for media type, `x-form-button`/`x-button` for actions,
+      shared error/loading patterns. **Keep intact:** drag-drop Alpine controller, chunked
+      upload progress, SSE status stream, auto-trim toggle, the singleton-per-page contract
+      documented in [MediaUpload.php](../../app/Livewire/MediaUpload.php). Behavioural assertions
+      live in `MediaUploadFieldTest` / `MediaUploadProgressTest` / `MediaUploadStatusTest` —
+      they must pass unchanged.
+- [ ] Move the page under the services prefix: route `admin.services.upload-recording`
+      (`/admin/services/upload-recording`), with `admin.sermon-upload.create` kept as a 302.
+      Title: "Upload recording". Update the Add menu target.
+- [ ] [UploadChurchService](../../resources/views/livewire/admin/church-services/upload-church-service.blade.php)
+      header: cross-link buttons reduce to the Add-menu pattern (`Back to services` only);
+      sidebar "Recent imports" stays.
+- [ ] On both upload pages, success states link onward to the created/affected service
+      (already true for `.osz`; for recordings, link to the matched service when the identity
+      resolver finds one — the workbench is where processing progress lives).
+- [ ] Dusk: smoke-test the restyled recording form (type select → file input appears) since
+      this is the page with the most bespoke JS. Feature tests: route redirect.
+
+**Exit criteria:** both upload forms read as one product; old sermon-upload URL redirects;
+upload JS behaviour tests unchanged and green.
+
+---
+
+## Phase 5 — Retire the remaining queues + polish
+
+- [ ] `admin.services.inbound-emails` → 302 inbox `?filter=emails`. Delete component/view after
+      porting any uncovered behaviours (re-parse, edit-and-approve are already in the inbox).
+      Migrate `AdminInboundEmailReviewTest`.
+- [ ] `admin.services.processing.review.index` → 302 inbox `?filter=segments`. Delete
+      list component/view. Migrate `ProcessingReviewListTest`.
+- [ ] `admin.services.section-publications` → 302 inbox `?filter=sections`. Delete list
+      component/view (preview-media routes stay). **Conscious loss:** the global
+      published-sections history table goes; per-service publication state remains on the
+      workbench timeline and outputs are on the Sermons list. Revisit only if missed in
+      practice. Migrate `AdminSectionPublicationQueueTest`.
+- [ ] Sweep for dead references: `route('admin.services.review')` etc. in views/components,
+      members-home counts, breadcrumbs:
+      `rg -n "services\.review|section-publications|processing\.review\.index|inbound-emails"`.
+- [ ] Colour-discipline pass over the surviving pages (service-type chips → neutral; amber
+      reserved for needs-human) — touches
+      [list-church-services](../../resources/views/livewire/admin/church-services/list-church-services.blade.php),
+      timeline partials, inbox.
+- [ ] Redirect tests for all three retired routes; full quality gates; update
+      [docs/design-style-guide.md](../design-style-guide.md) if any new shared component
+      (`pipeline-steps`, `action-menu`, `attention-strip`) merits a gallery entry, and add them
+      to `/dev/components`. While in that file, **fix its stale intro line** (it still says
+      "Laravel 12 + Livewire + Tailwind v3"; the project is Laravel 13 / Livewire 4 /
+      Tailwind v4).
+
+**Exit criteria:** 6 surfaces remain (hub, workbench, inbox, edit form, the two restyled upload
+pages behind the single Add menu, songs); all legacy queue URLs redirect; no orphaned
+views/components; suite + Dusk green.
+
+---
+
+## Test migration map
+
+| Existing test | Destination |
+|---|---|
+| `AdminChurchServiceTest` (list) | Grows in Phase 1 (hub) |
+| `ShowChurchServiceTest`, `ServiceFlowRowRenderingTest` | Grow in Phase 3 (workbench) |
+| `AdminServiceReviewDashboardTest` | Split: inbox quick-actions (P2) + workbench editing (P3) + redirect test (P3.4) |
+| `AdminInboundEmailReviewTest` | Inbox email actions (P2/P5) + redirect test |
+| `AdminSectionPublicationQueueTest` | Inbox section filter (P2/P5) + redirect test |
+| `ProcessingReviewListTest` | Inbox segment entries (P2/P5) + redirect test |
+| `MediaUploadFieldTest` / `MediaUploadProgressTest` / `MediaUploadStatusTest` | Unchanged (P4 must keep green) |
+| `MembersTest` (Dusk) | Updated button set (P2) |
+| Action/query tests (`Actions/ServiceReview/*`, `Actions/InboundEmail/*`, etc.) | Untouched — domain layer doesn't change |
+
+## Risks & mitigations
+
+- **ShowChurchService component bloat** (P3): cap via extracted traits/partials; presenter keeps
+  render() thin. Watch Livewire payload size — section edit state arrays should only seed for
+  review-candidate sections (as the dashboard does today).
+- **Unbounded review groups** (P2): `reviewGroups()` has no pagination; the inbox caps per
+  source and the hub only uses counts. Do not ship the inbox without the caps.
+- **Route order**: new `/services/inbox` and `/services/upload-recording` must precede the
+  `/{churchService}` catch-all (existing pattern in [routes/web.php](../../routes/web.php)).
+- **Orphan paused runs** (P3.3): keep the standalone segment-review page; never assume a run
+  has a matching service.
+- **Bookmarked URLs**: every retired route 302s to its successor — no 404s for muscle memory.
+- **Config-gated installs**: all new surfaces honour `service-tracking.enabled` and
+  `media-processing.section_publishing.enabled` exactly as the pages they replace.

--- a/resources/views/components/admin/action-menu-item.blade.php
+++ b/resources/views/components/admin/action-menu-item.blade.php
@@ -1,0 +1,16 @@
+@props([
+    'link',
+    'icon' => null,
+])
+
+<a
+    href="{{ $link }}"
+    wire:navigate
+    role="menuitem"
+    {{ $attributes->merge(['class' => 'flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none']) }}
+>
+    @if($icon)
+        <x-dynamic-component :component="'heroicon-o-'.$icon" class="h-4 w-4 shrink-0 text-gray-400" aria-hidden="true" />
+    @endif
+    {{ $slot }}
+</a>

--- a/resources/views/components/admin/action-menu.blade.php
+++ b/resources/views/components/admin/action-menu.blade.php
@@ -1,0 +1,37 @@
+@props([
+    'label' => 'Add',
+    'icon' => 'plus',
+])
+
+<div
+    x-data="{ open: false }"
+    @click.outside="open = false"
+    @keydown.escape.prevent.stop="open = false; $refs.trigger.focus()"
+    class="relative"
+>
+    <button
+        type="button"
+        x-ref="trigger"
+        @click="open = !open"
+        :aria-expanded="open"
+        aria-haspopup="menu"
+        class="no-underline rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 transition-all active:scale-95 inline-flex items-center justify-center gap-2 px-4 py-2 text-base bg-cbc-pattern bg-size-cover text-white hover:brightness-110"
+    >
+        @if($icon)
+            <x-dynamic-component :component="'heroicon-o-'.$icon" class="h-4 w-4" aria-hidden="true" />
+        @endif
+        {{ $label }}
+        <x-heroicon-o-chevron-down class="h-4 w-4" aria-hidden="true" />
+    </button>
+
+    <div
+        x-cloak
+        x-show="open"
+        x-transition.origin.top.right
+        role="menu"
+        aria-label="{{ $label }}"
+        class="absolute right-0 z-20 mt-2 w-64 rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+    >
+        {{ $slot }}
+    </div>
+</div>

--- a/resources/views/components/admin/attention-strip.blade.php
+++ b/resources/views/components/admin/attention-strip.blade.php
@@ -1,0 +1,32 @@
+@props([
+    /** list<array{label: string, count: int, href: string}> */
+    'chips' => [],
+])
+
+@php
+    $visibleChips = collect($chips)->filter(fn (array $chip): bool => ($chip['count'] ?? 0) > 0);
+@endphp
+
+<div {{ $attributes }}>
+    @if($visibleChips->isEmpty())
+        <p class="flex items-center gap-2 text-sm text-gray-500">
+            <x-heroicon-o-check-circle class="h-5 w-5 text-cbc-teal" aria-hidden="true" />
+            All caught up — nothing needs your attention.
+        </p>
+    @else
+        <ul class="flex flex-wrap gap-2" aria-label="Items needing attention">
+            @foreach($visibleChips as $chip)
+                <li wire:key="attention-chip-{{ Str::slug($chip['label']) }}">
+                    <a
+                        href="{{ $chip['href'] }}"
+                        wire:navigate
+                        class="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1.5 text-sm font-medium text-amber-900 hover:bg-amber-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
+                    >
+                        <span class="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-amber-200 px-1 text-xs font-semibold text-amber-900">{{ $chip['count'] }}</span>
+                        {{ $chip['label'] }}
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+    @endif
+</div>

--- a/resources/views/components/admin/pipeline-steps.blade.php
+++ b/resources/views/components/admin/pipeline-steps.blade.php
@@ -1,0 +1,40 @@
+@props([
+    /** list<array{label: string, state: 'done'|'active'|'blocked'|'todo'}> */
+    'steps' => [],
+])
+
+<ol {{ $attributes->merge(['class' => 'flex flex-wrap items-center gap-y-1']) }} aria-label="Pipeline progress">
+    @foreach($steps as $step)
+        @php
+            $state = $step['state'] ?? 'todo';
+            $dotClasses = match ($state) {
+                'done' => 'bg-cbc-teal border-cbc-teal',
+                'active' => 'bg-sky-400 border-sky-400 motion-safe:animate-pulse',
+                'blocked' => 'bg-amber-400 border-amber-400',
+                default => 'bg-white border-gray-300',
+            };
+            $labelClasses = match ($state) {
+                'done' => 'text-cbc-teal-dark',
+                'active' => 'text-sky-800',
+                'blocked' => 'text-amber-800',
+                default => 'text-gray-400',
+            };
+            $stateDescription = match ($state) {
+                'done' => 'complete',
+                'active' => 'in progress',
+                'blocked' => 'needs attention',
+                default => 'not started',
+            };
+        @endphp
+        <li class="flex items-center" wire:key="pipeline-step-{{ $loop->index }}-{{ $step['label'] }}">
+            @if(!$loop->first)
+                <span class="mx-2 h-px w-4 bg-gray-300 sm:w-6" aria-hidden="true"></span>
+            @endif
+            <span class="flex items-center gap-1.5">
+                <span class="h-2.5 w-2.5 rounded-full border {{ $dotClasses }}" aria-hidden="true"></span>
+                <span class="text-xs font-medium {{ $labelClasses }}">{{ $step['label'] }}</span>
+                <span class="sr-only">({{ $stateDescription }})</span>
+            </span>
+        </li>
+    @endforeach
+</ol>

--- a/resources/views/livewire/admin/church-services/list-church-services.blade.php
+++ b/resources/views/livewire/admin/church-services/list-church-services.blade.php
@@ -1,53 +1,60 @@
 <x-admin.list-shell
     title="Services"
-    description="View imported order-of-service records"
+    description="Plan, recording, and review status for every service"
 >
     <x-slot:actions>
-        <x-button link="{{ route('admin.services.review') }}" variant="outline" inline>
-            Review dashboard
-        </x-button>
-        <x-button link="{{ route('admin.services.processing.review.index') }}" variant="outline" icon="video-camera" inline>
-            Livestream review
-        </x-button>
-        <x-button link="{{ route('admin.services.inbound-emails') }}" variant="outline" icon="envelope" inline>
-            Review emails
-        </x-button>
         <x-button link="{{ route('admin.services.songs.index') }}" variant="outline" icon="musical-note" inline>
             Song catalogue
         </x-button>
-        <x-button link="{{ route('admin.services.create') }}" variant="outline" icon="plus" inline>
-            Create service
-        </x-button>
-        <x-button link="{{ route('admin.services.upload') }}" variant="primary" icon="arrow-up-tray" inline>
-            Upload service
-        </x-button>
+        <x-admin.action-menu label="Add">
+            <x-admin.action-menu-item link="{{ route('admin.sermon-upload.create') }}" icon="film">
+                Upload recording
+            </x-admin.action-menu-item>
+            <x-admin.action-menu-item link="{{ route('admin.services.upload') }}" icon="arrow-up-tray">
+                Upload order of service
+            </x-admin.action-menu-item>
+            <x-admin.action-menu-item link="{{ route('admin.services.submit-email') }}" icon="envelope">
+                Paste email text
+            </x-admin.action-menu-item>
+            <x-admin.action-menu-item link="{{ route('admin.services.create') }}" icon="pencil-square">
+                Create manually
+            </x-admin.action-menu-item>
+        </x-admin.action-menu>
     </x-slot:actions>
 
     <x-slot:filters>
-        <x-admin.filter-bar loading-target="search, serviceFilter, needsReviewFilter, resetFilters">
-            <x-input
-                placeholder="Search by filename, date, or service..."
-                wire:model.live.debounce="search"
-                icon="magnifying-glass"
-                clearable
-                class="w-72"
-                shortcut="slash" />
+        <div class="space-y-4">
+            <x-admin.attention-strip :chips="$attentionChips" />
 
-            <x-select
-                placeholder="Service"
-                wire:model.live="serviceFilter"
-                :options="collect($services)->map(fn($service) => ['id' => $service->value, 'name' => $service->label()])->toArray()"
-                class="w-40" />
+            @if($heroService !== null)
+                @include('livewire.admin.church-services.partials.services-hub-hero')
+            @endif
 
-            <x-select
-                placeholder="Review"
-                wire:model.live="needsReviewFilter"
-                :options="[
-                    ['id' => '1', 'name' => 'Needs review'],
-                    ['id' => '0', 'name' => 'Ready'],
-                ]"
-                class="w-44" />
-        </x-admin.filter-bar>
+            <x-admin.filter-bar loading-target="search, serviceFilter, needsReviewFilter, resetFilters">
+                <x-input
+                    placeholder="Search by filename, date, or service..."
+                    wire:model.live.debounce="search"
+                    icon="magnifying-glass"
+                    clearable
+                    class="w-72"
+                    shortcut="slash" />
+
+                <x-select
+                    placeholder="Service"
+                    wire:model.live="serviceFilter"
+                    :options="collect($services)->map(fn($service) => ['id' => $service->value, 'name' => $service->label()])->toArray()"
+                    class="w-40" />
+
+                <x-select
+                    placeholder="Review"
+                    wire:model.live="needsReviewFilter"
+                    :options="[
+                        ['id' => '1', 'name' => 'Needs review'],
+                        ['id' => '0', 'name' => 'Ready'],
+                    ]"
+                    class="w-44" />
+            </x-admin.filter-bar>
+        </div>
     </x-slot:filters>
 
     <x-slot:pagination>
@@ -71,14 +78,11 @@
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
             @forelse($churchServices as $churchService)
-                <tr class="hover:bg-gray-50" wire:loading.class.delay.200ms="opacity-50">
+                @php $rollup = $rollups[$churchService->id] ?? null; @endphp
+                <tr class="hover:bg-gray-50" wire:loading.class.delay.200ms="opacity-50" wire:key="service-row-{{ $churchService->id }}">
                     <td class="px-4 py-3">
                         <p class="font-medium">{{ $churchService->date->format('j M Y') }}</p>
-                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ match($churchService->service) {
-                            \App\Enums\SermonService::Morning => 'bg-green-100 text-green-800',
-                            \App\Enums\SermonService::Evening => 'bg-amber-100 text-amber-800',
-                            default => 'bg-gray-100 text-gray-800',
-                        } }}">
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700">
                             {{ $churchService->service->label() }}
                         </span>
                     </td>
@@ -89,22 +93,11 @@
                         <span class="text-sm uppercase">{{ $churchService->source }}</span>
                     </td>
                     <td class="px-4 py-3">
-                        <div class="flex flex-wrap gap-1">
-                            @if($churchService->needs_review)
-                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-rose-100 text-rose-800">
-                                    Needs review
-                                </span>
-                            @else
-                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-cbc-teal-light/15 text-cbc-teal-dark">
-                                    Ready
-                                </span>
-                            @endif
-                            @if($churchService->pending_structure_merge_source !== null)
-                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
-                                    Pending merge
-                                </span>
-                            @endif
-                        </div>
+                        @if($rollup !== null)
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ $rollup['status']->badgeClasses() }}">
+                                {{ $rollup['status']->label() . ($rollup['status'] === \App\Enums\ChurchServiceRollupStatus::NeedsReview ? " ({$rollup['attention_count']})" : '') }}
+                            </span>
+                        @endif
                     </td>
                     <td class="px-4 py-3">
                         <p class="text-sm font-medium">{{ $churchService->original_filename ?: '-' }}</p>

--- a/resources/views/livewire/admin/church-services/partials/services-hub-hero.blade.php
+++ b/resources/views/livewire/admin/church-services/partials/services-hub-hero.blade.php
@@ -1,0 +1,32 @@
+{{-- "This Sunday" hero card: expects $heroService, $heroRollup, $heroIsCurrent --}}
+<x-card class="border-l-4 border-l-cbc-teal">
+    <div class="flex flex-wrap items-start justify-between gap-4">
+        <div class="space-y-2">
+            <p class="text-xs font-medium uppercase tracking-wider text-gray-500">
+                {{ $heroIsCurrent ? 'This Sunday' : 'Most recent service' }}
+            </p>
+            <div class="flex flex-wrap items-center gap-2">
+                <h2 class="font-display text-2xl text-gray-900">
+                    {{ $heroService->date->format('j M Y') }} — {{ $heroService->service->label() }}
+                </h2>
+                @if($heroRollup !== null)
+                    <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $heroRollup['status']->badgeClasses() }}">
+                        {{ $heroRollup['status']->label() . ($heroRollup['status'] === \App\Enums\ChurchServiceRollupStatus::NeedsReview ? " ({$heroRollup['attention_count']})" : '') }}
+                    </span>
+                @endif
+            </div>
+            <p class="text-sm text-gray-600">
+                {{ $heroService->items_count ?? $heroService->items->count() }} planned {{ \Illuminate\Support\Str::plural('item', $heroService->items_count ?? $heroService->items->count()) }}
+                @if($heroRollup !== null)
+                    · {{ $heroRollup['run_count'] }} {{ \Illuminate\Support\Str::plural('processing run', $heroRollup['run_count']) }}
+                @endif
+            </p>
+            @if($heroRollup !== null)
+                <x-admin.pipeline-steps :steps="$heroRollup['steps']" class="pt-1" />
+            @endif
+        </div>
+        <x-button link="{{ route('admin.services.show', $heroService) }}" variant="outline" icon="arrow-right" iconPosition="trailing" inline>
+            Open service
+        </x-button>
+    </div>
+</x-card>

--- a/tests/Feature/Livewire/AdminChurchServiceTest.php
+++ b/tests/Feature/Livewire/AdminChurchServiceTest.php
@@ -35,6 +35,7 @@ use App\Livewire\Admin\ChurchServices\ShowChurchService;
 use App\Livewire\Admin\ChurchServices\UploadChurchService;
 use App\Models\ChurchService;
 use App\Models\ChurchServiceItem;
+use App\Models\InboundEmail;
 use App\Models\MediaProcessingLog;
 use App\Models\SermonProcessingStep;
 use App\Models\ServiceSection;
@@ -1093,7 +1094,7 @@ class AdminChurchServiceTest extends TestCase
     }
 
     #[Test]
-    public function list_component_shows_pending_merge_badge(): void
+    public function list_component_rolls_pending_merge_into_the_needs_review_chip(): void
     {
         $this->actingAs($this->admin);
 
@@ -1116,7 +1117,163 @@ class AdminChurchServiceTest extends TestCase
             ])
             ->create();
 
+        // needs_review flag + pending merge = 2 attention items rolled up
         Livewire::test(ListChurchServices::class)
-            ->assertSee('Pending merge');
+            ->assertSee('Needs review (2)')
+            ->assertSee('Pending merges');
+    }
+
+    #[Test]
+    public function hub_shows_rollup_status_chips_for_services_without_runs(): void
+    {
+        $this->actingAs($this->admin);
+
+        ChurchService::factory()->create([
+            'date' => now()->subDays(10)->toDateString(),
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        ChurchService::factory()->create([
+            'date' => now()->addDays(10)->toDateString(),
+            'service' => SermonService::Evening,
+            'needs_review' => false,
+        ]);
+
+        Livewire::test(ListChurchServices::class)
+            ->assertSee('Awaiting recording')
+            ->assertSee('Plan only');
+    }
+
+    #[Test]
+    public function hub_shows_an_all_caught_up_attention_strip_when_nothing_is_pending(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListChurchServices::class)
+            ->assertSee('All caught up');
+    }
+
+    #[Test]
+    public function hub_attention_strip_links_to_the_existing_queue_pages(): void
+    {
+        $this->actingAs($this->admin);
+
+        InboundEmail::factory()->create();
+
+        $this->churchServiceScenario()
+            ->needsReview()
+            ->state(['date' => '2026-01-19', 'service' => SermonService::Evening])
+            ->create();
+
+        Livewire::test(ListChurchServices::class)
+            ->assertSee('Inbound emails')
+            ->assertSee('Services needing review')
+            ->assertSeeHtml(route('admin.services.inbound-emails'))
+            ->assertDontSee('All caught up');
+    }
+
+    #[Test]
+    public function hub_header_offers_a_single_add_menu(): void
+    {
+        $this->actingAs($this->admin);
+
+        Livewire::test(ListChurchServices::class)
+            ->assertSee('Upload recording')
+            ->assertSee('Upload order of service')
+            ->assertSee('Paste email text')
+            ->assertSee('Create manually')
+            ->assertSee('Song catalogue')
+            ->assertSeeHtml(route('admin.sermon-upload.create'));
+    }
+
+    #[Test]
+    public function hub_hero_picks_the_service_closest_to_today(): void
+    {
+        $this->actingAs($this->admin);
+
+        $near = ChurchService::factory()->create([
+            'date' => now()->addDays(2)->toDateString(),
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        ChurchService::factory()->create([
+            'date' => now()->addDays(6)->toDateString(),
+            'service' => SermonService::Evening,
+            'needs_review' => false,
+        ]);
+
+        Livewire::test(ListChurchServices::class)
+            ->assertSee('This Sunday')
+            ->assertSee($near->date->format('j M Y').' — Morning')
+            ->assertSee('Open service');
+    }
+
+    #[Test]
+    public function hub_hero_tie_breaks_equidistant_services_on_attention(): void
+    {
+        $this->actingAs($this->admin);
+
+        $flaggedPast = ChurchService::factory()->create([
+            'date' => now()->subDays(3)->toDateString(),
+            'service' => SermonService::Morning,
+            'needs_review' => true,
+        ]);
+
+        ChurchService::factory()->create([
+            'date' => now()->addDays(3)->toDateString(),
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        Livewire::test(ListChurchServices::class)
+            ->assertSee($flaggedPast->date->format('j M Y').' — Morning');
+    }
+
+    #[Test]
+    public function hub_hero_falls_back_to_the_most_recent_past_service(): void
+    {
+        $this->actingAs($this->admin);
+
+        $old = ChurchService::factory()->create([
+            'date' => now()->subDays(30)->toDateString(),
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        ChurchService::factory()->create([
+            'date' => now()->subDays(60)->toDateString(),
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        Livewire::test(ListChurchServices::class)
+            ->assertSee('Most recent service')
+            ->assertSee($old->date->format('j M Y').' — Morning');
+    }
+
+    #[Test]
+    public function hub_returns_404_when_service_tracking_is_disabled(): void
+    {
+        config(['service-tracking.enabled' => false]);
+
+        $this->actingAs($this->admin)
+            ->get(route('admin.services.index'))
+            ->assertNotFound();
+    }
+
+    #[Test]
+    public function hub_service_type_chips_are_neutral(): void
+    {
+        $this->actingAs($this->admin);
+
+        $this->churchServiceScenario()
+            ->state(['date' => '2026-01-12', 'service' => SermonService::Morning])
+            ->create();
+
+        Livewire::test(ListChurchServices::class)
+            ->assertSeeHtml('bg-gray-100 text-gray-700')
+            ->assertDontSeeHtml('bg-green-100 text-green-800');
     }
 }

--- a/tests/Feature/Queries/AdminAttentionCountsTest.php
+++ b/tests/Feature/Queries/AdminAttentionCountsTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Queries;
+
+use App\Enums\InboundEmailStatus;
+use App\Enums\SermonService;
+use App\Enums\ServiceSectionPublicationStatus;
+use App\Models\ChurchService;
+use App\Models\InboundEmail;
+use App\Models\MediaProcessingLog;
+use App\Models\ServiceSection;
+use App\Queries\AdminAttentionCounts;
+use App\Support\ServiceSectionConfidence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AdminAttentionCountsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private AdminAttentionCounts $query;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->query = app(AdminAttentionCounts::class);
+    }
+
+    #[Test]
+    public function it_returns_all_zeros_when_nothing_needs_attention(): void
+    {
+        $counts = $this->query->counts();
+
+        $this->assertSame([
+            'pending_emails' => 0,
+            'awaiting_segment_runs' => 0,
+            'flagged_sections' => 0,
+            'pending_merges' => 0,
+            'services_needing_review' => 0,
+        ], $counts);
+        $this->assertSame(0, $this->query->total($counts));
+    }
+
+    #[Test]
+    public function it_counts_pending_and_failed_inbound_emails_only(): void
+    {
+        InboundEmail::factory()->create(['status' => InboundEmailStatus::Pending->value]);
+        InboundEmail::factory()->create(['status' => InboundEmailStatus::Failed->value]);
+        InboundEmail::factory()->create(['status' => InboundEmailStatus::Processed->value]);
+        InboundEmail::factory()->create(['status' => InboundEmailStatus::Rejected->value]);
+
+        $this->assertSame(2, $this->query->counts()['pending_emails']);
+    }
+
+    #[Test]
+    public function it_counts_runs_awaiting_manual_sermon_review(): void
+    {
+        MediaProcessingLog::factory()->livestream()->manualReviewRequired()->create();
+        MediaProcessingLog::factory()->livestream()->completed()->create();
+
+        $this->assertSame(1, $this->query->counts()['awaiting_segment_runs']);
+    }
+
+    #[Test]
+    public function it_counts_sections_flagged_for_low_confidence_only_not_just_pending_approval(): void
+    {
+        $run = MediaProcessingLog::factory()->livestream()->completed()->create([
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+        ]);
+
+        // A review candidate for low confidence alone — a raw pending_approval
+        // count would miss this section entirely (contract C1).
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'needs_manual_review' => false,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
+            'confidence' => ServiceSectionConfidence::HIGH_THRESHOLD - 0.1,
+        ]);
+
+        $this->assertSame(1, $this->query->counts()['flagged_sections']);
+    }
+
+    #[Test]
+    public function it_counts_pending_merges_and_services_needing_review(): void
+    {
+        ChurchService::factory()->create([
+            'date' => '2026-05-31',
+            'service' => SermonService::Morning,
+            'needs_review' => true,
+        ]);
+        ChurchService::factory()->create([
+            'date' => '2026-05-31',
+            'service' => SermonService::Evening,
+            'needs_review' => false,
+            'pending_structure_merge_source' => 'openlp',
+        ]);
+
+        $counts = $this->query->counts();
+
+        $this->assertSame(1, $counts['pending_merges']);
+        $this->assertSame(1, $counts['services_needing_review']);
+    }
+
+    #[Test]
+    public function flagged_sections_count_is_zero_when_section_publishing_is_disabled(): void
+    {
+        config(['media-processing.section_publishing.enabled' => false]);
+
+        $run = MediaProcessingLog::factory()->livestream()->completed()->create();
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'needs_manual_review' => true,
+        ]);
+
+        $this->assertSame(0, $this->query->counts()['flagged_sections']);
+    }
+
+    #[Test]
+    public function all_counts_are_zero_when_service_tracking_is_disabled(): void
+    {
+        config(['service-tracking.enabled' => false]);
+
+        InboundEmail::factory()->create(['status' => InboundEmailStatus::Pending->value]);
+        MediaProcessingLog::factory()->livestream()->manualReviewRequired()->create();
+        ChurchService::factory()->create([
+            'needs_review' => true,
+            'pending_structure_merge_source' => 'openlp',
+        ]);
+
+        $counts = $this->query->counts();
+
+        $this->assertSame(0, $this->query->total($counts));
+        $this->assertSame(0, $counts['pending_emails']);
+        $this->assertSame(0, $counts['awaiting_segment_runs']);
+    }
+
+    #[Test]
+    public function total_sums_every_count(): void
+    {
+        InboundEmail::factory()->create(['status' => InboundEmailStatus::Pending->value]);
+        ChurchService::factory()->create(['needs_review' => true]);
+
+        $this->assertSame(2, $this->query->total());
+    }
+
+    #[Test]
+    public function cached_counts_are_reused_within_the_cache_window(): void
+    {
+        $this->assertSame(0, $this->query->cached()['pending_emails']);
+
+        InboundEmail::factory()->create(['status' => InboundEmailStatus::Pending->value]);
+
+        $this->assertSame(0, $this->query->cached()['pending_emails']);
+        $this->assertSame(1, $this->query->counts()['pending_emails']);
+    }
+}

--- a/tests/Feature/Queries/ChurchServiceRollupQueryTest.php
+++ b/tests/Feature/Queries/ChurchServiceRollupQueryTest.php
@@ -1,0 +1,344 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Queries;
+
+use App\Enums\ChurchServiceRollupStatus;
+use App\Enums\SermonService;
+use App\Enums\ServiceSectionPublicationStatus;
+use App\Models\ChurchService;
+use App\Models\ChurchServiceItem;
+use App\Models\MediaProcessingLog;
+use App\Models\Sermon;
+use App\Models\ServiceSection;
+use App\Queries\ChurchServiceRollupQuery;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ChurchServiceRollupQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ChurchServiceRollupQuery $query;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->query = app(ChurchServiceRollupQuery::class);
+    }
+
+    /**
+     * @return Collection<int, ChurchService>
+     */
+    private function freshServices(): Collection
+    {
+        return ChurchService::query()->get();
+    }
+
+    #[Test]
+    public function it_returns_plan_only_for_a_future_service_without_runs(): void
+    {
+        $service = ChurchService::factory()->create([
+            'date' => now()->addDays(4)->toDateString(),
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        $rollups = $this->query->forServices($this->freshServices());
+
+        $this->assertSame(ChurchServiceRollupStatus::PlanOnly, $rollups[$service->id]['status']);
+        $this->assertSame(0, $rollups[$service->id]['attention_count']);
+    }
+
+    #[Test]
+    public function it_returns_awaiting_recording_for_a_past_service_without_runs(): void
+    {
+        $service = ChurchService::factory()->create([
+            'date' => now()->subDays(4)->toDateString(),
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        $rollups = $this->query->forServices($this->freshServices());
+
+        $this->assertSame(ChurchServiceRollupStatus::AwaitingRecording, $rollups[$service->id]['status']);
+    }
+
+    #[Test]
+    public function it_returns_processing_while_any_matching_run_is_in_flight(): void
+    {
+        $service = ChurchService::factory()->create([
+            'date' => '2026-06-07',
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        MediaProcessingLog::factory()->livestream()->processing()->create([
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+        ]);
+
+        $rollups = $this->query->forServices($this->freshServices());
+
+        $this->assertSame(ChurchServiceRollupStatus::Processing, $rollups[$service->id]['status']);
+    }
+
+    #[Test]
+    public function it_returns_needs_review_with_a_count_covering_every_attention_source(): void
+    {
+        $service = ChurchService::factory()->create([
+            'date' => '2026-06-07',
+            'service' => SermonService::Morning,
+            'needs_review' => true,
+            'pending_structure_merge_source' => 'openlp',
+        ]);
+
+        $completedRun = MediaProcessingLog::factory()->livestream()->completed()->create([
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+        ]);
+
+        MediaProcessingLog::factory()->livestream()->manualReviewRequired()->create([
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+        ]);
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $completedRun->id,
+            'needs_manual_review' => true,
+        ]);
+
+        $rollups = $this->query->forServices($this->freshServices());
+
+        $this->assertSame(ChurchServiceRollupStatus::NeedsReview, $rollups[$service->id]['status']);
+        // flagged section + awaiting-segment run + needs_review + pending merge
+        $this->assertSame(4, $rollups[$service->id]['attention_count']);
+    }
+
+    #[Test]
+    public function it_returns_needs_review_for_a_flagged_service_even_without_runs(): void
+    {
+        $service = ChurchService::factory()->create([
+            'date' => now()->subDays(10)->toDateString(),
+            'service' => SermonService::Morning,
+            'needs_review' => true,
+        ]);
+
+        $rollups = $this->query->forServices($this->freshServices());
+
+        $this->assertSame(ChurchServiceRollupStatus::NeedsReview, $rollups[$service->id]['status']);
+        $this->assertSame(1, $rollups[$service->id]['attention_count']);
+    }
+
+    #[Test]
+    public function it_returns_published_when_sections_are_resolved_and_a_sermon_exists(): void
+    {
+        $service = ChurchService::factory()->create([
+            'date' => '2026-06-07',
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        $sermon = Sermon::factory()->create();
+
+        $run = MediaProcessingLog::factory()->livestream()->completed()->create([
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+            'sermon_id' => $sermon->id,
+        ]);
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'needs_manual_review' => false,
+            'confidence' => 1.0,
+            'publication_status' => ServiceSectionPublicationStatus::Published->value,
+            'published_sermon_id' => $sermon->id,
+        ]);
+
+        $rollups = $this->query->forServices($this->freshServices());
+
+        $this->assertSame(ChurchServiceRollupStatus::Published, $rollups[$service->id]['status']);
+    }
+
+    #[Test]
+    public function it_returns_ready_for_a_completed_run_without_published_output(): void
+    {
+        $service = ChurchService::factory()->create([
+            'date' => '2026-06-07',
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        MediaProcessingLog::factory()->livestream()->completed()->create([
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+        ]);
+
+        $rollups = $this->query->forServices($this->freshServices());
+
+        $this->assertSame(ChurchServiceRollupStatus::Ready, $rollups[$service->id]['status']);
+    }
+
+    #[Test]
+    public function it_rolls_up_repaired_runs_matched_only_via_item_projection_columns(): void
+    {
+        $processingId = 'repaired-run-uuid-123';
+
+        $service = ChurchService::factory()->create([
+            'date' => now()->subDays(3)->toDateString(),
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        ChurchServiceItem::factory()->create([
+            'church_service_id' => $service->id,
+            'livestream_processing_id' => $processingId,
+        ]);
+
+        // Identity deliberately mismatched: only fallback path (c) can match.
+        MediaProcessingLog::factory()->livestream()->completed()->create([
+            'processing_id' => $processingId,
+            'extracted_date' => '1990-01-01',
+            'extracted_service' => SermonService::Evening->value,
+        ]);
+
+        $rollups = $this->query->forServices($this->freshServices());
+
+        $this->assertSame(ChurchServiceRollupStatus::Ready, $rollups[$service->id]['status']);
+        $this->assertSame(1, $rollups[$service->id]['run_count']);
+    }
+
+    #[Test]
+    public function it_rolls_up_runs_matched_via_import_metadata_projection(): void
+    {
+        $processingId = 'projection-run-uuid-456';
+
+        $service = ChurchService::factory()->create([
+            'date' => now()->subDays(3)->toDateString(),
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+            'import_metadata' => [
+                'livestream_projection' => ['processing_id' => $processingId],
+            ],
+        ]);
+
+        MediaProcessingLog::factory()->livestream()->completed()->create([
+            'processing_id' => $processingId,
+            'extracted_date' => '1990-01-01',
+            'extracted_service' => SermonService::Evening->value,
+        ]);
+
+        $rollups = $this->query->forServices($this->freshServices());
+
+        $this->assertSame(1, $rollups[$service->id]['run_count']);
+    }
+
+    #[Test]
+    public function it_computes_a_page_of_rollups_with_a_constant_number_of_queries(): void
+    {
+        foreach (range(1, 5) as $week) {
+            $service = ChurchService::factory()->create([
+                'date' => now()->subWeeks($week)->toDateString(),
+                'service' => SermonService::Morning,
+                'needs_review' => false,
+            ]);
+
+            ChurchServiceItem::factory()->create(['church_service_id' => $service->id]);
+
+            MediaProcessingLog::factory()->livestream()->completed()->create([
+                'extracted_date' => $service->date->toDateString(),
+                'extracted_service' => SermonService::Morning->value,
+            ]);
+        }
+
+        $services = $this->freshServices();
+
+        $queryCount = 0;
+        DB::listen(function () use (&$queryCount): void {
+            $queryCount++;
+        });
+
+        $this->query->forServices($services);
+
+        // items eager-load + run query + serviceSections eager-load
+        $this->assertSame(3, $queryCount);
+    }
+
+    #[Test]
+    public function it_never_selects_blob_columns_for_rollup_runs(): void
+    {
+        $service = ChurchService::factory()->create([
+            'date' => '2026-06-07',
+            'service' => SermonService::Morning,
+        ]);
+
+        MediaProcessingLog::factory()->livestream()->completed()->create([
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+        ]);
+
+        $selectQueries = [];
+        DB::listen(function ($query) use (&$selectQueries): void {
+            if (str_contains($query->sql, 'media_processing_logs') && str_starts_with(ltrim($query->sql), 'select')) {
+                $selectQueries[] = $query->sql;
+            }
+        });
+
+        $this->query->forServices($this->freshServices());
+
+        $this->assertNotEmpty($selectQueries);
+
+        foreach ($selectQueries as $sql) {
+            $this->assertStringNotContainsString('select *', strtolower($sql));
+            $this->assertStringNotContainsString('"media_processing_logs".*', $sql);
+
+            foreach (['visual_samples', 'song_clusters', 'rms_stats', 'ai_analysis', 'rms_log_path'] as $column) {
+                $this->assertStringNotContainsString("`{$column}`", $sql);
+            }
+        }
+
+        // The matcher must keep the rollup honest for all three paths in the
+        // same query (sanity check that we used the shared clause builder).
+        $this->assertStringContainsString('church_service_id', $selectQueries[1] ?? $selectQueries[0]);
+    }
+
+    #[Test]
+    public function flagged_sections_do_not_trigger_needs_review_when_section_publishing_is_disabled(): void
+    {
+        config(['media-processing.section_publishing.enabled' => false]);
+
+        $service = ChurchService::factory()->create([
+            'date' => '2026-06-07',
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        $run = MediaProcessingLog::factory()->livestream()->completed()->create([
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+            'sermon_id' => null,
+        ]);
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'needs_manual_review' => true,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
+        ]);
+
+        $rollups = $this->query->forServices($this->freshServices());
+
+        $this->assertSame(ChurchServiceRollupStatus::Ready, $rollups[$service->id]['status']);
+        $this->assertSame(0, $rollups[$service->id]['attention_count']);
+    }
+
+    #[Test]
+    public function it_returns_an_empty_array_for_an_empty_collection(): void
+    {
+        $this->assertSame([], $this->query->forServices(new Collection));
+    }
+}


### PR DESCRIPTION
Phase 1 of [the service & livestream UI consolidation plan](docs/plans/SERVICE-UI-CONSOLIDATION-2026-06-10.md) (committed here as well). `/admin/services` now answers "does anything need me?" and "where is each Sunday in the pipeline?" at a glance. Pure addition — no route changes, nothing retired.

## What's new

- **`AdminAttentionCounts`** — single read model behind the hub strip and the members-home badges. Flagged sections are derived from `ServiceReviewDashboardQuery`'s seven-reason review-candidate predicate (contract C1), never a raw `pending_approval` count; everything returns zero when `service-tracking.enabled` is off (C5). `MemberController` now consumes the ≤60s-cached copy instead of inlining its own counts.
- **`ChurchServiceRunMatcher`** — the three-path run↔service matching (date/slot identity, `church_service_id` FK, fallback processing ids from item/import-metadata projection) extracted from `ChurchServiceProcessingRunQuery` and shared with the new bulk query, so the repaired-run regression coverage keeps one implementation honest (C2).
- **`ChurchServiceRollupQuery` + `ChurchServiceRollupStatus`** — one bulk run query per page (explicit safe column list per TD-004B, C3; no N+1 — pinned by a constant-query-count test) rolled up to a single status chip (`Plan only / Awaiting recording / Processing / Needs review (n) / Ready / Published`) plus pipeline-stepper states.
- **Hub UI** — attention strip (deep-links to the existing queue pages until the inbox lands in Phase 2, "All caught up" when idle), "This Sunday" hero (±7-day window, closest-to-today with attention tie-break, most-recent-past fallback) with the new `x-admin.pipeline-steps` component, and a single **+ Add** menu (`x-admin.action-menu`, keyboard-operable) replacing the six-button header row. Service-type chips go neutral so amber keeps its needs-a-human meaning.

## Tests

- `AdminAttentionCountsTest` — every count, the flagged-vs-pending distinction (low-confidence-only section counts), both config gates, cache behaviour.
- `ChurchServiceRollupQueryTest` — every rollup state, repaired-run fallback matching (both projection columns), constant query count, blob-column guard, section-publishing gate.
- `AdminChurchServiceTest` — strip, rollup chips, hero selection/tie-break/fallback, Add menu, service-tracking 404, neutral chips; pending-merge badge test migrated to the rollup chip.

## Quality gates

- `pint --dirty` ✅  · `composer phpstan` ✅ (0 errors) · `artisan test --parallel` ✅ (5,493) · `artisan dusk` ✅ (43)

🤖 Generated with [Claude Code](https://claude.com/claude-code)