### PR TITLE
🔦 Lighthouse: Enhance social sharing metadata with contextual labels

### DIFF
--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -19,6 +19,8 @@
             description="Upcoming events at Crockenhill Baptist Church."
             :image="asset('/images/homepage/may2024wide.webp')"
             image-alt="Crockenhill Baptist Church members outside the church building"
+            label1="Upcoming events"
+            :data1="$allEvents->count()"
         />
         <x-schema.webpage
             heading="Church Calendar"

--- a/resources/views/components/meta-tags.blade.php
+++ b/resources/views/components/meta-tags.blade.php
@@ -29,6 +29,7 @@
     $metaImage = $image ?? asset('images/Primary.png');
     $metaUrl = $canonical ?? url()->current();
     $twitterCard = $image ? 'summary_large_image' : 'summary';
+    $resolvedImageAlt = $imageAlt ?? ($image ? null : 'Crockenhill Baptist Church logo');
 @endphp
 
 {{-- Open Graph meta tags --}}
@@ -41,8 +42,8 @@
 <meta property="og:image" content="{{ $metaImage }}">
 <meta property="og:image:width" content="{{ $imageWidth }}">
 <meta property="og:image:height" content="{{ $imageHeight }}">
-@if($imageAlt)
-<meta property="og:image:alt" content="{{ $imageAlt }}">
+@if($resolvedImageAlt)
+<meta property="og:image:alt" content="{{ $resolvedImageAlt }}">
 @endif
 
 @if($audio)
@@ -90,8 +91,8 @@
 @if($twitterCreator)
 <meta name="twitter:creator" content="{{ $twitterCreator }}">
 @endif
-@if($imageAlt)
-<meta name="twitter:image:alt" content="{{ $imageAlt }}">
+@if($resolvedImageAlt)
+<meta name="twitter:image:alt" content="{{ $resolvedImageAlt }}">
 @endif
 @if($label1 && $data1)
 <meta name="twitter:label1" content="{{ $label1 }}">

--- a/resources/views/components/page/shell.blade.php
+++ b/resources/views/components/page/shell.blade.php
@@ -37,6 +37,8 @@
     :image="$headingpicture ?? null"
     :image-alt="$headingpicture ? 'Crockenhill Baptist Church: ' . $heading : null"
     :canonical="$canonical"
+    :label1="$area ? 'Section' : null"
+    :data1="$area ? \Illuminate\Support\Str::title($area) : null"
 />
 <x-schema.webpage
     :$heading

--- a/resources/views/meetings/show.blade.php
+++ b/resources/views/meetings/show.blade.php
@@ -29,6 +29,8 @@
             :description="$description ?? $heading"
             :image="$headingpicture ?? null"
             :image-alt="'Meeting: ' . $heading"
+            label1="When"
+            :data1="$meeting->day . ($meeting->start_time ? ' at ' . $meeting->start_time->format('g:ia') : '')"
         />
         <x-schema.webpage
             :heading="$heading"


### PR DESCRIPTION
💡 **What:** Enhanced social sharing metadata (Twitter Cards / Open Graph) across several key surfaces.
🎯 **Why:** To provide more informative previews when links are shared on social media and messaging platforms.
📊 **Impact:** Homepage, Meeting pages, and the Calendar page will now show relevant contextual labels (like event counts or meeting times) in link previews.
🔍 **Verification:** Changes were verified by inspecting the modified Blade files and component properties. Added default alt text to ensure accessibility for social crawlers.

---
*PR created automatically by Jules for task [4775723568463948888](https://jules.google.com/task/4775723568463948888) started by @GarethClarridge*