### PR TITLE
🛡️ Sentinel: Harden API responses and log sanitization

### DIFF
--- a/app/Actions/ConfirmLivestreamSermonSegment.php
+++ b/app/Actions/ConfirmLivestreamSermonSegment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Exceptions\SafeInvalidArgumentException;
 use App\Models\LivestreamSegment;
 use App\Models\MediaProcessingLog;
 use App\Models\User;
@@ -29,7 +30,7 @@ class ConfirmLivestreamSermonSegment
      * Validates all preconditions, persists confirmation metadata, and dispatches
      * the post-review processing chain. Returns the dispatched batch.
      *
-     * @throws \InvalidArgumentException When preconditions are not met
+     * @throws SafeInvalidArgumentException When preconditions are not met
      */
     public function execute(string $processingId, int $segmentId, User $user): void
     {
@@ -41,15 +42,15 @@ class ConfirmLivestreamSermonSegment
                 ->first();
 
             if ($log === null) {
-                throw new \InvalidArgumentException('Processing log not found.');
+                throw new SafeInvalidArgumentException('Processing log not found.');
             }
 
             if (! $log->canUseManualSermonReview()) {
-                throw new \InvalidArgumentException('Only segmentation-style runs can be confirmed via manual review.');
+                throw new SafeInvalidArgumentException('Only segmentation-style runs can be confirmed via manual review.');
             }
 
             if (! $log->requiresManualSermonReview()) {
-                throw new \InvalidArgumentException('This run is not currently awaiting manual sermon review.');
+                throw new SafeInvalidArgumentException('This run is not currently awaiting manual sermon review.');
             }
 
             $segment = LivestreamSegment::query()
@@ -58,11 +59,11 @@ class ConfirmLivestreamSermonSegment
                 ->first();
 
             if ($segment === null) {
-                throw new \InvalidArgumentException('Segment not found on this processing run.');
+                throw new SafeInvalidArgumentException('Segment not found on this processing run.');
             }
 
             if (! $segment->isSpeech()) {
-                throw new \InvalidArgumentException('Only speech segments may be confirmed as the sermon.');
+                throw new SafeInvalidArgumentException('Only speech segments may be confirmed as the sermon.');
             }
 
             $this->ensureSourceVideoExists($log);
@@ -86,16 +87,16 @@ class ConfirmLivestreamSermonSegment
     }
 
     /**
-     * @throws \InvalidArgumentException When the source video file is no longer available
+     * @throws SafeInvalidArgumentException When the source video file is no longer available
      */
     private function ensureSourceVideoExists(MediaProcessingLog $log): void
     {
         if (! is_string($log->source_file_path) || $log->source_file_path === '') {
-            throw new \InvalidArgumentException('No source video path recorded for this run. The file may have been removed.');
+            throw new SafeInvalidArgumentException('No source video path recorded for this run. The file may have been removed.');
         }
 
         if (! $this->videoStorageService->sourceVideoExistsForPath($log->source_file_path)) {
-            throw new \InvalidArgumentException('The source video file is no longer available. This run cannot be resumed.');
+            throw new SafeInvalidArgumentException('The source video file is no longer available. This run cannot be resumed.');
         }
     }
 }

--- a/app/Exceptions/SafeInvalidArgumentException.php
+++ b/app/Exceptions/SafeInvalidArgumentException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use App\Contracts\ProvidesSafeMessage;
+use InvalidArgumentException;
+
+/**
+ * Exception thrown when an argument is invalid but the message is safe for user display.
+ */
+class SafeInvalidArgumentException extends InvalidArgumentException implements ProvidesSafeMessage
+{
+    /**
+     * Get the safe error message.
+     */
+    public function getSafeMessage(): string
+    {
+        return $this->getMessage();
+    }
+}

--- a/app/Http/Controllers/Api/MediaController.php
+++ b/app/Http/Controllers/Api/MediaController.php
@@ -9,6 +9,7 @@ use App\Actions\GetMediaProcessingStatus;
 use App\Contracts\ProvidesSafeMessage;
 use App\Data\VideoProcessingOptions;
 use App\Enums\MediaType;
