### PR TITLE
📖 Editor: Fix inconsistent terminology in Children's Talk review panel

### DIFF
--- a/resources/views/livewire/admin/church-services/partials/section-review-panel.blade.php
+++ b/resources/views/livewire/admin/church-services/partials/section-review-panel.blade.php
@@ -93,18 +93,18 @@
     @if($section->section_type === \App\Enums\ServiceSectionType::ChildrensTalk)
         <div class="grid gap-3 rounded-lg border border-gray-200 bg-white p-3 md:grid-cols-2">
             <x-select
-                label="Choose preacher"
+                label="Choose speaker"
                 wire:model.blur="speakerEdits.{{ $section->id }}.preacher_id"
                 :options="$preacherOptions"
-                placeholder="Select a preacher..."
-                hint="Pick an existing preacher to confirm or override the detected speaker."
+                placeholder="Select a speaker..."
+                hint="Pick an existing speaker to confirm or override the detected one."
             />
 
             <x-input
                 label="Fallback speaker name"
                 wire:model.blur="speakerEdits.{{ $section->id }}.speaker_name"
                 maxlength="255"
-                hint="Use free text when the speaker is not in the preacher list."
+                hint="Use free text when the speaker is not in the speaker list."
             />
         </div>
 


### PR DESCRIPTION
Consistent terminology is now used for Children's Talk speaker selection in the church service review panel. Generic "preacher" references have been replaced with "speaker" to match the specific domain context for Children's Talks, improving microcopy clarity and alignment with existing patterns in the sermon editor.

- Updated label to "Choose speaker"
- Updated placeholder to "Select a speaker..."
- Harmonised hint text to use "speaker" throughout the Children's Talk block
- No functional changes - copy polish only.

---
*PR created automatically by Jules for task [16407834465876877872](https://jules.google.com/task/16407834465876877872) started by @GarethClarridge*