### PR TITLE
🏛️ Warden: Add missing index to church_service_items and harden validation

### DIFF
--- a/app/Models/ChurchServiceItem.php
+++ b/app/Models/ChurchServiceItem.php
@@ -135,7 +135,7 @@ class ChurchServiceItem extends Model
     public static function validationRules(?self $item = null, ?int $churchServiceId = null): array
     {
         return [
-            'church_service_id' => ['required', 'integer', 'min:1', 'max:18446744073709551615', 'exists:church_services,id'],
+            'church_service_id' => ['required', 'integer', 'min:1', 'exists:church_services,id'],
             'position' => ['required', 'integer', 'min:1', 'max:4294967295'],
             'title' => ['required', 'string', 'max:255'],
             'type' => ['required', 'string', 'max:50'],
@@ -143,9 +143,9 @@ class ChurchServiceItem extends Model
             'source' => ['nullable', Rule::enum(ChurchServiceItemSource::class)],
             'source_title' => ['nullable', 'string', 'max:255'],
             'openlp_search_title' => ['nullable', 'string', 'max:255'],
-            'song_id' => ['nullable', 'integer', 'min:1', 'max:18446744073709551615', 'exists:songs,id'],
+            'song_id' => ['nullable', 'integer', 'min:1', 'exists:songs,id'],
             'livestream_processing_id' => ['nullable', 'uuid'],
-            'livestream_service_section_id' => ['nullable', 'integer', 'min:1', 'max:18446744073709551615', 'exists:service_sections,id'],
+            'livestream_service_section_id' => ['nullable', 'integer', 'min:1', 'exists:service_sections,id'],
         ];
     }
 

--- a/app/Models/ChurchServiceItem.php
+++ b/app/Models/ChurchServiceItem.php
@@ -84,6 +84,7 @@ class ChurchServiceItem extends Model
             'section_type' => ServiceSectionType::class,
             'source' => ChurchServiceItemSource::class,
             'song_id' => 'integer',
+            'livestream_service_section_id' => 'integer',
             'metadata' => 'array',
         ];
     }
@@ -134,7 +135,7 @@ class ChurchServiceItem extends Model
     public static function validationRules(?self $item = null, ?int $churchServiceId = null): array
     {
         return [
-            'church_service_id' => ['required', 'integer', 'min:1', 'exists:church_services,id'],
+            'church_service_id' => ['required', 'integer', 'min:1', 'max:18446744073709551615', 'exists:church_services,id'],
             'position' => ['required', 'integer', 'min:1', 'max:4294967295'],
             'title' => ['required', 'string', 'max:255'],
             'type' => ['required', 'string', 'max:50'],
@@ -142,9 +143,9 @@ class ChurchServiceItem extends Model
             'source' => ['nullable', Rule::enum(ChurchServiceItemSource::class)],
             'source_title' => ['nullable', 'string', 'max:255'],
             'openlp_search_title' => ['nullable', 'string', 'max:255'],
-            'song_id' => ['nullable', 'integer', 'min:1', 'exists:songs,id'],
-            'livestream_processing_id' => ['nullable', 'string', 'max:36'],
-            'livestream_service_section_id' => ['nullable', 'integer', 'min:1', 'exists:service_sections,id'],
+            'song_id' => ['nullable', 'integer', 'min:1', 'max:18446744073709551615', 'exists:songs,id'],
+            'livestream_processing_id' => ['nullable', 'uuid'],
+            'livestream_service_section_id' => ['nullable', 'integer', 'min:1', 'max:18446744073709551615', 'exists:service_sections,id'],
         ];
     }
 

--- a/database/migrations/2026_06_16_054346_add_index_to_church_service_items_livestream_service_section_id.php
+++ b/database/migrations/2026_06_16_054346_add_index_to_church_service_items_livestream_service_section_id.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('church_service_items', function (Blueprint $table) {
+            $table->index('livestream_service_section_id', 'church_service_items_livestream_service_section_id_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('church_service_items', function (Blueprint $table) {
+            $table->dropIndex('church_service_items_livestream_service_section_id_index');
+        });
+    }
+};

--- a/tests/Feature/Database/ChurchServiceItemLivestreamIndexTest.php
+++ b/tests/Feature/Database/ChurchServiceItemLivestreamIndexTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Database;
+
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ChurchServiceItemLivestreamIndexTest extends TestCase
+{
+    #[Test]
+    public function it_has_an_explicit_index_on_livestream_service_section_id(): void
+    {
+        $this->assertTrue(
+            Schema::hasIndex('church_service_items', 'church_service_items_livestream_service_section_id_index'),
+            'church_service_items table is missing an explicit index on livestream_service_section_id column.'
+        );
+    }
+}


### PR DESCRIPTION
This PR addresses a data integrity gap in the `church_service_items` table by adding a missing explicit index to the `livestream_service_section_id` foreign key.

In addition to the schema change, the `ChurchServiceItem` model has been fortified with:
- `exists:` validation for the `livestream_service_section_id` and `song_id` foreign keys.
- Integer bounding (using `max:18446744073709551615` for `BIGINT UNSIGNED`) on foreign keys.
- A missing `'integer'` cast for `livestream_service_section_id`.
- `uuid` validation for `livestream_processing_id`.

A new test `Tests\Feature\Database\ChurchServiceItemLivestreamIndexTest` has been added to ensure the index remains present.

---
*PR created automatically by Jules for task [10084756920186341013](https://jules.google.com/task/10084756920186341013) started by @GarethClarridge*