### PR TITLE
📝 Scribe: Add tests for ServiceSectionType and ChurchServiceItem categorization

### DIFF
--- a/.Jules/scribe.md
+++ b/.Jules/scribe.md
@@ -5,3 +5,11 @@
 ## 2025-06-05 - [Legacy Fallback Testing]
 **Learning:** Some models maintain legacy fallback logic (e.g., parsing string-based `error_message` when `processing_metadata` is null). Testing these ensures backward compatibility during migrations.
 **Action:** Use `grep` to find these legacy patterns and explicitly test them alongside modern implementations.
+
+## 2026-06-15 - [Enum Inference Testing]
+**Learning:** For Enums that provide domain categorization via inference (e.g. `ServiceSectionType::inferFromTitle`), unit tests should cover both direct keyword matches and case-insensitivity to ensure robust classification.
+**Action:** Always include a dedicated unit test for Enums that contain logic beyond simple case definitions.
+
+## 2026-06-15 - [Model Precedence Testing]
+**Learning:** Testing methods like `semanticSectionType` which combine explicit property checks, type mapping, and fuzzy inference requires multiple test cases to verify the correct precedence order (Explicit property > Type match > Fuzzy inference).
+**Action:** Write separate test methods for each level of precedence in the model to ensure behavior is exactly as intended and protected against refactoring.

--- a/tests/Integration/Models/ChurchServiceItemTest.php
+++ b/tests/Integration/Models/ChurchServiceItemTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Models;
 
 use App\Enums\ChurchServiceItemSource;
+use App\Enums\ServiceSectionType;
 use App\Models\ChurchService;
 use App\Models\ChurchServiceItem;
 use App\Models\ServiceSection;
@@ -85,5 +86,49 @@ class ChurchServiceItemTest extends TestCase
 
         $this->assertSoftDeleted('church_service_items', ['id' => $id]);
         $this->assertNotNull(ChurchServiceItem::withTrashed()->find($id)->deleted_at);
+    }
+
+    #[Test]
+    public function it_returns_explicit_semantic_section_type_when_set(): void
+    {
+        $item = ChurchServiceItem::factory()->create([
+            'section_type' => ServiceSectionType::Welcome,
+        ]);
+
+        $this->assertSame(ServiceSectionType::Welcome, $item->semanticSectionType());
+    }
+
+    #[Test]
+    public function it_infers_semantic_section_type_from_explicit_type_songs(): void
+    {
+        $item = ChurchServiceItem::factory()->create([
+            'section_type' => null,
+            'type' => 'songs',
+        ]);
+
+        $this->assertSame(ServiceSectionType::Song, $item->semanticSectionType());
+    }
+
+    #[Test]
+    public function it_infers_semantic_section_type_from_explicit_type_bibles(): void
+    {
+        $item = ChurchServiceItem::factory()->create([
+            'section_type' => null,
+            'type' => 'bibles',
+        ]);
+
+        $this->assertSame(ServiceSectionType::BibleReading, $item->semanticSectionType());
+    }
+
+    #[Test]
+    public function it_infers_semantic_section_type_from_title_when_no_explicit_type_match(): void
+    {
+        $item = ChurchServiceItem::factory()->create([
+            'section_type' => null,
+            'type' => 'custom',
+            'title' => 'Opening Prayer',
+        ]);
+
+        $this->assertSame(ServiceSectionType::Prayer, $item->semanticSectionType());
     }
 }

--- a/tests/Unit/Enums/ServiceSectionTypeTest.php
+++ b/tests/Unit/Enums/ServiceSectionTypeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\ServiceSectionType;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ServiceSectionTypeTest extends TestCase
+{
+    #[Test]
+    public function it_returns_correct_labels(): void
+    {
+        $this->assertSame('Welcome', ServiceSectionType::Welcome->label());
+        $this->assertSame('Prayer', ServiceSectionType::Prayer->label());
+        $this->assertSame('Notices', ServiceSectionType::Notices->label());
+        $this->assertSame('Song', ServiceSectionType::Song->label());
+        $this->assertSame("Children's Talk", ServiceSectionType::ChildrensTalk->label());
+        $this->assertSame('Bible Reading', ServiceSectionType::BibleReading->label());
+        $this->assertSame('Sermon', ServiceSectionType::Sermon->label());
+        $this->assertSame('Other', ServiceSectionType::Other->label());
+    }
+
+    #[Test]
+    public function it_infers_type_from_title(): void
+    {
+        $this->assertSame(ServiceSectionType::Welcome, ServiceSectionType::inferFromTitle('Welcome to our service'));
+        $this->assertSame(ServiceSectionType::Prayer, ServiceSectionType::inferFromTitle('Opening Prayer'));
+        $this->assertSame(ServiceSectionType::Notices, ServiceSectionType::inferFromTitle('Weekly Notices'));
+        $this->assertSame(ServiceSectionType::Notices, ServiceSectionType::inferFromTitle('Announcements'));
+        $this->assertSame(ServiceSectionType::ChildrensTalk, ServiceSectionType::inferFromTitle("Children's Corner"));
+        $this->assertSame(ServiceSectionType::Sermon, ServiceSectionType::inferFromTitle('Morning Sermon'));
+        $this->assertSame(ServiceSectionType::Sermon, ServiceSectionType::inferFromTitle('Today\'s Message'));
+        $this->assertSame(ServiceSectionType::Other, ServiceSectionType::inferFromTitle('Communion'));
+    }
+
+    #[Test]
+    public function it_is_case_insensitive_when_inferring_from_title(): void
+    {
+        $this->assertSame(ServiceSectionType::Welcome, ServiceSectionType::inferFromTitle('WELCOME'));
+        $this->assertSame(ServiceSectionType::Prayer, ServiceSectionType::inferFromTitle('prayer'));
+    }
+}


### PR DESCRIPTION
Add tests for church service item categorization logic in `ServiceSectionType` enum and `ChurchServiceItem` model.

---
*PR created automatically by Jules for task [12242161511704815014](https://jules.google.com/task/12242161511704815014) started by @GarethClarridge*