### PR TITLE
🏛️ Warden: fortify speaker models integrity

### DIFF
--- a/.Jules/warden.md
+++ b/.Jules/warden.md
@@ -10,3 +10,7 @@
 1.  Application-level validation (e.g., `lowercase` rule).
 2.  Model-level normalization (e.g., Eloquent Attribute mutators) to gracefully handle and fix data before it reaches the database.
 3.  Defensive testing that asserts both DB rejection and validation-level handling.
+
+## 2026-06-12 - Mirroring Schema in Model Layer
+**Learning:** `SpeakerProfile` and `SpeakerSample` models lacked complete validation rules and casts, leading to inconsistent integrity across the stack. Schema attributes like `exists`, `max` (string length), and standardized integer bounds were present in migrations but missing from `validationRules()`.
+**Action:** Fortify models by explicitly mirroring ALL database columns in both `casts()` (for type safety) and `validationRules()` (for defensive input handling). Adhere to the "Integer Bounding Pattern" using `max:2147483647` for standard ID fields to ensure cross-language compatibility.

--- a/app/Models/SpeakerProfile.php
+++ b/app/Models/SpeakerProfile.php
@@ -59,6 +59,8 @@ class SpeakerProfile extends Model
     protected function casts(): array
     {
         return [
+            'id' => 'integer',
+            'preacher_id' => 'integer',
             'centroid_embedding' => 'array',
             'sample_count' => 'integer',
             'quality_score' => 'float',
@@ -106,14 +108,20 @@ class SpeakerProfile extends Model
     }
 
     /**
-     * @return array<string, list<string>>
+     * @return array<string, list<string|mixed>>
      */
     public static function validationRules(): array
     {
         return [
+            'preacher_id' => ['required', 'integer', 'min:1', 'max:2147483647', 'exists:preachers,id'],
+            'provider' => ['required', 'string', 'max:50'],
+            'model_version' => ['required', 'string', 'max:50'],
+            'centroid_embedding' => ['required', 'array'],
+            'sample_count' => ['integer', 'min:0', 'max:2147483647'],
             'quality_score' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'accept_threshold' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'margin_threshold' => ['nullable', 'numeric', 'min:0', 'max:1'],
+            'is_active' => ['boolean'],
         ];
     }
 }

