### PR TITLE
♿ Aria: [a11y improvement] fix skipped heading levels

### DIFF
--- a/.Jules/aria.md
+++ b/.Jules/aria.md
@@ -1,0 +1,5 @@
+# Accessibility Journal (Aria ♿)
+
+## 2026-06-15 - [Heading Hierarchy Convention]
+**Pattern:** Reusable layout components (e.g., `x-card`, `x-empty-state`) and dashboard views (e.g., `members/home`) were using `<h3>` tags for primary section titles, skipping `<h2>` and breaking the logical document outline under the page `<h1>`.
+**Fix:** Standardize on `<h2>` for primary structural headings within sections to ensure a continuous hierarchy (`<h1>` -> `<h2>`). Use visual utility classes (`text-lg`, `text-2xl`) to maintain design intent without sacrificing semantic structure.

--- a/resources/views/components/admin/empty-state.blade.php
+++ b/resources/views/components/admin/empty-state.blade.php
@@ -21,7 +21,7 @@
             <div class="rounded-full bg-white shadow-sm ring-1 ring-gray-200 p-3">
                 <x-dynamic-component :component="'heroicon-o-' . $icon" class="h-8 w-8 text-cbc-teal/60" aria-hidden="true" />
             </div>
-            <h3 class="text-base font-semibold text-gray-900">{{ $title }}</h3>
+            <h2 class="text-base font-semibold text-gray-900">{{ $title }}</h2>
             <p class="text-sm text-gray-500 max-w-sm mx-auto">
                 {{ $description }}
             </p>

--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -6,9 +6,9 @@
 <div {{ $attributes->merge(['class' => 'rounded-lg shadow bg-white border border-gray-300']) }}>
     <div class="p-6">
         @isset($heading)
-            <h3 class="mb-3 font-display text-2xl">
+            <h2 class="mb-3 font-display text-2xl">
                 {{ $heading }}
-            </h3>
+            </h2>
         @endisset
         <div @class(['prose max-w-none' => $prose])>
             {{ $slot }}

--- a/resources/views/components/empty-state.blade.php
+++ b/resources/views/components/empty-state.blade.php
@@ -9,7 +9,7 @@
         <x-dynamic-component :component="'heroicon-o-' . $icon" class="h-12 w-12" aria-hidden="true" />
     </div>
 
-    <h3 class="mb-3 font-display text-3xl text-slate-900">{{ $title }}</h3>
+    <h2 class="mb-3 font-display text-3xl text-slate-900">{{ $title }}</h2>
 
     @if($description)
         <p class="mx-auto max-w-lg text-lg text-slate-600">

--- a/resources/views/members/home.blade.php
+++ b/resources/views/members/home.blade.php
@@ -28,10 +28,10 @@
         @if (auth()->user()?->canAccessAdmin())
         <div class="rounded-lg shadow bg-white border border-gray-300 overflow-hidden">
           <div class="bg-gray-50 border-b border-gray-200 px-4 py-3">
-            <h3 class="font-display text-lg text-gray-900 flex items-center gap-2">
+            <h2 class="font-display text-lg text-gray-900 flex items-center gap-2">
               <x-heroicon-o-microphone class="h-5 w-5 text-gray-500" aria-hidden="true" />
               Services, sermons and songs
-            </h3>
+            </h2>
           </div>
           <div class="p-4 grid grid-cols-2 gap-2">
             @if($serviceTrackingEnabled ?? true)
@@ -72,10 +72,10 @@
         @if (auth()->user()?->canAccessAdmin())
         <div class="rounded-lg shadow bg-white border border-gray-300 overflow-hidden">
           <div class="bg-gray-50 border-b border-gray-200 px-4 py-3">
-            <h3 class="font-display text-lg text-gray-900 flex items-center gap-2">
+            <h2 class="font-display text-lg text-gray-900 flex items-center gap-2">
               <x-heroicon-o-calendar-days class="h-5 w-5 text-gray-500" aria-hidden="true" />
               Meetings and events
-            </h3>
+            </h2>
           </div>
           <div class="p-4 grid grid-cols-2 gap-2">
             <x-button link="{{ route('admin.meetings.index') }}" icon="pencil-square" iconStyle="solid">
@@ -104,10 +104,10 @@
         @if (auth()->user()?->canAccessAdmin())
         <div class="rounded-lg shadow bg-white border border-gray-300 overflow-hidden">
           <div class="bg-gray-50 border-b border-gray-200 px-4 py-3">
-            <h3 class="font-display text-lg text-gray-900 flex items-center gap-2">
+            <h2 class="font-display text-lg text-gray-900 flex items-center gap-2">
               <x-heroicon-o-document-text class="h-5 w-5 text-gray-500" aria-hidden="true" />
               Content
-            </h3>
+            </h2>
           </div>
           <div class="p-4">
             <x-button link="/admin/pages" icon="pencil-square" iconStyle="solid">


### PR DESCRIPTION
💡 **What:** Fixed skipped heading levels in reusable components (`x-card`, `x-empty-state`) and the members dashboard. Changed `<h3>` tags to `<h2>` to maintain a correct heading hierarchy (`<h1>` -> `<h2>`).

🎯 **Who:** Screen reader users and users of other assistive technologies that rely on logical heading levels to navigate and understand page structure.

🧪 **How to verify:** Inspect the HTML markup on the Members dashboard or any page using the `x-card` component. Verify that section titles are now using `<h2>` tags.

🔄 **Behavior:** Same visible behaviour — visual styling (font size, weight, etc.) is preserved via Tailwind utility classes, only the semantic HTML tags have changed.

---
*PR created automatically by Jules for task [2870511375444158195](https://jules.google.com/task/2870511375444158195) started by @GarethClarridge*