### PR TITLE
📝 Scribe: Add tests for SermonCandidateConfidenceService

### DIFF
--- a/tests/Integration/Services/SermonCandidateConfidenceServiceTest.php
+++ b/tests/Integration/Services/SermonCandidateConfidenceServiceTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Services;
+
+use App\Models\LivestreamSegment;
+use App\Models\MediaProcessingLog;
+use App\Services\Sermon\SermonCandidateConfidenceService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonCandidateConfidenceServiceTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private SermonCandidateConfidenceService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new SermonCandidateConfidenceService;
+    }
+
+    #[Test]
+    public function it_identifies_a_clear_sermon_candidate_from_the_database(): void
+    {
+        $log = MediaProcessingLog::factory()->create();
+
+        // One long speech segment (25 mins = 1500s)
+        $candidate = LivestreamSegment::factory()->speech()->create([
+            'media_processing_log_id' => $log->id,
+            'processing_id' => $log->processing_id,
+            'duration' => 1500.0,
+            'start_time' => 1000.0,
+        ]);
+
+        // One short speech segment (5 mins = 300s)
+        LivestreamSegment::factory()->speech()->create([
+            'media_processing_log_id' => $log->id,
+            'processing_id' => $log->processing_id,
+            'duration' => 300.0,
+            'start_time' => 500.0,
+        ]);
+
+        // One long SONG segment (should be ignored)
+        LivestreamSegment::factory()->song()->create([
+            'media_processing_log_id' => $log->id,
+            'processing_id' => $log->processing_id,
+            'duration' => 2000.0,
+        ]);
+
+        $result = $this->service->evaluateForProcessingLog($log);
+
+        $this->assertTrue($result['is_clear']);
+        $this->assertSame('clear', $result['reason']);
+        $this->assertSame($candidate->id, $result['candidate']?->id);
+        $this->assertCount(2, $result['speech_segments']);
+
+        // Verify ordering in speech_segments (by start_time)
+        $this->assertEquals(500.0, $result['speech_segments'][0]['start_time']);
+        $this->assertEquals(1000.0, $result['speech_segments'][1]['start_time']);
+    }
+
+    #[Test]
+    public function it_flags_review_when_multiple_qualifying_speech_blocks_exist_in_db(): void
+    {
+        $log = MediaProcessingLog::factory()->create();
+
+        LivestreamSegment::factory()->speech()->create([
+            'media_processing_log_id' => $log->id,
+            'processing_id' => $log->processing_id,
+            'duration' => 1500.0,
+        ]);
+
+        LivestreamSegment::factory()->speech()->create([
+            'media_processing_log_id' => $log->id,
+            'processing_id' => $log->processing_id,
+            'duration' => 1600.0,
+        ]);
+
+        $result = $this->service->evaluateForProcessingLog($log);
+
+        $this->assertFalse($result['is_clear']);
+        $this->assertSame('multiple_qualifying_speech_blocks', $result['reason']);
+        $this->assertNull($result['candidate']);
+        $this->assertEquals(2, $result['qualifying_segments_count']);
+    }
+
+    #[Test]
+    public function it_flags_review_when_no_speech_block_is_long_enough(): void
+    {
+        $log = MediaProcessingLog::factory()->create();
+
+        LivestreamSegment::factory()->speech()->create([
+            'media_processing_log_id' => $log->id,
+            'processing_id' => $log->processing_id,
+            'duration' => 600.0,
+        ]);
+
+        $result = $this->service->evaluateForProcessingLog($log);
+
+        $this->assertFalse($result['is_clear']);
+        $this->assertSame('no_qualifying_speech_block', $result['reason']);
+        $this->assertNull($result['candidate']);
+    }
+
+    #[Test]
+    public function it_flags_review_when_ratio_between_longest_segments_is_too_low(): void
+    {
+        $log = MediaProcessingLog::factory()->create();
+
+        // Longest is 25 mins (1500s) - Qualifying
+        LivestreamSegment::factory()->speech()->create([
+            'media_processing_log_id' => $log->id,
+            'processing_id' => $log->processing_id,
+            'duration' => 1500.0,
+        ]);
+
+        // Second longest is 18.3 mins (1100s) - Not qualifying (threshold is 20 mins)
+        // 1500 / 1100 = 1.36 (< 1.5 threshold)
+        LivestreamSegment::factory()->speech()->create([
+            'media_processing_log_id' => $log->id,
+            'processing_id' => $log->processing_id,
+            'duration' => 1100.0,
+        ]);
+
+        $result = $this->service->evaluateForProcessingLog($log);
+
+        $this->assertFalse($result['is_clear']);
+        $this->assertSame('ratio_below_threshold', $result['reason']);
+        $this->assertNull($result['candidate']);
+    }
+
+    #[Test]
+    public function it_only_considers_segments_belonging_to_the_specified_log(): void
+    {
+        $log1 = MediaProcessingLog::factory()->create();
+        $log2 = MediaProcessingLog::factory()->create();
+
+        LivestreamSegment::factory()->speech()->create([
+            'media_processing_log_id' => $log1->id,
+            'processing_id' => $log1->processing_id,
+            'duration' => 1500.0,
+        ]);
+
+        // Long segment for DIFFERENT log
+        LivestreamSegment::factory()->speech()->create([
+            'media_processing_log_id' => $log2->id,
+            'processing_id' => $log2->processing_id,
+            'duration' => 2000.0,
+        ]);
+
+        $result = $this->service->evaluateForProcessingLog($log1);
+
+        $this->assertTrue($result['is_clear']);
+        $this->assertSame(1, $result['qualifying_segments_count']);
+        $this->assertEquals(0.0, $result['next_longest_duration']);
+    }
+}

