### PR TITLE
Synthesise improvements from 10 closed Jules PRs

### DIFF
--- a/app/Actions/ConfirmLivestreamSermonSegment.php
+++ b/app/Actions/ConfirmLivestreamSermonSegment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Exceptions\SafeInvalidArgumentException;
 use App\Models\LivestreamSegment;
 use App\Models\MediaProcessingLog;
 use App\Models\User;
@@ -29,7 +30,7 @@ class ConfirmLivestreamSermonSegment
      * Validates all preconditions, persists confirmation metadata, and dispatches
      * the post-review processing chain. Returns the dispatched batch.
      *
-     * @throws \InvalidArgumentException When preconditions are not met
+     * @throws SafeInvalidArgumentException When preconditions are not met
      */
     public function execute(string $processingId, int $segmentId, User $user): void
     {
@@ -41,15 +42,15 @@ class ConfirmLivestreamSermonSegment
                 ->first();
 
             if ($log === null) {
-                throw new \InvalidArgumentException('Processing log not found.');
+                throw new SafeInvalidArgumentException('Processing log not found.');
             }
 
             if (! $log->canUseManualSermonReview()) {
-                throw new \InvalidArgumentException('Only segmentation-style runs can be confirmed via manual review.');
+                throw new SafeInvalidArgumentException('Only segmentation-style runs can be confirmed via manual review.');
             }
 
             if (! $log->requiresManualSermonReview()) {
-                throw new \InvalidArgumentException('This run is not currently awaiting manual sermon review.');
+                throw new SafeInvalidArgumentException('This run is not currently awaiting manual sermon review.');
             }
 
             $segment = LivestreamSegment::query()
@@ -58,11 +59,11 @@ class ConfirmLivestreamSermonSegment
                 ->first();
 
             if ($segment === null) {
-                throw new \InvalidArgumentException('Segment not found on this processing run.');
+                throw new SafeInvalidArgumentException('Segment not found on this processing run.');
             }
 
             if (! $segment->isSpeech()) {
-                throw new \InvalidArgumentException('Only speech segments may be confirmed as the sermon.');
+                throw new SafeInvalidArgumentException('Only speech segments may be confirmed as the sermon.');
             }
 
             $this->ensureSourceVideoExists($log);
@@ -86,16 +87,16 @@ class ConfirmLivestreamSermonSegment
     }
 
     /**
-     * @throws \InvalidArgumentException When the source video file is no longer available
+     * @throws SafeInvalidArgumentException When the source video file is no longer available
      */
     private function ensureSourceVideoExists(MediaProcessingLog $log): void
     {
         if (! is_string($log->source_file_path) || $log->source_file_path === '') {
-            throw new \InvalidArgumentException('No source video path recorded for this run. The file may have been removed.');
+            throw new SafeInvalidArgumentException('No source video path recorded for this run. The file may have been removed.');
         }
 
         if (! $this->videoStorageService->sourceVideoExistsForPath($log->source_file_path)) {
-            throw new \InvalidArgumentException('The source video file is no longer available. This run cannot be resumed.');
+            throw new SafeInvalidArgumentException('The source video file is no longer available. This run cannot be resumed.');
         }
     }
 }

--- a/app/Exceptions/SafeInvalidArgumentException.php
+++ b/app/Exceptions/SafeInvalidArgumentException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use App\Contracts\ProvidesSafeMessage;
+use InvalidArgumentException;
+
+class SafeInvalidArgumentException extends InvalidArgumentException implements ProvidesSafeMessage
+{
+    public function getSafeMessage(): string
+    {
+        return $this->getMessage();
+    }
+}

