### PR TITLE
🛡️ Sentinel: Harden API error responses against information leakage

### DIFF
--- a/app/Actions/ConfirmLivestreamSermonSegment.php
+++ b/app/Actions/ConfirmLivestreamSermonSegment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Exceptions\SafeInvalidArgumentException;
 use App\Models\LivestreamSegment;
 use App\Models\MediaProcessingLog;
 use App\Models\User;
@@ -29,7 +30,7 @@ class ConfirmLivestreamSermonSegment
      * Validates all preconditions, persists confirmation metadata, and dispatches
      * the post-review processing chain. Returns the dispatched batch.
      *
-     * @throws \InvalidArgumentException When preconditions are not met
+     * @throws SafeInvalidArgumentException When preconditions are not met
      */
     public function execute(string $processingId, int $segmentId, User $user): void
     {
@@ -41,15 +42,15 @@ class ConfirmLivestreamSermonSegment
                 ->first();
 
             if ($log === null) {
-                throw new \InvalidArgumentException('Processing log not found.');
+                throw new SafeInvalidArgumentException('Processing log not found.');
             }
 
             if (! $log->canUseManualSermonReview()) {
-                throw new \InvalidArgumentException('Only segmentation-style runs can be confirmed via manual review.');
+                throw new SafeInvalidArgumentException('Only segmentation-style runs can be confirmed via manual review.');
             }
 
             if (! $log->requiresManualSermonReview()) {
-                throw new \InvalidArgumentException('This run is not currently awaiting manual sermon review.');
+                throw new SafeInvalidArgumentException('This run is not currently awaiting manual sermon review.');
             }
 
             $segment = LivestreamSegment::query()
@@ -58,11 +59,11 @@ class ConfirmLivestreamSermonSegment
                 ->first();
 
             if ($segment === null) {
-                throw new \InvalidArgumentException('Segment not found on this processing run.');
+                throw new SafeInvalidArgumentException('Segment not found on this processing run.');
             }
 
             if (! $segment->isSpeech()) {
-                throw new \InvalidArgumentException('Only speech segments may be confirmed as the sermon.');
+                throw new SafeInvalidArgumentException('Only speech segments may be confirmed as the sermon.');
             }
 
             $this->ensureSourceVideoExists($log);
@@ -86,16 +87,16 @@ class ConfirmLivestreamSermonSegment
     }
 
     /**
-     * @throws \InvalidArgumentException When the source video file is no longer available
+     * @throws SafeInvalidArgumentException When the source video file is no longer available
      */
     private function ensureSourceVideoExists(MediaProcessingLog $log): void
     {
         if (! is_string($log->source_file_path) || $log->source_file_path === '') {
-            throw new \InvalidArgumentException('No source video path recorded for this run. The file may have been removed.');
+            throw new SafeInvalidArgumentException('No source video path recorded for this run. The file may have been removed.');
         }
 
         if (! $this->videoStorageService->sourceVideoExistsForPath($log->source_file_path)) {
-            throw new \InvalidArgumentException('The source video file is no longer available. This run cannot be resumed.');
+            throw new SafeInvalidArgumentException('The source video file is no longer available. This run cannot be resumed.');
         }
     }
 }

--- a/app/Exceptions/SafeInvalidArgumentException.php
+++ b/app/Exceptions/SafeInvalidArgumentException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use App\Contracts\ProvidesSafeMessage;
+use InvalidArgumentException;
+
+/**
+ * Exception for invalid arguments that are safe to expose to the end user.
+ *
+ * This exception implements ProvidesSafeMessage, indicating that its message
+ * contains no sensitive system details and can be returned in API responses.
+ */
+class SafeInvalidArgumentException extends InvalidArgumentException implements ProvidesSafeMessage
+{
+    public function getSafeMessage(): string
+    {
+        return $this->getMessage();
+    }
+}

--- a/app/Http/Controllers/Api/MediaController.php
+++ b/app/Http/Controllers/Api/MediaController.php
@@ -186,7 +186,7 @@ class MediaController extends Controller
      * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
      * Stack traces are sanitized to prevent information leakage.
      *
