### PR TITLE
⚡ Bolt: optimize sermon patch generation memory and I/O

### DIFF
--- a/app/Console/Commands/GenerateProdSermonPatchCommand.php
+++ b/app/Console/Commands/GenerateProdSermonPatchCommand.php
@@ -48,15 +48,31 @@ class GenerateProdSermonPatchCommand extends Command
             $prodIndex[$key] = $row;
         }
 
-        $localSermons = DB::table('sermons')->orderBy('date')->orderBy('service')->get();
-        $this->line('Local sermons: '.$localSermons->count());
+        $localSermonsQuery = DB::table('sermons')
+            ->select([
+                'id', 'date', 'service', 'content_type', 'audio_file_path',
+                'source_type', 'duration', 'filetype', 'title', 'slug',
+                'reference', 'preacher', 'preacher_source', 'preacher_confidence',
+                'needs_preacher_review', 'series', 'created_at', 'updated_at',
+            ])
+            ->orderBy('date')
+            ->orderBy('service');
+
+        $this->line('Local sermons: '.$localSermonsQuery->count());
 
         $updates = [];
         $inserts = [];
         $skipped = 0;
         $reservedInsertSlugs = $this->buildReservedInsertSlugs($prodSermons);
 
-        foreach ($localSermons as $local) {
+        /**
+         * Performance Optimization: Uses lazy() to iterate over the local sermon
+         * collection one-by-one, significantly reducing memory usage when
+         * processing large datasets. select() limits retrieved columns to only
+         * those required for comparison and patch generation, avoiding expensive
+         * longText columns.
+         */
+        foreach ($localSermonsQuery->lazy() as $local) {
             $key = $local->date.'|'.$local->service;
 
             if (isset($prodIndex[$key])) {

--- a/app/Console/Commands/GenerateProdSermonPatchCommand.php
+++ b/app/Console/Commands/GenerateProdSermonPatchCommand.php
@@ -56,7 +56,8 @@ class GenerateProdSermonPatchCommand extends Command
                 'needs_preacher_review', 'series', 'created_at', 'updated_at',
             ])
             ->orderBy('date')
-            ->orderBy('service');
+            ->orderBy('service')
+            ->orderBy('id');
 
         $this->line('Local sermons: '.$localSermonsQuery->count());
 
@@ -70,9 +71,10 @@ class GenerateProdSermonPatchCommand extends Command
          * collection one-by-one, significantly reducing memory usage when
          * processing large datasets. select() limits retrieved columns to only
          * those required for comparison and patch generation, avoiding expensive
-         * longText columns.
+         * longText columns. Added id to the sort order to ensure deterministic
+         * results when chunking.
          */
-        foreach ($localSermonsQuery->lazy() as $local) {
+        foreach ($localSermonsQuery->lazy(200) as $local) {
             $key = $local->date.'|'.$local->service;
 
             if (isset($prodIndex[$key])) {


### PR DESCRIPTION
Optimized the `GenerateProdSermonPatchCommand` to use `select()` and `lazy()`, significantly reducing the memory footprint when generating production patches for large sermon datasets. Verified with existing feature tests and a full suite run.

---
*PR created automatically by Jules for task [10635447673451956986](https://jules.google.com/task/10635447673451956986) started by @GarethClarridge*