### PR TITLE
Workbench inline section review on the timeline (consolidation P3.2)

### DIFF
--- a/app/Data/ChurchServiceShowReadModel.php
+++ b/app/Data/ChurchServiceShowReadModel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Data;
 
 use App\Models\ChurchService;
+use App\Models\ServiceSection;
 
 final readonly class ChurchServiceShowReadModel
 {
@@ -13,6 +14,8 @@ final readonly class ChurchServiceShowReadModel
      * @param  list<string>  $warnings
      * @param  list<ChurchServiceProcessingRunView>  $processingRunViews
      * @param  list<array{label: string, state: string}>  $pipelineSteps
+     * @param  array<int, array{section: ServiceSection, reasons: array<int, array{key: string, label: string, classes: string}>, review_reason: string|null, audio_url: string|null, video_url: string|null}>  $sectionReviewPanels
+     * @param  array<int, int>  $mergeCandidatePairs
      */
     public function __construct(
         public ChurchService $churchService,
@@ -23,6 +26,10 @@ final readonly class ChurchServiceShowReadModel
         public ?PendingStructureMergeMetadata $pendingMerge,
         public ?string $pendingMergeSource,
         public array $pipelineSteps,
+        public array $sectionReviewPanels,
+        public array $mergeCandidatePairs,
+        public int $pendingApprovalCount,
+        public bool $sectionPublishingEnabled,
     ) {}
 
     /**
@@ -34,7 +41,11 @@ final readonly class ChurchServiceShowReadModel
      *     processingRunViews: list<ChurchServiceProcessingRunView>,
      *     pendingMerge: ?PendingStructureMergeMetadata,
      *     pendingMergeSource: ?string,
-     *     pipelineSteps: list<array{label: string, state: string}>
+     *     pipelineSteps: list<array{label: string, state: string}>,
+     *     sectionReviewPanels: array<int, array{section: ServiceSection, reasons: array<int, array{key: string, label: string, classes: string}>, review_reason: string|null, audio_url: string|null, video_url: string|null}>,
+     *     mergeCandidatePairs: array<int, int>,
+     *     pendingApprovalCount: int,
+     *     sectionPublishingEnabled: bool
      * }
      */
     public function toViewData(): array
@@ -48,6 +59,10 @@ final readonly class ChurchServiceShowReadModel
             'pendingMerge' => $this->pendingMerge,
             'pendingMergeSource' => $this->pendingMergeSource,
             'pipelineSteps' => $this->pipelineSteps,
+            'sectionReviewPanels' => $this->sectionReviewPanels,
+            'mergeCandidatePairs' => $this->mergeCandidatePairs,
+            'pendingApprovalCount' => $this->pendingApprovalCount,
+            'sectionPublishingEnabled' => $this->sectionPublishingEnabled,
         ];
     }
 }

