### PR TITLE
Review inbox: one queue for emails, sections, segments, merges, and flags (consolidation P2)

### DIFF
--- a/app/Http/Controllers/MemberController.php
+++ b/app/Http/Controllers/MemberController.php
@@ -13,12 +13,10 @@ class MemberController extends Controller
     {
         $isAdmin = auth()->user()?->canAccessAdmin() === true;
 
-        $counts = $isAdmin ? $attentionCounts->cached() : null;
-
         return view('members.home', [
             'heading' => 'Members',
-            'pendingInboundEmailCount' => $counts['pending_emails'] ?? 0,
-            'pendingSermonReviewCount' => $counts['awaiting_segment_runs'] ?? 0,
+            'reviewInboxCount' => $isAdmin ? $attentionCounts->total($attentionCounts->cached()) : 0,
+            'serviceTrackingEnabled' => (bool) config('service-tracking.enabled', true),
         ]);
     }
 }

--- a/app/Livewire/Admin/ChurchServices/ListChurchServices.php
+++ b/app/Livewire/Admin/ChurchServices/ListChurchServices.php
@@ -168,11 +168,11 @@ class ListChurchServices extends Component
     private function attentionChips(array $counts): array
     {
         return [
-            ['label' => 'Inbound emails', 'count' => $counts['pending_emails'], 'href' => route('admin.services.inbound-emails')],
-            ['label' => 'Sermon segments', 'count' => $counts['awaiting_segment_runs'], 'href' => route('admin.services.processing.review.index')],
-            ['label' => 'Flagged sections', 'count' => $counts['flagged_sections'], 'href' => route('admin.services.review')],
-            ['label' => 'Pending merges', 'count' => $counts['pending_merges'], 'href' => route('admin.services.review')],
-            ['label' => 'Services needing review', 'count' => $counts['services_needing_review'], 'href' => route('admin.services.index', ['needsReviewFilter' => 1])],
+            ['label' => 'Inbound emails', 'count' => $counts['pending_emails'], 'href' => route('admin.services.inbox', ['filter' => 'emails'])],
+            ['label' => 'Sermon segments', 'count' => $counts['awaiting_segment_runs'], 'href' => route('admin.services.inbox', ['filter' => 'segments'])],
+            ['label' => 'Flagged sections', 'count' => $counts['flagged_sections'], 'href' => route('admin.services.inbox', ['filter' => 'sections'])],
+            ['label' => 'Pending merges', 'count' => $counts['pending_merges'], 'href' => route('admin.services.inbox', ['filter' => 'services'])],
+            ['label' => 'Services needing review', 'count' => $counts['services_needing_review'], 'href' => route('admin.services.inbox', ['filter' => 'services'])],
         ];
     }
 

--- a/app/Livewire/Admin/ChurchServices/ReviewInbox.php
+++ b/app/Livewire/Admin/ChurchServices/ReviewInbox.php
@@ -14,6 +14,7 @@ use App\Livewire\Traits\WithAdminAuthorization;
 use App\Livewire\Traits\WithNotifications;
 use App\Models\ChurchService;
 use App\Models\InboundEmail;
+use App\Queries\AdminAttentionCounts;
 use App\Queries\ReviewInboxQuery;
 use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Auth;
@@ -167,7 +168,7 @@ class ReviewInbox extends Component
         $this->success('Service marked as reviewed.');
     }
 
-    public function render(ReviewInboxQuery $query): View
+    public function render(ReviewInboxQuery $query, AdminAttentionCounts $attentionCounts): View
     {
         $inbox = $query->build();
 
@@ -190,7 +191,39 @@ class ReviewInbox extends Component
             'groups' => $groups,
             'counts' => $inbox['counts'],
             'filterChips' => $this->filterChips($inbox['counts']),
+            'overflowNotices' => $this->overflowNotices($inbox['counts'], $attentionCounts),
         ])->layout('layouts.admin', ['title' => 'Review inbox', 'heading' => 'Review inbox']);
