### PR TITLE
🧪 Steward: Harden caching and log assertions

### DIFF
--- a/.Jules/steward.md
+++ b/.Jules/steward.md
@@ -12,3 +12,8 @@
 **Pattern:** Brittle HTML-string assertions and misclassified unit tests.
 **Cause:** Exact markup matching with volatile CSS classes (Tailwind) in feature tests; presence of database-hitting tests in the Unit/ directory.
 **Fix:** Replaced `assertSeeHtml` with `assertSeeInOrder` for more robust content verification. Relocated `MeetingPhotoMigrationServiceTest` and `MeetingShowPresenterTest` to the Integration/ directory to align with architectural standards and ensure proper environment setup.
+
+## 2026-06-17 - Harden caching and log assertions
+**Pattern:** Implementation-detail assertions (`Cache::has()`) and exact-string log assertions.
+**Cause:** Caching tests previously relied on private key names and only checked existence, not effectiveness. Log assertions used exact string matching, making them brittle to minor copy changes.
+**Fix:** Replaced `Cache::has()` with behavioral tests using `DB::enableQueryLog()` to verify zero queries on subsequent calls (after clearing internal memoization). Loosened log assertions to use `str_contains` via `withArgs` for resilience against rephrasing.

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -204,11 +204,10 @@ class LoginTest extends TestCase
 
         Log::shouldReceive('warning')
             ->once()
-            ->with('Admin logged in', \Mockery::on(function ($context) use ($crafted) {
-                return isset($context['email'])
-                    && $context['email'] !== $crafted
-                    && ! str_contains((string) $context['email'], "\n");
-            }));
+            ->withArgs(fn ($message, $context) => str_contains($message, 'Admin logged in') &&
+                isset($context['email']) &&
+                $context['email'] !== $crafted &&
+                ! str_contains((string) $context['email'], "\n"));
 
         Livewire::test(LoginComponent::class)
             ->set('email', $admin->email)
@@ -221,11 +220,10 @@ class LoginTest extends TestCase
     {
         Log::shouldReceive('warning')
             ->once()
-            ->with('Admin login attempt failed', \Mockery::on(function ($context) {
-                return isset($context['admin_id'])
-                    && isset($context['email'])
-                    && isset($context['ip']);
-            }));
+            ->withArgs(fn ($message, $context) => str_contains($message, 'Admin login attempt failed') &&
+                isset($context['admin_id']) &&
+                isset($context['email']) &&
+                isset($context['ip']));
 
         $admin = User::factory()->create([
             'is_admin' => true,

--- a/tests/Feature/Livewire/Admin/Meetings/ListMeetingsTest.php
+++ b/tests/Feature/Livewire/Admin/Meetings/ListMeetingsTest.php
@@ -186,11 +186,10 @@ class ListMeetingsTest extends TestCase
 
         Log::shouldReceive('warning')
             ->once()
-            ->with('Meeting deleted by admin', \Mockery::on(function ($args) use ($meeting) {
-                return $args['admin_id'] === $this->admin->id &&
-                       $args['meeting_id'] === $meeting->id &&
-                       $args['slug'] === $meeting->slug;
-            }));
+            ->withArgs(fn ($message, $context) => str_contains($message, 'Meeting deleted') &&
+                $context['admin_id'] === $this->admin->id &&
+                $context['meeting_id'] === $meeting->id &&
+                $context['slug'] === $meeting->slug);
 
         Livewire::test(ListMeetings::class)
             ->call('delete', $meeting)

--- a/tests/Integration/Services/PreacherListCacheTest.php
+++ b/tests/Integration/Services/PreacherListCacheTest.php
@@ -10,6 +10,7 @@ use App\Models\Sermon;
 use App\Services\Public\PreacherListCache;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -36,14 +37,22 @@ class PreacherListCacheTest extends TestCase
         $preacherB = Preacher::factory()->create(['name' => 'Adam', 'is_active' => true]);
         Preacher::factory()->inactive()->create(['name' => 'Inactive']);
 
+        // First call populates the cache
+        DB::enableQueryLog();
+        $this->repository->forAdminList();
+        $this->assertNotEmpty(DB::getQueryLog());
+        DB::flushQueryLog();
+
+        // Second call (clearing internal memoization) should hit cache
+        $this->repository->clearInternalCaches();
         $list = $this->repository->forAdminList();
+
+        $this->assertCount(0, DB::getQueryLog());
 
         $this->assertCount(2, $list);
         $this->assertEquals(['Adam', 'Zack'], $list->values()->all());
         $this->assertEquals($preacherB->id, $list->keys()[0]);
         $this->assertEquals($preacherA->id, $list->keys()[1]);
-
-        $this->assertTrue(Cache::has(PreacherListCache::ADMIN_LIST_CACHE_KEY));
     }
 
     #[Test]
@@ -70,15 +79,23 @@ class PreacherListCacheTest extends TestCase
             'content_type' => SermonContentType::ChildrensTalk,
         ]);
 
+        // First call populates the cache
+        DB::enableQueryLog();
+        $this->repository->forPublicList();
+        $this->assertNotEmpty(DB::getQueryLog());
+        DB::flushQueryLog();
+
+        // Second call (clearing internal memoization) should hit cache
+        $this->repository->clearInternalCaches();
         $list = $this->repository->forPublicList();
+
+        $this->assertCount(0, DB::getQueryLog());
 
         $this->assertCount(2, $list);
         $this->assertEquals('Preacher A', $list->first()->name);
         $this->assertEquals(2, $list->first()->sermons_count);
         $this->assertEquals('Preacher B', $list->last()->name);
         $this->assertEquals(1, $list->last()->sermons_count);
-
-        $this->assertTrue(Cache::has(PreacherListCache::PUBLIC_LIST_CACHE_KEY));
     }
 
     #[Test]


### PR DESCRIPTION
Hardened existing tests against brittleness by:
1.  Replacing implementation-detail `Cache::has()` assertions in `PreacherListCacheTest.php` with behavior-based verification using `DB::enableQueryLog()`. This confirms the cache is actually being used by asserting that zero queries are made on subsequent calls after internal memoization is cleared.
2.  Loosening exact-string log assertions in `ListMeetingsTest.php` and `LoginTest.php` to use partial matches with `str_contains`. This makes tests resilient to minor copy changes in log messages while still validating the integrity of the logged context (IDs, emails, etc.).
3.  Resolving a "Vite manifest not found" failure in `LoginTest.php` by performing a fresh asset build.
4.  Updating the Steward journal with these hardening patterns.

---
*PR created automatically by Jules for task [5160362002985488230](https://jules.google.com/task/5160362002985488230) started by @GarethClarridge*