### PR TITLE
🔗 Pathfinder: Fix broken fragment links in Christmas page structured data

### DIFF
--- a/resources/views/full-width-pages/christmas.blade.php
+++ b/resources/views/full-width-pages/christmas.blade.php
@@ -104,31 +104,31 @@
 
   <div class="mx-auto max-w-screen-xl text-center pt-24 pb-12">
     <h2 class="sr-only">Events</h2>
-    <h3 class="font-display text-white mt-8 text-xl lg:text-2xl sm:px-16 lg:px-48">
+    <h3 id="event-preparing-room" class="font-display text-white mt-8 text-xl lg:text-2xl sm:px-16 lg:px-48">
       Preparing Room
     </h3>
     <p class="mb-8 text-lg text-white font-normal lg:text-xl sm:px-16 lg:px-48">
       Saturday 30th November, 3-6pm
     </p>
-    <h3 class="font-display text-white mt-8 text-xl lg:text-2xl sm:px-16 lg:px-48">
+    <h3 id="event-coffee-cup-carols" class="font-display text-white mt-8 text-xl lg:text-2xl sm:px-16 lg:px-48">
       Coffee Cup Carols
     </h3>
     <p class="mb-8 text-lg text-white font-normal lg:text-xl sm:px-16 lg:px-48">
       Thursday 12th, 10:30am
     </p>
-    <h3 class="font-display text-white mt-8 text-xl lg:text-2xl sm:px-16 lg:px-48">
+    <h3 id="event-carols-in-the-chequers" class="font-display text-white mt-8 text-xl lg:text-2xl sm:px-16 lg:px-48">
       Carols in the Chequers
     </h3>
     <p class="mb-8 text-lg text-white font-normal lg:text-xl sm:px-16 lg:px-48">
       Wednesday 18th, 7:30pm
     </p>
-    <h3 class="font-display text-white mt-8 text-xl lg:text-2xl sm:px-16 lg:px-48">
+    <h3 id="event-carols-by-candlelight" class="font-display text-white mt-8 text-xl lg:text-2xl sm:px-16 lg:px-48">
       Carols by Candlelight
     </h3>
     <p class="mb-8 text-lg text-white font-normal lg:text-xl sm:px-16 lg:px-48">
       Sunday 22nd, 6:00pm
     </p>
-    <h3 class="font-display text-white mt-8 text-xl lg:text-2xl sm:px-16 lg:px-48">
+    <h3 id="event-christmas-morning-service" class="font-display text-white mt-8 text-xl lg:text-2xl sm:px-16 lg:px-48">
       Christmas Morning Service
     </h3>
     <p class="mb-8 text-lg text-white font-normal lg:text-xl sm:px-16 lg:px-48">


### PR DESCRIPTION
Added missing id attributes to event headings on the Christmas page to match the fragment links defined in the JSON-LD structured data. This ensures that the structured event data is correctly associated with the visible content on the page.

---
*PR created automatically by Jules for task [11539873298698745276](https://jules.google.com/task/11539873298698745276) started by @GarethClarridge*