### PR TITLE
📘 Editor: Correct FIEC full name and improve punctuation

### DIFF
--- a/resources/views/full-width-pages/church.blade.php
+++ b/resources/views/full-width-pages/church.blade.php
@@ -173,7 +173,7 @@ Church
       If you come to our services you'll notice we spend a lot of
       time reading and explaining the Bible. We believe the Bible
       is God's perfect word to us - it's how he speaks into our
-      everyday lives. When we hear the Bible preached God speaks
+      everyday lives. When we hear the Bible preached, God speaks
       to our hearts by his Spirit and forms us to be more and more
       like Jesus.
     </p>
@@ -278,7 +278,7 @@ Church
       We don't want to isolate ourselves from Christians in other
       places though. We are affiliated with
       <a href="https://fiec.org.uk/">
-        the Fellowship of Evangelical Churches
+        the Fellowship of Independent Evangelical Churches
       </a>, a nationwide group of like-minded churches.
     </p>
   </x-text>


### PR DESCRIPTION
This PR addresses two copy issues on the public-facing "Church" page (`/church`):

1.  **Factual Correction:** Properly named "the Fellowship of Independent Evangelical Churches" (FIEC). The word "Independent" was missing, which is a key part of the organization's name and the church's own identity as described in the same section.
2.  **Grammatical Polish:** Added a missing comma after the introductory clause "When we hear the Bible preached" to improve readability and flow.

Both changes are localized to `resources/views/full-width-pages/church.blade.php` and have no impact on application logic or behavior. Verified via existing tests and visual inspection.

---
*PR created automatically by Jules for task [12369465241560292059](https://jules.google.com/task/12369465241560292059) started by @GarethClarridge*