--- a/app/Livewire/Admin/ChurchServices/Concerns/ReviewsServiceSections.php
+++ b/app/Livewire/Admin/ChurchServices/Concerns/ReviewsServiceSections.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Admin\ChurchServices\Concerns;
+
+use App\Actions\ServiceReview\BatchApproveServicePublications;
+use App\Actions\ServiceReview\MarkServiceReviewed;
+use App\Actions\ServiceReview\MergeAdjacentServiceSections;
+use App\Actions\ServiceReview\SaveServiceSection;
+use App\Enums\ServiceSectionType;
+use App\Models\ChurchService;
+use App\Models\Preacher;
+use App\Models\ServiceSection;
+use App\Queries\ServiceReviewDashboardQuery;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Computed;
+
+/**
+ * Section review editing shared by the service workbench and (until it
+ * retires) the review dashboard: inline type/title edits, children's-talk
+ * speaker picks, batch approval, and adjacent-section merging.
+ *
+ * Edit state is seeded for review-candidate sections only — seeding every
+ * section of every run would balloon the Livewire payload.
+ */
+trait ReviewsServiceSections
+{
+    /**
+     * @var array<int, array{section_type: string, title: string}>
+     */
+    public array $sectionEdits = [];
+
+    /**
+     * @var array<int, array{preacher_id: string, speaker_name: string}>
+     */
+    public array $speakerEdits = [];
+
+    /**
+     * @var array{primary_id: int, secondary_id: int}|null
+     */
+    public ?array $pendingSectionMerge = null;
+
+    protected ServiceReviewDashboardQuery $dashboardQuery;
+
+    protected SaveServiceSection $saveSectionAction;
+
+    protected MarkServiceReviewed $markReviewedAction;
+
+    protected BatchApproveServicePublications $batchApproveAction;
+
+    protected MergeAdjacentServiceSections $mergeAction;
+
+    public function bootReviewsServiceSections(
+        ServiceReviewDashboardQuery $dashboardQuery,
+        SaveServiceSection $saveSectionAction,
+        MarkServiceReviewed $markReviewedAction,
+        BatchApproveServicePublications $batchApproveAction,
+        MergeAdjacentServiceSections $mergeAction,
+    ): void {
+        $this->dashboardQuery = $dashboardQuery;
+        $this->saveSectionAction = $saveSectionAction;
+        $this->markReviewedAction = $markReviewedAction;
+        $this->batchApproveAction = $batchApproveAction;
+        $this->mergeAction = $mergeAction;
+    }
+
+    public function saveSection(int $sectionId): void
+    {
+        $this->authorizeAdmin();
+
+        $section = ServiceSection::query()->find($sectionId);
+        if (! $section instanceof ServiceSection) {
+            $this->error('Section not found.');
+
+            return;
+        }
+
+        if (! $this->dashboardQuery->isReviewCandidate($section)) {
+            $this->error('Section is no longer awaiting review.');
+
+            return;
+        }
+
+        $this->saveSectionAction->execute(
+            section: $section,
+            sectionEdits: $this->sectionEdits,
+            speakerEdits: $this->speakerEdits,
+            userId: $this->reviewingUserId(),
+        );
+
+        $this->sectionEdits[$section->id] = [
+            'section_type' => $section->section_type->value,
+            'title' => (string) ($section->title ?? ''),
+        ];
+        $publicationSpeaker = $section->publicationChildrensTalkSpeaker();
+        $this->speakerEdits[$section->id] = [
+            'preacher_id' => is_array($publicationSpeaker) && is_numeric($publicationSpeaker['preacher_id'] ?? null)
+                ? (string) $publicationSpeaker['preacher_id']
+                : '',
+            'speaker_name' => $publicationSpeaker['preacher_name'] ?? '',
+        ];
+
+        $this->success('Section changes saved.');
+    }
+
+    public function markServiceReviewed(int $serviceId): void
+    {
+        $this->authorizeAdmin();
+
+        $service = ChurchService::query()->find($serviceId);
+        if (! $service instanceof ChurchService) {
+            $this->error('Service not found.');
+
+            return;
+        }
+
+        $this->markReviewedAction->execute($service, $this->reviewingUserId());
+
+        $this->success('Service marked as reviewed.');
+    }
+
+    public function approvePendingPublications(int $serviceId): void
+    {
+        $this->authorizeAdmin();
+
+        $service = ChurchService::query()->find($serviceId);
+        if (! $service instanceof ChurchService) {
+            $this->error('Service not found.');
+
+            return;
+        }
+
+        $result = $this->batchApproveAction->execute($service, $this->reviewingUserId());
+
+        $approvedCount = $result['approved_count'];
+        $skippedReasons = $result['skipped_reasons'];
+
+        if ($approvedCount === 0) {
+            $this->error(sprintf(
+                'No sections were batch-approved. %s',
+                $this->formatBatchApprovalSkipSummary($skippedReasons)
+            ));
+
+            return;
+        }
+
+        if ($skippedReasons === []) {
+            $this->success(sprintf(
+                'Approved all %d pending %s for this service.',
+                $approvedCount,
+                Str::plural('publication', $approvedCount)
+            ));
+
+            return;
+        }
+
+        $this->success(sprintf(
+            'Approved %d pending %s. %s',
+            $approvedCount,
+            Str::plural('publication', $approvedCount),
+            $this->formatBatchApprovalSkipSummary($skippedReasons)
+        ));
+    }
+
+    public function initiateMerge(int $sectionIdA, int $sectionIdB): void
+    {
+        $this->pendingSectionMerge = ['primary_id' => $sectionIdA, 'secondary_id' => $sectionIdB];
+    }
+
+    public function confirmMerge(): void
+    {
+        $this->authorizeAdmin();
+
+        if ($this->pendingSectionMerge === null) {
+            return;
+        }
+
+        $primary = ServiceSection::query()->find($this->pendingSectionMerge['primary_id']);
+        $secondary = ServiceSection::query()->find($this->pendingSectionMerge['secondary_id']);
+
+        if (! $primary instanceof ServiceSection || ! $secondary instanceof ServiceSection) {
+            $this->pendingSectionMerge = null;
+            $this->error('One or both sections could not be found.');
+
+            return;
+        }
+
+        $error = $this->mergeAction->execute($primary, $secondary, $this->reviewingUserId());
+
+        $this->pendingSectionMerge = null;
+
+        if ($error !== null) {
+            $this->error($error);
+
+            return;
+        }
+
+        $this->success('Sections merged successfully.');
+    }
+
+    public function cancelMerge(): void
+    {
+        $this->pendingSectionMerge = null;
+    }
+
+    /**
+     * @return array<int, array{id: string, name: string}>
+     */
+    #[Computed]
+    public function sectionTypeOptions(): array
+    {
+        return collect(ServiceSectionType::cases())
+            ->map(fn (ServiceSectionType $type): array => [
+                'id' => $type->value,
+                'name' => $type->label(),
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<int, array{id: string, name: string}>
+     */
+    #[Computed]
+    public function preacherOptions(): array
+    {
+        return Preacher::query()->active()
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->map(fn (Preacher $preacher): array => [
+                'id' => (string) $preacher->id,
+                'name' => $preacher->name,
+            ])
+            ->all();
+    }
+
+    /**
+     * @param  iterable<int, ServiceSection>  $sections
+     */
+    protected function seedSectionEditsForSections(iterable $sections): void
+    {
+        foreach ($sections as $section) {
+            if (! array_key_exists($section->id, $this->sectionEdits)) {
+                $this->sectionEdits[$section->id] = [
+                    'section_type' => $section->section_type->value,
+                    'title' => (string) ($section->title ?? ''),
+                ];
+            }
+
+            if (! array_key_exists($section->id, $this->speakerEdits)) {
+                $speaker = $section->publicationChildrensTalkSpeaker();
+                $this->speakerEdits[$section->id] = [
+                    'preacher_id' => is_array($speaker) && is_numeric($speaker['preacher_id'] ?? null)
+                        ? (string) $speaker['preacher_id']
+                        : '',
+                    'speaker_name' => is_string($speaker['preacher_name'] ?? null)
+                        ? (string) $speaker['preacher_name']
+                        : '',
+                ];
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, int>  $skippedReasons
+     */
+    protected function formatBatchApprovalSkipSummary(array $skippedReasons): string
+    {
+        $totalSkipped = array_sum($skippedReasons);
+        if ($totalSkipped === 0) {
+            return 'No sections were skipped.';
+        }
+
+        $reasons = collect($skippedReasons)
+            ->map(fn (int $count, string $reason): string => sprintf('%s (%d)', $reason, $count))
+            ->implode(', ');
+
+        return sprintf(
+            'Skipped %d %s: %s.',
+            $totalSkipped,
+            Str::plural('section', $totalSkipped),
+            $reasons
+        );
+    }
+
+    protected function reviewingUserId(): int
+    {
+        return is_numeric(Auth::id()) ? (int) Auth::id() : 0;
+    }
+}

--- a/app/Livewire/Admin/ChurchServices/Concerns/ReviewsServiceSections.php
+++ b/app/Livewire/Admin/ChurchServices/Concerns/ReviewsServiceSections.php
@@ -166,6 +166,8 @@ trait ReviewsServiceSections
 
     public function initiateMerge(int $sectionIdA, int $sectionIdB): void
     {
+        $this->authorizeAdmin();
+
         $this->pendingSectionMerge = ['primary_id' => $sectionIdA, 'secondary_id' => $sectionIdB];
     }
 
@@ -202,6 +204,8 @@ trait ReviewsServiceSections
 
     public function cancelMerge(): void
     {
+        $this->authorizeAdmin();
+
         $this->pendingSectionMerge = null;
     }
 

--- a/app/Livewire/Admin/ChurchServices/ServiceReviewDashboard.php
+++ b/app/Livewire/Admin/ChurchServices/ServiceReviewDashboard.php
@@ -4,224 +4,35 @@ declare(strict_types=1);
 
 namespace App\Livewire\Admin\ChurchServices;
 
-use App\Actions\ServiceReview\BatchApproveServicePublications;
-use App\Actions\ServiceReview\MarkServiceReviewed;
-use App\Actions\ServiceReview\MergeAdjacentServiceSections;
-use App\Actions\ServiceReview\SaveServiceSection;
-use App\Enums\ServiceSectionType;
 use App\Livewire\Admin\ChurchServices\Concerns\ManagesSectionPublication;
+use App\Livewire\Admin\ChurchServices\Concerns\ReviewsServiceSections;
 use App\Livewire\Traits\WithAdminAuthorization;
 use App\Livewire\Traits\WithNotifications;
-use App\Models\ChurchService;
-use App\Models\Preacher;
 use App\Models\ServiceSection;
-use App\Queries\ServiceReviewDashboardQuery;
 use App\Support\ServiceSectionConfidence;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Str;
 use Illuminate\View\View;
-use Livewire\Attributes\Computed;
 use Livewire\Component;
 
 class ServiceReviewDashboard extends Component
 {
     use ManagesSectionPublication;
+    use ReviewsServiceSections;
     use WithAdminAuthorization;
     use WithNotifications;
-
-    /**
-     * @var array<int, array{section_type:string,title:string}>
-     */
-    public array $sectionEdits = [];
-
-    /**
-     * @var array<int, array{preacher_id:string,speaker_name:string}>
-     */
-    public array $speakerEdits = [];
-
-    /**
-     * @var array{primary_id: int, secondary_id: int}|null
-     */
-    public ?array $pendingMerge = null;
-
-    private ServiceReviewDashboardQuery $dashboardQuery;
-
-    private SaveServiceSection $saveSectionAction;
-
-    private MarkServiceReviewed $markReviewedAction;
-
-    private BatchApproveServicePublications $batchApproveAction;
-
-    private MergeAdjacentServiceSections $mergeAction;
-
-    public function boot(
-        ServiceReviewDashboardQuery $dashboardQuery,
-        SaveServiceSection $saveSectionAction,
-        MarkServiceReviewed $markReviewedAction,
-        BatchApproveServicePublications $batchApproveAction,
-        MergeAdjacentServiceSections $mergeAction,
-    ): void {
-        $this->dashboardQuery = $dashboardQuery;
-        $this->saveSectionAction = $saveSectionAction;
-        $this->markReviewedAction = $markReviewedAction;
-        $this->batchApproveAction = $batchApproveAction;
-        $this->mergeAction = $mergeAction;
-    }
 
     public function mount(): void
     {
         $this->abortIfDisabled();
 
         $groups = $this->dashboardQuery->reviewGroups();
-        $this->seedSectionEdits($groups);
-    }
 
-    public function saveSection(int $sectionId): void
-    {
-
-        $this->authorizeAdmin();
-
-        $section = ServiceSection::query()->find($sectionId);
-        if (! $section instanceof ServiceSection) {
-            $this->error('Section not found.');
-
-            return;
-        }
-
-        if (! $this->dashboardQuery->isReviewCandidate($section)) {
-            $this->error('Section is no longer awaiting review.');
-
-            return;
-        }
-
-        $userId = is_numeric(Auth::id()) ? (int) Auth::id() : 0;
-
-        $this->saveSectionAction->execute(
-            section: $section,
-            sectionEdits: $this->sectionEdits,
-            speakerEdits: $this->speakerEdits,
-            userId: $userId,
+        $this->seedSectionEditsForSections(
+            collect($groups)->flatMap(
+                fn (array $group) => collect($group['sections'])->map(
+                    fn (array $entry): ServiceSection => $entry['section']
+                )
+            )
         );
-
-        $this->sectionEdits[$section->id] = [
-            'section_type' => $section->section_type->value,
-            'title' => (string) ($section->title ?? ''),
-        ];
-        $publicationSpeaker = $section->publicationChildrensTalkSpeaker();
-        $this->speakerEdits[$section->id] = [
-            'preacher_id' => is_array($publicationSpeaker) && is_numeric($publicationSpeaker['preacher_id'] ?? null)
-                ? (string) $publicationSpeaker['preacher_id']
-                : '',
-            'speaker_name' => $publicationSpeaker['preacher_name'] ?? '',
-        ];
-
-        $this->success('Section changes saved.');
-    }
-
-    public function markServiceReviewed(int $serviceId): void
-    {
-
-        $this->authorizeAdmin();
-
-        $service = ChurchService::query()->find($serviceId);
-        if (! $service instanceof ChurchService) {
-            $this->error('Service not found.');
-
-            return;
-        }
-
-        $userId = is_numeric(Auth::id()) ? (int) Auth::id() : 0;
-
-        $this->markReviewedAction->execute($service, $userId);
-
-        $this->success('Service marked as reviewed.');
-    }
-
-    public function approvePendingPublications(int $serviceId): void
-    {
-
-        $this->authorizeAdmin();
-
-        $service = ChurchService::query()->find($serviceId);
-        if (! $service instanceof ChurchService) {
-            $this->error('Service not found.');
-
-            return;
-        }
-
-        $userId = is_numeric(Auth::id()) ? (int) Auth::id() : 0;
-
-        $result = $this->batchApproveAction->execute($service, $userId);
-
-        $approvedCount = $result['approved_count'];
-        $skippedReasons = $result['skipped_reasons'];
-
-        if ($approvedCount === 0) {
-            $this->error(sprintf(
-                'No sections were batch-approved. %s',
-                $this->formatBatchApprovalSkipSummary($skippedReasons)
-            ));
-
-            return;
-        }
-
-        if ($skippedReasons === []) {
-            $this->success(sprintf(
-                'Approved all %d pending %s for this service.',
-                $approvedCount,
-                Str::plural('publication', $approvedCount)
-            ));
-
-            return;
-        }
-
-        $this->success(sprintf(
-            'Approved %d pending %s. %s',
-            $approvedCount,
-            Str::plural('publication', $approvedCount),
-            $this->formatBatchApprovalSkipSummary($skippedReasons)
-        ));
-    }
-
-    public function initiateMerge(int $sectionIdA, int $sectionIdB): void
-    {
-        $this->pendingMerge = ['primary_id' => $sectionIdA, 'secondary_id' => $sectionIdB];
-    }
-
-    public function confirmMerge(): void
-    {
-        if ($this->pendingMerge === null) {
-            return;
-        }
-
-        $primary = ServiceSection::query()->find($this->pendingMerge['primary_id']);
-        $secondary = ServiceSection::query()->find($this->pendingMerge['secondary_id']);
-
-        if (! $primary instanceof ServiceSection || ! $secondary instanceof ServiceSection) {
-            $this->pendingMerge = null;
-            $this->error('One or both sections could not be found.');
-
-            return;
-        }
-
-        $userId = is_numeric(Auth::id()) ? (int) Auth::id() : 0;
-
-        $error = $this->mergeAction->execute($primary, $secondary, $userId);
-
-        $this->pendingMerge = null;
-
-        if ($error !== null) {
-            $this->error($error);
-
-            return;
-        }
-
-        $this->success('Sections merged successfully.');
-    }
-
-    public function cancelMerge(): void
-    {
-        $this->pendingMerge = null;
     }
 
     public function render(): View
@@ -238,91 +49,6 @@ class ServiceReviewDashboard extends Component
             'title' => 'Service Review Dashboard',
             'heading' => 'Service Review Dashboard',
         ]);
-    }
-
-    /**
-     * @return array<int, array{id:string,name:string}>
-     */
-    #[Computed]
-    public function sectionTypeOptions(): array
-    {
-        return collect(ServiceSectionType::cases())
-            ->map(fn (ServiceSectionType $type): array => [
-                'id' => $type->value,
-                'name' => $type->label(),
-            ])
-            ->all();
-    }
-
-    /**
-     * @return array<int, array{id:string,name:string}>
-     */
-    #[Computed]
-    public function preacherOptions(): array
-    {
-        return Preacher::query()->active()
-            ->orderBy('name')
-            ->get(['id', 'name'])
-            ->map(fn (Preacher $preacher): array => [
-                'id' => (string) $preacher->id,
-                'name' => $preacher->name,
-            ])
-            ->all();
-    }
-
-    /**
-     * @param  array<int, array{
-     *     sections:array<int, array{section:ServiceSection}>
-     * }>  $groups
-     */
-    private function seedSectionEdits(array $groups): void
-    {
-        foreach ($groups as $group) {
-            foreach ($group['sections'] as $entry) {
-                $section = $entry['section'];
-
-                if (! array_key_exists($section->id, $this->sectionEdits)) {
-                    $this->sectionEdits[$section->id] = [
-                        'section_type' => $section->section_type->value,
-                        'title' => (string) ($section->title ?? ''),
-                    ];
-                }
-
-                if (! array_key_exists($section->id, $this->speakerEdits)) {
-                    $speaker = $section->publicationChildrensTalkSpeaker();
-                    $this->speakerEdits[$section->id] = [
-                        'preacher_id' => is_array($speaker) && is_numeric($speaker['preacher_id'] ?? null)
-                            ? (string) $speaker['preacher_id']
-                            : '',
-                        'speaker_name' => is_string($speaker['preacher_name'] ?? null)
-                            ? (string) $speaker['preacher_name']
-                            : '',
-                    ];
-                }
-            }
-        }
-    }
-
-    /**
-     * @param  array<string, int>  $skippedReasons
-     */
-    private function formatBatchApprovalSkipSummary(array $skippedReasons): string
-    {
-        $totalSkipped = array_sum($skippedReasons);
-        if ($totalSkipped === 0) {
-            return 'No sections were skipped.';
-        }
-
-        $reasons = collect($skippedReasons)
-            ->map(fn (int $count, string $reason): string => sprintf('%s (%d)', $reason, $count))
-            ->implode(', ');
-
-        return sprintf(
-            'Skipped %d %s: %s.',
-            $totalSkipped,
-            Str::plural('section', $totalSkipped),
-            $reasons
-        );
     }
 
     private function abortIfDisabled(): void

--- a/app/Livewire/Admin/ChurchServices/ShowChurchService.php
+++ b/app/Livewire/Admin/ChurchServices/ShowChurchService.php
@@ -7,10 +7,13 @@ namespace App\Livewire\Admin\ChurchServices;
 use App\Actions\DeleteLivestreamUpload;
 use App\Actions\ServiceReview\ResolvePendingStructureMerge;
 use App\Enums\MediaType;
+use App\Livewire\Admin\ChurchServices\Concerns\ManagesSectionPublication;
+use App\Livewire\Admin\ChurchServices\Concerns\ReviewsServiceSections;
 use App\Livewire\Traits\WithAdminAuthorization;
 use App\Livewire\Traits\WithNotifications;
 use App\Models\ChurchService;
 use App\Models\MediaProcessingLog;
+use App\Models\ServiceSection;
 use App\Presenters\ChurchServiceShowPresenter;
 use App\Queries\ChurchServiceProcessingRunQuery;
 use App\Services\Processing\ProcessingRunOrchestrator;
@@ -23,7 +26,10 @@ use Livewire\Features\SupportRedirects\Redirector;
 
 class ShowChurchService extends Component
 {
-    use WithAdminAuthorization, WithNotifications;
+    use ManagesSectionPublication;
+    use ReviewsServiceSections;
+    use WithAdminAuthorization;
+    use WithNotifications;
 
     public ChurchService $churchService;
 
@@ -37,6 +43,15 @@ class ShowChurchService extends Component
                 ->orderBy('position')
                 ->orderBy('id'),
         ]);
+
+        // Seed edit state for review candidates only — seeding every section
+        // of every run would balloon the Livewire payload.
+        $this->seedSectionEditsForSections(
+            app(ChurchServiceProcessingRunQuery::class)
+                ->forService($this->churchService)
+                ->flatMap(fn (MediaProcessingLog $run) => $run->serviceSections)
+                ->filter(fn (ServiceSection $section): bool => $this->dashboardQuery->isReviewCandidate($section))
+        );
     }
 
     public function render(): View
@@ -45,7 +60,11 @@ class ShowChurchService extends Component
 
         $label = $this->churchService->date->format('j M Y').' '.$this->churchService->service->label();
 
-        return view('livewire.admin.church-services.show-church-service', $readModel->toViewData())
+        return view('livewire.admin.church-services.show-church-service', [
+            ...$readModel->toViewData(),
+            'sectionTypeOptions' => $this->sectionTypeOptions(),
+            'preacherOptions' => $this->preacherOptions(),
+        ])
             ->layout('layouts.admin', [
                 'title' => $label,
                 'heading' => $label,

--- a/app/Presenters/ChurchServiceShowPresenter.php
+++ b/app/Presenters/ChurchServiceShowPresenter.php
@@ -10,8 +10,10 @@ use App\Enums\ServiceSectionPublicationStatus;
 use App\Models\ChurchService;
 use App\Models\ChurchServiceItem;
 use App\Models\MediaProcessingLog;
+use App\Models\ServiceSection;
 use App\Queries\ChurchServiceProcessingRunQuery;
 use App\Queries\ChurchServiceRollupQuery;
+use App\Queries\ServiceReviewDashboardQuery;
 use App\Support\ProcessingRunTimelineBuilder;
 use App\Support\ServiceTimelineBuilder;
 use Illuminate\Database\Eloquent\Collection;
@@ -21,6 +23,7 @@ class ChurchServiceShowPresenter
     public function __construct(
         private readonly ChurchServiceProcessingRunQuery $processingRunQuery,
         private readonly ChurchServiceRollupQuery $rollupQuery,
+        private readonly ServiceReviewDashboardQuery $dashboardQuery,
     ) {}
 
     public function present(ChurchService $churchService): ChurchServiceShowReadModel
@@ -59,7 +62,77 @@ class ChurchServiceShowPresenter
             pendingMerge: $hasPendingMerge ? $pendingMerge : null,
             pendingMergeSource: $hasPendingMerge ? $pendingMergeSource : null,
             pipelineSteps: $this->rollupQuery->rollupFor($churchService, $processingRuns)['steps'],
+            sectionReviewPanels: $this->sectionReviewPanels($processingRuns),
+            mergeCandidatePairs: $this->mergeCandidatePairs($processingRuns),
+            pendingApprovalCount: $processingRuns
+                ->flatMap(fn (MediaProcessingLog $run) => $run->serviceSections)
+                ->filter(fn (ServiceSection $section): bool => $section->publication_status === ServiceSectionPublicationStatus::PendingApproval)
+                ->count(),
+            sectionPublishingEnabled: (bool) config('media-processing.section_publishing.enabled', true),
         );
+    }
+
+    /**
+     * Inline review panels for the timeline rows, keyed by section id. Reuses
+     * the dashboard query's review-candidate predicate (contract C1) so the
+     * workbench flags exactly the sections the inbox counts.
+     *
+     * @param  Collection<int, MediaProcessingLog>  $processingRuns
+     * @return array<int, array{
+     *     section: ServiceSection,
+     *     reasons: array<int, array{key: string, label: string, classes: string}>,
+     *     review_reason: string|null,
+     *     audio_url: string|null,
+     *     video_url: string|null
+     * }>
+     */
+    private function sectionReviewPanels(Collection $processingRuns): array
+    {
+        $panels = [];
+
+        foreach ($processingRuns as $run) {
+            foreach ($run->serviceSections as $section) {
+                $entry = $this->dashboardQuery->reviewEntryFor($section);
+
+                if ($entry !== null) {
+                    $panels[$section->id] = ['section' => $section, ...$entry];
+                }
+            }
+        }
+
+        return $panels;
+    }
+
+    /**
+     * Adjacent same-type sections that can be merged (≤2s gap, neither
+     * published), keyed by the earlier section's id.
+     *
+     * @param  Collection<int, MediaProcessingLog>  $processingRuns
+     * @return array<int, int>
+     */
+    private function mergeCandidatePairs(Collection $processingRuns): array
+    {
+        $pairs = [];
+
+        foreach ($processingRuns as $run) {
+            $sections = $run->serviceSections->values();
+
+            foreach ($sections as $index => $section) {
+                $next = $sections[$index + 1] ?? null;
+
+                if (
+                    $next instanceof ServiceSection
+                    && $next->section_type === $section->section_type
+                    && abs($next->start_time - $section->end_time) <= 2
+                    && $section->publication_status !== ServiceSectionPublicationStatus::Published
+                    && $next->publication_status !== ServiceSectionPublicationStatus::Published
+                ) {
+                    $pairs[$section->id] = $next->id;
+                }
+            }
+        }
+
+        return $pairs;
     }
 
     /**

--- a/app/Queries/ServiceReviewDashboardQuery.php
+++ b/app/Queries/ServiceReviewDashboardQuery.php
@@ -303,6 +303,33 @@ class ServiceReviewDashboardQuery
         return $this->reviewReasons($section) !== [];
     }
 
+    /**
+     * Per-section review entry for surfaces that already hold the section
+     * (workbench timeline rows, inbox): the same reasons and guarded preview
+     * URLs that reviewGroups() builds, or null when nothing flags the section.
+     *
+     * @return array{
+     *     reasons: array<int, array{key: string, label: string, classes: string}>,
+     *     review_reason: string|null,
+     *     audio_url: string|null,
+     *     video_url: string|null
+     * }|null
+     */
+    public function reviewEntryFor(ServiceSection $section): ?array
+    {
+        $reasons = $this->reviewReasons($section);
+        if ($reasons === []) {
+            return null;
+        }
+
+        return [
+            'reasons' => $reasons,
+            'review_reason' => $this->reviewReasonLabel($section),
+            'audio_url' => $this->assetUrl($section, 'audio', $section->extracted_audio_path),
+            'video_url' => $this->assetUrl($section, 'video', $section->extracted_video_path),
+        ];
+    }
+
     public function batchApprovalSkipReason(ServiceSection $section): ?string
     {
         $additionalReviewFlags = collect($this->reviewReasons($section))

--- a/app/Queries/ServiceReviewDashboardQuery.php
+++ b/app/Queries/ServiceReviewDashboardQuery.php
@@ -8,8 +8,10 @@ use App\Enums\SermonService;
 use App\Enums\ServiceSectionPublicationStatus;
 use App\Enums\ServiceSectionType;
 use App\Models\ChurchService;
+use App\Models\MediaProcessingLog;
 use App\Models\ServiceSection;
 use App\Services\Processing\MediaProcessingIdentityResolver;
+use App\Support\ChurchServiceRunMatcher;
 use App\Support\ServiceSectionConfidence;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -26,6 +28,7 @@ class ServiceReviewDashboardQuery
 
     public function __construct(
         private readonly MediaProcessingIdentityResolver $identityResolver,
+        private readonly ChurchServiceRunMatcher $runMatcher,
     ) {}
 
     /**
@@ -230,10 +233,17 @@ class ServiceReviewDashboardQuery
     }
 
     /**
+     * Pending sections scoped to a service via ChurchServiceRunMatcher's
+     * three match paths (contract C2), so batch approval covers exactly the
+     * sections the workbench counts — including repaired runs matched only
+     * through fallback processing ids.
+     *
      * @return EloquentCollection<int, ServiceSection>
      */
     public function pendingPublicationSectionsForService(ChurchService $service): EloquentCollection
     {
+        $fallbackProcessingIds = $this->runMatcher->fallbackProcessingIdsForService($service);
+
         return ServiceSection::query()
             ->with([
                 'processingLog:id,processing_id,extracted_date,extracted_service,processing_metadata,church_service_id',
@@ -242,14 +252,11 @@ class ServiceReviewDashboardQuery
                 'churchServiceItem.churchService:id,date,service,needs_review',
             ])
             ->where('publication_status', ServiceSectionPublicationStatus::PendingApproval->value)
-            ->where(function (Builder $query) use ($service): void {
-                $query->whereHas('processingLog', function (Builder $query) use ($service): void {
-                    $query->where('church_service_id', $service->id)
-                        ->orWhere(function (Builder $query) use ($service): void {
-                            $query->whereDate('extracted_date', $service->date->toDateString())
-                                ->where('extracted_service', $service->service->value);
-                        });
-                })->orWhereHas('churchServiceItem', fn (Builder $query): Builder => $query->where('church_service_id', $service->id));
+            ->where(function (Builder $query) use ($service, $fallbackProcessingIds): void {
+                $query->whereIn('media_processing_log_id', MediaProcessingLog::query()
+                    ->select('id')
+                    ->tap(fn ($query) => $this->runMatcher->applyMatchClauses($query, $service, $fallbackProcessingIds)))
+                    ->orWhereHas('churchServiceItem', fn (Builder $query): Builder => $query->where('church_service_id', $service->id));
             })
             ->orderBy('section_order')
             ->orderBy('id')
@@ -399,6 +406,7 @@ class ServiceReviewDashboardQuery
                 $query->where('needs_manual_review', true)
                     ->orWhere('publication_status', ServiceSectionPublicationStatus::PendingApproval->value)
                     ->orWhere('confidence', '<', ServiceSectionConfidence::HIGH_THRESHOLD)
+                    ->orWhereJsonContains('metadata->review_flags', 'heuristic_demotion')
                     ->orWhere(function (Builder $query): void {
                         $query->where('section_type', ServiceSectionType::Song->value)
                             ->where(function (Builder $query): void {

--- a/resources/views/livewire/admin/church-services/partials/processing-run-review-actions.blade.php
+++ b/resources/views/livewire/admin/church-services/partials/processing-run-review-actions.blade.php
@@ -19,15 +19,10 @@
         @endif
 
         @if($processingRunView->needsSectionReview)
-            <x-button
-                link="{{ route('admin.services.review') }}"
-                variant="outline"
-                size="xs"
-                icon="exclamation-triangle"
-                inline
-            >
-                Review sections
-            </x-button>
+            <span class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-800">
+                <x-heroicon-o-exclamation-triangle class="h-3.5 w-3.5" aria-hidden="true" />
+                Flagged sections are expanded in the timeline below
+            </span>
         @endif
 
         @if($processingRunView->hasPendingPublications)

--- a/resources/views/livewire/admin/church-services/partials/section-review-panel.blade.php
+++ b/resources/views/livewire/admin/church-services/partials/section-review-panel.blade.php
@@ -1,0 +1,162 @@
+{{-- Inline section review panel: expects $panel (section, reasons, review_reason,
+     audio_url, video_url), $sectionTypeOptions, $preacherOptions, $sectionPublishingEnabled --}}
+@php
+    $section = $panel['section'];
+    $publicationSpeaker = $section->publicationChildrensTalkSpeaker();
+    $predictedSpeaker = $section->predictedChildrensTalkSpeaker();
+    $speakerOutcome = is_array($predictedSpeaker) ? ($predictedSpeaker['outcome'] ?? null) : null;
+@endphp
+
+<div id="section-{{ $section->id }}" class="rounded-lg border border-amber-200 bg-amber-50/40 p-3 space-y-3" wire:key="section-review-panel-{{ $section->id }}">
+    <div class="flex flex-wrap items-center justify-between gap-2">
+        <div class="flex flex-wrap items-center gap-2">
+            @foreach($panel['reasons'] as $reason)
+                <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $reason['classes'] }}">
+                    {{ $reason['label'] }}
+                </span>
+            @endforeach
+            @if($panel['review_reason'])
+                <span class="text-xs text-gray-500">{{ $panel['review_reason'] }}</span>
+            @endif
+        </div>
+
+        @if($sectionPublishingEnabled)
+            <div class="flex flex-wrap gap-2">
+                @if($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::PendingApproval)
+                    <x-form-button
+                        type="button"
+                        size="xs"
+                        variant="primary"
+                        wire:click="approve({{ $section->id }})"
+                        wire:target="approve({{ $section->id }})"
+                    >
+                        Approve
+                    </x-form-button>
+                @endif
+
+                @if(in_array($section->publication_status, [
+                    \App\Enums\ServiceSectionPublicationStatus::PendingApproval,
+                    \App\Enums\ServiceSectionPublicationStatus::Approved,
+                ], true))
+                    <x-form-button
+                        type="button"
+                        size="xs"
+                        variant="outline"
+                        wire:click="reject({{ $section->id }})"
+                        wire:target="reject({{ $section->id }})"
+                    >
+                        Reject
+                    </x-form-button>
+                @endif
+
+                @if($section->publication_status === \App\Enums\ServiceSectionPublicationStatus::Rejected)
+                    <x-form-button
+                        type="button"
+                        size="xs"
+                        variant="outline"
+                        wire:click="requeue({{ $section->id }})"
+                        wire:target="requeue({{ $section->id }})"
+                    >
+                        Requeue
+                    </x-form-button>
+                @endif
+            </div>
+        @endif
+    </div>
+
+    <div class="grid gap-3 md:grid-cols-[12rem_minmax(0,1fr)_auto]">
+        <x-select
+            label="Section type"
+            wire:model.blur="sectionEdits.{{ $section->id }}.section_type"
+            :options="$sectionTypeOptions"
+        />
+
+        <x-input
+            label="Section title"
+            wire:model.blur="sectionEdits.{{ $section->id }}.title"
+            maxlength="255"
+        />
+
+        <div class="flex items-end">
+            <x-form-button
+                type="button"
+                size="sm"
+                variant="primary"
+                wire:click="saveSection({{ $section->id }})"
+                wire:target="saveSection({{ $section->id }})"
+            >
+                Save
+            </x-form-button>
+        </div>
+    </div>
+
+    @if($section->section_type === \App\Enums\ServiceSectionType::ChildrensTalk)
+        <div class="grid gap-3 rounded-lg border border-gray-200 bg-white p-3 md:grid-cols-2">
+            <x-select
+                label="Choose preacher"
+                wire:model.blur="speakerEdits.{{ $section->id }}.preacher_id"
+                :options="$preacherOptions"
+                placeholder="Select a preacher..."
+                hint="Pick an existing preacher to confirm or override the detected speaker."
+            />
+
+            <x-input
+                label="Fallback speaker name"
+                wire:model.blur="speakerEdits.{{ $section->id }}.speaker_name"
+                maxlength="255"
+                hint="Use free text when the speaker is not in the preacher list."
+            />
+        </div>
+
+        <div class="rounded-lg border border-cbc-teal/15 bg-white px-3 py-2 text-xs text-gray-600">
+            @if($publicationSpeaker)
+                <p>
+                    Publication speaker:
+                    <span class="font-semibold text-gray-900">{{ $publicationSpeaker['preacher_name'] }}</span>
+                    @if(($publicationSpeaker['confidence'] ?? null) !== null)
+                        <span class="text-gray-500">· {{ number_format($publicationSpeaker['confidence'] * 100, 0) }}%</span>
+                    @endif
+                </p>
+            @endif
+
+            @if($predictedSpeaker)
+                <p @class(['mt-1' => $publicationSpeaker])>
+                    Detected speaker:
+                    @if(is_string($predictedSpeaker['preacher_name'] ?? null) && trim((string) $predictedSpeaker['preacher_name']) !== '')
+                        <span class="font-semibold text-gray-900">{{ $predictedSpeaker['preacher_name'] }}</span>
+                    @else
+                        <span class="font-semibold text-gray-900">{{ \Illuminate\Support\Str::headline((string) $speakerOutcome) }}</span>
+                    @endif
+                    @if(($predictedSpeaker['confidence'] ?? null) !== null)
+                        <span class="text-gray-500">· {{ number_format($predictedSpeaker['confidence'] * 100, 0) }}%</span>
+                    @endif
+                </p>
+
+                @if(is_string($predictedSpeaker['reason'] ?? null) && $predictedSpeaker['reason'] !== '')
+                    <p class="mt-1 text-gray-500">{{ $predictedSpeaker['reason'] }}</p>
+                @endif
+            @elseif(!$publicationSpeaker)
+                <p>No speaker has been confirmed for this children's talk yet.</p>
+            @endif
+        </div>
+    @endif
+
+    @if($panel['audio_url'] || $panel['video_url'])
+        <div class="grid gap-3 md:grid-cols-2">
+            @if($panel['audio_url'])
+                <div>
+                    <p class="mb-1 text-xs text-gray-500">Audio preview</p>
+                    <audio src="{{ $panel['audio_url'] }}" class="w-full" controls preload="none">
+                        Your browser does not support audio playback.
+                    </audio>
+                </div>
+            @endif
+            @if($panel['video_url'])
+                <div>
+                    <p class="mb-1 text-xs text-gray-500">Video preview</p>
+                    <video src="{{ $panel['video_url'] }}" class="w-full rounded-md bg-black" controls preload="none"></video>
+                </div>
+            @endif
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/admin/church-services/partials/service-flow-row.blade.php
+++ b/resources/views/livewire/admin/church-services/partials/service-flow-row.blade.php
@@ -20,11 +20,18 @@
         'planned_only' => 'bg-slate-50/70',
         default        => '',
     };
+
+    $reviewPanel = ($item['section_id'] ?? null) !== null
+        ? (($sectionReviewPanels ?? [])[$item['section_id']] ?? null)
+        : null;
+    $mergeSecondaryId = ($item['section_id'] ?? null) !== null
+        ? (($mergeCandidatePairs ?? [])[$item['section_id']] ?? null)
+        : null;
 @endphp
 
 <li
     class="py-3 px-1 {{ $rowBorder }} {{ $rowBg }}"
-    x-data="{ expanded: false }"
+    x-data="{ expanded: {{ $reviewPanel !== null ? 'true' : 'false' }} }"
     wire:key="flow-item-{{ $rowIndex }}"
 >
     <button
@@ -203,5 +210,46 @@
                 </div>
             @endif
         </div>
+
+        @if($reviewPanel !== null)
+            <div class="mt-3">
+                @include('livewire.admin.church-services.partials.section-review-panel', [
+                    'panel' => $reviewPanel,
+                ])
+            </div>
+        @endif
     </div>
+
+    @if($mergeSecondaryId !== null)
+        @php $pendingSectionMergePair = $pendingSectionMerge ?? null; @endphp
+        @if($pendingSectionMergePair !== null
+            && $pendingSectionMergePair['primary_id'] === $item['section_id']
+            && $pendingSectionMergePair['secondary_id'] === $mergeSecondaryId)
+            <div class="mt-3 ml-27 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm">
+                <p class="font-medium text-amber-900">Merge these two {{ $item['type_label'] }} sections into one?</p>
+                <p class="mt-1 text-amber-700">
+                    Any extracted media will be cleared and re-extracted automatically if the source recording is still available.
+                </p>
+                <div class="mt-3 flex gap-2">
+                    <x-form-button variant="primary" size="sm" wire:click="confirmMerge"
+                        wire:target="confirmMerge" wire:loading.attr="disabled">
+                        Confirm merge
+                    </x-form-button>
+                    <x-form-button variant="outline" size="sm" wire:click="cancelMerge">
+                        Cancel
+                    </x-form-button>
+                </div>
+            </div>
+        @else
+            <div class="mt-2 ml-27 flex">
+                <x-form-button
+                    variant="ghost"
+                    size="xs"
+                    wire:click="initiateMerge({{ $item['section_id'] }}, {{ $mergeSecondaryId }})"
+                >
+                    ⇕ Merge with the next {{ $item['type_label'] }} section
+                </x-form-button>
+            </div>
+        @endif
+    @endif
 </li>

--- a/resources/views/livewire/admin/church-services/service-review-dashboard.blade.php
+++ b/resources/views/livewire/admin/church-services/service-review-dashboard.blade.php
@@ -335,9 +335,9 @@
                             </div>
 
                             @if($isMergeCandidate)
-                                @if($pendingMerge
-                                    && $pendingMerge['primary_id'] === $section->id
-                                    && $pendingMerge['secondary_id'] === $nextSection->id)
+                                @if($pendingSectionMerge
+                                    && $pendingSectionMerge['primary_id'] === $section->id
+                                    && $pendingSectionMerge['secondary_id'] === $nextSection->id)
                                     <div class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm">
                                         <p class="font-medium text-amber-900">Merge these two {{ $section->section_type->label() }} sections into one?</p>
                                         <p class="mt-1 text-amber-700">

--- a/resources/views/livewire/admin/church-services/show-church-service.blade.php
+++ b/resources/views/livewire/admin/church-services/show-church-service.blade.php
@@ -3,22 +3,39 @@
     description="Review the planned service, processing runs, and publication state."
 >
     <x-slot:actions>
-        <x-button link="{{ route('admin.services.review') }}" variant="outline" inline>
-            Review dashboard
+        <x-button link="{{ route('admin.services.inbox') }}" variant="outline" icon="inbox" inline>
+            Review inbox
         </x-button>
         <x-button link="{{ route('admin.services.edit', $churchService) }}" variant="outline" icon="pencil-square" inline>
             Edit service
         </x-button>
-        <x-button link="{{ route('admin.services.songs.index') }}" variant="outline" icon="musical-note" inline>
-            Song catalogue
-        </x-button>
-        <x-button link="{{ route('admin.services.section-publications') }}" variant="outline" inline>
-            Section queue
+        <x-button link="{{ route('admin.services.index') }}" variant="outline" inline>
+            Back to services
         </x-button>
     </x-slot:actions>
 
     <x-card class="py-3">
-        <x-admin.pipeline-steps :steps="$pipelineSteps" />
+        <div class="flex flex-wrap items-center justify-between gap-3">
+            <x-admin.pipeline-steps :steps="$pipelineSteps" />
+
+            @if($sectionPublishingEnabled && $pendingApprovalCount > 0)
+                <div class="flex items-center gap-3">
+                    <p class="text-xs text-gray-500">
+                        {{ $pendingApprovalCount }} pending {{ \Illuminate\Support\Str::plural('publication', $pendingApprovalCount) }}
+                    </p>
+                    <x-form-button
+                        type="button"
+                        variant="primary"
+                        size="sm"
+                        wire:click="approvePendingPublications({{ $churchService->id }})"
+                        wire:target="approvePendingPublications({{ $churchService->id }})"
+                        wire:loading.attr="disabled"
+                    >
+                        Approve all pending publications
+                    </x-form-button>
+                </div>
+            @endif
+        </div>
     </x-card>
 
     <div class="grid grid-cols-1 lg:grid-cols-4 gap-6">

--- a/tests/Feature/Livewire/Admin/ChurchServices/ShowChurchServiceTest.php
+++ b/tests/Feature/Livewire/Admin/ChurchServices/ShowChurchServiceTest.php
@@ -6,6 +6,8 @@ namespace Tests\Feature\Livewire\Admin\ChurchServices;
 
 use App\Enums\ProcessingStatus;
 use App\Enums\SermonService;
+use App\Enums\ServiceSectionPublicationStatus;
+use App\Enums\ServiceSectionType;
 use App\Livewire\Admin\ChurchServices\ListSectionPublications;
 use App\Livewire\Admin\ChurchServices\ProcessingReviewList;
 use App\Livewire\Admin\ChurchServices\ShowChurchService;
@@ -15,11 +17,13 @@ use App\Models\ChurchService;
 use App\Models\ChurchServiceItem;
 use App\Models\MediaProcessingLog;
 use App\Models\Sermon;
+use App\Models\ServiceSection;
 use App\Models\User;
 use App\Presenters\ChurchServiceShowPresenter;
 use App\Services\Processing\ProcessingPipelineBuilder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
@@ -284,5 +288,194 @@ class ShowChurchServiceTest extends TestCase
             ->assertSee($log->processing_id)
             ->assertSee('Reclassify')
             ->assertSee('Delete upload');
+    }
+
+    // -------------------------------------------------------------------------
+    // Inline section review (P3.2)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return array{0: ChurchService, 1: MediaProcessingLog}
+     */
+    private function workbenchServiceWithRun(): array
+    {
+        $service = ChurchService::factory()->create([
+            'date' => '2026-06-07',
+            'service' => SermonService::Morning,
+            'needs_review' => false,
+        ]);
+
+        $run = MediaProcessingLog::factory()->livestream()->completed()->create([
+            'extracted_date' => '2026-06-07',
+            'extracted_service' => SermonService::Morning->value,
+            'sermon_id' => null,
+        ]);
+
+        return [$service, $run];
+    }
+
+    #[Test]
+    public function it_renders_inline_review_panels_for_flagged_sections(): void
+    {
+        [$service, $run] = $this->workbenchServiceWithRun();
+
+        $section = ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'section_type' => ServiceSectionType::Song->value,
+            'title' => 'Flagged Song',
+            'needs_manual_review' => true,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(ShowChurchService::class, ['churchService' => $service])
+            ->assertSee('Manual review')
+            ->assertSee('Section type')
+            ->assertSee('Section title')
+            ->assertSeeHtml('id="section-'.$section->id.'"')
+            ->assertSeeHtml('wire:click="saveSection('.$section->id.')"')
+            ->assertSet('sectionEdits.'.$section->id.'.title', 'Flagged Song');
+    }
+
+    #[Test]
+    public function it_does_not_seed_edit_state_for_clean_sections(): void
+    {
+        [$service, $run] = $this->workbenchServiceWithRun();
+
+        $clean = ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'needs_manual_review' => false,
+            'confidence' => 1.0,
+        ]);
+
+        $component = Livewire::actingAs($this->admin)
+            ->test(ShowChurchService::class, ['churchService' => $service]);
+
+        $this->assertArrayNotHasKey($clean->id, $component->get('sectionEdits'));
+    }
+
+    #[Test]
+    public function it_saves_section_edits_inline_on_the_workbench(): void
+    {
+        [$service, $run] = $this->workbenchServiceWithRun();
+
+        $section = ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'section_type' => ServiceSectionType::Song->value,
+            'title' => 'Original Title',
+            'needs_manual_review' => true,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(ShowChurchService::class, ['churchService' => $service])
+            ->set("sectionEdits.{$section->id}.section_type", ServiceSectionType::Prayer->value)
+            ->set("sectionEdits.{$section->id}.title", 'Updated Title')
+            ->call('saveSection', $section->id)
+            ->assertDispatched('notify', type: 'success', message: 'Section changes saved.');
+
+        $section->refresh();
+        $this->assertSame(ServiceSectionType::Prayer, $section->section_type);
+        $this->assertSame('Updated Title', $section->title);
+    }
+
+    #[Test]
+    public function it_merges_adjacent_sections_inline_on_the_workbench(): void
+    {
+        Queue::fake();
+
+        [$service, $run] = $this->workbenchServiceWithRun();
+
+        $first = ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'section_type' => ServiceSectionType::Song->value,
+            'section_order' => 1,
+            'needs_manual_review' => true,
+            'start_time' => 100.0,
+            'end_time' => 107.0,
+        ]);
+
+        $second = ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'section_type' => ServiceSectionType::Song->value,
+            'section_order' => 2,
+            'needs_manual_review' => true,
+            'start_time' => 107.0,
+            'end_time' => 231.0,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(ShowChurchService::class, ['churchService' => $service])
+            ->assertSee('Merge with the next Song section')
+            ->call('initiateMerge', $first->id, $second->id)
+            ->assertSee('Merge these two Song sections into one?')
+            ->call('confirmMerge')
+            ->assertDispatched('notify', type: 'success', message: 'Sections merged successfully.');
+
+        // The action keeps the longer section and absorbs the shorter one.
+        $second->refresh();
+        $this->assertSame(100.0, $second->start_time);
+        $this->assertSame(231.0, $second->end_time);
+        $this->assertDatabaseMissing('service_sections', ['id' => $first->id]);
+    }
+
+    #[Test]
+    public function workbench_mutating_actions_require_admin(): void
+    {
+        [$service, $run] = $this->workbenchServiceWithRun();
+
+        $section = ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'needs_manual_review' => true,
+        ]);
+
+        $member = User::factory()->create(['is_admin' => false]);
+
+        foreach ([
+            fn ($component) => $component->call('saveSection', $section->id),
+            fn ($component) => $component->call('approvePendingPublications', $service->id),
+            // The confirmMerge() authorization gap from the dashboard must not be copied (C4).
+            fn ($component) => $component->call('initiateMerge', $section->id, $section->id)->call('confirmMerge'),
+            fn ($component) => $component->call('markServiceReviewed', $service->id),
+        ] as $invoke) {
+            $invoke(
+                Livewire::actingAs($member)->test(ShowChurchService::class, ['churchService' => $service])
+            )->assertForbidden();
+        }
+    }
+
+    #[Test]
+    public function it_offers_batch_approval_when_publications_are_pending(): void
+    {
+        [$service, $run] = $this->workbenchServiceWithRun();
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(ShowChurchService::class, ['churchService' => $service])
+            ->assertSee('1 pending publication')
+            ->assertSee('Approve all pending publications')
+            ->call('approvePendingPublications', $service->id)
+            ->assertDispatched('notify');
+    }
+
+    #[Test]
+    public function it_hides_publication_affordances_when_section_publishing_is_disabled(): void
+    {
+        config(['media-processing.section_publishing.enabled' => false]);
+
+        [$service, $run] = $this->workbenchServiceWithRun();
+
+        $section = ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
+            'needs_manual_review' => true,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(ShowChurchService::class, ['churchService' => $service])
+            ->assertDontSee('Approve all pending publications')
+            ->assertDontSeeHtml('wire:click="approve('.$section->id.')"');
     }
 }

