### PR TITLE
♿ Aria: Standardise heading hierarchy to prevent skips

### DIFF
--- a/.Jules/aria.md
+++ b/.Jules/aria.md
@@ -1,0 +1,3 @@
+## 2026-08-11 - Heading Hierarchy Standardisation
+**Pattern:** Content regions (cards, empty states, footers) jumping from `<h1>` to `<h3>` causing accessibility skips.
+**Fix:** Standardise internal structural headings in base components and layouts to use `<h2>`. Visual font size remains controlled by Tailwind utility classes, preserving design while fixing semantic hierarchy.

--- a/resources/views/components/admin/empty-state.blade.php
+++ b/resources/views/components/admin/empty-state.blade.php
@@ -21,7 +21,7 @@
             <div class="rounded-full bg-white shadow-sm ring-1 ring-gray-200 p-3">
                 <x-dynamic-component :component="'heroicon-o-' . $icon" class="h-8 w-8 text-cbc-teal/60" aria-hidden="true" />
             </div>
-            <h3 class="text-base font-semibold text-gray-900">{{ $title }}</h3>
+            <h2 class="text-base font-semibold text-gray-900">{{ $title }}</h2>
             <p class="text-sm text-gray-500 max-w-sm mx-auto">
                 {{ $description }}
             </p>

--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -6,9 +6,9 @@
 <div {{ $attributes->merge(['class' => 'rounded-lg shadow bg-white border border-gray-300']) }}>
     <div class="p-6">
         @isset($heading)
-            <h3 class="mb-3 font-display text-2xl">
+            <h2 class="mb-3 font-display text-2xl">
                 {{ $heading }}
-            </h3>
+            </h2>
         @endisset
         <div @class(['prose max-w-none' => $prose])>
             {{ $slot }}

--- a/resources/views/components/empty-state.blade.php
+++ b/resources/views/components/empty-state.blade.php
@@ -9,7 +9,7 @@
         <x-dynamic-component :component="'heroicon-o-' . $icon" class="h-12 w-12" aria-hidden="true" />
     </div>
 
-    <h3 class="mb-3 font-display text-3xl text-slate-900">{{ $title }}</h3>
+    <h2 class="mb-3 font-display text-3xl text-slate-900">{{ $title }}</h2>
 
     @if($description)
         <p class="mx-auto max-w-lg text-lg text-slate-600">

--- a/resources/views/components/layout/footer.blade.php
+++ b/resources/views/components/layout/footer.blade.php
@@ -6,7 +6,7 @@ $linkClasses = 'rounded-sm text-cbc-teal-dark underline decoration-cbc-teal-dark
   <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
 
     <section class="rounded-xl border border-white/80 bg-white/85 p-6 shadow-sm backdrop-blur-sm">
-      <h3 class="mb-3 font-display text-2xl text-cbc-teal-dark">Catch up</h3>
+      <h2 class="mb-3 font-display text-2xl text-cbc-teal-dark">Catch up</h2>
       <p class="mb-4 text-sm text-slate-700">Keep up with services and recent teaching.</p>
       <div class="flex flex-col items-center space-y-3">
         <a class="inline-flex items-center justify-center rounded-md bg-[linear-gradient(120deg,var(--color-cbc-teal)_0%,var(--color-cbc-teal-dark)_55%,#0e3a3c_100%)] px-3 py-1.5 text-sm text-white no-underline transition-all hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-cbc-teal focus:ring-offset-2" href="{{ config('organization.social.youtube') }}" rel="noopener" target="_blank">
@@ -19,7 +19,7 @@ $linkClasses = 'rounded-sm text-cbc-teal-dark underline decoration-cbc-teal-dark
     </section>
 
     <section class="rounded-xl border border-white/80 bg-white/85 p-6 shadow-sm backdrop-blur-sm">
-      <h3 class="mb-3 font-display text-2xl text-cbc-teal-dark">Contact us</h3>
+      <h2 class="mb-3 font-display text-2xl text-cbc-teal-dark">Contact us</h2>
       <ul class="mb-0 list-none space-y-1 text-cbc-teal-dark">
         <li>
           <a class="{{ $linkClasses }} flex items-center justify-center gap-2 py-2" href="tel:{{ config('organization.phone') }}">
@@ -49,7 +49,7 @@ $linkClasses = 'rounded-sm text-cbc-teal-dark underline decoration-cbc-teal-dark
     </section>
 
     <section class="rounded-xl border border-white/80 bg-white/85 p-6 shadow-sm backdrop-blur-sm">
-      <h3 class="mb-3 font-display text-2xl text-cbc-teal-dark">Visit us</h3>
+      <h2 class="mb-3 font-display text-2xl text-cbc-teal-dark">Visit us</h2>
       <address class="mb-4 not-italic text-slate-700">
         {{ config('organization.name') }}<br>
         {{ config('organization.address.street') }}<br>

--- a/resources/views/members/home.blade.php
+++ b/resources/views/members/home.blade.php
@@ -28,10 +28,10 @@
         @if (auth()->user()?->canAccessAdmin())
         <div class="rounded-lg shadow bg-white border border-gray-300 overflow-hidden">
           <div class="bg-gray-50 border-b border-gray-200 px-4 py-3">
-            <h3 class="font-display text-lg text-gray-900 flex items-center gap-2">
+            <h2 class="font-display text-lg text-gray-900 flex items-center gap-2">
               <x-heroicon-o-microphone class="h-5 w-5 text-gray-500" aria-hidden="true" />
               Services, sermons and songs
-            </h3>
+            </h2>
           </div>
           <div class="p-4 grid grid-cols-2 gap-2">
             @if($serviceTrackingEnabled ?? true)
@@ -72,10 +72,10 @@
         @if (auth()->user()?->canAccessAdmin())
         <div class="rounded-lg shadow bg-white border border-gray-300 overflow-hidden">
           <div class="bg-gray-50 border-b border-gray-200 px-4 py-3">
-            <h3 class="font-display text-lg text-gray-900 flex items-center gap-2">
+            <h2 class="font-display text-lg text-gray-900 flex items-center gap-2">
               <x-heroicon-o-calendar-days class="h-5 w-5 text-gray-500" aria-hidden="true" />
               Meetings and events
-            </h3>
+            </h2>
           </div>
           <div class="p-4 grid grid-cols-2 gap-2">
             <x-button link="{{ route('admin.meetings.index') }}" icon="pencil-square" iconStyle="solid">
@@ -104,10 +104,10 @@
         @if (auth()->user()?->canAccessAdmin())
         <div class="rounded-lg shadow bg-white border border-gray-300 overflow-hidden">
           <div class="bg-gray-50 border-b border-gray-200 px-4 py-3">
-            <h3 class="font-display text-lg text-gray-900 flex items-center gap-2">
+            <h2 class="font-display text-lg text-gray-900 flex items-center gap-2">
               <x-heroicon-o-document-text class="h-5 w-5 text-gray-500" aria-hidden="true" />
               Content
-            </h3>
+            </h2>
           </div>
           <div class="p-4">
             <x-button link="/admin/pages" icon="pencil-square" iconStyle="solid">


### PR DESCRIPTION
Promoted internal headings from <h3> to <h2> in footer, cards, empty states, and the members home page to ensure logical nesting after top-level <h1> landmarks. This improves accessibility for screen reader users by removing heading skips while maintaining the existing visual design via Tailwind utility classes.

---
*PR created automatically by Jules for task [4604262790547466903](https://jules.google.com/task/4604262790547466903) started by @GarethClarridge*