### PR TITLE
🧪 Steward: Harden test isolation and date assertions

### DIFF
--- a/tests/Unit/Services/MeetingPhotoMigrationServiceTest.php
+++ b/tests/Unit/Services/MeetingPhotoMigrationServiceTest.php
@@ -6,7 +6,7 @@ namespace Tests\Unit\Services;
 
 use App\Models\Meeting;
 use App\Services\MeetingPhotoMigrationService;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\Test;
@@ -15,16 +15,17 @@ use Tests\TestCase;
 
 class MeetingPhotoMigrationServiceTest extends TestCase
 {
-    use DatabaseTransactions;
+    use RefreshDatabase;
 
     private MeetingPhotoMigrationService $service;
 
-    private string $testSlug = 'test-migration-meeting';
+    private string $testSlug;
 
     protected function setUp(): void
     {
         parent::setUp();
 
+        $this->testSlug = 'test-migration-'.\Illuminate\Support\Str::lower((string) \Illuminate\Support\Str::ulid());
         $this->service = new MeetingPhotoMigrationService;
         Storage::fake('public');
     }
@@ -39,9 +40,6 @@ class MeetingPhotoMigrationServiceTest extends TestCase
     #[Test]
     public function it_migrates_photos_successfully(): void
     {
-        // Clear any existing meetings to have a predictable count
-        Meeting::query()->delete();
-
         $meeting = Meeting::factory()->create(['slug' => $this->testSlug]);
         $directory = public_path("images/meetings/{$this->testSlug}");
 
@@ -73,7 +71,6 @@ class MeetingPhotoMigrationServiceTest extends TestCase
     #[Test]
     public function it_respects_dry_run_option(): void
     {
-        Meeting::query()->delete();
         $meeting = Meeting::factory()->create(['slug' => $this->testSlug]);
         $directory = public_path("images/meetings/{$this->testSlug}");
 
@@ -93,8 +90,7 @@ class MeetingPhotoMigrationServiceTest extends TestCase
     #[Test]
     public function it_skips_when_directory_does_not_exist(): void
     {
-        Meeting::query()->delete();
-        Meeting::factory()->create(['slug' => 'non-existent-slug']);
+        Meeting::factory()->create(['slug' => 'non-existent-slug-'.\Illuminate\Support\Str::lower((string) \Illuminate\Support\Str::ulid())]);
 
         $result = $this->service->migrate();
 
@@ -108,7 +104,6 @@ class MeetingPhotoMigrationServiceTest extends TestCase
     #[Test]
     public function it_skips_when_no_supported_files_are_found(): void
     {
-        Meeting::query()->delete();
         Meeting::factory()->create(['slug' => $this->testSlug]);
         $directory = public_path("images/meetings/{$this->testSlug}");
 
@@ -124,7 +119,6 @@ class MeetingPhotoMigrationServiceTest extends TestCase
     #[Test]
     public function it_skips_already_migrated_photos(): void
     {
-        Meeting::query()->delete();
         $meeting = Meeting::factory()->create(['slug' => $this->testSlug]);
         $directory = public_path("images/meetings/{$this->testSlug}");
 
@@ -156,8 +150,6 @@ class MeetingPhotoMigrationServiceTest extends TestCase
     #[Test]
     public function it_handles_failures_during_media_addition(): void
     {
-        Meeting::query()->delete();
-
         // Create a meeting but we will mock the addMedia to fail
         // Actually it's easier to provide a broken file path or similar,
         // but the service uses $photo->getPathname() which is real.

--- a/tests/Unit/Services/MetadataExtractionServiceTest.php
+++ b/tests/Unit/Services/MetadataExtractionServiceTest.php
@@ -125,7 +125,7 @@ class MetadataExtractionServiceTest extends TestCase
 
         foreach ($testCases as $filename) {
             $result = $this->service->extractDateFromFilename($filename);
-            $this->assertEquals('2026-05-27', $result->format('Y-m-d'), "Failed for filename: {$filename}");
+            $this->assertEquals(now()->toDateString(), $result->format('Y-m-d'), "Failed for filename: {$filename}");
         }
     }
 
@@ -198,7 +198,7 @@ class MetadataExtractionServiceTest extends TestCase
 
         foreach ($testCases as $filename) {
             $result = $this->service->extractDateFromFilename($filename);
-            $this->assertEquals('2026-05-27', $result->format('Y-m-d'), "Failed for filename: {$filename}");
+            $this->assertEquals(now()->toDateString(), $result->format('Y-m-d'), "Failed for filename: {$filename}");
         }
     }
 
@@ -471,11 +471,11 @@ class MetadataExtractionServiceTest extends TestCase
     {
         // Empty filename
         $result = $this->service->extractDateFromFilename('');
-        $this->assertEquals('2026-05-27', $result->format('Y-m-d'));
+        $this->assertEquals(now()->toDateString(), $result->format('Y-m-d'));
 
         // Filename with only extension
         $result = $this->service->extractDateFromFilename('.mp3');
-        $this->assertEquals('2026-05-27', $result->format('Y-m-d'));
+        $this->assertEquals(now()->toDateString(), $result->format('Y-m-d'));
 
         // Filename with multiple extensions
         $result = $this->service->extractDateFromFilename('2024-01-15.backup.mp3');


### PR DESCRIPTION
This PR hardens existing tests against brittleness and parallel execution flakiness. Specifically, it addresses manual state cleanup and path collisions in `MeetingPhotoMigrationServiceTest` by leveraging `RefreshDatabase` and unique identifiers. It also decouples `MetadataExtractionServiceTest` from a specific frozen date literal, making it more resilient to future test setup refactors.

---
*PR created automatically by Jules for task [6571603506065329172](https://jules.google.com/task/6571603506065329172) started by @GarethClarridge*