### PR TITLE
🛡️ Sentinel: Harden MediaController API responses

### DIFF
--- a/app/Http/Controllers/Api/MediaController.php
+++ b/app/Http/Controllers/Api/MediaController.php
@@ -185,8 +185,6 @@ class MediaController extends Controller
      *
      * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
      * Stack traces are sanitized to prevent information leakage.
-     *
-     * @throws \InvalidArgumentException
      */
     public function confirmSegment(ConfirmMediaSegmentRequest $request, string $processingId, ConfirmLivestreamSermonSegment $action): JsonResponse
     {
@@ -208,7 +206,11 @@ class MediaController extends Controller
                 'status_url' => route('api.media.processing.status', ['processingId' => $this->sanitizeForLog($processingId)]),
             ], 202);
         } catch (\InvalidArgumentException $e) {
-            return response()->json(['success' => false, 'message' => $e->getMessage()], 422);
+            $message = $e instanceof ProvidesSafeMessage
+                ? $e->getSafeMessage()
+                : 'Invalid request parameters.';
+
+            return response()->json(['success' => false, 'message' => $message], 422);
         } catch (\Exception $e) {
             return $this->handleApiException($e, 'Segment confirmation failed', [
                 'processing_id' => $this->sanitizeForLog($processingId),


### PR DESCRIPTION
### Security Hardening: API Error Response Improvement

**Vulnerability:** Raw exception messages from `InvalidArgumentException` were being returned directly to API clients in `MediaController::confirmSegment`, potentially leaking internal application logic or state.

**Fix:** 
- Modified `app/Http/Controllers/Api/MediaController.php` to check if the caught `InvalidArgumentException` implements the `ProvidesSafeMessage` contract.
- If it does, the safe message is returned; otherwise, a generic 'Invalid request parameters.' message is used.
- This aligns the `confirmSegment` method with the security pattern already used in the `status` method of the same controller.
- Removed redundant `@throws` documentation for exceptions that are caught and handled within the method.

**Verification:**
- Verified that all 15 tests in `tests/Feature/Api/MediaControllerTest.php` pass.
- Confirmed `phpstan` reports 0 errors.
- Verified that `ProvidesSafeMessage` was already correctly imported and utilized elsewhere in the file.

---
*PR created automatically by Jules for task [14693371589141202015](https://jules.google.com/task/14693371589141202015) started by @GarethClarridge*