+    }
+
+    /**
+     * Sources whose true backlog exceeds the capped queue. True totals come
+     * from AdminAttentionCounts (same predicates as the capped lists, briefly
+     * cached — contract C1), so the notice can say "newest N of M" without
+     * re-materialising the backlog.
+     *
+     * @param  array{all: int, emails: int, sections: int, segments: int, services: int}  $counts
+     * @return list<array{label: string, shown: int, total: int}>
+     */
+    private function overflowNotices(array $counts, AdminAttentionCounts $attentionCounts): array
+    {
+        $totals = $attentionCounts->cached();
+
+        $sources = [
+            'emails' => ['label' => 'emails', 'total' => $totals['pending_emails']],
+            'sections' => ['label' => 'sections', 'total' => $totals['flagged_sections']],
+            'segments' => ['label' => 'segment confirmations', 'total' => $totals['awaiting_segment_runs']],
+            'services' => ['label' => 'service items', 'total' => $totals['pending_merges'] + $totals['services_needing_review']],
+        ];
+
+        $notices = [];
+
+        foreach ($sources as $key => $source) {
+            if ($source['total'] > $counts[$key]) {
+                $notices[] = ['label' => $source['label'], 'shown' => $counts[$key], 'total' => $source['total']];
+            }
+        }
+
+        return $notices;
     }
 
     /**

--- a/app/Livewire/Admin/ChurchServices/ReviewInbox.php
+++ b/app/Livewire/Admin/ChurchServices/ReviewInbox.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Admin\ChurchServices;
+
+use App\Actions\InboundEmail\ApproveInboundEmailImport;
+use App\Actions\InboundEmail\RejectInboundEmail;
+use App\Actions\InboundEmail\ReparseInboundEmail;
+use App\Actions\ServiceReview\MarkServiceReviewed;
+use App\Enums\InboundEmailStatus;
+use App\Livewire\Admin\ChurchServices\Concerns\ManagesSectionPublication;
+use App\Livewire\Traits\WithAdminAuthorization;
+use App\Livewire\Traits\WithNotifications;
+use App\Models\ChurchService;
+use App\Models\InboundEmail;
+use App\Queries\ReviewInboxQuery;
+use App\Traits\SanitizesLogData;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+/**
+ * The "Monday-morning sweep" queue: one inbox for inbound emails, flagged
+ * sections, paused sermon-segment runs, pending merges, and service review
+ * flags, grouped by service with inline quick actions.
+ */
+class ReviewInbox extends Component
+{
+    use ManagesSectionPublication;
+    use SanitizesLogData;
+    use WithAdminAuthorization;
+    use WithNotifications;
+
+    #[Url(except: 'all')]
+    public string $filter = 'all';
+
+    public function mount(): void
+    {
+        $this->abortIfDisabled();
+    }
+
+    public function approveEmail(int $inboundEmailId, ApproveInboundEmailImport $action): mixed
+    {
+        $this->authorizeAdmin();
+
+        $inboundEmail = $this->findReviewableEmail($inboundEmailId);
+        if (! $inboundEmail instanceof InboundEmail) {
+            $this->error('Inbound email not found.');
+
+            return null;
+        }
+
+        $userId = $this->adminUserId();
+        if ($userId === null) {
+            $this->error('Unable to approve this inbound email right now.');
+
+            return null;
+        }
+
+        $result = $action->execute($inboundEmail, $userId);
+
+        if (is_string($result)) {
+            $this->error($result);
+
+            return null;
+        }
+
+        return $this->success(
+            'Inbound email approved and imported.',
+            redirectTo: route('admin.services.show', $result),
+        );
+    }
+
+    public function editAndApproveEmail(int $inboundEmailId): mixed
+    {
+        $this->authorizeAdmin();
+
+        $inboundEmail = $this->findReviewableEmail($inboundEmailId);
+        if (! $inboundEmail instanceof InboundEmail) {
+            $this->error('Inbound email not found.');
+
+            return null;
+        }
+
+        return $this->redirect(
+            route('admin.services.create', ['inboundEmailId' => $inboundEmail->id]),
+            navigate: true,
+        );
+    }
+
+    public function reparseEmail(int $inboundEmailId, ReparseInboundEmail $action): void
+    {
+        $this->authorizeAdmin();
+
+        $inboundEmail = $this->findReviewableEmail($inboundEmailId);
+        if (! $inboundEmail instanceof InboundEmail) {
+            $this->error('Inbound email not found.');
+
+            return;
+        }
+
+        $error = $action->execute($inboundEmail);
+
+        if ($error !== null) {
+            $this->error($error);
+
+            return;
+        }
+
+        $this->success('Inbound email re-parsed. Review the updated preview before approving.');
+    }
+
+    public function rejectEmail(int $inboundEmailId, RejectInboundEmail $action): void
+    {
+        $this->authorizeAdmin();
+
+        $inboundEmail = $this->findReviewableEmail($inboundEmailId);
+        if (! $inboundEmail instanceof InboundEmail) {
+            $this->error('Inbound email not found.');
+
+            return;
+        }
+
+        $userId = $this->adminUserId();
+        if ($userId === null) {
+            $this->error('Unable to reject this inbound email right now.');
+
+            return;
+        }
+
+        Log::warning('Inbound email rejected by admin', [
+            'admin_id' => $userId,
+            'inbound_email_id' => $inboundEmail->id,
+            'message_id' => $this->sanitizeForLog((string) $inboundEmail->message_id),
+            'from' => $this->sanitizeForLog((string) $inboundEmail->from),
+            'subject' => $this->sanitizeForLog((string) $inboundEmail->subject),
+        ]);
+
+        $action->execute($inboundEmail, $userId);
+
+        $this->success('Inbound email rejected.');
+    }
+
+    public function markServiceReviewed(int $serviceId, MarkServiceReviewed $action): void
+    {
+        $this->authorizeAdmin();
+
+        $service = ChurchService::query()->find($serviceId);
+        if (! $service instanceof ChurchService) {
+            $this->error('Service not found.');
+
+            return;
+        }
+
+        $userId = $this->adminUserId();
+        if ($userId === null) {
+            $this->error('Unable to mark this service as reviewed right now.');
+
+            return;
+        }
+
+        $action->execute($service, $userId);
+
+        $this->success('Service marked as reviewed.');
+    }
+
+    public function render(ReviewInboxQuery $query): View
+    {
+        $inbox = $query->build();
+
+        $visibleKinds = $this->visibleKinds();
+
+        $groups = collect($inbox['groups'])
+            ->map(function (array $group) use ($visibleKinds): array {
+                $group['items'] = array_values(array_filter(
+                    $group['items'],
+                    fn (array $item): bool => in_array($item['kind'], $visibleKinds, true),
+                ));
+
+                return $group;
+            })
+            ->filter(fn (array $group): bool => $group['items'] !== [])
+            ->values()
+            ->all();
+
+        return view('livewire.admin.church-services.review-inbox', [
+            'groups' => $groups,
+            'counts' => $inbox['counts'],
+            'filterChips' => $this->filterChips($inbox['counts']),
+        ])->layout('layouts.admin', ['title' => 'Review inbox', 'heading' => 'Review inbox']);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function visibleKinds(): array
+    {
+        return match ($this->filter) {
+            'emails' => ['email'],
+            'sections' => ['section'],
+            'segments' => ['segment'],
+            'services' => ['merge', 'service_flag'],
+            default => ['email', 'section', 'segment', 'merge', 'service_flag'],
+        };
+    }
+
+    /**
+     * Chips with a zero count are omitted (except All); the Sections chip is
+     * also omitted when section publishing is disabled (contract C5 — its
+     * count is already zero in that state).
+     *
+     * @param  array{all: int, emails: int, sections: int, segments: int, services: int}  $counts
+     * @return list<array{key: string, label: string, count: int}>
+     */
+    private function filterChips(array $counts): array
+    {
+        $chips = [['key' => 'all', 'label' => 'All', 'count' => $counts['all']]];
+
+        foreach (['emails' => 'Emails', 'sections' => 'Sections', 'segments' => 'Segments', 'services' => 'Services'] as $key => $label) {
+            if ($counts[$key] > 0) {
+                $chips[] = ['key' => $key, 'label' => $label, 'count' => $counts[$key]];
+            }
+        }
+
+        return $chips;
+    }
+
+    private function findReviewableEmail(int $inboundEmailId): ?InboundEmail
+    {
+        return InboundEmail::query()
+            ->whereKey($inboundEmailId)
+            ->whereIn('status', [
+                InboundEmailStatus::Pending->value,
+                InboundEmailStatus::Failed->value,
+            ])
+            ->first();
+    }
+
+    private function adminUserId(): ?int
+    {
+        $id = Auth::id();
+
+        return is_int($id) ? $id : null;
+    }
+
+    private function abortIfDisabled(): void
+    {
+        if (! (bool) config('service-tracking.enabled', true)) {
+            abort(404);
+        }
+    }
+}

--- a/app/Queries/ReviewInboxQuery.php
+++ b/app/Queries/ReviewInboxQuery.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Actions\InboundEmail\InboundEmailPreviewFactory;
+use App\Enums\InboundEmailStatus;
+use App\Enums\SermonService;
+use App\Models\ChurchService;
+use App\Models\InboundEmail;
+use App\Models\MediaProcessingLog;
+use App\Services\Processing\MediaProcessingIdentityResolver;
+use Illuminate\Support\Carbon;
+
+/**
+ * One chronological review queue for everything that needs a human:
+ * inbound emails, flagged sections, paused sermon-segment runs, pending
+ * structure merges, and service-level review flags — grouped by service.
+ *
+ * Sections reuse ServiceReviewDashboardQuery::reviewGroups() (the
+ * seven-reason predicate, contract C1); segment rows inherit the
+ * blob-column-safe select (contract C3); each source is capped so the
+ * unbounded dashboard grouping cannot balloon the page.
+ *
+ * @phpstan-type InboxGroup array{
+ *     key: string,
+ *     date_label: string,
+ *     service_label: string,
+ *     service: ChurchService|null,
+ *     sort_date: string,
+ *     service_sort: int,
+ *     items: list<array<string, mixed>>
+ * }
+ */
+class ReviewInboxQuery
+{
+    public const SOURCE_CAP = 50;
+
+    private const UNATTRIBUTED_KEY = 'unattributed';
+
+    /** @var array<string, ChurchService|null> */
+    private array $serviceLookupCache = [];
+
+    public function __construct(
+        private readonly ServiceReviewDashboardQuery $dashboardQuery,
+        private readonly InboundEmailPreviewFactory $previewFactory,
+        private readonly MediaProcessingIdentityResolver $identityResolver,
+    ) {}
+
+    /**
+     * @return array{
+     *     groups: list<InboxGroup>,
+     *     counts: array{all: int, emails: int, sections: int, segments: int, services: int}
+     * }
+     */
+    public function build(): array
+    {
+        $groups = [];
+
+        $counts = [
+            'emails' => $this->collectEmails($groups),
+            'sections' => $this->collectSections($groups),
+            'segments' => $this->collectSegments($groups),
+            'services' => $this->collectServiceItems($groups),
+        ];
+        $counts['all'] = array_sum($counts);
+
+        $groups = array_values($groups);
+
+        usort($groups, function (array $left, array $right): int {
+            $unattributed = ($right['key'] === self::UNATTRIBUTED_KEY) <=> ($left['key'] === self::UNATTRIBUTED_KEY);
+            if ($unattributed !== 0) {
+                return $unattributed;
+            }
+
+            $dateCompare = strcmp($right['sort_date'], $left['sort_date']);
+            if ($dateCompare !== 0) {
+                return $dateCompare;
+            }
+
+            return $left['service_sort'] <=> $right['service_sort'];
+        });
+
+        return ['groups' => $groups, 'counts' => $counts];
+    }
+
+    /**
+     * @param  array<string, InboxGroup>  $groups
+     */
+    private function collectEmails(array &$groups): int
+    {
+        $emails = InboundEmail::query()
+            ->whereIn('status', [
+                InboundEmailStatus::Pending->value,
+                InboundEmailStatus::Failed->value,
+            ])
+            ->orderByDesc('received_at')
+            ->limit(self::SOURCE_CAP)
+            ->get();
+
+        foreach ($emails as $email) {
+            $preview = $this->previewFactory->build($email);
+
+            $date = $this->identityResolver->parseDate($preview['resolved_date']);
+            $service = $this->identityResolver->parseService($preview['resolved_service']);
+
+            $this->push($groups, $date, $service, [
+                'kind' => 'email',
+                'email' => $email,
+                'preview' => $preview,
+            ]);
+        }
+
+        return $emails->count();
+    }
+
+    /**
+     * @param  array<string, InboxGroup>  $groups
+     */
+    private function collectSections(array &$groups): int
+    {
+        if (! (bool) config('media-processing.section_publishing.enabled', true)) {
+            return 0;
+        }
+
+        $count = 0;
+
+        foreach ($this->dashboardQuery->reviewGroups() as $reviewGroup) {
+            foreach ($reviewGroup['sections'] as $entry) {
+                if ($count >= self::SOURCE_CAP) {
+                    return $count;
+                }
+
+                $this->push(
+                    $groups,
+                    $reviewGroup['date'],
+                    $reviewGroup['service_enum'],
+                    [
+                        'kind' => 'section',
+                        'section' => $entry['section'],
+                        'reasons' => $entry['reasons'],
+                        'review_reason' => $entry['review_reason'],
+                        'audio_url' => $entry['audio_url'],
+                        'video_url' => $entry['video_url'],
+                    ],
+                    $reviewGroup['service'],
+                );
+
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param  array<string, InboxGroup>  $groups
+     */
+    private function collectSegments(array &$groups): int
+    {
+        // Explicit safe column list (TD-004B / contract C3): never hydrate the
+        // oversized JSON blob columns for queue rendering.
+        $runs = MediaProcessingLog::query()
+            ->select([
+                'id',
+                'processing_id',
+                'processing_type',
+                'status',
+                'current_step',
+                'error_message',
+                'original_filename',
+                'extracted_date',
+                'extracted_service',
+                'processing_metadata',
+                'updated_at',
+            ])
+            ->awaitingManualSermonReview()
+            ->orderByDesc('updated_at')
+            ->limit(self::SOURCE_CAP)
+            ->get();
+
+        foreach ($runs as $run) {
+            $identity = $this->identityResolver->resolve($run);
+
+            $this->push(
+                $groups,
+                $identity['date'] ?? null,
+                $identity['service'] ?? null,
+                [
+                    'kind' => 'segment',
+                    'run' => $run,
+                ],
+            );
+        }
+
+        return $runs->count();
+    }
+
+    /**
+     * Pending structure merges and service-level review flags. A service with
+     * both produces two entries in the same group.
+     *
+     * @param  array<string, InboxGroup>  $groups
+     */
+    private function collectServiceItems(array &$groups): int
+    {
+        $services = ChurchService::query()
+            ->where('needs_review', true)
+            ->orWhereNotNull('pending_structure_merge_source')
+            ->orderByDesc('date')
+            ->limit(self::SOURCE_CAP)
+            ->get();
+
+        $count = 0;
+
+        foreach ($services as $service) {
+            if ($service->pending_structure_merge_source !== null) {
+                $this->push($groups, $service->date->toDateString(), $service->service, [
+                    'kind' => 'merge',
+                    'service' => $service,
+                ], $service);
+                $count++;
+            }
+
+            if ($service->needs_review) {
+                $this->push($groups, $service->date->toDateString(), $service->service, [
+                    'kind' => 'service_flag',
+                    'service' => $service,
+                ], $service);
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param  array<string, InboxGroup>  $groups
+     * @param  Carbon|string|null  $date
+     * @param  array<string, mixed>  $item
+     */
+    private function push(array &$groups, mixed $date, ?SermonService $service, array $item, ?ChurchService $serviceModel = null): void
+    {
+        $dateString = $date instanceof Carbon ? $date->toDateString() : (is_string($date) ? $date : null);
+
+        $key = ($dateString !== null && $service instanceof SermonService)
+            ? "{$dateString}|{$service->value}"
+            : self::UNATTRIBUTED_KEY;
+
+        if (! array_key_exists($key, $groups)) {
+            $groups[$key] = [
+                'key' => $key,
+                'date_label' => $dateString !== null ? Carbon::parse($dateString)->format('j M Y') : 'Unattributed',
+                'service_label' => $service?->label() ?? '',
+                'service' => null,
+                'sort_date' => $dateString ?? '',
+                'service_sort' => match ($service) {
+                    SermonService::Morning => 1,
+                    SermonService::Evening => 2,
+                    SermonService::Other => 3,
+                    default => 9,
+                },
+                'items' => [],
+            ];
+        }
+
+        if ($serviceModel instanceof ChurchService && ! $groups[$key]['service'] instanceof ChurchService) {
+            $groups[$key]['service'] = $serviceModel;
+        }
+
+        if (! $groups[$key]['service'] instanceof ChurchService && $dateString !== null && $service instanceof SermonService) {
+            $groups[$key]['service'] = $this->lookupService($dateString, $service);
+        }
+
+        $groups[$key]['items'][] = $item;
+    }
+
+    private function lookupService(string $date, SermonService $service): ?ChurchService
+    {
+        $key = "{$date}|{$service->value}";
+
+        if (! array_key_exists($key, $this->serviceLookupCache)) {
+            $this->serviceLookupCache[$key] = ChurchService::query()
+                ->whereDate('date', $date)
+                ->where('service', $service->value)
+                ->first();
+        }
+
+        return $this->serviceLookupCache[$key];
+    }
+}

--- a/app/Queries/ReviewInboxQuery.php
+++ b/app/Queries/ReviewInboxQuery.php
@@ -126,7 +126,7 @@ class ReviewInboxQuery
 
         $count = 0;
 
-        foreach ($this->dashboardQuery->reviewGroups() as $reviewGroup) {
+        foreach ($this->dashboardQuery->reviewGroups(self::SOURCE_CAP) as $reviewGroup) {
             foreach ($reviewGroup['sections'] as $entry) {
                 if ($count >= self::SOURCE_CAP) {
                     return $count;
@@ -198,41 +198,42 @@ class ReviewInboxQuery
     }
 
     /**
-     * Pending structure merges and service-level review flags. A service with
-     * both produces two entries in the same group.
+     * Pending structure merges and service-level review flags. Each source is
+     * capped independently so a backlog of review flags can never push a
+     * pending merge out of the queue (the hub's merge chip counts them all);
+     * a service with both produces two entries in the same group.
      *
      * @param  array<string, InboxGroup>  $groups
      */
     private function collectServiceItems(array &$groups): int
     {
-        $services = ChurchService::query()
-            ->where('needs_review', true)
-            ->orWhereNotNull('pending_structure_merge_source')
+        $merges = ChurchService::query()
+            ->whereNotNull('pending_structure_merge_source')
             ->orderByDesc('date')
             ->limit(self::SOURCE_CAP)
             ->get();
 
-        $count = 0;
+        $flagged = ChurchService::query()
+            ->where('needs_review', true)
+            ->orderByDesc('date')
+            ->limit(self::SOURCE_CAP)
+            ->get();
 
-        foreach ($services as $service) {
-            if ($service->pending_structure_merge_source !== null) {
-                $this->push($groups, $service->date->toDateString(), $service->service, [
-                    'kind' => 'merge',
-                    'service' => $service,
-                ], $service);
-                $count++;
-            }
-
-            if ($service->needs_review) {
-                $this->push($groups, $service->date->toDateString(), $service->service, [
-                    'kind' => 'service_flag',
-                    'service' => $service,
-                ], $service);
-                $count++;
-            }
+        foreach ($merges as $service) {
+            $this->push($groups, $service->date->toDateString(), $service->service, [
+                'kind' => 'merge',
+                'service' => $service,
+            ], $service);
         }
 
-        return $count;
+        foreach ($flagged as $service) {
+            $this->push($groups, $service->date->toDateString(), $service->service, [
+                'kind' => 'service_flag',
+                'service' => $service,
+            ], $service);
+        }
+
+        return $merges->count() + $flagged->count();
     }
 
     /**

--- a/app/Queries/ServiceReviewDashboardQuery.php
+++ b/app/Queries/ServiceReviewDashboardQuery.php
@@ -14,15 +14,25 @@ use App\Support\ServiceSectionConfidence;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 class ServiceReviewDashboardQuery
 {
+    private const LAZY_CHUNK_SIZE = 100;
+
+    /** @var array<string, ChurchService|null> */
+    private array $serviceKeyLookupCache = [];
+
     public function __construct(
         private readonly MediaProcessingIdentityResolver $identityResolver,
     ) {}
 
     /**
+     * @param  int|null  $sectionLimit  When set, at most this many flagged sections are
+     *                                  collected (newest first) and the backlog is iterated
+     *                                  lazily — the capped inbox path. Null keeps the full,
+     *                                  exact result the dashboard summary and counts rely on.
      * @return array<int, array{
      *     key:string,
      *     date:string|null,
@@ -45,7 +55,7 @@ class ServiceReviewDashboardQuery
      *     }>
      * }>
      */
-    public function reviewGroups(): array
+    public function reviewGroups(?int $sectionLimit = null): array
     {
         $reviewServices = ChurchService::query()
             ->where('needs_review', true)
@@ -53,10 +63,19 @@ class ServiceReviewDashboardQuery
             ->orderBy('service')
             ->get();
 
-        $sections = $this->reviewSections();
-        $serviceLookup = $this->serviceLookup($sections, $reviewServices);
+        if ($sectionLimit === null) {
+            $sections = $this->reviewSections();
+            $serviceLookup = $this->serviceLookup($sections, $reviewServices);
+        } else {
+            // Capped callers (the inbox) iterate lazily so a large backlog is
+            // never fully hydrated; group services are resolved per key on
+            // demand instead of via the upfront identity scan.
+            $sections = $this->reviewSectionsQuery()->lazy(self::LAZY_CHUNK_SIZE);
+            $serviceLookup = $this->keyedServices($reviewServices);
+        }
 
         $groups = [];
+        $flaggedSectionCount = 0;
 
         foreach ($reviewServices as $service) {
             $key = $this->serviceKey($service->date->toDateString(), $service->service);
@@ -69,12 +88,16 @@ class ServiceReviewDashboardQuery
         }
 
         foreach ($sections as $section) {
+            if ($sectionLimit !== null && $flaggedSectionCount >= $sectionLimit) {
+                break;
+            }
+
             $reasons = $this->reviewReasons($section);
             if ($reasons === []) {
                 continue;
             }
 
-            $context = $this->resolveGroupContext($section, $serviceLookup);
+            $context = $this->resolveGroupContext($section, $serviceLookup, lookupOnMiss: $sectionLimit !== null);
             $key = $context['key'];
 
             if (! array_key_exists($key, $groups)) {
@@ -102,6 +125,8 @@ class ServiceReviewDashboardQuery
                     ? route('admin.services.edit', $serviceModel)
                     : null,
             ];
+
+            $flaggedSectionCount++;
         }
 
         $groups = array_values($groups);
@@ -322,6 +347,14 @@ class ServiceReviewDashboardQuery
      */
     private function reviewSections(): EloquentCollection
     {
+        return $this->reviewSectionsQuery()->get();
+    }
+
+    /**
+     * @return Builder<ServiceSection>
+     */
+    private function reviewSectionsQuery(): Builder
+    {
         return ServiceSection::query()
             ->with([
                 'processingLog:id,processing_id,extracted_date,extracted_service,processing_metadata,church_service_id',
@@ -342,8 +375,7 @@ class ServiceReviewDashboardQuery
                             });
                     });
             })
-            ->orderByDesc('updated_at')
-            ->get();
+            ->orderByDesc('updated_at');
     }
 
     /**
@@ -369,9 +401,16 @@ class ServiceReviewDashboardQuery
                 ->whereIn('service', $services)
                 ->get();
 
-        return $reviewServices
-            ->merge($matchedServices)
-            ->unique('id')
+        return $this->keyedServices($reviewServices->merge($matchedServices)->unique('id'));
+    }
+
+    /**
+     * @param  Collection<int, ChurchService>  $services
+     * @return array<string, ChurchService>
+     */
+    private function keyedServices(Collection $services): array
+    {
+        return $services
             ->keyBy(fn (ChurchService $service): string => $this->serviceKey($service->date->toDateString(), $service->service))
             ->all();
     }
@@ -385,7 +424,7 @@ class ServiceReviewDashboardQuery
      *     service_model:ChurchService|null
      * }
      */
-    private function resolveGroupContext(ServiceSection $section, array $serviceLookup): array
+    private function resolveGroupContext(ServiceSection $section, array $serviceLookup, bool $lookupOnMiss = false): array
     {
         $service = $section->processingLog->churchService ?? $section->churchServiceItem?->churchService;
         if ($service instanceof ChurchService) {
@@ -401,11 +440,16 @@ class ServiceReviewDashboardQuery
         if ($identity !== null) {
             $key = $this->serviceKey($identity['date'], $identity['service']);
 
+            $serviceModel = $serviceLookup[$key] ?? null;
+            if ($serviceModel === null && $lookupOnMiss) {
+                $serviceModel = $this->findServiceByIdentity($key, $identity['date'], $identity['service']);
+            }
+
             return [
                 'key' => $key,
                 'date' => Carbon::parse($identity['date']),
                 'service' => $identity['service'],
-                'service_model' => $serviceLookup[$key] ?? null,
+                'service_model' => $serviceModel,
             ];
         }
 
@@ -415,6 +459,22 @@ class ServiceReviewDashboardQuery
             'service' => null,
             'service_model' => null,
         ];
+    }
+
+    /**
+     * Memoised per-key service lookup for the lazily iterated (capped) path,
+     * where the upfront bulk identity scan is skipped.
+     */
+    private function findServiceByIdentity(string $key, string $date, SermonService $service): ?ChurchService
+    {
+        if (! array_key_exists($key, $this->serviceKeyLookupCache)) {
+            $this->serviceKeyLookupCache[$key] = ChurchService::query()
+                ->whereDate('date', $date)
+                ->where('service', $service->value)
+                ->first();
+        }
+
+        return $this->serviceKeyLookupCache[$key];
     }
 
     /**

--- a/app/Queries/ServiceReviewDashboardQuery.php
+++ b/app/Queries/ServiceReviewDashboardQuery.php
@@ -30,9 +30,11 @@ class ServiceReviewDashboardQuery
 
     /**
      * @param  int|null  $sectionLimit  When set, at most this many flagged sections are
-     *                                  collected (newest first) and the backlog is iterated
-     *                                  lazily — the capped inbox path. Null keeps the full,
-     *                                  exact result the dashboard summary and counts rely on.
+     *                                  collected (newest first), the backlog is iterated
+     *                                  lazily, and section-less needs_review service groups
+     *                                  are omitted — the capped inbox path, which only reads
+     *                                  section entries. Null keeps the full, exact result the
+     *                                  dashboard summary and counts rely on.
      * @return array<int, array{
      *     key:string,
      *     date:string|null,
@@ -57,21 +59,24 @@ class ServiceReviewDashboardQuery
      */
     public function reviewGroups(?int $sectionLimit = null): array
     {
-        $reviewServices = ChurchService::query()
-            ->where('needs_review', true)
-            ->orderByDesc('date')
-            ->orderBy('service')
-            ->get();
-
         if ($sectionLimit === null) {
+            $reviewServices = ChurchService::query()
+                ->where('needs_review', true)
+                ->orderByDesc('date')
+                ->orderBy('service')
+                ->get();
+
             $sections = $this->reviewSections();
             $serviceLookup = $this->serviceLookup($sections, $reviewServices);
         } else {
-            // Capped callers (the inbox) iterate lazily so a large backlog is
-            // never fully hydrated; group services are resolved per key on
-            // demand instead of via the upfront identity scan.
+            // Capped callers (the inbox) only consume section entries, so the
+            // needs_review service seeding is skipped too — hydrating every
+            // flagged service would unbound the render cost the cap exists to
+            // contain. Sections iterate lazily and group services resolve per
+            // key on demand instead of via the upfront identity scan.
+            $reviewServices = new EloquentCollection;
             $sections = $this->reviewSectionsQuery()->lazy(self::LAZY_CHUNK_SIZE);
-            $serviceLookup = $this->keyedServices($reviewServices);
+            $serviceLookup = [];
         }
 
         $groups = [];

--- a/resources/views/livewire/admin/church-services/list-section-publications.blade.php
+++ b/resources/views/livewire/admin/church-services/list-section-publications.blade.php
@@ -5,11 +5,8 @@
     items-name="section"
 >
     <x-slot:actions>
-        <x-button link="{{ route('admin.services.review') }}" variant="outline" inline>
-            Review dashboard
-        </x-button>
-        <x-button link="{{ route('admin.services.songs.index') }}" variant="outline" icon="musical-note" inline>
-            Song catalogue
+        <x-button link="{{ route('admin.services.inbox') }}" variant="outline" icon="inbox" inline>
+            Review inbox
         </x-button>
         <x-button link="{{ route('admin.services.index') }}" variant="outline" inline>
             Back to services

--- a/resources/views/livewire/admin/church-services/processing-review-list.blade.php
+++ b/resources/views/livewire/admin/church-services/processing-review-list.blade.php
@@ -5,6 +5,9 @@
     items-name="run"
 >
     <x-slot:actions>
+        <x-button link="{{ route('admin.services.inbox') }}" variant="outline" icon="inbox" inline>
+            Review inbox
+        </x-button>
         <x-button link="{{ route('admin.services.index') }}" variant="outline" inline>
             Back to services
         </x-button>

--- a/resources/views/livewire/admin/church-services/review-inbound-emails.blade.php
+++ b/resources/views/livewire/admin/church-services/review-inbound-emails.blade.php
@@ -3,14 +3,11 @@
     description="Review low-confidence or failed order-of-service emails before they become canonical."
 >
     <x-slot:actions>
+        <x-button link="{{ route('admin.services.inbox') }}" variant="outline" icon="inbox" inline>
+            Review inbox
+        </x-button>
         <x-button link="{{ route('admin.services.index') }}" variant="outline" inline>
             Back to services
-        </x-button>
-        <x-button link="{{ route('admin.services.upload') }}" variant="outline" icon="arrow-up-tray" inline>
-            Upload service
-        </x-button>
-        <x-button link="{{ route('admin.services.submit-email') }}" variant="outline" icon="envelope" inline>
-            Import email text
         </x-button>
     </x-slot:actions>
 

--- a/resources/views/livewire/admin/church-services/review-inbox.blade.php
+++ b/resources/views/livewire/admin/church-services/review-inbox.blade.php
@@ -1,0 +1,210 @@
+<x-admin.page
+    title="Review inbox"
+    description="Everything that needs a human, grouped by service"
+>
+    <x-slot:actions>
+        <x-button link="{{ route('admin.services.index') }}" variant="outline" inline>
+            Back to services
+        </x-button>
+    </x-slot:actions>
+
+    {{-- Filter chips --}}
+    <div class="flex flex-wrap gap-2" role="group" aria-label="Filter inbox by item type">
+        @foreach($filterChips as $chip)
+            <button
+                type="button"
+                wire:click="$set('filter', '{{ $chip['key'] }}')"
+                wire:key="inbox-filter-{{ $chip['key'] }}"
+                aria-pressed="{{ $filter === $chip['key'] ? 'true' : 'false' }}"
+                class="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 {{ $filter === $chip['key'] ? 'bg-cbc-teal text-white' : 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-50' }}"
+            >
+                {{ $chip['label'] }}
+                <span class="inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-xs font-semibold {{ $filter === $chip['key'] ? 'bg-white/20 text-white' : 'bg-gray-100 text-gray-600' }}">
+                    {{ $chip['count'] }}
+                </span>
+            </button>
+        @endforeach
+    </div>
+
+    <div class="mt-6 space-y-6" wire:loading.class.delay.200ms="opacity-50">
+        @forelse($groups as $group)
+            <x-card wire:key="inbox-group-{{ $group['key'] }}">
+                <div class="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 pb-3">
+                    <h2 class="font-display text-lg text-gray-900">
+                        {{ $group['date_label'] }}{{ $group['service_label'] !== '' ? ' — '.$group['service_label'] : '' }}
+                    </h2>
+                    @if($group['service'] !== null)
+                        <x-button link="{{ route('admin.services.show', $group['service']) }}" variant="ghost" size="xs" icon="arrow-right" iconPosition="trailing" inline>
+                            Open service
+                        </x-button>
+                    @endif
+                </div>
+
+                <ul class="divide-y divide-gray-100">
+                    @foreach($group['items'] as $index => $item)
+                        <li class="py-4" wire:key="inbox-item-{{ $group['key'] }}-{{ $item['kind'] }}-{{ $index }}">
+                            @if($item['kind'] === 'email')
+                                @php $preview = $item['preview']; @endphp
+                                <div class="flex flex-wrap items-start justify-between gap-4">
+                                    <div class="min-w-0 space-y-1">
+                                        <p class="flex items-center gap-2 text-sm font-medium text-gray-900">
+                                            <x-heroicon-o-envelope class="h-4 w-4 shrink-0 text-gray-400" aria-hidden="true" />
+                                            {{ $item['email']->subject ?: '(no subject)' }}
+                                        </p>
+                                        <p class="text-xs text-gray-500">
+                                            From {{ $item['email']->from }} · received {{ $item['email']->received_at?->format('j M Y H:i') }}
+                                        </p>
+                                        <p class="text-xs text-gray-500">
+                                            {{ count($preview['preview_items']) }} parsed {{ \Illuminate\Support\Str::plural('item', count($preview['preview_items'])) }}
+                                            @if($preview['confidence_score'] !== null)
+                                                · {{ round($preview['confidence_score'] * 100) }}% confidence
+                                            @endif
+                                            @if($preview['warnings'] !== [])
+                                                · {{ count($preview['warnings']) }} {{ \Illuminate\Support\Str::plural('warning', count($preview['warnings'])) }}
+                                            @endif
+                                        </p>
+                                        @if($preview['failure_message'] !== null)
+                                            <p class="text-xs text-rose-700">{{ $preview['failure_message'] }}</p>
+                                        @endif
+                                    </div>
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        @if($preview['can_approve'])
+                                            <x-form-button size="xs" variant="primary" icon="check" wire:click="approveEmail({{ $item['email']->id }})">
+                                                Approve
+                                            </x-form-button>
+                                        @endif
+                                        <x-form-button size="xs" variant="outline" icon="pencil-square" wire:click="editAndApproveEmail({{ $item['email']->id }})">
+                                            Edit &amp; approve
+                                        </x-form-button>
+                                        <x-form-button size="xs" variant="outline" icon="arrow-path" wire:click="reparseEmail({{ $item['email']->id }})">
+                                            Re-parse
+                                        </x-form-button>
+                                        <x-form-button
+                                            size="xs"
+                                            variant="danger"
+                                            icon="x-mark"
+                                            wire:click="rejectEmail({{ $item['email']->id }})"
+                                            wire:confirm="Are you sure you want to reject this email? This cannot be undone."
+                                        >
+                                            Reject
+                                        </x-form-button>
+                                        <x-button link="{{ route('admin.services.inbound-emails') }}" variant="ghost" size="xs" icon="arrow-top-right-on-square" inline aria-label="Open the full email review page">
+                                            Full view
+                                        </x-button>
+                                    </div>
+                                </div>
+                            @elseif($item['kind'] === 'section')
+                                @php $section = $item['section']; @endphp
+                                <div class="flex flex-wrap items-start justify-between gap-4">
+                                    <div class="min-w-0 space-y-1">
+                                        <p class="flex items-center gap-2 text-sm font-medium text-gray-900">
+                                            <x-heroicon-o-rectangle-stack class="h-4 w-4 shrink-0 text-gray-400" aria-hidden="true" />
+                                            {{ $section->title ?: $section->section_type->label() }}
+                                        </p>
+                                        <div class="flex flex-wrap gap-1">
+                                            @foreach($item['reasons'] as $reason)
+                                                <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {{ $reason['classes'] }}">{{ $reason['label'] }}</span>
+                                            @endforeach
+                                        </div>
+                                        @if($item['review_reason'] !== null)
+                                            <p class="text-xs text-gray-500">{{ $item['review_reason'] }}</p>
+                                        @endif
+                                        <p class="space-x-3 text-xs">
+                                            @if($item['audio_url'] !== null)
+                                                <a href="{{ $item['audio_url'] }}" target="_blank" rel="noopener" class="text-cbc-teal-dark underline hover:no-underline">Audio preview</a>
+                                            @endif
+                                            @if($item['video_url'] !== null)
+                                                <a href="{{ $item['video_url'] }}" target="_blank" rel="noopener" class="text-cbc-teal-dark underline hover:no-underline">Video preview</a>
+                                            @endif
+                                        </p>
+                                    </div>
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        @if($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::PendingApproval)
+                                            <x-form-button size="xs" variant="primary" icon="check" wire:click="approve({{ $section->id }})">
+                                                Approve
+                                            </x-form-button>
+                                            <x-form-button size="xs" variant="danger" icon="x-mark" wire:click="reject({{ $section->id }})" wire:confirm="Reject this section?">
+                                                Reject
+                                            </x-form-button>
+                                        @elseif($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::Rejected)
+                                            <x-form-button size="xs" variant="outline" icon="arrow-uturn-left" wire:click="requeue({{ $section->id }})">
+                                                Requeue
+                                            </x-form-button>
+                                        @endif
+                                        <x-button link="{{ route('admin.services.review') }}" variant="ghost" size="xs" icon="arrow-top-right-on-square" inline aria-label="Edit this section on the review dashboard">
+                                            Edit
+                                        </x-button>
+                                    </div>
+                                </div>
+                            @elseif($item['kind'] === 'segment')
+                                @php $run = $item['run']; @endphp
+                                <div class="flex flex-wrap items-start justify-between gap-4">
+                                    <div class="min-w-0 space-y-1">
+                                        <p class="flex items-center gap-2 text-sm font-medium text-gray-900">
+                                            <x-heroicon-o-video-camera class="h-4 w-4 shrink-0 text-gray-400" aria-hidden="true" />
+                                            {{ $run->original_filename }}
+                                        </p>
+                                        <p class="text-xs text-gray-500">
+                                            Sermon segment needs confirming
+                                            @if(($item['run']->manualReviewMetadata()['reason_message'] ?? null) !== null)
+                                                · {{ $item['run']->manualReviewMetadata()['reason_message'] }}
+                                            @endif
+                                        </p>
+                                    </div>
+                                    <x-button link="{{ route('admin.services.processing.review', $run) }}" variant="primary" size="xs" icon="arrow-right" iconPosition="trailing" inline>
+                                        Choose segment
+                                    </x-button>
+                                </div>
+                            @elseif($item['kind'] === 'merge')
+                                <div class="flex flex-wrap items-start justify-between gap-4">
+                                    <div class="min-w-0 space-y-1">
+                                        <p class="flex items-center gap-2 text-sm font-medium text-gray-900">
+                                            <x-heroicon-o-arrows-pointing-in class="h-4 w-4 shrink-0 text-gray-400" aria-hidden="true" />
+                                            Pending structure merge
+                                        </p>
+                                        <p class="text-xs text-gray-500">
+                                            Incoming {{ strtoupper((string) $item['service']->pending_structure_merge_source) }} plan conflicts with the current order of service.
+                                        </p>
+                                    </div>
+                                    <x-button link="{{ route('admin.services.show', $item['service']) }}" variant="primary" size="xs" icon="arrow-right" iconPosition="trailing" inline>
+                                        Resolve
+                                    </x-button>
+                                </div>
+                            @elseif($item['kind'] === 'service_flag')
+                                <div class="flex flex-wrap items-start justify-between gap-4">
+                                    <div class="min-w-0 space-y-1">
+                                        <p class="flex items-center gap-2 text-sm font-medium text-gray-900">
+                                            <x-heroicon-o-flag class="h-4 w-4 shrink-0 text-gray-400" aria-hidden="true" />
+                                            Service flagged for review
+                                        </p>
+                                        <p class="text-xs text-gray-500">
+                                            Check the imported order of service, then mark it reviewed.
+                                        </p>
+                                    </div>
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <x-form-button size="xs" variant="outline" icon="check" wire:click="markServiceReviewed({{ $item['service']->id }})">
+                                            Mark reviewed
+                                        </x-form-button>
+                                        <x-button link="{{ route('admin.services.show', $item['service']) }}" variant="ghost" size="xs" icon="arrow-right" iconPosition="trailing" inline>
+                                            Open service
+                                        </x-button>
+                                    </div>
+                                </div>
+                            @endif
+                        </li>
+                    @endforeach
+                </ul>
+            </x-card>
+        @empty
+            <x-card>
+                <div class="flex flex-col items-center gap-3 py-10 text-center">
+                    <x-heroicon-o-check-circle class="h-10 w-10 text-cbc-teal" aria-hidden="true" />
+                    <p class="font-display text-lg text-gray-900">All caught up — nothing needs review.</p>
+                    <x-button link="{{ route('admin.services.index') }}" variant="outline" inline>
+                        Back to services
+                    </x-button>
+                </div>
+            </x-card>
+        @endforelse
+    </div>
+</x-admin.page>

--- a/resources/views/livewire/admin/church-services/review-inbox.blade.php
+++ b/resources/views/livewire/admin/church-services/review-inbox.blade.php
@@ -26,6 +26,15 @@
         @endforeach
     </div>
 
+    @if($overflowNotices !== [])
+        <p class="mt-3 text-sm text-gray-500">
+            @foreach($overflowNotices as $notice)
+                Showing the newest {{ $notice['shown'] }} of {{ $notice['total'] }} {{ $notice['label'] }}.
+            @endforeach
+            Action items to surface the rest.
+        </p>
+    @endif
+
     <div class="mt-6 space-y-6" wire:loading.class.delay.200ms="opacity-50">
         @forelse($groups as $group)
             <x-card wire:key="inbox-group-{{ $group['key'] }}">

--- a/resources/views/livewire/admin/church-services/service-review-dashboard.blade.php
+++ b/resources/views/livewire/admin/church-services/service-review-dashboard.blade.php
@@ -1,7 +1,7 @@
 <x-admin.page title="Service review dashboard" description="Review flagged services and classified sections in one queue">
     <x-slot:actions>
-        <x-button link="{{ route('admin.services.section-publications') }}" variant="outline" inline>
-            Section queue
+        <x-button link="{{ route('admin.services.inbox') }}" variant="outline" icon="inbox" inline>
+            Review inbox
         </x-button>
         <x-button link="{{ route('admin.services.index') }}" variant="outline" inline>
             Back to services

--- a/resources/views/members/home.blade.php
+++ b/resources/views/members/home.blade.php
@@ -34,43 +34,36 @@
             </h3>
           </div>
           <div class="p-4 grid grid-cols-2 gap-2">
+            @if($serviceTrackingEnabled ?? true)
+            <x-button link="{{ route('admin.services.index') }}" icon="queue-list" iconStyle="solid">
+              Services
+            </x-button>
+
+            <x-button link="{{ route('admin.services.inbox') }}" icon="inbox" iconStyle="solid">
+              Review inbox
+              @if(($reviewInboxCount ?? 0) > 0)
+              <span class="rounded-full bg-white/20 px-2 py-0.5 text-xs font-semibold">
+                {{ $reviewInboxCount }}
+              </span>
+              @endif
+            </x-button>
+            @else
+            {{-- Recording upload is gated only by the Sermon create Gate, so it
+                 stays reachable when service tracking is switched off. --}}
             <x-button link="{{ route('admin.sermon-upload.create') }}" icon="arrow-up-tray" iconStyle="solid">
               Upload sermon
             </x-button>
+            @endif
 
             <x-button link="{{ route('admin.sermons.index') }}" icon="pencil-square" iconStyle="solid">
               Manage sermons
             </x-button>
 
-            <x-button link="{{ route('admin.services.upload') }}" icon="arrow-up-tray" iconStyle="solid">
-              Upload service order
-            </x-button>
-
-            <x-button link="{{ route('admin.services.index') }}" icon="queue-list" iconStyle="solid">
-              View services
-            </x-button>
-
-            <x-button link="{{ route('admin.services.inbound-emails') }}" icon="envelope" iconStyle="solid">
-              Review inbound emails
-              @if(($pendingInboundEmailCount ?? 0) > 0)
-              <span class="rounded-full bg-white/20 px-2 py-0.5 text-xs font-semibold">
-                {{ $pendingInboundEmailCount }}
-              </span>
-              @endif
-            </x-button>
-
-            <x-button link="{{ route('admin.services.processing.review.index') }}" icon="video-camera" iconStyle="solid">
-              Sermon review
-              @if(($pendingSermonReviewCount ?? 0) > 0)
-              <span class="rounded-full bg-white/20 px-2 py-0.5 text-xs font-semibold">
-                {{ $pendingSermonReviewCount }}
-              </span>
-              @endif
-            </x-button>
-
+            @if($serviceTrackingEnabled ?? true)
             <x-button link="{{ route('admin.services.songs.index') }}" icon="musical-note" iconStyle="solid">
               Song catalogue
             </x-button>
+            @endif
           </div>
         </div>
         @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,7 @@ use App\Livewire\Admin\ChurchServices\ManageChurchService;
 use App\Livewire\Admin\ChurchServices\ProcessingReview;
 use App\Livewire\Admin\ChurchServices\ProcessingReviewList;
 use App\Livewire\Admin\ChurchServices\ReviewInboundEmails;
+use App\Livewire\Admin\ChurchServices\ReviewInbox;
 use App\Livewire\Admin\ChurchServices\ServiceReviewDashboard;
 use App\Livewire\Admin\ChurchServices\ShowChurchService;
 use App\Livewire\Admin\ChurchServices\ShowSong;
@@ -191,6 +192,7 @@ Route::middleware(['auth', 'verified', 'admin'])->prefix('admin')->name('admin.'
 
     // Church Services
     Route::get('/services', ListChurchServices::class)->name('services.index');
+    Route::get('/services/inbox', ReviewInbox::class)->name('services.inbox');
     Route::get('/services/create', ManageChurchService::class)->name('services.create');
     Route::get('/services/upload', UploadChurchService::class)->name('services.upload');
     Route::get('/services/inbound-emails', ReviewInboundEmails::class)->name('services.inbound-emails');

--- a/tests/Browser/MembersTest.php
+++ b/tests/Browser/MembersTest.php
@@ -43,8 +43,10 @@ class MembersTest extends DuskTestCase
             $browser->loginAs($admin)
                 ->visit('/church/members')
                 ->assertSee('Services, sermons and songs')
-                ->assertSee('Upload sermon')
-                ->assertSee('Manage sermons');
+                ->assertSee('Services')
+                ->assertSee('Review inbox')
+                ->assertSee('Manage sermons')
+                ->assertSee('Song catalogue');
         });
     }
 
@@ -55,22 +57,22 @@ class MembersTest extends DuskTestCase
         $this->browse(function (Browser $browser) use ($user) {
             $browser->loginAs($user)
                 ->visit('/church/members')
-                ->assertDontSee('Upload sermon')
+                ->assertDontSee('Review inbox')
                 ->assertDontSee('Manage sermons')
                 ->assertSee('Welcome back');
         });
     }
 
-    public function test_admin_upload_sermon_link_navigates(): void
+    public function test_admin_review_inbox_link_navigates(): void
     {
         $admin = User::factory()->crockenhillAdmin()->create();
 
         $this->browse(function (Browser $browser) use ($admin) {
             $browser->loginAs($admin)
                 ->visit('/church/members')
-                ->clickLink('Upload sermon')
-                ->waitForLocation('/admin/sermon-upload')
-                ->assertPathIs('/admin/sermon-upload');
+                ->clickLink('Review inbox')
+                ->waitForLocation('/admin/services/inbox')
+                ->assertPathIs('/admin/services/inbox');
         });
     }
 

--- a/tests/Feature/Admin/AdminLivewireAuthorizationTest.php
+++ b/tests/Feature/Admin/AdminLivewireAuthorizationTest.php
@@ -182,6 +182,7 @@ class AdminLivewireAuthorizationTest extends TestCase
             ['admin.sermons.index', []],
             ['admin.sermons.edit', ['sermon' => $sermon]],
             ['admin.services.index', []],
+            ['admin.services.inbox', []],
             ['admin.services.create', []],
             ['admin.services.upload', []],
             ['admin.services.inbound-emails', []],

--- a/tests/Feature/Livewire/Admin/ChurchServices/ReviewInboxTest.php
+++ b/tests/Feature/Livewire/Admin/ChurchServices/ReviewInboxTest.php
@@ -13,7 +13,9 @@ use App\Models\InboundEmail;
 use App\Models\MediaProcessingLog;
 use App\Models\ServiceSection;
 use App\Models\User;
+use App\Queries\ReviewInboxQuery;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
@@ -316,6 +318,47 @@ class ReviewInboxTest extends TestCase
             ->assertDontSee('Hidden Section')
             ->assertDontSee('Sections')
             ->assertSee('All caught up');
+    }
+
+    #[Test]
+    public function a_pending_merge_is_never_displaced_by_newer_review_flags(): void
+    {
+        ChurchService::factory()->create([
+            'date' => '2025-01-05',
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+            'pending_structure_merge_source' => 'openlp',
+        ]);
+
+        // A full cap of newer review-flagged services must not push the
+        // older pending merge out of the queue (the hub chip counts it).
+        foreach (range(1, ReviewInboxQuery::SOURCE_CAP) as $week) {
+            ChurchService::factory()->create([
+                'date' => Carbon::parse('2025-02-01')->addWeeks($week)->toDateString(),
+                'service' => SermonService::Morning,
+                'needs_review' => true,
+            ]);
+        }
+
+        Livewire::test(ReviewInbox::class)
+            ->set('filter', 'services')
+            ->assertSee('Pending structure merge');
+    }
+
+    #[Test]
+    public function an_overflow_notice_reports_the_true_backlog_when_a_source_is_capped(): void
+    {
+        InboundEmail::factory()->count(ReviewInboxQuery::SOURCE_CAP + 1)->create([
+            'status' => InboundEmailStatus::Pending->value,
+            'processing_metadata' => null,
+        ]);
+
+        Livewire::test(ReviewInbox::class)
+            ->assertSee(sprintf(
+                'Showing the newest %d of %d emails.',
+                ReviewInboxQuery::SOURCE_CAP,
+                ReviewInboxQuery::SOURCE_CAP + 1,
+            ));
     }
 
     #[Test]

--- a/tests/Feature/Livewire/Admin/ChurchServices/ReviewInboxTest.php
+++ b/tests/Feature/Livewire/Admin/ChurchServices/ReviewInboxTest.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire\Admin\ChurchServices;
+
+use App\Enums\InboundEmailStatus;
+use App\Enums\SermonService;
+use App\Enums\ServiceSectionPublicationStatus;
+use App\Livewire\Admin\ChurchServices\ReviewInbox;
+use App\Models\ChurchService;
+use App\Models\InboundEmail;
+use App\Models\MediaProcessingLog;
+use App\Models\ServiceSection;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Tests\Traits\WithInboundEmailTestHelpers;
+
+class ReviewInboxTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithInboundEmailTestHelpers;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create([
+            'is_admin' => true,
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($this->admin);
+    }
+
+    #[Test]
+    public function it_renders_every_item_kind_grouped_by_service(): void
+    {
+        InboundEmail::factory()->create([
+            'subject' => 'Order of service 7 June',
+            'status' => InboundEmailStatus::Pending->value,
+            'processing_metadata' => $this->processingMetadata(
+                '2026-06-07',
+                'morning',
+                [['title' => 'Welcome', 'type' => 'custom']],
+            ),
+        ]);
+
+        $service = ChurchService::factory()->create([
+            'date' => '2026-06-07',
+            'service' => SermonService::Morning,
+            'needs_review' => true,
+            'pending_structure_merge_source' => 'openlp',
+        ]);
+
+        $run = MediaProcessingLog::factory()->livestream()->completed()->create([
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+            'sermon_id' => null,
+        ]);
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'title' => 'Flagged Children Talk',
+            'needs_manual_review' => true,
+        ]);
+
+        MediaProcessingLog::factory()->livestream()->manualReviewRequired()->create([
+            'original_filename' => 'livestream-2026-06-07.mp4',
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+        ]);
+
+        Livewire::test(ReviewInbox::class)
+            ->assertSee('7 Jun 2026 — Morning')
+            ->assertSee('Order of service 7 June')
+            ->assertSee('Flagged Children Talk')
+            ->assertSee('livestream-2026-06-07.mp4')
+            ->assertSee('Choose segment')
+            ->assertSee('Pending structure merge')
+            ->assertSee('Service flagged for review')
+            ->assertSeeHtml(route('admin.services.show', $service));
+    }
+
+    #[Test]
+    public function unparsed_emails_land_in_a_pinned_unattributed_group(): void
+    {
+        InboundEmail::factory()->create([
+            'subject' => 'Mystery email',
+            'status' => InboundEmailStatus::Failed->value,
+            'processing_metadata' => null,
+        ]);
+
+        ChurchService::factory()->create([
+            'date' => '2026-06-07',
+            'service' => SermonService::Morning,
+            'needs_review' => true,
+        ]);
+
+        Livewire::test(ReviewInbox::class)
+            ->assertSeeInOrder(['Unattributed', 'Mystery email', '7 Jun 2026']);
+    }
+
+    #[Test]
+    public function filter_chips_narrow_the_queue_and_zero_count_chips_are_hidden(): void
+    {
+        InboundEmail::factory()->create([
+            'subject' => 'Filterable email',
+            'status' => InboundEmailStatus::Pending->value,
+            'processing_metadata' => $this->processingMetadata(
+                '2026-06-07',
+                'morning',
+                [['title' => 'Welcome', 'type' => 'custom']],
+            ),
+        ]);
+
+        ChurchService::factory()->create([
+            'date' => '2026-06-14',
+            'service' => SermonService::Morning,
+            'needs_review' => true,
+        ]);
+
+        Livewire::test(ReviewInbox::class)
+            ->assertSee('Emails')
+            ->assertSee('Services')
+            ->assertDontSee('Segments') // zero-count chip hidden
+            ->set('filter', 'emails')
+            ->assertSee('Filterable email')
+            ->assertDontSee('Service flagged for review')
+            ->set('filter', 'services')
+            ->assertSee('Service flagged for review')
+            ->assertDontSee('Filterable email');
+    }
+
+    #[Test]
+    public function approve_email_imports_the_service_and_redirects_to_it(): void
+    {
+        $email = InboundEmail::factory()->create([
+            'status' => InboundEmailStatus::Pending->value,
+            'processing_metadata' => $this->processingMetadata(
+                '2026-06-07',
+                'morning',
+                [
+                    ['position' => 1, 'type' => 'custom', 'title' => 'Welcome', 'metadata' => ['email_type' => 'welcome']],
+                    ['position' => 2, 'type' => 'custom', 'title' => 'Sermon', 'metadata' => ['email_type' => 'sermon']],
+                ],
+            ),
+        ]);
+
+        Livewire::test(ReviewInbox::class)
+            ->call('approveEmail', $email->id);
+
+        $service = ChurchService::query()
+            ->whereDate('date', '2026-06-07')
+            ->where('service', SermonService::Morning->value)
+            ->first();
+
+        $this->assertNotNull($service);
+        $this->assertSame(InboundEmailStatus::Processed, $email->fresh()->status);
+    }
+
+    #[Test]
+    public function edit_and_approve_redirects_to_the_manual_form_prefilled_with_the_email(): void
+    {
+        $email = InboundEmail::factory()->create([
+            'status' => InboundEmailStatus::Pending->value,
+            'processing_metadata' => $this->processingMetadata(
+                '2026-06-07',
+                'morning',
+                [['title' => 'Welcome', 'type' => 'custom']],
+            ),
+        ]);
+
+        Livewire::test(ReviewInbox::class)
+            ->call('editAndApproveEmail', $email->id)
+            ->assertRedirect(route('admin.services.create', ['inboundEmailId' => $email->id]));
+    }
+
+    #[Test]
+    public function reject_email_marks_it_rejected_and_refreshes_the_list(): void
+    {
+        $email = InboundEmail::factory()->create([
+            'subject' => 'Reject me',
+            'status' => InboundEmailStatus::Pending->value,
+            'processing_metadata' => null,
+        ]);
+
+        Livewire::test(ReviewInbox::class)
+            ->assertSee('Reject me')
+            ->call('rejectEmail', $email->id)
+            ->assertDispatched('notify', type: 'success', message: 'Inbound email rejected.')
+            ->assertDontSee('Reject me');
+
+        $this->assertSame(InboundEmailStatus::Rejected, $email->fresh()->status);
+    }
+
+    #[Test]
+    public function section_reject_and_requeue_delegate_to_the_publication_actions(): void
+    {
+        $run = MediaProcessingLog::factory()->livestream()->completed()->create([
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+            'sermon_id' => null,
+        ]);
+
+        $section = ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'title' => 'Pending Section',
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
+        ]);
+
+        $component = Livewire::test(ReviewInbox::class)
+            ->assertSee('Pending Section')
+            ->call('reject', $section->id)
+            ->assertDispatched('notify', type: 'success', message: 'Section rejected.');
+
+        $this->assertSame(ServiceSectionPublicationStatus::Rejected, $section->fresh()->publication_status);
+
+        $component
+            ->call('requeue', $section->id)
+            ->assertDispatched('notify', type: 'success', message: 'Section moved back to pending approval.');
+
+        $this->assertSame(ServiceSectionPublicationStatus::PendingApproval, $section->fresh()->publication_status);
+    }
+
+    #[Test]
+    public function mark_service_reviewed_clears_the_flag(): void
+    {
+        $service = ChurchService::factory()->create([
+            'date' => '2026-06-07',
+            'service' => SermonService::Morning,
+            'needs_review' => true,
+        ]);
+
+        Livewire::test(ReviewInbox::class)
+            ->assertSee('Service flagged for review')
+            ->call('markServiceReviewed', $service->id)
+            ->assertDispatched('notify', type: 'success', message: 'Service marked as reviewed.')
+            ->assertDontSee('Service flagged for review');
+
+        $this->assertFalse($service->fresh()->needs_review);
+    }
+
+    #[Test]
+    public function every_mutating_action_rejects_non_admin_users(): void
+    {
+        $member = User::factory()->create([
+            'is_admin' => false,
+            'email_verified_at' => now(),
+        ]);
+
+        $email = InboundEmail::factory()->create(['status' => InboundEmailStatus::Pending->value]);
+        $service = ChurchService::factory()->create(['needs_review' => true]);
+        $run = MediaProcessingLog::factory()->livestream()->completed()->create(['sermon_id' => null]);
+        $section = ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
+        ]);
+
+        $this->actingAs($member);
+
+        foreach ([
+            ['approveEmail', $email->id],
+            ['editAndApproveEmail', $email->id],
+            ['reparseEmail', $email->id],
+            ['rejectEmail', $email->id],
+            ['approve', $section->id],
+            ['reject', $section->id],
+            ['requeue', $section->id],
+            ['markServiceReviewed', $service->id],
+        ] as [$action, $argument]) {
+            Livewire::test(ReviewInbox::class)
+                ->call($action, $argument)
+                ->assertForbidden();
+        }
+    }
+
+    #[Test]
+    public function the_inbox_route_is_admin_only_and_respects_the_service_tracking_gate(): void
+    {
+        $this->get(route('admin.services.inbox'))->assertOk();
+
+        config(['service-tracking.enabled' => false]);
+        $this->get(route('admin.services.inbox'))->assertNotFound();
+
+        config(['service-tracking.enabled' => true]);
+        $member = User::factory()->create(['is_admin' => false, 'email_verified_at' => now()]);
+        $this->actingAs($member);
+        $this->get(route('admin.services.inbox'))->assertForbidden();
+    }
+
+    #[Test]
+    public function sections_are_omitted_when_section_publishing_is_disabled(): void
+    {
+        config(['media-processing.section_publishing.enabled' => false]);
+
+        $run = MediaProcessingLog::factory()->livestream()->completed()->create([
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+            'sermon_id' => null,
+        ]);
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'title' => 'Hidden Section',
+            'needs_manual_review' => true,
+        ]);
+
+        Livewire::test(ReviewInbox::class)
+            ->assertDontSee('Hidden Section')
+            ->assertDontSee('Sections')
+            ->assertSee('All caught up');
+    }
+
+    #[Test]
+    public function it_shows_the_empty_state_when_nothing_needs_review(): void
+    {
+        Livewire::test(ReviewInbox::class)
+            ->assertSee('All caught up — nothing needs review.')
+            ->assertSeeHtml(route('admin.services.index'));
+    }
+
+    #[Test]
+    public function segment_entries_never_hydrate_blob_columns(): void
+    {
+        MediaProcessingLog::factory()->livestream()->manualReviewRequired()->create([
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+        ]);
+
+        $selectQueries = [];
+
+        DB::listen(function ($query) use (&$selectQueries): void {
+            if (str_contains($query->sql, 'media_processing_logs') && str_starts_with(ltrim($query->sql), 'select')) {
+                $selectQueries[] = $query->sql;
+            }
+        });
+
+        Livewire::test(ReviewInbox::class)->assertStatus(200);
+
+        $this->assertNotEmpty($selectQueries);
+
+        foreach ($selectQueries as $sql) {
+            $this->assertStringNotContainsString('select *', strtolower($sql));
+            $this->assertStringNotContainsString('"media_processing_logs".*', $sql);
+
+            foreach (['visual_samples', 'song_clusters', 'rms_stats', 'ai_analysis', 'rms_log_path'] as $column) {
+                $this->assertStringNotContainsString("`{$column}`", $sql);
+            }
+        }
+    }
+}