--- a/app/Models/SpeakerProfile.php
+++ b/app/Models/SpeakerProfile.php
@@ -59,6 +59,7 @@ class SpeakerProfile extends Model
     protected function casts(): array
     {
         return [
+            'preacher_id' => 'integer',
             'centroid_embedding' => 'array',
             'sample_count' => 'integer',
             'quality_score' => 'float',
@@ -106,14 +107,20 @@ class SpeakerProfile extends Model
     }
 
     /**
-     * @return array<string, list<string>>
+     * @return array<string, list<string|mixed>>
      */
     public static function validationRules(): array
     {
         return [
+            'preacher_id' => ['sometimes', 'required', 'integer', 'min:1', 'max:2147483647', 'exists:preachers,id'],
+            'provider' => ['sometimes', 'required', 'string', 'max:50'],
+            'model_version' => ['sometimes', 'required', 'string', 'max:50'],
+            'centroid_embedding' => ['sometimes', 'required', 'array'],
+            'sample_count' => ['nullable', 'integer', 'min:0', 'max:2147483647'],
             'quality_score' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'accept_threshold' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'margin_threshold' => ['nullable', 'numeric', 'min:0', 'max:1'],
+            'is_active' => ['boolean'],
         ];
     }
 }

--- a/app/Models/SpeakerSample.php
+++ b/app/Models/SpeakerSample.php
@@ -53,6 +53,9 @@ class SpeakerSample extends Model
     protected function casts(): array
     {
         return [
+            'speaker_profile_id' => 'integer',
+            'sermon_id' => 'integer',
+            'media_processing_log_id' => 'integer',
             'embedding' => 'array',
             'duration_seconds' => 'float',
             'quality_score' => 'float',
@@ -91,12 +94,14 @@ class SpeakerSample extends Model
     public static function validationRules(): array
     {
         return [
-            'speaker_profile_id' => ['sometimes', 'required', 'integer', 'exists:speaker_profiles,id'],
-            'sermon_id' => ['nullable', 'integer', 'exists:sermons,id'],
-            'media_processing_log_id' => ['nullable', 'integer', 'exists:media_processing_logs,id'],
+            'speaker_profile_id' => ['sometimes', 'required', 'integer', 'min:1', 'max:2147483647', 'exists:speaker_profiles,id'],
+            'sermon_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:sermons,id'],
+            'media_processing_log_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:media_processing_logs,id'],
+            'embedding' => ['sometimes', 'required', 'array'],
             'quality_score' => ['nullable', 'numeric', 'min:0', 'max:1'],
-            'duration_seconds' => ['sometimes', 'required', 'numeric', 'min:0'],
+            'duration_seconds' => ['sometimes', 'required', 'numeric', 'min:0', 'max:9999999.999'],
             'source' => ['sometimes', 'required', Rule::enum(SampleSource::class)],
+            'approved' => ['boolean'],
         ];
     }
 }

--- a/app/Services/Media/Thumbnail/PixianClient.php
+++ b/app/Services/Media/Thumbnail/PixianClient.php
@@ -53,9 +53,9 @@ class PixianClient
 
         $imageContents = @file_get_contents($imagePath);
         if (! is_string($imageContents) || $imageContents === '') {
-            Log::warning('Pixian request skipped: image could not be read', [
-                'image_path' => $this->sanitizeForLog($imagePath),
-            ]);
+            Log::warning('Pixian request skipped: image could not be read', $this->sanitizeArrayForLog([
+                'image_path' => $imagePath,
+            ]));
 
             return null;
         }
@@ -63,10 +63,10 @@ class PixianClient
         try {
             $response = $this->makeRequest($imagePath, $imageContents);
         } catch (ConnectionException $e) {
-            Log::warning('Pixian connection error during background removal', [
-                'image_path' => $this->sanitizeForLog($imagePath),
-                'error' => $this->sanitizeForLog($e->getMessage()),
-            ]);
+            Log::warning('Pixian connection error during background removal', $this->sanitizeArrayForLog([
+                'image_path' => $imagePath,
+                'error' => $e->getMessage(),
+            ]));
 
             return null;
         }
@@ -79,10 +79,10 @@ class PixianClient
 
         $body = $response->body();
         if ($body === '') {
-            Log::warning('Pixian returned an empty response body', [
-                'image_path' => $this->sanitizeForLog($imagePath),
-                'request_id' => $this->sanitizeForLog((string) $response->header('x-request-id')),
-            ]);
+            Log::warning('Pixian returned an empty response body', $this->sanitizeArrayForLog([
+                'image_path' => $imagePath,
+                'request_id' => (string) $response->header('x-request-id'),
+            ]));
 
             return null;
         }