+use App\Exceptions\SafeInvalidArgumentException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\CancelMediaProcessingRequest;
 use App\Http\Requests\ConfirmMediaSegmentRequest;
@@ -186,7 +187,7 @@ class MediaController extends Controller
      * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
      * Stack traces are sanitized to prevent information leakage.
      *
-     * @throws \InvalidArgumentException
+     * @throws \InvalidArgumentException|SafeInvalidArgumentException
      */
     public function confirmSegment(ConfirmMediaSegmentRequest $request, string $processingId, ConfirmLivestreamSermonSegment $action): JsonResponse
     {
@@ -208,7 +209,11 @@ class MediaController extends Controller
                 'status_url' => route('api.media.processing.status', ['processingId' => $this->sanitizeForLog($processingId)]),
             ], 202);
         } catch (\InvalidArgumentException $e) {
-            return response()->json(['success' => false, 'message' => $e->getMessage()], 422);
+            $message = $e instanceof ProvidesSafeMessage
+                ? $e->getSafeMessage()
+                : 'Confirmation failed due to an internal error.';
+
+            return response()->json(['success' => false, 'message' => $message], 422);
         } catch (\Exception $e) {
             return $this->handleApiException($e, 'Segment confirmation failed', [
                 'processing_id' => $this->sanitizeForLog($processingId),

--- a/app/Services/Media/Thumbnail/PixianClient.php
+++ b/app/Services/Media/Thumbnail/PixianClient.php
@@ -53,9 +53,9 @@ class PixianClient
 
         $imageContents = @file_get_contents($imagePath);
         if (! is_string($imageContents) || $imageContents === '') {
-            Log::warning('Pixian request skipped: image could not be read', [
-                'image_path' => $this->sanitizeForLog($imagePath),
-            ]);
+            Log::warning('Pixian request skipped: image could not be read', $this->sanitizeArrayForLog([
+                'image_path' => $imagePath,
+            ]));
 
             return null;
         }
@@ -63,10 +63,10 @@ class PixianClient
         try {
             $response = $this->makeRequest($imagePath, $imageContents);
         } catch (ConnectionException $e) {
-            Log::warning('Pixian connection error during background removal', [
-                'image_path' => $this->sanitizeForLog($imagePath),
-                'error' => $this->sanitizeForLog($e->getMessage()),
-            ]);
+            Log::warning('Pixian connection error during background removal', $this->sanitizeArrayForLog([
+                'image_path' => $imagePath,
+                'error' => $e->getMessage(),
+            ]));
 
             return null;
         }
@@ -79,10 +79,10 @@ class PixianClient
 
         $body = $response->body();
         if ($body === '') {
-            Log::warning('Pixian returned an empty response body', [
-                'image_path' => $this->sanitizeForLog($imagePath),
-                'request_id' => $this->sanitizeForLog((string) $response->header('x-request-id')),
-            ]);
+            Log::warning('Pixian returned an empty response body', $this->sanitizeArrayForLog([
+                'image_path' => $imagePath,
+                'request_id' => (string) $response->header('x-request-id'),
+            ]));
 
             return null;
         }
@@ -109,12 +109,12 @@ class PixianClient
     {
         $body = $response->body();
 
-        Log::warning('Pixian background removal failed', [
-            'image_path' => $this->sanitizeForLog($imagePath),
+        Log::warning('Pixian background removal failed', $this->sanitizeArrayForLog([
+            'image_path' => $imagePath,
             'status' => $response->status(),
-            'body' => $this->sanitizeForLog($body !== '' ? $body : (string) json_encode($response->json())),
-            'request_id' => $this->sanitizeForLog((string) $this->extractRequestId($response)),
-        ]);
+            'body' => $body !== '' ? $body : (string) json_encode($response->json()),
+            'request_id' => (string) $this->extractRequestId($response),
+        ]));
     }
 
     private function extractRequestId(Response $response): ?string

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,6 +15,3 @@ parameters:
         # Spatie Media Library's nonQueued() method type is not correctly inferred
         # The method exists on Conversion class and works correctly at runtime
         - '#Call to an undefined method Spatie\\Image\\Drivers\\ImageDriver::nonQueued\(\)#'
-        -
-            message: '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::andThrow\(\)#'
-            path: tests/Feature/Api/MediaControllerHardeningTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,3 +15,6 @@ parameters:
         # Spatie Media Library's nonQueued() method type is not correctly inferred
         # The method exists on Conversion class and works correctly at runtime
         - '#Call to an undefined method Spatie\\Image\\Drivers\\ImageDriver::nonQueued\(\)#'
+        -
+            message: '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::andThrow\(\)#'
+            path: tests/Feature/Api/MediaControllerHardeningTest.php

--- a/tests/Feature/Api/MediaControllerHardeningTest.php
+++ b/tests/Feature/Api/MediaControllerHardeningTest.php
@@ -25,15 +25,17 @@ class MediaControllerHardeningTest extends TestCase
         $processingId = '00000000-0000-0000-0000-000000000000';
 
         // Create processing log first to satisfy foreign key
+        /** @var MediaProcessingLog $log */
         $log = MediaProcessingLog::factory()->create();
         /** @var LivestreamSegment $segment */
         $segment = LivestreamSegment::factory()->create(['media_processing_log_id' => $log->id]);
         $segmentId = $segment->id;
 
-        /** @var \Mockery\MockInterface $actionMock */
+        /** @var \Mockery\MockInterface&\App\Actions\ConfirmLivestreamSermonSegment $actionMock */
         $actionMock = $this->mock(ConfirmLivestreamSermonSegment::class);
-        $actionMock->shouldReceive('execute')
-            ->andThrow(new SafeInvalidArgumentException('This is a safe message.'));
+        /** @var \Mockery\Expectation $expectation */
+        $expectation = $actionMock->shouldReceive('execute');
+        $expectation->andThrow(new SafeInvalidArgumentException('This is a safe message.'));
 
         $response = $this->actingAs($user)
             ->postJson(route('api.media.processing.confirm-segment', ['processingId' => $processingId]), [
@@ -55,15 +57,17 @@ class MediaControllerHardeningTest extends TestCase
         $processingId = '00000000-0000-0000-0000-000000000000';
 
         // Create processing log first to satisfy foreign key
+        /** @var MediaProcessingLog $log */
         $log = MediaProcessingLog::factory()->create();
         /** @var LivestreamSegment $segment */
         $segment = LivestreamSegment::factory()->create(['media_processing_log_id' => $log->id]);
         $segmentId = $segment->id;
 
-        /** @var \Mockery\MockInterface $actionMock */
+        /** @var \Mockery\MockInterface&\App\Actions\ConfirmLivestreamSermonSegment $actionMock */
         $actionMock = $this->mock(ConfirmLivestreamSermonSegment::class);
-        $actionMock->shouldReceive('execute')
-            ->andThrow(new \InvalidArgumentException('This is an unsafe internal error message.'));
+        /** @var \Mockery\Expectation $expectation */
+        $expectation = $actionMock->shouldReceive('execute');
+        $expectation->andThrow(new \InvalidArgumentException('This is an unsafe internal error message.'));
 
         $response = $this->actingAs($user)
             ->postJson(route('api.media.processing.confirm-segment', ['processingId' => $processingId]), [

--- a/tests/Feature/Api/MediaControllerHardeningTest.php
+++ b/tests/Feature/Api/MediaControllerHardeningTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Actions\ConfirmLivestreamSermonSegment;
+use App\Exceptions\SafeInvalidArgumentException;
+use App\Models\LivestreamSegment;
+use App\Models\MediaProcessingLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MediaControllerHardeningTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_returns_raw_message_for_safe_invalid_argument_exception(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->admin()->create();
+        $processingId = '00000000-0000-0000-0000-000000000000';
+
+        // Create processing log first to satisfy foreign key
+        $log = MediaProcessingLog::factory()->create();
+        /** @var LivestreamSegment $segment */
+        $segment = LivestreamSegment::factory()->create(['media_processing_log_id' => $log->id]);
+        $segmentId = $segment->id;
+
+        /** @var \Mockery\MockInterface $actionMock */
+        $actionMock = $this->mock(ConfirmLivestreamSermonSegment::class);
+        $actionMock->shouldReceive('execute')
+            ->andThrow(new SafeInvalidArgumentException('This is a safe message.'));
+
+        $response = $this->actingAs($user)
+            ->postJson(route('api.media.processing.confirm-segment', ['processingId' => $processingId]), [
+                'segment_id' => $segmentId,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'success' => false,
+                'message' => 'This is a safe message.',
+            ]);
+    }
+
+    #[Test]
+    public function it_returns_generic_message_for_unsafe_invalid_argument_exception(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->admin()->create();
+        $processingId = '00000000-0000-0000-0000-000000000000';
+
+        // Create processing log first to satisfy foreign key
+        $log = MediaProcessingLog::factory()->create();
+        /** @var LivestreamSegment $segment */
+        $segment = LivestreamSegment::factory()->create(['media_processing_log_id' => $log->id]);
+        $segmentId = $segment->id;
+
+        /** @var \Mockery\MockInterface $actionMock */
+        $actionMock = $this->mock(ConfirmLivestreamSermonSegment::class);
+        $actionMock->shouldReceive('execute')
+            ->andThrow(new \InvalidArgumentException('This is an unsafe internal error message.'));
+
+        $response = $this->actingAs($user)
+            ->postJson(route('api.media.processing.confirm-segment', ['processingId' => $processingId]), [
+                'segment_id' => $segmentId,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'success' => false,
+                'message' => 'Confirmation failed due to an internal error.',
+            ]);
+
+        $response->assertJsonMissing(['message' => 'This is an unsafe internal error message.']);
+    }
+}

--- a/tests/Integration/Actions/ConfirmLivestreamSermonSegmentTest.php
+++ b/tests/Integration/Actions/ConfirmLivestreamSermonSegmentTest.php
@@ -8,6 +8,7 @@ use App\Actions\ConfirmLivestreamSermonSegment;
 use App\Enums\ProcessingStatus;
 use App\Jobs\ExtractSermon;
 use App\Mail\LivestreamProcessingFailed;
+use App\Exceptions\SafeInvalidArgumentException;
 use App\Models\LivestreamSegment;
 use App\Models\MediaProcessingLog;
 use App\Models\User;
@@ -94,7 +95,7 @@ class ConfirmLivestreamSermonSegmentTest extends TestCase
     #[Test]
     public function it_rejects_an_unknown_processing_id(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(SafeInvalidArgumentException::class);
         $this->expectExceptionMessage('Processing log not found.');
 
         $this->action->execute('00000000-0000-0000-0000-000000000000', 1, $this->admin);
@@ -113,7 +114,7 @@ class ConfirmLivestreamSermonSegmentTest extends TestCase
 
         $segment = LivestreamSegment::factory()->speech()->forProcessingLog($log->id)->create();
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(SafeInvalidArgumentException::class);
         $this->expectExceptionMessage('Only segmentation-style runs');
 
         $this->action->execute($log->processing_id, $segment->id, $this->admin);
@@ -125,7 +126,7 @@ class ConfirmLivestreamSermonSegmentTest extends TestCase
         $log = MediaProcessingLog::factory()->livestream()->completed()->create();
         $segment = LivestreamSegment::factory()->speech()->forProcessingLog($log->id)->create();
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(SafeInvalidArgumentException::class);
         $this->expectExceptionMessage('not currently awaiting manual sermon review');
 
         $this->action->execute($log->processing_id, $segment->id, $this->admin);
@@ -141,7 +142,7 @@ class ConfirmLivestreamSermonSegmentTest extends TestCase
         $otherLog = MediaProcessingLog::factory()->livestream()->create();
         $foreignSegment = LivestreamSegment::factory()->speech()->forProcessingLog($otherLog->id)->create();
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(SafeInvalidArgumentException::class);
         $this->expectExceptionMessage('Segment not found on this processing run.');
 
         $this->action->execute($log->processing_id, $foreignSegment->id, $this->admin);
@@ -155,7 +156,7 @@ class ConfirmLivestreamSermonSegmentTest extends TestCase
         $log = $this->makeLivestreamLogAwaitingReview('livestreams/2026/service.mp4');
         $segment = LivestreamSegment::factory()->song()->forProcessingLog($log->id)->create();
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(SafeInvalidArgumentException::class);
         $this->expectExceptionMessage('Only speech segments');
 
         $this->action->execute($log->processing_id, $segment->id, $this->admin);
@@ -167,7 +168,7 @@ class ConfirmLivestreamSermonSegmentTest extends TestCase
         $log = $this->makeLivestreamLogAwaitingReview('livestreams/2026/missing.mp4');
         $segment = LivestreamSegment::factory()->speech()->forProcessingLog($log->id)->create();
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(SafeInvalidArgumentException::class);
         $this->expectExceptionMessage('source video file is no longer available');
 
         $this->action->execute($log->processing_id, $segment->id, $this->admin);
@@ -179,7 +180,7 @@ class ConfirmLivestreamSermonSegmentTest extends TestCase
         $log = $this->makeLivestreamLogAwaitingReview(null);
         $segment = LivestreamSegment::factory()->speech()->forProcessingLog($log->id)->create();
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(SafeInvalidArgumentException::class);
         $this->expectExceptionMessage('No source video path recorded');
 
         $this->action->execute($log->processing_id, $segment->id, $this->admin);
@@ -202,7 +203,7 @@ class ConfirmLivestreamSermonSegmentTest extends TestCase
         $this->action->execute($log->processing_id, $segment->id, $this->admin);
 
         // Second attempt fails because status is now pending (not required)
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(SafeInvalidArgumentException::class);
         $this->expectExceptionMessage('not currently awaiting manual sermon review');
 
         $this->action->execute($log->processing_id, $segment->id, $this->admin);


### PR DESCRIPTION
### 🚨 Severity: MEDIUM

### 💡 Vulnerability
1. **Information Leakage**: `MediaController::confirmSegment` was returning raw `InvalidArgumentException` messages directly to API clients. While mostly containing business logic validation, an unexpected exception from deeper in the stack could leak internal system details.
2. **Inconsistent Log Sanitization**: `PixianClient` was sanitizing log context manually on a per-field basis, which is brittle and error-prone compared to the project's standard `sanitizeArrayForLog` pattern.

### 🎯 Impact
1. Exploitation could allow an attacker to gain insights into the internal code structure or data state through unhandled exception messages.
2. Insufficient log sanitization could lead to log injection or accidental exposure of sensitive metadata in system logs.

### 🔧 Fix
1. **Safe Exceptions**: Introduced `App\Exceptions\SafeInvalidArgumentException` (implementing `ProvidesSafeMessage`) to explicitly mark validation errors intended for end-user display.
2. **API Hardening**: Modified `MediaController::confirmSegment` to return generic error messages unless the exception is explicitly marked as safe.
3. **Log Standardization**: Refactored `PixianClient` to use `$this->sanitizeArrayForLog($context)` for all `Log::` calls, ensuring consistent protection against log injection.
4. **PhpDoc**: Added `@throws` annotations for better static analysis and developer awareness.

### ✅ Verification
1. **Automated Tests**: Created `tests/Feature/Api/MediaControllerHardeningTest.php` which mocks the action to throw both safe and unsafe exceptions, asserting that raw messages are only returned for safe ones.
2. **Existing Tests**: Ran `tests/Feature/Api/MediaControllerTest.php` and `tests/Integration/Actions/ConfirmLivestreamSermonSegmentTest.php` to ensure no regression in existing business logic.
3. **Static Analysis**: Verified with `composer phpstan` (Level 8) and `./vendor/bin/pint`.

---
*PR created automatically by Jules for task [2228729662599816156](https://jules.google.com/task/2228729662599816156) started by @GarethClarridge*