### PR TITLE
🎨 Palette: Refine sermon thumbnail selection UX

### DIFF
--- a/resources/views/livewire/admin/sermons/edit-sermon-thumbnails.blade.php
+++ b/resources/views/livewire/admin/sermons/edit-sermon-thumbnails.blade.php
@@ -14,16 +14,26 @@
                         wire:key="thumbnail-candidate-{{ $candidate['id'] }}"
                         wire:loading.class="opacity-50"
                         wire:target="selectThumbnailCandidate('{{ $candidate['id'] }}')"
-                        class="rounded-lg border p-3 {{ $candidate['is_selected'] ? 'border-cbc-teal bg-cbc-teal/5' : 'border-gray-200 bg-white' }}"
+                        @unless($candidate['is_selected'])
+                            wire:click="selectThumbnailCandidate('{{ $candidate['id'] }}')"
+                        @endunless
+                        class="group rounded-lg border p-3 transition-all duration-200 {{ $candidate['is_selected'] ? 'border-cbc-teal bg-cbc-teal/5 ring-1 ring-cbc-teal/20' : 'border-gray-200 bg-white cursor-pointer hover:border-cbc-teal/50 hover:shadow-md active:scale-[0.98]' }}"
                     >
                         <div class="space-y-3">
                             @if($candidate['preview_url'])
-                                <img
-                                    src="{{ $candidate['preview_url'] }}"
-                                    alt="Thumbnail candidate {{ $loop->iteration }}"
-                                    class="h-32 w-full rounded-lg border border-gray-200 object-cover"
-                                    loading="lazy"
-                                >
+                                <div class="relative">
+                                    <img
+                                        src="{{ $candidate['preview_url'] }}"
+                                        alt="Thumbnail candidate {{ $loop->iteration }}"
+                                        class="h-32 w-full rounded-lg border border-gray-200 object-cover transition-opacity duration-200 {{ $candidate['is_selected'] ? '' : 'group-hover:opacity-90' }}"
+                                        loading="lazy"
+                                    >
+                                    @if($candidate['is_selected'])
+                                        <div class="absolute top-2 right-2 rounded-full bg-cbc-teal p-1 shadow-lg ring-2 ring-white">
+                                            <x-heroicon-s-check class="h-3 w-3 text-white" aria-hidden="true" />
+                                        </div>
+                                    @endif
+                                </div>
                             @endif
 
                             <div class="grid grid-cols-[1fr_auto] items-center gap-3">
@@ -54,8 +64,9 @@
                                     <x-form-button
                                         variant="outline"
                                         size="sm"
-                                        wire:click="selectThumbnailCandidate('{{ $candidate['id'] }}')"
+                                        wire:click.stop="selectThumbnailCandidate('{{ $candidate['id'] }}')"
                                         wire:loading.attr="disabled"
+                                        class="group-hover:bg-cbc-teal group-hover:text-white group-hover:border-cbc-teal transition-colors"
                                     >
                                         Use this
                                     </x-form-button>
@@ -78,9 +89,12 @@
                 </p>
             </div>
         @else
-            <p class="text-sm text-gray-500">
-                No saved sermon thumbnails yet.
-            </p>
+            <div class="flex flex-col items-center justify-center space-y-2 border-2 border-dashed border-gray-200 rounded-xl bg-gray-50/50 p-6 text-center">
+                <x-heroicon-o-photo class="h-8 w-8 text-gray-300" aria-hidden="true" />
+                <p class="text-sm font-medium text-gray-500">
+                    No saved sermon thumbnails yet.
+                </p>
+            </div>
         @endif
 
         <div class="space-y-2">


### PR DESCRIPTION
This PR implements a series of micro-UX improvements to the sermon thumbnail selection component in the admin editor.

💡 **What:**
- Transformed static thumbnail candidate cards into interactive elements.
- Added `wire:click` to the entire card container.
- Added a `group` hover effect that highlights both the card and the "Use this" button simultaneously.
- Added a branded checkmark overlay on the selected thumbnail for immediate visual confirmation.
- Redesigned the "no thumbnails" state using the project's standard dashed-border "blank slate" pattern.

🎯 **Why:**
The previous interface required precise clicking on small buttons and lacked tactile feedback. These changes make the selection process feel more responsive, intuitive, and "delightful" for administrators.

♿ **Accessibility:**
- Maintained existing ARIA attributes and focus management.
- Ensured all new icons are marked with `aria-hidden="true"`.
- Used semantic checkmark overlays that are purely decorative.

📱 **Responsive:**
- Hover and active states are optimized for both mouse and touch interaction (using `active:scale-[0.98]`).
- Grid layout remains robust across screen sizes.

---
*PR created automatically by Jules for task [12380152586173160723](https://jules.google.com/task/12380152586173160723) started by @GarethClarridge*