### PR TITLE
🛡️ Sentinel: [security improvement] harden log sanitization in MetadataExtractionService

### DIFF
--- a/app/Services/Processing/MetadataExtractionService.php
+++ b/app/Services/Processing/MetadataExtractionService.php
@@ -598,8 +598,8 @@ class MetadataExtractionService
             }
         } catch (\Exception $e) {
             Log::debug('Failed to get file size from storage', [
-                'file_path' => $filePath,
-                'error' => $e->getMessage(),
+                'file_path' => $this->sanitizeForLog($filePath),
+                'error' => $this->sanitizeForLog($e->getMessage()),
             ]);
         }
 


### PR DESCRIPTION
### 🛡️ Sentinel: [security improvement]

**🚨 Severity:** MEDIUM
**💡 Vulnerability:** Information leakage and potential log injection.
**🎯 Impact:** Sensitive file paths and internal error messages could be logged in plain text in certain failure paths. This exposes internal server structure and state to anyone with access to the application logs.
**🔧 Fix:** Applied `$this->sanitizeForLog()` to previously unsanitized fields in `MetadataExtractionService.php`, closing the gap where internal paths and raw exception messages were written to logs. This extends the existing sanitization pattern to all `Log::*` call sites in the file.
**✅ Verification:**
- Audited all 16 `Log` call sites in `MetadataExtractionService.php`.
- Verified fix for the identified gap in `getFileSize()`.
- Ran `tests/Unit/Services/MetadataExtractionServiceTest.php` (All 23 tests passed).
- Ran `phpstan analyze app/Services/Processing/MetadataExtractionService.php` (No errors).

---
*PR created automatically by Jules for task [14739879163074879497](https://jules.google.com/task/14739879163074879497) started by @GarethClarridge*