### PR TITLE
🏛️ Warden: fortify speaker and media log integrity

### DIFF
--- a/app/Models/SpeakerProfile.php
+++ b/app/Models/SpeakerProfile.php
@@ -106,11 +106,13 @@ class SpeakerProfile extends Model
     }
 
     /**
-     * @return array<string, list<string>>
+     * @return array<string, list<string|mixed>>
      */
     public static function validationRules(): array
     {
         return [
+            'preacher_id' => ['required', 'integer', 'min:1', 'max:2147483647', 'exists:preachers,id'],
+            'sample_count' => ['nullable', 'integer', 'min:0', 'max:2147483647'],
             'quality_score' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'accept_threshold' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'margin_threshold' => ['nullable', 'numeric', 'min:0', 'max:1'],

--- a/app/Models/SpeakerSample.php
+++ b/app/Models/SpeakerSample.php
@@ -91,9 +91,9 @@ class SpeakerSample extends Model
     public static function validationRules(): array
     {
         return [
-            'speaker_profile_id' => ['sometimes', 'required', 'integer', 'exists:speaker_profiles,id'],
-            'sermon_id' => ['nullable', 'integer', 'exists:sermons,id'],
-            'media_processing_log_id' => ['nullable', 'integer', 'exists:media_processing_logs,id'],
+            'speaker_profile_id' => ['sometimes', 'required', 'integer', 'min:1', 'max:2147483647', 'exists:speaker_profiles,id'],
+            'sermon_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:sermons,id'],
+            'media_processing_log_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:media_processing_logs,id'],
             'quality_score' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'duration_seconds' => ['sometimes', 'required', 'numeric', 'min:0'],
             'source' => ['sometimes', 'required', Rule::enum(SampleSource::class)],

--- a/database/migrations/2026_06_13_051543_add_missing_fk_indexes_to_media_processing_logs_and_speaker_samples.php
+++ b/database/migrations/2026_06_13_051543_add_missing_fk_indexes_to_media_processing_logs_and_speaker_samples.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('media_processing_logs', function (Blueprint $table) {
+            if (! Schema::hasIndex('media_processing_logs', 'media_processing_logs_sermon_id_index')) {
+                $table->index('sermon_id');
+            }
+            if (! Schema::hasIndex('media_processing_logs', 'media_processing_logs_owner_user_id_index')) {
+                $table->index('owner_user_id');
+            }
+            if (! Schema::hasIndex('media_processing_logs', 'media_processing_logs_church_service_id_index')) {
+                $table->index('church_service_id');
+            }
+        });
+
+        Schema::table('speaker_samples', function (Blueprint $table) {
+            if (! Schema::hasIndex('speaker_samples', 'speaker_samples_media_processing_log_id_index')) {
+                $table->index('media_processing_log_id');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('media_processing_logs', function (Blueprint $table) {
+            $table->dropIndex(['sermon_id']);
+            $table->dropIndex(['owner_user_id']);
+            $table->dropIndex(['church_service_id']);
+        });
+
+        Schema::table('speaker_samples', function (Blueprint $table) {
+            $table->dropIndex(['media_processing_log_id']);
+        });
+    }
+};

--- a/tests/Feature/DataIntegrity/SpeakerIntegrityTest.php
+++ b/tests/Feature/DataIntegrity/SpeakerIntegrityTest.php
@@ -155,12 +155,14 @@ class SpeakerIntegrityTest extends TestCase
     public function it_validates_profile_rules_at_application_level(): void
     {
         $rules = SpeakerProfile::validationRules();
+        $preacher = Preacher::factory()->create();
+        $validData = ['preacher_id' => $preacher->id];
 
-        $this->assertTrue(Validator::make(['quality_score' => 0.5], $rules)->passes());
-        $this->assertTrue(Validator::make(['quality_score' => null], $rules)->passes());
-        $this->assertFalse(Validator::make(['quality_score' => 1.1], $rules)->passes());
-        $this->assertFalse(Validator::make(['accept_threshold' => -0.1], $rules)->passes());
-        $this->assertFalse(Validator::make(['margin_threshold' => 1.01], $rules)->passes());
+        $this->assertTrue(Validator::make(array_merge($validData, ['quality_score' => 0.5]), $rules)->passes());
+        $this->assertTrue(Validator::make(array_merge($validData, ['quality_score' => null]), $rules)->passes());
+        $this->assertFalse(Validator::make(array_merge($validData, ['quality_score' => 1.1]), $rules)->passes());
+        $this->assertFalse(Validator::make(array_merge($validData, ['accept_threshold' => -0.1]), $rules)->passes());
+        $this->assertFalse(Validator::make(array_merge($validData, ['margin_threshold' => 1.01]), $rules)->passes());
     }
 
     #[Test]


### PR DESCRIPTION
This PR improves data integrity by adding missing database indexes on foreign key columns and fortifying model-level validation for speaker-related models.

### 💡 What:
- Added a migration to index `sermon_id`, `owner_user_id`, and `church_service_id` on `media_processing_logs`.
- Added an index to `media_processing_log_id` on `speaker_samples`.
- Fortified `SpeakerProfile` validation rules by making `preacher_id` required and adding standard integer bounds (`max:2147483647`).
- Fortified `SpeakerSample` validation rules with integer bounds and existence checks for foreign keys.

### 🎯 Why:
- Missing indexes on frequently joined/filtered foreign keys can lead to performance degradation as the database grows.
- Tightening validation rules ensures that data is rejected at the application layer before hitting database constraints, providing better feedback and preventing corrupt data from entering the system.

### 🗄️ Migration:
- `2026_06_13_051543_add_missing_fk_indexes_to_media_processing_logs_and_speaker_samples.php`

### ✅ Verification:
- Verified new indexes exist using `Schema::getIndexes()`.
- Fixed and ran `SpeakerIntegrityTest` to ensure application-level validation works as expected.
- Ran quality gates (`phpstan`, `pint`).

### ⚠️ Rollback:
- `php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [15949122802653530338](https://jules.google.com/task/15949122802653530338) started by @GarethClarridge*