### PR TITLE
Add PHPDoc to ProcessingLogService

### DIFF
--- a/.Jules/herald.md
+++ b/.Jules/herald.md
@@ -17,3 +17,7 @@
 ## 2026-06-08 - Documenting Fuzzy Reassembly Logic
 **Learning:** Documentation for reassembly and deduplication logic (like in `AudioChunkingService`) must explicitly bridge the gap between technical implementation (85% similarity threshold) and domain impact (Whisper transcription variations across chunk boundaries). Precise `list<array{...}>` shapes for multi-segment data are essential for ensuring callers provide the necessary metadata (indices, timestamps) for correct ordering and overlap handling.
 **Action:** When documenting fuzzy matching or deduplication, always explain the calibration rationale for similarity thresholds to prevent arbitrary adjustments that might break edge-case handling.
+
+## 2026-06-15 - Documenting Log Parsing and Performance Summaries
+**Learning:** Documenting services that parse unstructured logs into structured data (like `ProcessingLogService`) requires precise return shapes to ensure downstream consumers (like status dashboards) can safely access nested metrics. Identifying that `timestamp` might be null in `step_metrics` (if a log entry lacks a timestamp but has performance data) was a critical catch for PHPStan accuracy.
+**Action:** Use nullable types in array shapes (`type|null`) for keys derived from logs or external inputs that might be malformed or missing.

--- a/app/Services/Processing/ProcessingLogService.php
+++ b/app/Services/Processing/ProcessingLogService.php
@@ -10,12 +10,29 @@ use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 
+/**
+ * Service for retrieving and parsing media processing logs.
+ *
+ * Provides structured visibility into the media processing pipeline's
+ * execution, progress, and performance metrics by parsing application-level
+ * log entries associated with a specific processing ID.
+ */
 class ProcessingLogService
 {
+    /**
+     * @param  string  $logFilePath  Optional path to the log file (defaults to storage/logs/laravel.log)
+     */
     public function __construct(
         private readonly string $logFilePath = ''
     ) {}
 
+    /**
+     * Retrieve a collection of processing logs for a specific ID.
+     *
+     * @param  string  $processingId  The unique processing identifier
+     * @param  int  $limit  Maximum number of entries to return (default: 50)
+     * @return ProcessingLogCollection The structured collection of log entries
+     */
     public function getProcessingLogs(string $processingId, int $limit = 50): ProcessingLogCollection
     {
         $logs = $this->parseLogsFromFile($processingId, $limit);
@@ -27,6 +44,13 @@ class ProcessingLogService
         );
     }
 
+    /**
+     * Retrieve processing logs generated since a specific timestamp.
+     *
+     * @param  string  $processingId  The unique processing identifier
+     * @param  Carbon  $since  The cutoff timestamp
+     * @return ProcessingLogCollection The structured collection of log entries
+     */
     public function getLogsSince(string $processingId, Carbon $since): ProcessingLogCollection
     {
         $logs = $this->parseLogsFromFile($processingId, null, $since);
@@ -38,6 +62,13 @@ class ProcessingLogService
         );
     }
 
+    /**
+     * Retrieve processing logs for a specific pipeline step.
+     *
+     * @param  string  $processingId  The unique processing identifier
+     * @param  string  $step  The step identifier to filter by
+     * @return ProcessingLogCollection The structured collection of log entries
+     */
     public function getLogsByStep(string $processingId, string $step): ProcessingLogCollection
     {
         $allLogs = $this->parseLogsFromFile($processingId);
@@ -51,7 +82,24 @@ class ProcessingLogService
     }
 
     /**
-     * @return array<string, mixed>|null
+     * Aggregates performance and resource usage metrics from log entries.
+     *
+     * Summarizes execution time and memory usage across all steps of a
+     * processing run, providing a breakdown of metrics per discrete step.
+     *
+     * @param  string  $processingId  The unique processing identifier
+     * @return array{
+     *     total_execution_time: float,
+     *     peak_memory_usage: int,
+     *     step_metrics: array<string, array{
+     *         execution_time: float|null,
+     *         memory_usage: int|null,
+     *         timestamp: string|null
+     *     }>,
+     *     total_entries: int,
+     *     error_count: int,
+     *     warning_count: int,
+     * }|null
      */
     public function getPerformanceMetrics(string $processingId): ?array
     {


### PR DESCRIPTION
I have enhanced the documentation for the `ProcessingLogService` class in `app/Services/Processing/ProcessingLogService.php`. This includes class-level descriptions and detailed PHPDoc blocks for all public methods. Notably, I've added a specific array shape annotation for the `getPerformanceMetrics` method to clarify its complex return structure, aiding both developers and static analysis tools like PHPStan. I have verified these changes using Pint, PHPStan, and integration tests to ensure accuracy and consistency.

---
*PR created automatically by Jules for task [4120855956563227544](https://jules.google.com/task/4120855956563227544) started by @GarethClarridge*