--- a/app/Models/SpeakerProfile.php
+++ b/app/Models/SpeakerProfile.php
@@ -59,7 +59,6 @@ class SpeakerProfile extends Model
     protected function casts(): array
     {
         return [
-            'id' => 'integer',
             'preacher_id' => 'integer',
             'centroid_embedding' => 'array',
             'sample_count' => 'integer',

--- a/app/Models/SpeakerSample.php
+++ b/app/Models/SpeakerSample.php
@@ -53,6 +53,10 @@ class SpeakerSample extends Model
     protected function casts(): array
     {
         return [
+            'id' => 'integer',
+            'speaker_profile_id' => 'integer',
+            'sermon_id' => 'integer',
+            'media_processing_log_id' => 'integer',
             'embedding' => 'array',
             'duration_seconds' => 'float',
             'quality_score' => 'float',
@@ -91,12 +95,14 @@ class SpeakerSample extends Model
     public static function validationRules(): array
     {
         return [
-            'speaker_profile_id' => ['sometimes', 'required', 'integer', 'exists:speaker_profiles,id'],
-            'sermon_id' => ['nullable', 'integer', 'exists:sermons,id'],
-            'media_processing_log_id' => ['nullable', 'integer', 'exists:media_processing_logs,id'],
+            'speaker_profile_id' => ['sometimes', 'required', 'integer', 'min:1', 'max:2147483647', 'exists:speaker_profiles,id'],
+            'sermon_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:sermons,id'],
+            'media_processing_log_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:media_processing_logs,id'],
+            'embedding' => ['required', 'array'],
             'quality_score' => ['nullable', 'numeric', 'min:0', 'max:1'],
-            'duration_seconds' => ['sometimes', 'required', 'numeric', 'min:0'],
+            'duration_seconds' => ['sometimes', 'required', 'numeric', 'min:0', 'max:9999999.999'],
             'source' => ['sometimes', 'required', Rule::enum(SampleSource::class)],
+            'approved' => ['boolean'],
         ];
     }
 }

--- a/app/Models/SpeakerSample.php
+++ b/app/Models/SpeakerSample.php
@@ -53,7 +53,6 @@ class SpeakerSample extends Model
     protected function casts(): array
     {
         return [
-            'id' => 'integer',
             'speaker_profile_id' => 'integer',
             'sermon_id' => 'integer',
             'media_processing_log_id' => 'integer',
@@ -95,13 +94,13 @@ class SpeakerSample extends Model
     public static function validationRules(): array
     {
         return [
-            'speaker_profile_id' => ['sometimes', 'required', 'integer', 'min:1', 'max:2147483647', 'exists:speaker_profiles,id'],
+            'speaker_profile_id' => ['required', 'integer', 'min:1', 'max:2147483647', 'exists:speaker_profiles,id'],
             'sermon_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:sermons,id'],
             'media_processing_log_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:media_processing_logs,id'],
             'embedding' => ['required', 'array'],
             'quality_score' => ['nullable', 'numeric', 'min:0', 'max:1'],
-            'duration_seconds' => ['sometimes', 'required', 'numeric', 'min:0', 'max:9999999.999'],
-            'source' => ['sometimes', 'required', Rule::enum(SampleSource::class)],
+            'duration_seconds' => ['required', 'numeric', 'min:0', 'max:9999999.999'],
+            'source' => ['required', Rule::enum(SampleSource::class)],
             'approved' => ['boolean'],
         ];
     }

--- a/tests/Integration/Models/SpeakerValidationIntegrityTest.php
+++ b/tests/Integration/Models/SpeakerValidationIntegrityTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Enums\SampleSource;
+use App\Models\MediaProcessingLog;
+use App\Models\Preacher;
+use App\Models\Sermon;
+use App\Models\SpeakerProfile;
+use App\Models\SpeakerSample;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SpeakerValidationIntegrityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function speaker_profile_validation_rules_accept_valid_data(): void
+    {
+        $preacher = Preacher::factory()->create();
+
+        $data = [
+            'preacher_id' => $preacher->id,
+            'provider' => 'resemblyzer',
+            'model_version' => 'v1.0',
+            'centroid_embedding' => array_fill(0, 256, 0.1),
+            'sample_count' => 10,
+            'quality_score' => 0.95,
+            'accept_threshold' => 0.75,
+            'margin_threshold' => 0.10,
+            'is_active' => true,
+        ];
+
+        $validator = Validator::make($data, SpeakerProfile::validationRules());
+
+        $this->assertFalse($validator->fails(), 'Validation should have passed for valid SpeakerProfile data.');
+    }
+
+    #[Test]
+    public function speaker_profile_validation_rules_reject_invalid_data(): void
+    {
+        $cases = [
+            'missing preacher_id' => [
+                'data' => ['provider' => 'resemblyzer', 'model_version' => 'v1.0', 'centroid_embedding' => []],
+                'field' => 'preacher_id',
+            ],
+            'preacher_id does not exist' => [
+                'data' => ['preacher_id' => 9999, 'provider' => 'resemblyzer', 'model_version' => 'v1.0', 'centroid_embedding' => []],
+                'field' => 'preacher_id',
+            ],
+            'provider too long' => [
+                'data' => ['preacher_id' => 1, 'provider' => str_repeat('a', 51), 'model_version' => 'v1.0', 'centroid_embedding' => []],
+                'field' => 'provider',
+            ],
+            'model_version too long' => [
+                'data' => ['preacher_id' => 1, 'provider' => 'resemblyzer', 'model_version' => str_repeat('v', 51), 'centroid_embedding' => []],
+                'field' => 'model_version',
+            ],
+            'negative sample_count' => [
+                'data' => ['preacher_id' => 1, 'provider' => 'resemblyzer', 'model_version' => 'v1.0', 'centroid_embedding' => [], 'sample_count' => -1],
+                'field' => 'sample_count',
+            ],
+            'quality_score > 1' => [
+                'data' => ['preacher_id' => 1, 'provider' => 'resemblyzer', 'model_version' => 'v1.0', 'centroid_embedding' => [], 'quality_score' => 1.1],
+                'field' => 'quality_score',
+            ],
+            'accept_threshold < 0' => [
+                'data' => ['preacher_id' => 1, 'provider' => 'resemblyzer', 'model_version' => 'v1.0', 'centroid_embedding' => [], 'accept_threshold' => -0.1],
+                'field' => 'accept_threshold',
+            ],
+        ];
+
+        foreach ($cases as $name => $case) {
+            $validator = Validator::make($case['data'], SpeakerProfile::validationRules());
+            $this->assertTrue($validator->fails(), "Validation should have failed for: $name");
+            $this->assertArrayHasKey($case['field'], $validator->errors()->toArray(), "Error should have been for field: {$case['field']}");
+        }
+    }
+
+    #[Test]
+    public function speaker_sample_validation_rules_accept_valid_data(): void
+    {
+        $profile = SpeakerProfile::factory()->create();
+        $sermon = Sermon::factory()->create();
+        $log = MediaProcessingLog::factory()->create();
+
+        $data = [
+            'speaker_profile_id' => $profile->id,
+            'sermon_id' => $sermon->id,
+            'media_processing_log_id' => $log->id,
+            'embedding' => array_fill(0, 256, 0.1),
+            'duration_seconds' => 30.5,
+            'quality_score' => 0.99,
+            'source' => SampleSource::UploadAuto->value,
+            'approved' => true,
+        ];
+
+        $validator = Validator::make($data, SpeakerSample::validationRules());
+
+        $this->assertFalse($validator->fails(), 'Validation should have passed for valid SpeakerSample data.');
+    }
+
+    #[Test]
+    public function speaker_sample_validation_rules_reject_invalid_data(): void
+    {
+        $cases = [
+            'speaker_profile_id does not exist' => [
+                'data' => ['speaker_profile_id' => 9999, 'embedding' => [], 'duration_seconds' => 10, 'source' => SampleSource::UploadAuto->value],
+                'field' => 'speaker_profile_id',
+            ],
+            'sermon_id does not exist' => [
+                'data' => ['speaker_profile_id' => 1, 'sermon_id' => 9999, 'embedding' => [], 'duration_seconds' => 10, 'source' => SampleSource::UploadAuto->value],
+                'field' => 'sermon_id',
+            ],
+            'negative duration' => [
+                'data' => ['speaker_profile_id' => 1, 'embedding' => [], 'duration_seconds' => -1, 'source' => SampleSource::UploadAuto->value],
+                'field' => 'duration_seconds',
+            ],
+            'duration too large' => [
+                'data' => ['speaker_profile_id' => 1, 'embedding' => [], 'duration_seconds' => 10000000, 'source' => SampleSource::UploadAuto->value],
+                'field' => 'duration_seconds',
+            ],
+            'invalid source' => [
+                'data' => ['speaker_profile_id' => 1, 'embedding' => [], 'duration_seconds' => 10, 'source' => 'invalid'],
+                'field' => 'source',
+            ],
+        ];
+
+        foreach ($cases as $name => $case) {
+            $validator = Validator::make($case['data'], SpeakerSample::validationRules());
+            $this->assertTrue($validator->fails(), "Validation should have failed for: $name");
+            $this->assertArrayHasKey($case['field'], $validator->errors()->toArray(), "Error should have been for field: {$case['field']}");
+        }
+    }
+}


### PR DESCRIPTION
💡 **What:** Added missing model casts and expanded `validationRules()` for `SpeakerProfile` and `SpeakerSample` to mirror the database schema.
🎯 **Why:** Ensures data integrity at the model layer and prevents invalid data from reaching the database, providing better error surfacing.
🗄️ **Migration:** No schema changes (additive model-layer fortification).
✅ **Verification:** Added `tests/Integration/Models/SpeakerValidationIntegrityTest.php` and verified all existing speaker-related tests pass.
⚠️ **Rollback:** Revert the changes to `SpeakerProfile.php` and `SpeakerSample.php` and delete the new test file.

---
*PR created automatically by Jules for task [16628844911062925453](https://jules.google.com/task/16628844911062925453) started by @GarethClarridge*