--- a/tests/Feature/Livewire/Admin/ChurchServices/ShowChurchServiceTest.php
+++ b/tests/Feature/Livewire/Admin/ChurchServices/ShowChurchServiceTest.php
@@ -432,8 +432,11 @@ class ShowChurchServiceTest extends TestCase
         foreach ([
             fn ($component) => $component->call('saveSection', $section->id),
             fn ($component) => $component->call('approvePendingPublications', $service->id),
-            // The confirmMerge() authorization gap from the dashboard must not be copied (C4).
-            fn ($component) => $component->call('initiateMerge', $section->id, $section->id)->call('confirmMerge'),
+            // The confirmMerge() authorization gap from the dashboard must not be copied (C4),
+            // and the pending-merge state setters are guarded too.
+            fn ($component) => $component->call('initiateMerge', $section->id, $section->id),
+            fn ($component) => $component->call('confirmMerge'),
+            fn ($component) => $component->call('cancelMerge'),
             fn ($component) => $component->call('markServiceReviewed', $service->id),
         ] as $invoke) {
             $invoke(

--- a/tests/Feature/Queries/ServiceReviewDashboardQueryTest.php
+++ b/tests/Feature/Queries/ServiceReviewDashboardQueryTest.php
@@ -543,4 +543,72 @@ class ServiceReviewDashboardQueryTest extends TestCase
         $this->assertCount(1, $result);
         $this->assertSame($matchedSection->id, $result->first()->id);
     }
+
+    #[Test]
+    public function pending_publication_sections_for_service_includes_fallback_matched_repaired_runs(): void
+    {
+        $processingId = '55555555-5555-5555-5555-555555555555';
+
+        $service = ChurchService::factory()->create([
+            'date' => '2026-06-07',
+            'service' => SermonService::Morning,
+        ]);
+
+        ChurchServiceItem::factory()->livestream()->create([
+            'church_service_id' => $service->id,
+            'position' => 1,
+            'title' => 'Sermon',
+            'livestream_processing_id' => $processingId,
+        ]);
+
+        $repairedRun = MediaProcessingLog::factory()->livestream()->create([
+            'processing_id' => $processingId,
+            'church_service_id' => null,
+            'extracted_date' => '2026-01-01',
+            'extracted_service' => SermonService::Evening->value,
+        ]);
+
+        $section = ServiceSection::factory()->create([
+            'media_processing_log_id' => $repairedRun->id,
+            'church_service_item_id' => null,
+            'publication_status' => ServiceSectionPublicationStatus::PendingApproval->value,
+        ]);
+
+        $result = $this->query->pendingPublicationSectionsForService($service);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($section->id, $result->first()->id);
+    }
+
+    #[Test]
+    public function review_groups_includes_sections_flagged_only_by_heuristic_demotion(): void
+    {
+        $run = MediaProcessingLog::factory()->livestream()->create([
+            'extracted_date' => '2026-05-31',
+            'extracted_service' => SermonService::Morning->value,
+        ]);
+
+        ServiceSection::factory()->create([
+            'media_processing_log_id' => $run->id,
+            'section_type' => ServiceSectionType::ChildrensTalk->value,
+            'title' => 'Demoted Talk',
+            'needs_manual_review' => false,
+            'confidence' => 0.99,
+            'publication_status' => ServiceSectionPublicationStatus::NotApplicable->value,
+            'metadata' => [
+                'confidence_level' => 'high',
+                'review_flags' => ['heuristic_demotion'],
+            ],
+        ]);
+
+        $groups = $this->query->reviewGroups();
+
+        $this->assertCount(1, $groups);
+        $this->assertCount(1, $groups[0]['sections']);
+        $this->assertSame('Demoted Talk', $groups[0]['sections'][0]['section']->title);
+        $this->assertContains(
+            'heuristic_demotion',
+            array_column($groups[0]['sections'][0]['reasons'], 'key')
+        );
+    }
 }