-     * @throws \InvalidArgumentException
+     * @throws \App\Exceptions\SafeInvalidArgumentException
      */
     public function confirmSegment(ConfirmMediaSegmentRequest $request, string $processingId, ConfirmLivestreamSermonSegment $action): JsonResponse
     {
@@ -208,7 +208,11 @@ class MediaController extends Controller
                 'status_url' => route('api.media.processing.status', ['processingId' => $this->sanitizeForLog($processingId)]),
             ], 202);
         } catch (\InvalidArgumentException $e) {
-            return response()->json(['success' => false, 'message' => $e->getMessage()], 422);
+            $message = $e instanceof ProvidesSafeMessage
+                ? $e->getSafeMessage()
+                : 'Invalid request parameters.';
+
+            return response()->json(['success' => false, 'message' => $message], 422);
         } catch (\Exception $e) {
             return $this->handleApiException($e, 'Segment confirmation failed', [
                 'processing_id' => $this->sanitizeForLog($processingId),

--- a/tests/Feature/Api/MediaControllerHardeningTest.php
+++ b/tests/Feature/Api/MediaControllerHardeningTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Actions\ConfirmLivestreamSermonSegment;
+use App\Contracts\ProvidesSafeMessage;
+use App\Models\LivestreamSegment;
+use App\Models\MediaProcessingLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Str;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MediaControllerHardeningTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_returns_generic_message_for_unsafe_invalid_argument_exception(): void
+    {
+        $user = User::factory()->admin()->create();
+        $this->actingAs($user);
+
+        $log = MediaProcessingLog::factory()->livestream()->manualReviewRequired()->create();
+        $segment = LivestreamSegment::factory()->forProcessingLog($log->id)->speech()->create();
+
+        $mockAction = Mockery::mock(ConfirmLivestreamSermonSegment::class);
+        $mockAction->shouldReceive('execute')
+            ->andThrow(new \InvalidArgumentException('Sensitive internal detail'));
+
+        $this->app->instance(ConfirmLivestreamSermonSegment::class, $mockAction);
+
+        $response = $this->postJson(route('api.media.processing.confirm-segment', ['processingId' => $log->processing_id]), [
+            'segment_id' => $segment->id
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJson([
+            'success' => false,
+            'message' => 'Invalid request parameters.'
+        ]);
+        $response->assertJsonMissing(['message' => 'Sensitive internal detail']);
+    }
+
+    #[Test]
+    public function it_returns_safe_message_for_safe_invalid_argument_exception(): void
+    {
+        $user = User::factory()->admin()->create();
+        $this->actingAs($user);
+
+        $log = MediaProcessingLog::factory()->livestream()->manualReviewRequired()->create();
+        $segment = LivestreamSegment::factory()->forProcessingLog($log->id)->speech()->create();
+
+        $safeException = new class('Safe business error') extends \InvalidArgumentException implements ProvidesSafeMessage {
+            public function getSafeMessage(): string { return $this->getMessage(); }
+        };
+
+        $mockAction = Mockery::mock(ConfirmLivestreamSermonSegment::class);
+        $mockAction->shouldReceive('execute')
+            ->andThrow($safeException);
+
+        $this->app->instance(ConfirmLivestreamSermonSegment::class, $mockAction);
+
+        $response = $this->postJson(route('api.media.processing.confirm-segment', ['processingId' => $log->processing_id]), [
+            'segment_id' => $segment->id
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJson([
+            'success' => false,
+            'message' => 'Safe business error'
+        ]);
+    }
+}


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Information leakage in API error responses. Raw exception messages from `\InvalidArgumentException` were being returned directly to clients in `MediaController::confirmSegment`.
🎯 **Impact:** Internal system details, logic constraints, or file paths could be exposed to end-users if an unexpected `\InvalidArgumentException` was thrown.
🔧 **Fix:** Implemented a safe exception pattern. Created `SafeInvalidArgumentException` (implementing `ProvidesSafeMessage`) for safe business logic errors. Updated `MediaController` to only expose messages from "safe" exceptions, defaulting to a generic error message otherwise.
✅ **Verification:** Added `MediaControllerHardeningTest` to verify that unsafe exception messages are redacted while safe ones are preserved. Verified existing tests still pass.

---
*PR created automatically by Jules for task [9664945405379307695](https://jules.google.com/task/9664945405379307695) started by @GarethClarridge*