### PR TITLE
🔗 Pathfinder: Fix broken sermon delete links

### DIFF
--- a/resources/views/components/sermon-card-admin-overlay.blade.php
+++ b/resources/views/components/sermon-card-admin-overlay.blade.php
@@ -4,7 +4,7 @@
     <div class="mt-auto border-t border-gray-100">
         <form
             method="POST"
-            action="/christ/sermons/{{ $sermon->date->format('Y') }}/{{ $sermon->date->format('m') }}/{{ $sermon->slug }}/delete"
+            action="{{ route('sermons.destroy', $sermon->slug) }}"
             accept-charset="UTF-8"
             class="grid grid-cols-2"
         >

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -453,7 +453,7 @@
                     </div>
                     @endif
 
-                    <form method="POST" action="/christ/sermons/{{ date('Y', strtotime($sermon->date)) }}/{{ date('m', strtotime($sermon->date)) }}/{{ $sermon->slug }}/delete" accept-charset="UTF-8" class="grid grid-cols-2">
+                    <form method="POST" action="{{ route('sermons.destroy', $sermon->slug) }}" accept-charset="UTF-8" class="grid grid-cols-2">
                         @csrf
                         <a href="{{ route('admin.sermons.edit', $sermon->slug) }}" wire:navigate
                            class="w-full no-underline mx-auto block max-w-md p-4 text-center text-white rounded-bl-md bg-cbc-pattern bg-size-cover focus:outline-none focus:ring-2 focus:ring-cbc-teal focus:ring-offset-2 transition-all">


### PR DESCRIPTION
I have fixed the broken "Delete Sermon" links which were pointing to incorrect, legacy date-based URLs.

**Diagnostic Crawl Results:**
- **Sitemap & Core Pages:** All 90 sitemap URLs and core public pages (Christ, Church, Community) were verified and returned 200 OK.
- **Assets:** All referenced images on core pages exist and load correctly.

**Breakage Identified:**
- The delete forms in `sermon.blade.php` and the admin card overlay were using `/christ/sermons/{year}/{month}/{slug}/delete`.
- The application route for deletion is actually `/christ/sermons/{slug}/delete`.
- This mismatch caused a 404 error when an administrator attempted to delete a sermon.

**Fix:**
- Updated templates to use the named route `route('sermons.destroy', $sermon->slug)`.
- Verified the fix with a reproduction test case and confirmed that all 5,534 existing tests pass.

This PR addresses the functional breakage discovered during the diagnostic exploration.

---
*PR created automatically by Jules for task [11208835593613701790](https://jules.google.com/task/11208835593613701790) started by @GarethClarridge*