### PR DESCRIPTION
Phase 3.2 of the [service & livestream UI consolidation plan](docs/plans/SERVICE-UI-CONSOLIDATION-2026-06-10.md). **Stacked on #800** (P3.1) ← #799 (P2) ← #798 (P1).

The service page becomes the in-context review surface. Flagged timeline rows now auto-expand into an inline review panel — reason chips, type/title edits, children's-talk speaker picker, audio/video candidate previews, Approve/Reject/Requeue — with a merge-adjacent affordance between sibling rows and a per-service **Approve all pending publications** button beside the pipeline stepper.

## How the port stays honest

- **`ReviewsServiceSections` trait** carries the section-edit state (`sectionEdits`/`speakerEdits`, candidates only — no payload ballooning), `saveSection`, `approvePendingPublications`, and the merge flow. Both `ShowChurchService` and the still-live `ServiceReviewDashboard` consume it, so behaviour is single-sourced until 3.4 deletes the dashboard. All 20 dashboard tests pass unchanged on the trait.
- **C4 fix included, not copied:** the dashboard's `confirmMerge()` mutated without a per-action authorize call; the trait adds `$this->authorizeAdmin()` and a workbench test calls every mutating action as a non-admin and asserts 403.
- **C1:** `ServiceReviewDashboardQuery::reviewEntryFor()` exposes the same seven-reason predicate + guarded preview URLs (`section-publications.preview-{audio,video}` routes stay) that the inbox counts.
- **C5:** publication/approval affordances hide when `media-processing.section_publishing.enabled` is off (tested).
- Panels carry `#section-{id}` anchors ready for the inbox `Edit ↗` re-pointing in 3.4. The run card's "Review sections" dashboard link becomes an in-page hint; the workbench header now carries Review inbox / Edit service / Back to services.
- Section-merge state is `pendingSectionMerge` — the view already had a `pendingMerge` (structure merge) variable.

## Tests

New `ShowChurchServiceTest` coverage: panel rendering + anchor, candidates-only seeding, inline save, merge affordance → confirm (asserting the longer-section-wins semantics), batch-approve button + delegation, per-action authorization, section-publishing gate. `ServiceFlowRowRenderingTest` untouched (the partial defaults its new inputs).

## Quality gates

`pint` ✅ · `phpstan` ✅ · full parallel suite ✅ (5,516 — one known worker-DB ordering flake on first run, clean on rerun) · Dusk ✅ (43)

🤖 Generated with [Claude Code](https://claude.com/claude-code)