### PR TITLE
🛡️ Sentinel: Harden media validation and document failure paths

### DIFF
--- a/app/Http/Controllers/Api/ChurchServiceController.php
+++ b/app/Http/Controllers/Api/ChurchServiceController.php
@@ -19,6 +19,9 @@ class ChurchServiceController extends Controller
         private readonly ImportChurchServiceFromOpenLp $importChurchServiceFromOpenLp,
     ) {}
 
+    /**
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
     public function store(UploadChurchServiceRequest $request): JsonResponse
     {
         $this->abortIfDisabled();
@@ -37,6 +40,9 @@ class ChurchServiceController extends Controller
             ->setStatusCode(201);
     }
 
+    /**
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
     public function show(ChurchService $churchService): ChurchServiceResource
     {
         $this->abortIfDisabled();

--- a/app/Http/Controllers/Api/SermonApiController.php
+++ b/app/Http/Controllers/Api/SermonApiController.php
@@ -119,6 +119,8 @@ class SermonApiController extends Controller
 
     /**
      * Display the specified sermon
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function show(Sermon $sermon, SermonExposurePolicy $exposurePolicy): SermonResource
     {

--- a/app/Http/Requests/UploadChurchServiceRequest.php
+++ b/app/Http/Requests/UploadChurchServiceRequest.php
@@ -32,7 +32,7 @@ class UploadChurchServiceRequest extends FormRequest
         $maxSize = (int) config('service-tracking.upload.max_size_kb', 614400);
 
         return [
-            'file' => ['required', 'file', 'mimes:zip', 'max:'.$maxSize],
+            'file' => ['required', 'file', 'mimes:zip', 'mimetypes:application/zip', 'max:'.$maxSize],
         ];
     }
 

--- a/app/Services/Processing/MediaValidationService.php
+++ b/app/Services/Processing/MediaValidationService.php
@@ -21,9 +21,16 @@ class MediaValidationService
         $config = config("media-processing.types.{$type->value}");
         $maxSizeKB = (int) ($config['max_file_size'] / 1024);
         $extensions = implode(',', $config['allowed_extensions']);
+        $mimes = implode(',', $config['allowed_mimes'] ?? []);
+
+        $rules = "required|file|mimes:{$extensions}|max:{$maxSizeKB}";
+
+        if ($mimes !== '') {
+            $rules .= "|mimetypes:{$mimes}";
+        }
 
         return [
-            'file' => "required|file|mimes:{$extensions}|max:{$maxSizeKB}",
+            'file' => $rules,
         ];
     }
 

--- a/tests/Feature/Security/RateLimitingSecurityTest.php
+++ b/tests/Feature/Security/RateLimitingSecurityTest.php
@@ -53,7 +53,7 @@ class RateLimitingSecurityTest extends TestCase
         // We'll attempt 6 uploads.
         for ($i = 0; $i < 5; $i++) {
             $response = $this->postJson('/api/media/audio', [
-                'file' => UploadedFile::fake()->create('sermon.mp3', 100),
+                'file' => UploadedFile::fake()->create('sermon.mp3', 100, 'audio/mpeg'),
             ]);
 
             $response->assertStatus(202);
@@ -61,7 +61,7 @@ class RateLimitingSecurityTest extends TestCase
 
         // The 6th request should be throttled
         $response = $this->postJson('/api/media/audio', [
-            'file' => UploadedFile::fake()->create('sermon.mp3', 100),
+            'file' => UploadedFile::fake()->create('sermon.mp3', 100, 'audio/mpeg'),
         ]);
 
         $response->assertStatus(429);
@@ -87,13 +87,13 @@ class RateLimitingSecurityTest extends TestCase
 
         // The 'media-upload' limiter allows 1 per minute for video/livestream.
         $response = $this->postJson('/api/media/video', [
-            'file' => UploadedFile::fake()->create('sermon.mp4', 1000),
+            'file' => UploadedFile::fake()->create('sermon.mp4', 1000, 'video/mp4'),
         ]);
         $response->assertStatus(202);
 
         // The 2nd request should be throttled
         $response = $this->postJson('/api/media/video', [
-            'file' => UploadedFile::fake()->create('sermon.mp4', 1000),
+            'file' => UploadedFile::fake()->create('sermon.mp4', 1000, 'video/mp4'),
         ]);
         $response->assertStatus(429);
     }


### PR DESCRIPTION
Additive security hardening for media and service uploads, plus improved exception documentation.

---
*PR created automatically by Jules for task [7536773989949001947](https://jules.google.com/task/7536773989949001947) started by @GarethClarridge*