### PR TITLE
🔦 Lighthouse: SEO and Metadata Improvements

### DIFF
--- a/app/Presenters/PageCardPresenter.php
+++ b/app/Presenters/PageCardPresenter.php
@@ -28,7 +28,7 @@ class PageCardPresenter
 
         return [
             'area' => $area,
-            'description' => $page->description,
+            'description' => (string) $page->description,
             'heading' => $page->heading,
             'image_url' => $this->pageImagePresenter->headingImageSmallUrl($page) ?? '/images/headings/small/default.webp',
             'slug' => $page->slug,

--- a/resources/views/components/meta-tags.blade.php
+++ b/resources/views/components/meta-tags.blade.php
@@ -18,6 +18,8 @@
     'data1' => null,
     'label2' => null,
     'data2' => null,
+    'twitterSite' => null,
+    'twitterCreator' => null,
 ])
 
 @php
@@ -82,6 +84,12 @@
 <meta name="twitter:title" content="{{ $fullTitle }}">
 <meta name="twitter:description" content="{{ $metaDescription }}">
 <meta name="twitter:image" content="{{ $metaImage }}">
+@if($twitterSite)
+<meta name="twitter:site" content="{{ $twitterSite }}">
+@endif
+@if($twitterCreator)
+<meta name="twitter:creator" content="{{ $twitterCreator }}">
+@endif
 @if($imageAlt)
 <meta name="twitter:image:alt" content="{{ $imageAlt }}">
 @endif

--- a/resources/views/full-width-pages/christ.blade.php
+++ b/resources/views/full-width-pages/christ.blade.php
@@ -4,6 +4,10 @@
 
 @section('meta_description', 'Learn about Jesus Christ - who he is, why you need him, and what he has done for you. Explore the good news of Christianity at Crockenhill Baptist Church.')
 
+@section('canonical')
+<link rel="canonical" href="{{ url('/christ') }}">
+@endsection
+
 @section('meta_tags')
 <x-meta-tags
   title="Christ"

--- a/resources/views/full-width-pages/christmas.blade.php
+++ b/resources/views/full-width-pages/christmas.blade.php
@@ -4,6 +4,10 @@
 
 @section('meta_description', 'Celebrate Christmas at Crockenhill Baptist Church. Join us for Carols by Candlelight, our Christmas morning service, and more festive events.')
 
+@section('canonical')
+<link rel="canonical" href="{{ url('/christmas') }}">
+@endsection
+
 @section('meta_tags')
 <x-meta-tags
     title="Christmas"

--- a/resources/views/full-width-pages/church.blade.php
+++ b/resources/views/full-width-pages/church.blade.php
@@ -6,6 +6,10 @@ Church
 
 @section('meta_description', 'Learn about Crockenhill Baptist Church - who we are, when we meet, and what kind of church we are. An independent evangelical church in Kent.')
 
+@section('canonical')
+<link rel="canonical" href="{{ url('/church') }}">
+@endsection
+
 @section('meta_tags')
 <x-meta-tags
     title="Church"

--- a/resources/views/full-width-pages/community.blade.php
+++ b/resources/views/full-width-pages/community.blade.php
@@ -6,6 +6,10 @@ Community
 
 @section('meta_description', 'Join our community activities at Crockenhill Baptist Church. Meet local people, activities for children, and opportunities to learn about Jesus in Kent.')
 
+@section('canonical')
+<link rel="canonical" href="{{ url('/community') }}">
+@endsection
+
 @section('meta_tags')
 <x-meta-tags
   title="Community"

--- a/resources/views/full-width-pages/home.blade.php
+++ b/resources/views/full-width-pages/home.blade.php
@@ -1,8 +1,12 @@
 @extends('layouts.main')
 
-@section('title', 'Crockenhill Baptist Church')
+@section('title', 'Crockenhill Baptist Church | Worshipping God, Strengthening believers, Proclaiming Jesus Christ')
 
 @section('meta_description', 'We are an independent evangelical church in Crockenhill, Kent. Worshipping God, strengthening believers, proclaiming Jesus Christ to all.')
+
+@section('canonical')
+<link rel="canonical" href="{{ url('/') }}">
+@endsection
 
 @section('meta_tags')
 <x-meta-tags

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -9,8 +9,8 @@
     $pushedTitle = trim($__env->yieldPushContent('title'));
     $sectionTitle = trim($__env->yieldContent('title'));
     $resolvedTitle = $pushedTitle !== '' ? $pushedTitle : $sectionTitle;
-    $fullTitle = ($resolvedTitle === '' || $resolvedTitle === $siteName)
-      ? $siteName
+    $fullTitle = ($resolvedTitle === '' || $resolvedTitle === $siteName || \Illuminate\Support\Str::contains($resolvedTitle, $siteName))
+      ? ($resolvedTitle ?: $siteName)
       : $resolvedTitle.' | '.$siteName;
   @endphp
   <title>{{ $fullTitle }}</title>


### PR DESCRIPTION
This PR implements several SEO and metadata improvements to enhance the site's discoverability and social sharing presence.

### 💡 What
- **Home Page SEO**: The homepage title was updated to a more descriptive version that includes the church's mission while maintaining brand prominence: "Crockenhill Baptist Church | Worshipping God, Strengthening believers, Proclaiming Jesus Christ".
- **Metadata Hardening**: The `x-meta-tags` Blade component now supports `twitter:site` and `twitter:creator` properties, allowing for richer social sharing previews and proper attribution.
- **Canonical URLs**: Added explicit `<link rel="canonical">` tags to major landing pages (`/`, `/christ`, `/church`, `/community`, `/christmas`) via the `@section('canonical')` block.
- **Smart Title Resolution**: Updated `layouts/main.blade.php` to check if the site name is already present in the page-specific title before appending it. This ensures titles like the new homepage title aren't double-suffixed.
- **Bug Fix**: Addressed a PHPStan Level 8 error in `PageCardPresenter` by ensuring the `description` field is correctly cast to a string.

### 🎯 Why
These changes satisfy the Lighthouse mission of ensuring every public page has a unique, descriptive title and proper structured metadata. Explicit canonical URLs prevent duplicate content issues in search engines, and hardened social tags improve the appearance of shared links on platforms like X (Twitter).

### 📊 Impact
All public-facing landing pages benefit from improved indexing consistency and better social sharing previews.

### 🔍 Verification
- Verified Home Page title and canonical tags via `curl`.
- Ran `SitemapTest` and `SermonTest` suites (all passed).
- Confirmed 0 errors in `phpstan`.
- Captured visual verification of the homepage and 'Christ' section.

---
*PR created automatically by Jules for task [12591947846246570816](https://jules.google.com/task/12591947846246570816) started by @GarethClarridge*