### PR TITLE
⚡ Bolt: optimize relationship queries via column selection

### DIFF
--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -24,7 +24,12 @@ class MeetingController extends Controller
      */
     public function show(Meeting $meeting): ViewContract|RedirectResponse
     {
-        $meeting->loadMissing('page');
+        /**
+         * Performance Optimization: Limits retrieved columns for the eager-loaded page
+         * to required fields for visibility checks, read models, and view rendering
+         * to reduce memory usage and DB I/O.
+         */
+        $meeting->loadMissing('page:id,slug,heading,area,admin,navigation,description,created_at,updated_at,body,markdown');
 
         if ($redirect = $this->publicPageVisibilityGuard->enforce($meeting->page)) {
             return $redirect;

--- a/app/Http/Controllers/SermonController.php
+++ b/app/Http/Controllers/SermonController.php
@@ -103,11 +103,16 @@ class SermonController extends Controller
     {
         abort_unless($sermon->content_type === SermonContentType::Sermon, 404);
 
+        /**
+         * Performance Optimization: Limits retrieved columns for related models to
+         * required fields to reduce memory usage and DB I/O on the single sermon view.
+         */
         $sermon->loadMissing([
             'scripturePassage:id,display_reference,normalized_reference,html_content,copyright,fums_token',
             'preacherProfile:id,name,slug,image_path',
             'publishedServiceSection:id,published_sermon_id,media_processing_log_id',
-            'latestProcessingLog',
+            'latestProcessingLog' => fn ($query) => $query
+                ->select(['media_processing_logs.id', 'processing_id', 'media_processing_logs.sermon_id', 'status', 'current_step', 'error_message', 'original_filename', 'media_processing_logs.created_at', 'duration']),
             'livestreamProcessing' => fn ($query) => $query
                 ->select(['id', 'processing_id', 'sermon_id', 'original_filename', 'created_at', 'status', 'duration'])
                 ->with('segments:id,media_processing_log_id'),

--- a/app/Http/Controllers/SermonController.php
+++ b/app/Http/Controllers/SermonController.php
@@ -111,6 +111,8 @@ class SermonController extends Controller
             'scripturePassage:id,display_reference,normalized_reference,html_content,copyright,fums_token',
             'preacherProfile:id,name,slug,image_path',
             'publishedServiceSection:id,published_sermon_id,media_processing_log_id',
+            // Table-prefixed columns are required here: latestOfMany() uses an inner self-join,
+            // so ambiguous column names (id, sermon_id, created_at) must be qualified.
             'latestProcessingLog' => fn ($query) => $query
                 ->select(['media_processing_logs.id', 'processing_id', 'media_processing_logs.sermon_id', 'status', 'current_step', 'error_message', 'original_filename', 'media_processing_logs.created_at', 'duration']),
             'livestreamProcessing' => fn ($query) => $query

--- a/app/Services/Public/PageListCache.php
+++ b/app/Services/Public/PageListCache.php
@@ -44,7 +44,7 @@ class PageListCache
         $links = Cache::flexible($key, [86400, 172800], function () use ($areaValue) {
             return Page::query()
                 ->public()
-                ->select(['id', 'slug', 'heading', 'area', 'description', 'admin'])
+                ->select(['id', 'slug', 'heading', 'area', 'description', 'admin', 'navigation'])
                 ->where('area', $areaValue)
                 ->get();
         });
@@ -75,7 +75,7 @@ class PageListCache
         $links = Cache::flexible($cacheKey, [86400, 172800], function () use ($areaValue, $orderedSlugs) {
             return Page::query()
                 ->public()
-                ->select(['id', 'slug', 'heading', 'area', 'description', 'admin'])
+                ->select(['id', 'slug', 'heading', 'area', 'description', 'admin', 'navigation'])
                 ->where('area', $areaValue)
                 ->whereIn('slug', $orderedSlugs)
                 ->get()

--- a/app/Services/Sermon/SermonPageContextService.php
+++ b/app/Services/Sermon/SermonPageContextService.php
@@ -70,8 +70,14 @@ class SermonPageContextService
 
     private function queryReadingSection(int $processingLogId): ?ServiceSection
     {
+        /**
+         * Performance Optimization: Limits retrieved columns for the reading section
+         * and its related service item to required fields for reference resolution
+         * to reduce memory usage and DB I/O.
+         */
         $section = ServiceSection::query()
-            ->with('churchServiceItem')
+            ->select(['id', 'media_processing_log_id', 'church_service_item_id', 'section_type', 'section_order', 'start_time', 'title', 'metadata'])
+            ->with('churchServiceItem:id,church_service_id,title')
             ->where('media_processing_log_id', $processingLogId)
             ->where('section_type', ServiceSectionType::BibleReading)
             ->orderBy('section_order')


### PR DESCRIPTION
Implemented performance optimizations focused on reducing database I/O and memory usage by limiting columns fetched in eager-loaded relationships in `SermonController`, `MeetingController`, `SermonPageContextService`, and `PageListCache`. These optimizations target common read paths and include detailed PHPDoc explanations. All changes were verified with targeted tests.

---
*PR created automatically by Jules for task [216947047927453428](https://jules.google.com/task/216947047927453428) started by @GarethClarridge*