--- a/tests/Feature/Livewire/AdminChurchServiceTest.php
+++ b/tests/Feature/Livewire/AdminChurchServiceTest.php
@@ -1155,7 +1155,7 @@ class AdminChurchServiceTest extends TestCase
     }
 
     #[Test]
-    public function hub_attention_strip_links_to_the_existing_queue_pages(): void
+    public function hub_attention_strip_links_to_the_review_inbox_filters(): void
     {
         $this->actingAs($this->admin);
 
@@ -1169,7 +1169,8 @@ class AdminChurchServiceTest extends TestCase
         Livewire::test(ListChurchServices::class)
             ->assertSee('Inbound emails')
             ->assertSee('Services needing review')
-            ->assertSeeHtml(route('admin.services.inbound-emails'))
+            ->assertSeeHtml(route('admin.services.inbox', ['filter' => 'emails']))
+            ->assertSeeHtml(route('admin.services.inbox', ['filter' => 'services']))
             ->assertDontSee('All caught up');
     }
 

--- a/tests/Feature/MemberControllerTest.php
+++ b/tests/Feature/MemberControllerTest.php
@@ -80,7 +80,7 @@ class MemberControllerTest extends TestCase
     }
 
     #[Test]
-    public function members_home_shows_the_inbound_email_review_link_for_admins(): void
+    public function members_home_shows_the_review_inbox_link_with_an_attention_badge(): void
     {
         $admin = User::factory()->admin()->create([
             'email_verified_at' => now(),
@@ -94,13 +94,13 @@ class MemberControllerTest extends TestCase
         $response = $this->get(route('members.home'));
 
         $response->assertOk();
-        $response->assertSee(route('admin.services.inbound-emails'));
-        $response->assertSeeText('Review inbound emails');
+        $response->assertSee(route('admin.services.inbox'));
+        $response->assertSeeText('Review inbox');
         $response->assertSeeText('2');
     }
 
     #[Test]
-    public function members_home_counts_legacy_livestream_manual_review_runs_for_admins(): void
+    public function review_inbox_badge_counts_legacy_livestream_manual_review_runs(): void
     {
         $admin = User::factory()->admin()->create([
             'email_verified_at' => now(),
@@ -117,8 +117,27 @@ class MemberControllerTest extends TestCase
         $response = $this->get(route('members.home'));
 
         $response->assertOk();
-        $response->assertSeeText('Sermon review');
+        $response->assertSeeText('Review inbox');
         $response->assertSeeText('1');
+    }
+
+    #[Test]
+    public function members_home_hides_service_buttons_but_keeps_uploads_when_service_tracking_is_disabled(): void
+    {
+        config(['service-tracking.enabled' => false]);
+
+        $admin = User::factory()->admin()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($admin);
+        $response = $this->get(route('members.home'));
+
+        $response->assertOk();
+        $response->assertDontSeeText('Review inbox');
+        $response->assertDontSee(route('admin.services.index'));
+        $response->assertSeeText('Upload sermon');
+        $response->assertSeeText('Manage sermons');
     }
 
     #[Test]

--- a/tests/Feature/Queries/ServiceReviewDashboardQueryTest.php
+++ b/tests/Feature/Queries/ServiceReviewDashboardQueryTest.php
@@ -102,6 +102,37 @@ class ServiceReviewDashboardQueryTest extends TestCase
     }
 
     #[Test]
+    public function review_groups_section_limit_caps_collection_and_still_resolves_group_services(): void
+    {
+        $service = ChurchService::factory()->create([
+            'date' => '2026-05-24',
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        // No church_service_id FK — the group's service must resolve via the
+        // extracted-identity lookup, which the capped path performs lazily.
+        $run = MediaProcessingLog::factory()->livestream()->create([
+            'extracted_date' => '2026-05-24',
+            'extracted_service' => SermonService::Morning->value,
+        ]);
+
+        ServiceSection::factory()->count(3)->create([
+            'media_processing_log_id' => $run->id,
+            'church_service_item_id' => null,
+            'needs_manual_review' => true,
+        ]);
+
+        $unlimited = $this->query->reviewGroups();
+        $this->assertSame(3, collect($unlimited)->sum(fn (array $group): int => count($group['sections'])));
+
+        $limited = $this->query->reviewGroups(2);
+        $this->assertCount(1, $limited);
+        $this->assertCount(2, $limited[0]['sections']);
+        $this->assertTrue($service->is($limited[0]['service']));
+    }
+
+    #[Test]
     public function review_groups_sorts_by_date_descending_then_service_ascending(): void
     {
         $olderService = ChurchService::factory()->create([

--- a/tests/Feature/Queries/ServiceReviewDashboardQueryTest.php
+++ b/tests/Feature/Queries/ServiceReviewDashboardQueryTest.php
@@ -133,6 +133,21 @@ class ServiceReviewDashboardQueryTest extends TestCase
     }
 
     #[Test]
+    public function capped_review_groups_omit_section_less_flagged_services(): void
+    {
+        // The capped inbox path only reads section entries, so it must not
+        // hydrate (or emit groups for) every needs_review service.
+        ChurchService::factory()->create([
+            'date' => '2026-05-24',
+            'service' => SermonService::Morning,
+            'needs_review' => true,
+        ]);
+
+        $this->assertCount(1, $this->query->reviewGroups());
+        $this->assertSame([], $this->query->reviewGroups(10));
+    }
+
+    #[Test]
     public function review_groups_sorts_by_date_descending_then_service_ascending(): void
     {
         $olderService = ChurchService::factory()->create([


### PR DESCRIPTION
Phase 2 of the [service & livestream UI consolidation plan](docs/plans/SERVICE-UI-CONSOLIDATION-2026-06-10.md). **Stacked on #798** (Phase 1 — services hub); merge that first, then re-target this to `master`.

`/admin/services/inbox` is the single "Monday-morning sweep" queue: inbound emails, flagged sections, paused sermon-segment runs, pending merges, and service review flags, grouped by service with inline quick actions. The four old queue pages stay fully routable (bookmarks, mid-flight habits) but lose their cross-link mesh — each header now carries just `Review inbox` + `Back to services`.

## Read model — `ReviewInboxQuery`

- **Section entries** reuse `ServiceReviewDashboardQuery::reviewGroups()` — the seven-reason review-candidate predicate, never re-derived (contract C1); omitted entirely when `media-processing.section_publishing.enabled` is off (C5).
- **Segment entries** keep the explicit TD-004B safe column list (C3) — pinned by a blob-column regression test against the inbox.
- Every source capped at 50 (the dashboard grouping is unbounded; the cap lives here, per the plan).
- Emails attribute to a (date, slot) group via their stored parse result; unparseable ones land in an **Unattributed** group pinned first.
- Chip counts come from the same result set the rows come from (C1).

## Component — `ReviewInbox`

- Filter chips `All | Emails | Sections | Segments | Services` as a `#[Url]` param; zero-count chips hidden; merge + flag items live under `Services`.
- Quick actions all delegate to existing actions: email **Approve / Edit & approve / Re-parse / Reject** (ported from `ReviewInboundEmails`), section **Approve / Reject / Requeue** via `ManagesSectionPublication`, segment **Choose segment →** (standalone page until Phase 3), merge **Resolve →** (service page), **Mark reviewed** via `MarkServiceReviewed`.
- Every mutating action calls `$this->authorizeAdmin()` first (C4) — pinned by a test that calls all eight as a non-admin.
- Route registered before the `/services/{churchService}` catch-all; added to the admin-200 smoke scenarios.

## Navigation re-pointing

- Hub attention chips now deep-link to inbox filters.
- Members home "Services, sermons and songs" card shrinks to **Services · Review inbox (badge = cached attention total) · Manage sermons · Song catalogue**. When `service-tracking.enabled` is false the gated buttons are hidden and the recording upload stays reachable (C5) — previously the grid silently linked to 404s in that state.

## Tests

- New `ReviewInboxTest` (13 tests): every item kind, grouping/attribution, filter chips, each quick action, per-action authorization, both config gates, empty state, blob-column guard.
- `MemberControllerTest` migrated to the inbox badge + new gating test; Dusk `MembersTest` updated to the new button set; `AdminInboundEmailReviewTest` / `AdminSectionPublicationQueueTest` / `ProcessingReviewListTest` untouched and passing (pages live until Phase 5).

## Quality gates

- `pint --dirty` ✅ · `composer phpstan` ✅ (0 errors) · `artisan test --parallel` ✅ (5,507) · `artisan dusk` ✅ (43)

🤖 Generated with [Claude Code](https://claude.com/claude-code)