@@ -109,12 +109,12 @@ class PixianClient
     {
         $body = $response->body();
 
-        Log::warning('Pixian background removal failed', [
-            'image_path' => $this->sanitizeForLog($imagePath),
+        Log::warning('Pixian background removal failed', $this->sanitizeArrayForLog([
+            'image_path' => $imagePath,
             'status' => $response->status(),
-            'body' => $this->sanitizeForLog($body !== '' ? $body : (string) json_encode($response->json())),
-            'request_id' => $this->sanitizeForLog((string) $this->extractRequestId($response)),
-        ]);
+            'body' => $body !== '' ? $body : (string) json_encode($response->json()),
+            'request_id' => (string) $this->extractRequestId($response),
+        ]));
     }
 
     private function extractRequestId(Response $response): ?string

--- a/config/redirects.php
+++ b/config/redirects.php
@@ -25,7 +25,6 @@ return [
 
     'aboutus' => '/church',
     'contactus' => '/',
-    'contacttus' => '/',
     'links' => '/church/links',
     'whatson' => '/community',
     'whats-on' => '/community',

--- a/database/migrations/2026_06_14_200000_add_missing_fk_indexes_to_media_processing_logs_and_speaker_samples.php
+++ b/database/migrations/2026_06_14_200000_add_missing_fk_indexes_to_media_processing_logs_and_speaker_samples.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('media_processing_logs', function (Blueprint $table) {
+            if (! Schema::hasIndex('media_processing_logs', 'media_processing_logs_sermon_id_index')) {
+                $table->index('sermon_id');
+            }
+            if (! Schema::hasIndex('media_processing_logs', 'media_processing_logs_owner_user_id_index')) {
+                $table->index('owner_user_id');
+            }
+            if (! Schema::hasIndex('media_processing_logs', 'media_processing_logs_church_service_id_index')) {
+                $table->index('church_service_id');
+            }
+        });
+
+        Schema::table('speaker_samples', function (Blueprint $table) {
+            if (! Schema::hasIndex('speaker_samples', 'speaker_samples_media_processing_log_id_index')) {
+                $table->index('media_processing_log_id');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('media_processing_logs', function (Blueprint $table) {
+            if (Schema::hasIndex('media_processing_logs', 'media_processing_logs_sermon_id_index')) {
+                $table->dropIndex('media_processing_logs_sermon_id_index');
+            }
+            if (Schema::hasIndex('media_processing_logs', 'media_processing_logs_owner_user_id_index')) {
+                $table->dropIndex('media_processing_logs_owner_user_id_index');
+            }
+            if (Schema::hasIndex('media_processing_logs', 'media_processing_logs_church_service_id_index')) {
+                $table->dropIndex('media_processing_logs_church_service_id_index');
+            }
+        });
+
+        Schema::table('speaker_samples', function (Blueprint $table) {
+            if (Schema::hasIndex('speaker_samples', 'speaker_samples_media_processing_log_id_index')) {
+                $table->dropIndex('speaker_samples_media_processing_log_id_index');
+            }
+        });
+    }
+};

--- a/resources/views/components/calendar-event-card.blade.php
+++ b/resources/views/components/calendar-event-card.blade.php
@@ -28,7 +28,7 @@ $cardClasses = match($variant) {
     @if($variant === 'list' || $variant === 'compact')
         <div {{ $variant === 'list' ? $attributes->merge(['class' => 'flex items-start justify-between']) : $attributes->class(['flex items-start justify-between']) }}>
             <div class="flex-1">
-                <h4 class="font-medium text-gray-900 mb-2">{{ $event->title }}</h4>
+                <h2 class="font-medium text-gray-900 mb-2">{{ $event->title }}</h2>
 
                 <x-calendar-event-meta
                     :event="$event"
@@ -46,9 +46,9 @@ $cardClasses = match($variant) {
         </div>
     @else
         {{-- Card variant (default or admin) --}}
-        <h4 class="p-6 mx-6 mt-6 font-display text-4xl">
+        <h2 class="p-6 mx-6 mt-6 font-display text-4xl">
             {{ $event->title }}
-        </h4>
+        </h2>
 
         <ul class="mx-6 px-6 mb-6 pb-6 prose">
             @if($showDate)

--- a/resources/views/components/clickable-card.blade.php
+++ b/resources/views/components/clickable-card.blade.php
@@ -9,9 +9,9 @@ $isInternalLink = !str_starts_with($link, 'http') && !str_ends_with($link, '.pdf
 
 <a href="{{ $link }}" @if($isInternalLink) wire:navigate @endif {{ $attributes->merge(['class' => 'group block p-6 bg-white border border-gray-200 rounded-lg shadow transition-all duration-300 hover:bg-gray-50 hover:-translate-y-1 hover:shadow-lg hover:border-cbc-teal/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2']) }}>
     <div class="flex items-center justify-between gap-4 {{ $slot->isEmpty() ? '' : 'mb-3' }}">
-        <h5 class="text-2xl font-display font-semibold text-cbc-teal-dark group-hover:text-cbc-teal transition-colors">
+        <h2 class="text-2xl font-display font-semibold text-cbc-teal-dark group-hover:text-cbc-teal transition-colors">
             {{ $heading }}
-        </h5>
+        </h2>
         <x-heroicon-o-chevron-right class="w-5 h-5 text-gray-400 group-hover:text-cbc-teal group-hover:translate-x-1 transition-all shrink-0" aria-hidden="true" />
     </div>
     @if($slot->isNotEmpty())

--- a/resources/views/components/form-button.blade.php
+++ b/resources/views/components/form-button.blade.php
@@ -34,7 +34,7 @@ if ($slot->isEmpty() && $attributes->has('aria-label') && !$attributes->has('tit
 }
 @endphp
 
-<button {{ $filteredAttributes->merge(['class' => $classes, 'type' => $type]) }} wire:loading.attr="disabled" @if($target) wire:target="{{ $target }}" @endif>
+<button {{ $filteredAttributes->merge(['class' => $classes, 'type' => $type]) }} wire:loading.attr="disabled" aria-disabled="false" wire:loading.attr="aria-disabled" @if($target) wire:target="{{ $target }}" @endif>
     @if($icon)
       <span wire:loading.remove @if($target) wire:target="{{ $target }}" @endif class="contents">
         <x-dynamic-component :component="'heroicon-o-' . $icon" class="w-4 h-4 {{ $slot->isNotEmpty() ? 'mr-2' : '' }}" aria-hidden="true" />

--- a/resources/views/components/page-card.blade.php
+++ b/resources/views/components/page-card.blade.php
@@ -27,9 +27,9 @@
     <a class="relative block aspect-video overflow-hidden bg-slate-200" href="{{ $pageUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
         <img class="h-full w-full object-cover brightness-110 contrast-105 transition duration-500 ease-out group-hover:scale-105 group-hover:brightness-115" src="{{ $pageImageUrl }}" alt="{{ $pageHeading }}" onerror="this.onerror=null;this.src='/images/headings/small/default.webp';" loading="lazy" width="300" height="169">
         <div class="absolute inset-0 bg-gradient-to-t from-black/35 via-black/10 to-transparent"></div>
-        <h5 class="absolute inset-x-5 top-1/2 -translate-y-1/2 text-center font-display text-3xl leading-[0.95] text-white [text-shadow:0_2px_8px_rgba(0,0,0,0.45)] sm:text-4xl">
+        <h2 class="absolute inset-x-5 top-1/2 -translate-y-1/2 text-center font-display text-3xl leading-[0.95] text-white [text-shadow:0_2px_8px_rgba(0,0,0,0.45)] sm:text-4xl">
             {{ $pageHeading }}
-        </h5>
+        </h2>
     </a>
 
     <div class="flex flex-1 items-center justify-center px-6 py-5">

--- a/resources/views/components/sermon-card.blade.php
+++ b/resources/views/components/sermon-card.blade.php
@@ -38,9 +38,9 @@
       >
       <div class="absolute inset-0 bg-gradient-to-t from-black/35 via-black/10 to-transparent"></div>
       @if (($sermon->title != null))
-        <h4 class="absolute inset-x-5 top-1/2 -translate-y-1/2 text-center font-display text-2xl leading-[0.95] text-white [text-shadow:0_2px_8px_rgba(0,0,0,0.45)] sm:text-3xl">
+        <h2 class="absolute inset-x-5 top-1/2 -translate-y-1/2 text-center font-display text-2xl leading-[0.95] text-white [text-shadow:0_2px_8px_rgba(0,0,0,0.45)] sm:text-3xl">
           {{$sermon->title}}
-        </h4>
+        </h2>
       @endif
     </a>
   @endif
@@ -48,15 +48,15 @@
   <div class="flex flex-col flex-1 p-6">
     @if (($sermon->title != null) && ! $thumbnailUrl)
       <a class="group" href="{{ $sermonUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
-        <h4 class="font-display text-2xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
+        <h2 class="font-display text-2xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
           {{$sermon->title}}
-        </h4>
+        </h2>
       </a>
     @elseif ($sermon->title != null)
       <a class="group hidden" href="{{ $sermonUrl }}" wire:navigate data-sermon-card-title-fallback>
-        <h4 class="font-display text-2xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
+        <h2 class="font-display text-2xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
           {{$sermon->title}}
-        </h4>
+        </h2>
       </a>
     @endif
     <ul class="mt-4 space-y-2 prose">

--- a/resources/views/livewire/church/songs/browse-songs.blade.php
+++ b/resources/views/livewire/church/songs/browse-songs.blade.php
@@ -26,6 +26,8 @@
             <button
                 wire:click="$set('range', '{{ \App\Services\Public\PublicSongCatalogService::RANGE_ALL }}')"
                 wire:loading.attr="disabled"
+                aria-disabled="false"
+                wire:loading.attr="aria-disabled"
                 wire:loading.class="opacity-50"
                 wire:target="$set('range', '{{ \App\Services\Public\PublicSongCatalogService::RANGE_ALL }}')"
                 type="button"
@@ -41,6 +43,8 @@
             <button
                 wire:click="$set('range', '{{ \App\Services\Public\PublicSongCatalogService::RANGE_RECENT }}')"
                 wire:loading.attr="disabled"
+                aria-disabled="false"
+                wire:loading.attr="aria-disabled"
                 wire:loading.class="opacity-50"
                 wire:target="$set('range', '{{ \App\Services\Public\PublicSongCatalogService::RANGE_RECENT }}')"
                 type="button"
@@ -57,7 +61,7 @@
     </section>
 
     {{-- Results area --}}
-    <div id="song-results" tabindex="-1" class="focus:outline-none" wire:loading.class="opacity-60 pointer-events-none" wire:target="search, range">
+    <div id="song-results" tabindex="-1" class="focus:outline-none" wire:loading.class="opacity-60 pointer-events-none" wire:target="search, range" aria-busy="false" wire:loading.attr="aria-busy">
 
         {{-- Empty state --}}
         @if ($songs->isEmpty())

--- a/resources/views/livewire/processing-logs-viewer.blade.php
+++ b/resources/views/livewire/processing-logs-viewer.blade.php
@@ -27,6 +27,9 @@
             {{-- Manual refresh button --}}
             <button
                 wire:click="refreshLogs"
+                wire:loading.attr="disabled"
+                aria-disabled="false"
+                wire:loading.attr="aria-disabled"
                 class="p-1 text-gray-500 hover:text-gray-700 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
                 aria-label="Refresh logs"
             >
@@ -61,7 +64,7 @@
         </div>
     </div>
 
-    <div id="processing-logs-content" x-show="$wire.expanded" x-transition class="p-4">
+    <div id="processing-logs-content" x-show="$wire.expanded" x-transition class="p-4" aria-busy="false" wire:loading.attr="aria-busy" wire:target="refreshLogs, fetchLogs">
         {{-- Performance Summary --}}
         @if($showMetrics && !empty($performanceMetrics))
             <div class="grid grid-cols-3 gap-4 mb-6">

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -132,7 +132,7 @@
         Updating sermon results…
     </div>
 
-    <div id="sermon-results" tabindex="-1" wire:loading.class="pointer-events-none opacity-60" wire:target="bookFilter, chapterFilter, preacherFilter, seriesFilter, removeFilter, clearFilters">
+    <div id="sermon-results" tabindex="-1" wire:loading.class="pointer-events-none opacity-60" wire:target="bookFilter, chapterFilter, preacherFilter, seriesFilter, removeFilter, clearFilters" aria-busy="false" wire:loading.attr="aria-busy">
         @php
             /** @var \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, \App\Models\Sermon> $sermons */
         @endphp

--- a/tests/Feature/BladeShellRenderingTest.php
+++ b/tests/Feature/BladeShellRenderingTest.php
@@ -153,14 +153,14 @@ class BladeShellRenderingTest extends TestCase
     public function shells_render_main_content_with_tabindex(): void
     {
         // Auth Shell
-        $this->get('/login')->assertSeeHtml('<main id="main-content" class="mb-3" tabindex="-1">');
+        $this->get('/login')->assertSee('id="main-content"', false)->assertSee('tabindex="-1"', false);
 
         // Page Shell
         Page::factory()->create(['slug' => 'tabindex-test', 'area' => 'church']);
-        $this->get('/church/tabindex-test')->assertSeeHtml('<main id="main-content" class="mb-3" tabindex="-1">');
+        $this->get('/church/tabindex-test')->assertSee('id="main-content"', false)->assertSee('tabindex="-1"', false);
 
         // Admin Shell
         $admin = User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
-        $this->actingAs($admin)->get('/admin/meetings')->assertSeeHtml('<main id="main-content" class="mb-3" tabindex="-1">');
+        $this->actingAs($admin)->get('/admin/meetings')->assertSee('id="main-content"', false)->assertSee('tabindex="-1"', false);
     }
 }

--- a/tests/Feature/RedirectsTest.php
+++ b/tests/Feature/RedirectsTest.php
@@ -18,14 +18,6 @@ class RedirectsTest extends TestCase
     }
 
     #[Test]
-    public function it_redirects_typoed_contacttus_url(): void
-    {
-        $response = $this->get('/contacttus');
-        $response->assertRedirect('/');
-        $response->assertStatus(301);
-    }
-
-    #[Test]
     public function it_redirects_legacy_aboutus_url(): void
     {
         $response = $this->get('/aboutus');


### PR DESCRIPTION
## Summary

All 10 open Jules PRs (#802, #806, #810, #818, #821, #826, #830, #831, #835, #839) had merge conflicts with master after ~25 commits landed today. Rather than rebase each one, their unique contributions were evaluated and the genuine value from each was applied directly. All 10 PRs were closed with explanatory comments.

**What was superseded (already in master):** sermon delete link fix, Christmas fragment IDs, MeetingPhotoMigrationServiceTest relocation, AdminListAccessibilityTest improvements, MediaController ProvidesSafeMessage guard at upload.

**What is new here:**

### 🛡️ Sentinel (security)
- New `SafeInvalidArgumentException` implementing `ProvidesSafeMessage` (#826, #831)
- `ConfirmLivestreamSermonSegment` now throws `SafeInvalidArgumentException` so the controller's `ProvidesSafeMessage` guard returns real user-facing messages instead of `'Invalid request parameters.'`
- `PixianClient` consolidates per-field `sanitizeForLog` calls into `sanitizeArrayForLog` (#826)

### 🏛️ Warden (data integrity)
- `SpeakerProfile`: add `preacher_id` cast; expand `validationRules()` with `preacher_id`, `provider`, `model_version`, `centroid_embedding`, `sample_count`, `is_active` (#810, #821, #830)
- `SpeakerSample`: add FK id casts; add `min/max` bounds to FK validation rules; add `embedding` and `approved` rules (#810, #821, #830)
- Migration: add missing FK indexes on `media_processing_logs` (`sermon_id`, `owner_user_id`, `church_service_id`) and `speaker_samples` (`media_processing_log_id`) (#830)

### 🧪 Steward (test quality)
- `BladeShellRenderingTest`: decouple tabindex assertions from exact CSS class strings (#818)

### ♿ Aria (accessibility)
- Card heading hierarchy: `h4`/`h5` → `h2` in `sermon-card`, `clickable-card`, `calendar-event-card`, `page-card` (#802)
- `aria-busy` on Livewire results containers (`browse-sermons`, `browse-songs`, `processing-logs-viewer`) (#802)
- `aria-disabled` on `form-button` base component and `browse-songs` range buttons (#802)

### 🔗 Pathfinder (cleanup)
- Remove `contacttus` typo redirect and its test (#806)

## Test plan
- [x] Pint passes (no formatting issues)
- [x] PHPStan passes (no type errors)
- [x] Full parallel test suite: 5,547 tests, 16,859 assertions — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)