--- a/tests/Integration/Services/SermonCandidateConfidenceServiceTest.php
+++ b/tests/Integration/Services/SermonCandidateConfidenceServiceTest.php
@@ -32,7 +32,6 @@ class SermonCandidateConfidenceServiceTest extends TestCase
         // One long speech segment (25 mins = 1500s)
         $candidate = LivestreamSegment::factory()->speech()->create([
             'media_processing_log_id' => $log->id,
-            'processing_id' => $log->processing_id,
             'duration' => 1500.0,
             'start_time' => 1000.0,
         ]);
@@ -40,7 +39,6 @@ class SermonCandidateConfidenceServiceTest extends TestCase
         // One short speech segment (5 mins = 300s)
         LivestreamSegment::factory()->speech()->create([
             'media_processing_log_id' => $log->id,
-            'processing_id' => $log->processing_id,
             'duration' => 300.0,
             'start_time' => 500.0,
         ]);
@@ -48,7 +46,6 @@ class SermonCandidateConfidenceServiceTest extends TestCase
         // One long SONG segment (should be ignored)
         LivestreamSegment::factory()->song()->create([
             'media_processing_log_id' => $log->id,
-            'processing_id' => $log->processing_id,
             'duration' => 2000.0,
         ]);
 
@@ -71,13 +68,11 @@ class SermonCandidateConfidenceServiceTest extends TestCase
 
         LivestreamSegment::factory()->speech()->create([
             'media_processing_log_id' => $log->id,
-            'processing_id' => $log->processing_id,
             'duration' => 1500.0,
         ]);
 
         LivestreamSegment::factory()->speech()->create([
             'media_processing_log_id' => $log->id,
-            'processing_id' => $log->processing_id,
             'duration' => 1600.0,
         ]);
 
@@ -96,7 +91,6 @@ class SermonCandidateConfidenceServiceTest extends TestCase
 
         LivestreamSegment::factory()->speech()->create([
             'media_processing_log_id' => $log->id,
-            'processing_id' => $log->processing_id,
             'duration' => 600.0,
         ]);
 
@@ -115,7 +109,6 @@ class SermonCandidateConfidenceServiceTest extends TestCase
         // Longest is 25 mins (1500s) - Qualifying
         LivestreamSegment::factory()->speech()->create([
             'media_processing_log_id' => $log->id,
-            'processing_id' => $log->processing_id,
             'duration' => 1500.0,
         ]);
 
@@ -123,7 +116,6 @@ class SermonCandidateConfidenceServiceTest extends TestCase
         // 1500 / 1100 = 1.36 (< 1.5 threshold)
         LivestreamSegment::factory()->speech()->create([
             'media_processing_log_id' => $log->id,
-            'processing_id' => $log->processing_id,
             'duration' => 1100.0,
         ]);
 
@@ -142,14 +134,12 @@ class SermonCandidateConfidenceServiceTest extends TestCase
 
         LivestreamSegment::factory()->speech()->create([
             'media_processing_log_id' => $log1->id,
-            'processing_id' => $log1->processing_id,
             'duration' => 1500.0,
         ]);
 
         // Long segment for DIFFERENT log
         LivestreamSegment::factory()->speech()->create([
             'media_processing_log_id' => $log2->id,
-            'processing_id' => $log2->processing_id,
             'duration' => 2000.0,
         ]);
 

