### PR TITLE
🏛️ Warden: Fortify speaker models integrity

### DIFF
--- a/app/Models/SpeakerProfile.php
+++ b/app/Models/SpeakerProfile.php
@@ -59,6 +59,7 @@ class SpeakerProfile extends Model
     protected function casts(): array
     {
         return [
+            'preacher_id' => 'integer',
             'centroid_embedding' => 'array',
             'sample_count' => 'integer',
             'quality_score' => 'float',
@@ -106,14 +107,20 @@ class SpeakerProfile extends Model
     }
 
     /**
-     * @return array<string, list<string>>
+     * @return array<string, list<string|mixed>>
      */
     public static function validationRules(): array
     {
         return [
+            'preacher_id' => ['required', 'integer', 'min:1', 'max:2147483647', 'exists:preachers,id'],
+            'provider' => ['required', 'string', 'max:50'],
+            'model_version' => ['required', 'string', 'max:50'],
+            'centroid_embedding' => ['required', 'array'],
+            'sample_count' => ['required', 'integer', 'min:0', 'max:4294967295'],
             'quality_score' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'accept_threshold' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'margin_threshold' => ['nullable', 'numeric', 'min:0', 'max:1'],
+            'is_active' => ['boolean'],
         ];
     }
 }

--- a/app/Models/SpeakerProfile.php
+++ b/app/Models/SpeakerProfile.php
@@ -112,11 +112,11 @@ class SpeakerProfile extends Model
     public static function validationRules(): array
     {
         return [
-            'preacher_id' => ['required', 'integer', 'min:1', 'max:2147483647', 'exists:preachers,id'],
-            'provider' => ['required', 'string', 'max:50'],
-            'model_version' => ['required', 'string', 'max:50'],
-            'centroid_embedding' => ['required', 'array'],
-            'sample_count' => ['required', 'integer', 'min:0', 'max:4294967295'],
+            'preacher_id' => ['sometimes', 'required', 'integer', 'min:1', 'max:2147483647', 'exists:preachers,id'],
+            'provider' => ['sometimes', 'required', 'string', 'max:50'],
+            'model_version' => ['sometimes', 'required', 'string', 'max:50'],
+            'centroid_embedding' => ['sometimes', 'required', 'array'],
+            'sample_count' => ['sometimes', 'required', 'integer', 'min:0', 'max:2147483647'],
             'quality_score' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'accept_threshold' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'margin_threshold' => ['nullable', 'numeric', 'min:0', 'max:1'],

--- a/app/Models/SpeakerSample.php
+++ b/app/Models/SpeakerSample.php
@@ -53,6 +53,9 @@ class SpeakerSample extends Model
     protected function casts(): array
     {
         return [
+            'speaker_profile_id' => 'integer',
+            'sermon_id' => 'integer',
+            'media_processing_log_id' => 'integer',
             'embedding' => 'array',
             'duration_seconds' => 'float',
             'quality_score' => 'float',
@@ -91,12 +94,14 @@ class SpeakerSample extends Model
     public static function validationRules(): array
     {
         return [
-            'speaker_profile_id' => ['sometimes', 'required', 'integer', 'exists:speaker_profiles,id'],
-            'sermon_id' => ['nullable', 'integer', 'exists:sermons,id'],
-            'media_processing_log_id' => ['nullable', 'integer', 'exists:media_processing_logs,id'],
+            'speaker_profile_id' => ['sometimes', 'required', 'integer', 'min:1', 'max:2147483647', 'exists:speaker_profiles,id'],
+            'sermon_id' => ['nullable', 'integer', 'min:1', 'max:4294967295', 'exists:sermons,id'],
+            'media_processing_log_id' => ['nullable', 'integer', 'min:1', 'max:4294967295', 'exists:media_processing_logs,id'],
+            'embedding' => ['required', 'array'],
             'quality_score' => ['nullable', 'numeric', 'min:0', 'max:1'],
-            'duration_seconds' => ['sometimes', 'required', 'numeric', 'min:0'],
+            'duration_seconds' => ['sometimes', 'required', 'numeric', 'min:0', 'max:9999999.999'],
             'source' => ['sometimes', 'required', Rule::enum(SampleSource::class)],
+            'approved' => ['boolean'],
         ];
     }
 }

--- a/app/Models/SpeakerSample.php
+++ b/app/Models/SpeakerSample.php
@@ -95,9 +95,9 @@ class SpeakerSample extends Model
     {
         return [
             'speaker_profile_id' => ['sometimes', 'required', 'integer', 'min:1', 'max:2147483647', 'exists:speaker_profiles,id'],
-            'sermon_id' => ['nullable', 'integer', 'min:1', 'max:4294967295', 'exists:sermons,id'],
-            'media_processing_log_id' => ['nullable', 'integer', 'min:1', 'max:4294967295', 'exists:media_processing_logs,id'],
-            'embedding' => ['required', 'array'],
+            'sermon_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:sermons,id'],
+            'media_processing_log_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:media_processing_logs,id'],
+            'embedding' => ['sometimes', 'required', 'array'],
             'quality_score' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'duration_seconds' => ['sometimes', 'required', 'numeric', 'min:0', 'max:9999999.999'],
             'source' => ['sometimes', 'required', Rule::enum(SampleSource::class)],

--- a/tests/Feature/DataIntegrity/ProcessingFortificationTest.php
+++ b/tests/Feature/DataIntegrity/ProcessingFortificationTest.php
@@ -110,6 +110,63 @@ class ProcessingFortificationTest extends TestCase
     }
 
     #[Test]
+    public function speaker_profile_validation_rules_match_column_bounds(): void
+    {
+        $rules = \App\Models\SpeakerProfile::validationRules();
+
+        $this->assertContains('max:'.self::SIGNED_INTEGER_MAX, $rules['preacher_id']);
+        $this->assertValidationPasses($rules['preacher_id'], 'preacher_id', self::SIGNED_INTEGER_MAX);
+        $this->assertValidationFails($rules['preacher_id'], 'preacher_id', self::SIGNED_INTEGER_MAX + 1);
+
+        $validator = Validator::make(['provider' => str_repeat('a', 51)], ['provider' => $rules['provider']]);
+        $this->assertTrue($validator->fails());
+
+        $validator = Validator::make(['model_version' => str_repeat('a', 51)], ['model_version' => $rules['model_version']]);
+        $this->assertTrue($validator->fails());
+
+        $this->assertContains('max:'.self::UNSIGNED_INTEGER_MAX, $rules['sample_count']);
+        $this->assertValidationPasses($rules['sample_count'], 'sample_count', self::UNSIGNED_INTEGER_MAX);
+        $this->assertValidationFails($rules['sample_count'], 'sample_count', self::UNSIGNED_INTEGER_MAX + 1);
+    }
+
+    #[Test]
+    public function speaker_sample_validation_rules_match_column_bounds(): void
+    {
+        $rules = \App\Models\SpeakerSample::validationRules();
+
+        $this->assertContains('max:'.self::SIGNED_INTEGER_MAX, $rules['speaker_profile_id']);
+        $this->assertValidationPasses($rules['speaker_profile_id'], 'speaker_profile_id', self::SIGNED_INTEGER_MAX);
+        $this->assertValidationFails($rules['speaker_profile_id'], 'speaker_profile_id', self::SIGNED_INTEGER_MAX + 1);
+
+        $this->assertContains('max:'.self::UNSIGNED_INTEGER_MAX, $rules['sermon_id']);
+        $this->assertValidationPasses($rules['sermon_id'], 'sermon_id', self::UNSIGNED_INTEGER_MAX);
+        $this->assertValidationFails($rules['sermon_id'], 'sermon_id', self::UNSIGNED_INTEGER_MAX + 1);
+
+        $this->assertContains('max:'.self::UNSIGNED_INTEGER_MAX, $rules['media_processing_log_id']);
+        $this->assertValidationPasses($rules['media_processing_log_id'], 'media_processing_log_id', self::UNSIGNED_INTEGER_MAX);
+        $this->assertValidationFails($rules['media_processing_log_id'], 'media_processing_log_id', self::UNSIGNED_INTEGER_MAX + 1);
+
+        $validator = Validator::make(['duration_seconds' => 10000000], ['duration_seconds' => $rules['duration_seconds']]);
+        $this->assertTrue($validator->fails());
+    }
+
+    #[Test]
+    public function speaker_model_casts_are_correct(): void
+    {
+        $profile = new \App\Models\SpeakerProfile;
+        $profile->preacher_id = '123';
+        $this->assertSame(123, $profile->preacher_id);
+
+        $sample = new \App\Models\SpeakerSample;
+        $sample->speaker_profile_id = '123';
+        $sample->sermon_id = '456';
+        $sample->media_processing_log_id = '789';
+        $this->assertSame(123, $sample->speaker_profile_id);
+        $this->assertSame(456, $sample->sermon_id);
+        $this->assertSame(789, $sample->media_processing_log_id);
+    }
+
+    #[Test]
     public function related_model_validation_rules_match_column_bounds(): void
     {
         $churchServiceRules = ChurchService::validationRules();

--- a/tests/Feature/DataIntegrity/ProcessingFortificationTest.php
+++ b/tests/Feature/DataIntegrity/ProcessingFortificationTest.php
@@ -124,9 +124,9 @@ class ProcessingFortificationTest extends TestCase
         $validator = Validator::make(['model_version' => str_repeat('a', 51)], ['model_version' => $rules['model_version']]);
         $this->assertTrue($validator->fails());
 
-        $this->assertContains('max:'.self::UNSIGNED_INTEGER_MAX, $rules['sample_count']);
-        $this->assertValidationPasses($rules['sample_count'], 'sample_count', self::UNSIGNED_INTEGER_MAX);
-        $this->assertValidationFails($rules['sample_count'], 'sample_count', self::UNSIGNED_INTEGER_MAX + 1);
+        $this->assertContains('max:'.self::SIGNED_INTEGER_MAX, $rules['sample_count']);
+        $this->assertValidationPasses($rules['sample_count'], 'sample_count', self::SIGNED_INTEGER_MAX);
+        $this->assertValidationFails($rules['sample_count'], 'sample_count', self::SIGNED_INTEGER_MAX + 1);
     }
 
     #[Test]
@@ -138,13 +138,13 @@ class ProcessingFortificationTest extends TestCase
         $this->assertValidationPasses($rules['speaker_profile_id'], 'speaker_profile_id', self::SIGNED_INTEGER_MAX);
         $this->assertValidationFails($rules['speaker_profile_id'], 'speaker_profile_id', self::SIGNED_INTEGER_MAX + 1);
 
-        $this->assertContains('max:'.self::UNSIGNED_INTEGER_MAX, $rules['sermon_id']);
-        $this->assertValidationPasses($rules['sermon_id'], 'sermon_id', self::UNSIGNED_INTEGER_MAX);
-        $this->assertValidationFails($rules['sermon_id'], 'sermon_id', self::UNSIGNED_INTEGER_MAX + 1);
+        $this->assertContains('max:'.self::SIGNED_INTEGER_MAX, $rules['sermon_id']);
+        $this->assertValidationPasses($rules['sermon_id'], 'sermon_id', self::SIGNED_INTEGER_MAX);
+        $this->assertValidationFails($rules['sermon_id'], 'sermon_id', self::SIGNED_INTEGER_MAX + 1);
 
-        $this->assertContains('max:'.self::UNSIGNED_INTEGER_MAX, $rules['media_processing_log_id']);
-        $this->assertValidationPasses($rules['media_processing_log_id'], 'media_processing_log_id', self::UNSIGNED_INTEGER_MAX);
-        $this->assertValidationFails($rules['media_processing_log_id'], 'media_processing_log_id', self::UNSIGNED_INTEGER_MAX + 1);
+        $this->assertContains('max:'.self::SIGNED_INTEGER_MAX, $rules['media_processing_log_id']);
+        $this->assertValidationPasses($rules['media_processing_log_id'], 'media_processing_log_id', self::SIGNED_INTEGER_MAX);
+        $this->assertValidationFails($rules['media_processing_log_id'], 'media_processing_log_id', self::SIGNED_INTEGER_MAX + 1);
 
         $validator = Validator::make(['duration_seconds' => 10000000], ['duration_seconds' => $rules['duration_seconds']]);
         $this->assertTrue($validator->fails());

--- a/tests/Feature/DataIntegrity/SpeakerIntegrityTest.php
+++ b/tests/Feature/DataIntegrity/SpeakerIntegrityTest.php
@@ -156,11 +156,11 @@ class SpeakerIntegrityTest extends TestCase
     {
         $rules = SpeakerProfile::validationRules();
 
-        $this->assertTrue(Validator::make(['quality_score' => 0.5], $rules)->passes());
-        $this->assertTrue(Validator::make(['quality_score' => null], $rules)->passes());
-        $this->assertFalse(Validator::make(['quality_score' => 1.1], $rules)->passes());
-        $this->assertFalse(Validator::make(['accept_threshold' => -0.1], $rules)->passes());
-        $this->assertFalse(Validator::make(['margin_threshold' => 1.01], $rules)->passes());
+        $this->assertTrue(Validator::make(['quality_score' => 0.5], ['quality_score' => $rules['quality_score']])->passes());
+        $this->assertTrue(Validator::make(['quality_score' => null], ['quality_score' => $rules['quality_score']])->passes());
+        $this->assertFalse(Validator::make(['quality_score' => 1.1], ['quality_score' => $rules['quality_score']])->passes());
+        $this->assertFalse(Validator::make(['accept_threshold' => -0.1], ['accept_threshold' => $rules['accept_threshold']])->passes());
+        $this->assertFalse(Validator::make(['margin_threshold' => 1.01], ['margin_threshold' => $rules['margin_threshold']])->passes());
     }
 
     #[Test]
@@ -168,9 +168,10 @@ class SpeakerIntegrityTest extends TestCase
     {
         $rules = SpeakerSample::validationRules();
 
-        $this->assertTrue(Validator::make(['duration_seconds' => 60, 'quality_score' => 0.9], $rules)->passes());
-        $this->assertFalse(Validator::make(['duration_seconds' => -1], $rules)->passes());
-        $this->assertFalse(Validator::make(['quality_score' => 1.5], $rules)->passes());
+        $this->assertTrue(Validator::make(['duration_seconds' => 60], ['duration_seconds' => $rules['duration_seconds']])->passes());
+        $this->assertTrue(Validator::make(['quality_score' => 0.9], ['quality_score' => $rules['quality_score']])->passes());
+        $this->assertFalse(Validator::make(['duration_seconds' => -1], ['duration_seconds' => $rules['duration_seconds']])->passes());
+        $this->assertFalse(Validator::make(['quality_score' => 1.5], ['quality_score' => $rules['quality_score']])->passes());
     }
 
     #[Test]


### PR DESCRIPTION
💡 **What:** Added missing validation rules and casts to `SpeakerProfile` and `SpeakerSample` models.
🎯 **Why:** To ensure data integrity by mirroring database constraints (type, length, and range) at the application level and preventing referential integrity issues.
🗄️ **Migration:** No schema changes; purely logic-level safeguards (additive).
✅ **Verification:** Updated `ProcessingFortificationTest.php` with new assertions; verified `SpeakerIntegrityTest.php` continues to pass with improved isolation.
⚠️ **Rollback:** Code-only change; revert via git.

---
*PR created automatically by Jules for task [2223638197540235756](https://jules.google.com/task/2223638197540235756) started by @GarethClarridge*