### PR TITLE
🪦 Mortician: Report dead mailable App\Mail\LivestreamProcessingCompleted

### DIFF
--- a/docs/issues/mortician-dead-mailable-livestream-processing-completed.md
+++ b/docs/issues/mortician-dead-mailable-livestream-processing-completed.md
@@ -1,0 +1,37 @@
+# 🪦 Mortician: Possibly dead — Mailable `App\Mail\LivestreamProcessingCompleted`
+
+## 1. Dead Mailable `App\Mail\LivestreamProcessingCompleted`
+
+**Artefact:**
+`app/Mail/LivestreamProcessingCompleted.php`
+
+**Evidence:**
+Project-wide search for `LivestreamProcessingCompleted` returns zero callers in the application code. It is only referenced in its own test and in `AGENTS.md` documentation.
+
+```bash
+# Application code search (excluding class definition and tests)
+grep -rn "LivestreamProcessingCompleted" . | grep -vE "app/Mail/LivestreamProcessingCompleted.php|tests/|docs/"
+# Output:
+# ./AGENTS.md:254:- `LivestreamProcessingCompleted` — Success notification with sermon details.
+
+# Usage search (excluding class definition and tests)
+grep -rn "new LivestreamProcessingCompleted" app/ resources/ routes/ config/
+# Output: (empty)
+
+# Blade template search (markdown reference)
+grep -rn "emails.livestream-processing-completed" . | grep -v "app/Mail/LivestreamProcessingCompleted.php"
+# Output:
+# ./tests/Unit/Mail/LivestreamProcessingCompletedTest.php:42:        $this->assertEquals('emails.livestream-processing-completed', $content->markdown);
+```
+
+The mailable appears to be a legacy success notification from an earlier version of the media processing pipeline. Currently, success/failure notifications are handled either by `Mail::raw` in `SendCompletionNotification` or by other mailables like `ManualReviewRequired`.
+
+**Risk:**
+Low — Pure removal of unused code and its associated assets/tests.
+
+**Recommendation:**
+Safe to remove. A complete cleanup would involve:
+- `app/Mail/LivestreamProcessingCompleted.php`
+- `resources/views/emails/livestream-processing-completed.blade.php`
+- `tests/Unit/Mail/LivestreamProcessingCompletedTest.php`
+- Reference in `AGENTS.md` (line 254)


### PR DESCRIPTION
I have identified and documented a piece of dead code in the repository: the `App\Mail\LivestreamProcessingCompleted` mailable. 

Following the "Mortician" persona guidelines, I performed an exhaustive search for references to this mailable across the entire codebase, including its class name, associated Blade templates, and dispatch points. I found no active usage in the application code; it only remains in its definition, unit tests, and documentation.

I have created a detailed issue report at `docs/issues/mortician-dead-mailable-livestream-processing-completed.md` which includes the evidence gathered and recommendations for safe removal. I also cleaned up temporary diagnostic files created during the investigation.

---
*PR created automatically by Jules for task [6364352125306883953](https://jules.google.com/task/6364352125306883953) started by @GarethClarridge*