--- a/tests/Unit/Support/ServiceSectionConfidenceTest.php
+++ b/tests/Unit/Support/ServiceSectionConfidenceTest.php
@@ -45,5 +45,44 @@ class ServiceSectionConfidenceTest extends TestCase
     {
         $this->assertSame(1.0, ServiceSectionConfidence::resolve(1.5));
         $this->assertSame(0.0, ServiceSectionConfidence::resolve(-0.5));
+        $this->assertSame(1.0, ServiceSectionConfidence::clamp(1.1));
+        $this->assertSame(0.0, ServiceSectionConfidence::clamp(-0.1));
+    }
+
+    #[Test]
+    public function it_increases_confidence_with_clamping(): void
+    {
+        $this->assertSame(0.8, ServiceSectionConfidence::increase(0.5, 0.3));
+        $this->assertSame(1.0, ServiceSectionConfidence::increase(0.9, 0.2));
+    }
+
+    #[Test]
+    public function it_decreases_confidence_with_clamping(): void
+    {
+        $this->assertSame(0.2, ServiceSectionConfidence::decrease(0.5, 0.3));
+        $this->assertSame(0.0, ServiceSectionConfidence::decrease(0.1, 0.2));
+    }
+
+    #[Test]
+    public function it_returns_correct_level_for_confidence_scores(): void
+    {
+        $this->assertSame('high', ServiceSectionConfidence::levelFor(0.9));
+        $this->assertSame('high', ServiceSectionConfidence::levelFor(ServiceSectionConfidence::HIGH_THRESHOLD));
+
+        $this->assertSame('low', ServiceSectionConfidence::levelFor(0.6));
+        $this->assertSame('low', ServiceSectionConfidence::levelFor(ServiceSectionConfidence::LOW_THRESHOLD));
+
+        $this->assertSame('none', ServiceSectionConfidence::levelFor(0.4));
+        $this->assertSame('none', ServiceSectionConfidence::levelFor(0.0));
+    }
+
+    #[Test]
+    public function it_returns_default_scores_for_levels(): void
+    {
+        $this->assertSame(0.90, ServiceSectionConfidence::scoreForLevel('high'));
+        $this->assertSame(0.50, ServiceSectionConfidence::scoreForLevel('low'));
+        $this->assertSame(0.10, ServiceSectionConfidence::scoreForLevel('none'));
+        $this->assertSame(0.10, ServiceSectionConfidence::scoreForLevel('unknown'));
+        $this->assertSame(0.10, ServiceSectionConfidence::scoreForLevel(null));
     }
 }


### PR DESCRIPTION
Identified and covered an untested integration path in `SermonCandidateConfidenceService` that fetches segments from the database. Also added missing unit test coverage for the `ServiceSectionConfidence` utility class.

🎯 **Coverage:** 
- `App\Services\Sermon\SermonCandidateConfidenceService::evaluateForProcessingLog` (Integration)
- `App\Support\ServiceSectionConfidence` (Unit)

📋 **Tests added:**
- `SermonCandidateConfidenceServiceTest::it_identifies_a_clear_sermon_candidate_from_the_database`
- `SermonCandidateConfidenceServiceTest::it_flags_review_when_multiple_qualifying_speech_blocks_exist_in_db`
- `SermonCandidateConfidenceServiceTest::it_flags_review_when_no_speech_block_is_long_enough`
- `SermonCandidateConfidenceServiceTest::it_flags_review_when_ratio_between_longest_segments_is_too_low`
- `SermonCandidateConfidenceServiceTest::it_only_considers_segments_belonging_to_the_specified_log`
- `ServiceSectionConfidenceTest::it_clamps_values_into_the_unit_interval`
- `ServiceSectionConfidenceTest::it_increases_confidence_with_clamping`
- `ServiceSectionConfidenceTest::it_decreases_confidence_with_clamping`
- `ServiceSectionConfidenceTest::it_returns_correct_level_for_confidence_scores`
- `ServiceSectionConfidenceTest::it_returns_default_scores_for_levels`

🔍 **Why:** The automated sermon extraction pipeline relies heavily on these confidence calculations to decide whether to auto-publish or flag for manual review. Ensuring the integration between the database and this evaluation logic is solid is high priority for processing reliability.

✅ **Results:** 18 tests, 54 assertions passed. PHPStan and Pint clean.

---
*PR created automatically by Jules for task [12664889180293864443](https://jules.google.com/task/12664889180293864443) started by @GarethClarridge*