### PR TITLE
🧪 Steward: Harden Preacher cache tests

### DIFF
--- a/.Jules/steward.md
+++ b/.Jules/steward.md
@@ -17,3 +17,8 @@
 **Pattern:** Implementation-detail assertions (`Cache::has()`) and exact-string log assertions.
 **Cause:** Caching tests previously relied on private key names and only checked existence, not effectiveness. Log assertions used exact string matching, making them brittle to minor copy changes.
 **Fix:** Replaced `Cache::has()` with behavioral tests using `DB::enableQueryLog()` to verify zero queries on subsequent calls (after clearing internal memoization). Loosened log assertions to use `str_contains` via `withArgs` for resilience against rephrasing.
+
+## 2026-06-18 - Harden Preacher cache tests
+**Pattern:** Internal cache key assertion
+**Cause:** Previous tests used `Cache::has('key')` which is brittle and doesn't guarantee the cache is actually used by the code path.
+**Fix:** Replaced with behavioral verification using `DB::enableQueryLog()` and asserting zero subsequent queries to the 'preachers' table after cache warming.

--- a/tests/Feature/PreacherPublicCacheTest.php
+++ b/tests/Feature/PreacherPublicCacheTest.php
@@ -7,9 +7,11 @@ namespace Tests\Feature;
 use App\Models\Preacher;
 use App\Models\ScripturePassage;
 use App\Models\Sermon;
+use App\Services\Public\PreacherListCache;
 use App\Services\Public\SermonRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -20,61 +22,104 @@ class PreacherPublicCacheTest extends TestCase
     #[Test]
     public function preacher_public_list_is_cached_when_visiting_index(): void
     {
-        Cache::forget('public_preacher_list');
-        $this->assertFalse(Cache::has('public_preacher_list'));
-
         Preacher::factory()->create(['is_active' => true]);
 
-        $this->get('/christ/sermons/preachers');
+        DB::enableQueryLog();
 
-        $this->assertTrue(Cache::has('public_preacher_list'));
+        // 1. Initial hit - should trigger queries
+        DB::flushQueryLog();
+        $this->get('/christ/sermons/preachers')->assertOk();
+        $this->assertNotEmpty(DB::getQueryLog(), 'Expected the first request to trigger database queries.');
+
+        // 2. Second hit - should NOT trigger preacher queries
+        app(PreacherListCache::class)->clearInternalCaches();
+        DB::flushQueryLog();
+        $this->get('/christ/sermons/preachers')->assertOk();
+
+        $queries = collect(DB::getQueryLog());
+        $preacherQueries = $queries->filter(fn ($q) => str_contains($q['query'], 'preachers'));
+
+        $this->assertEmpty($preacherQueries, 'Expected the second request to be served from cache without queries to preachers table.');
     }
 
     #[Test]
     public function preacher_public_list_cache_is_invalidated_when_preacher_is_created(): void
     {
-        $this->get('/christ/sermons/preachers');
-        $this->assertTrue(Cache::has('public_preacher_list'));
+        Preacher::factory()->create(['is_active' => true]);
+        $this->get('/christ/sermons/preachers')->assertOk();
+
+        DB::enableQueryLog();
+        app(PreacherListCache::class)->clearInternalCaches();
 
         Preacher::factory()->create(['is_active' => true]);
 
-        $this->assertFalse(Cache::has('public_preacher_list'));
+        DB::flushQueryLog();
+        $this->get('/christ/sermons/preachers')->assertOk();
+
+        $queries = collect(DB::getQueryLog());
+        $preacherQueries = $queries->filter(fn ($q) => str_contains($q['query'], 'preachers'));
+
+        $this->assertNotEmpty($preacherQueries, 'Expected a new query to preachers table after a preacher was created.');
     }
 
     #[Test]
     public function preacher_public_list_cache_is_invalidated_when_preacher_is_updated(): void
     {
         $preacher = Preacher::factory()->create(['is_active' => true]);
-        $this->get('/christ/sermons/preachers');
-        $this->assertTrue(Cache::has('public_preacher_list'));
+        $this->get('/christ/sermons/preachers')->assertOk();
+
+        DB::enableQueryLog();
+        app(PreacherListCache::class)->clearInternalCaches();
 
         $preacher->update(['name' => 'Updated Name']);
 
-        $this->assertFalse(Cache::has('public_preacher_list'));
+        DB::flushQueryLog();
+        $this->get('/christ/sermons/preachers')->assertOk();
+
+        $queries = collect(DB::getQueryLog());
+        $preacherQueries = $queries->filter(fn ($q) => str_contains($q['query'], 'preachers'));
+
+        $this->assertNotEmpty($preacherQueries, 'Expected a new query to preachers table after a preacher was updated.');
     }
 
     #[Test]
     public function preacher_public_list_cache_is_invalidated_when_preacher_is_deleted(): void
     {
         $preacher = Preacher::factory()->create(['is_active' => true]);
-        $this->get('/christ/sermons/preachers');
-        $this->assertTrue(Cache::has('public_preacher_list'));
+        $this->get('/christ/sermons/preachers')->assertOk();
+
+        DB::enableQueryLog();
+        app(PreacherListCache::class)->clearInternalCaches();
 
         $preacher->delete();
 
-        $this->assertFalse(Cache::has('public_preacher_list'));
+        DB::flushQueryLog();
+        $this->get('/christ/sermons/preachers')->assertOk();
+
+        $queries = collect(DB::getQueryLog());
+        $preacherQueries = $queries->filter(fn ($q) => str_contains($q['query'], 'preachers'));
+
+        $this->assertNotEmpty($preacherQueries, 'Expected a new query to preachers table after a preacher was deleted.');
     }
 
     #[Test]
     public function preacher_public_list_cache_is_invalidated_when_sermon_is_created(): void
     {
         Preacher::factory()->create(['is_active' => true]);
-        $this->get('/christ/sermons/preachers');
-        $this->assertTrue(Cache::has('public_preacher_list'));
+        $this->get('/christ/sermons/preachers')->assertOk();
+
+        DB::enableQueryLog();
+        app(PreacherListCache::class)->clearInternalCaches();
 
         Sermon::factory()->create();
 
-        $this->assertFalse(Cache::has('public_preacher_list'));
+        DB::flushQueryLog();
+        $this->get('/christ/sermons/preachers')->assertOk();
+
+        $queries = collect(DB::getQueryLog());
+        $preacherQueries = $queries->filter(fn ($q) => str_contains($q['query'], 'preachers'));
+
+        $this->assertNotEmpty($preacherQueries, 'Expected a new query to preachers table after a sermon was created.');
     }
 
     #[Test]

--- a/tests/Integration/Services/PreacherListCacheTest.php
+++ b/tests/Integration/Services/PreacherListCacheTest.php
@@ -30,24 +30,25 @@ class PreacherListCacheTest extends TestCase
     #[Test]
     public function it_returns_active_preachers_for_admin_list_and_caches_the_result(): void
     {
-        Cache::forget(PreacherListCache::ADMIN_LIST_CACHE_KEY);
         Preacher::query()->delete();
 
         $preacherA = Preacher::factory()->create(['name' => 'Zack', 'is_active' => true]);
         $preacherB = Preacher::factory()->create(['name' => 'Adam', 'is_active' => true]);
         Preacher::factory()->inactive()->create(['name' => 'Inactive']);
 
-        // First call populates the cache
         DB::enableQueryLog();
-        $this->repository->forAdminList();
-        $this->assertNotEmpty(DB::getQueryLog());
-        DB::flushQueryLog();
 
-        // Second call (clearing internal memoization) should hit cache
-        $this->repository->clearInternalCaches();
+        // 1. Initial call - should trigger DB query
+        DB::flushQueryLog();
         $list = $this->repository->forAdminList();
 
-        $this->assertCount(0, DB::getQueryLog());
+        $this->assertNotEmpty(DB::getQueryLog(), 'Expected the first call to trigger a database query.');
+
+        // 2. Second call (with internal cache cleared) - should NOT trigger DB query
+        $this->repository->clearInternalCaches();
+        DB::flushQueryLog();
+        $this->repository->forAdminList();
+        $this->assertEmpty(DB::getQueryLog(), 'Expected the second call to be served from the cache without database queries.');
 
         $this->assertCount(2, $list);
         $this->assertEquals(['Adam', 'Zack'], $list->values()->all());
@@ -58,7 +59,6 @@ class PreacherListCacheTest extends TestCase
     #[Test]
     public function it_returns_active_preachers_with_sermon_counts_for_public_list_and_caches_the_result(): void
     {
-        Cache::forget(PreacherListCache::PUBLIC_LIST_CACHE_KEY);
         Preacher::query()->delete();
         Sermon::query()->delete();
 
@@ -79,23 +79,31 @@ class PreacherListCacheTest extends TestCase
             'content_type' => SermonContentType::ChildrensTalk,
         ]);
 
-        // First call populates the cache
         DB::enableQueryLog();
-        $this->repository->forPublicList();
-        $this->assertNotEmpty(DB::getQueryLog());
-        DB::flushQueryLog();
 
-        // Second call (clearing internal memoization) should hit cache
-        $this->repository->clearInternalCaches();
+        // 1. Initial call - should trigger DB query
+        DB::flushQueryLog();
         $list = $this->repository->forPublicList();
 
-        $this->assertCount(0, DB::getQueryLog());
+        $this->assertNotEmpty(DB::getQueryLog(), 'Expected the first call to trigger a database query.');
+
+        // 2. Second call (with internal cache cleared) - should NOT trigger DB query
+        $this->repository->clearInternalCaches();
+        DB::flushQueryLog();
+        $this->repository->forPublicList();
+        $this->assertEmpty(DB::getQueryLog(), 'Expected the second call to be served from the cache without database queries.');
 
         $this->assertCount(2, $list);
-        $this->assertEquals('Preacher A', $list->first()->name);
-        $this->assertEquals(2, $list->first()->sermons_count);
-        $this->assertEquals('Preacher B', $list->last()->name);
-        $this->assertEquals(1, $list->last()->sermons_count);
+
+        $first = $list->first();
+        $last = $list->last();
+
+        $this->assertNotNull($first);
+        $this->assertNotNull($last);
+        $this->assertEquals('Preacher A', $first->name);
+        $this->assertEquals(2, $first->sermons_count);
+        $this->assertEquals('Preacher B', $last->name);
+        $this->assertEquals(1, $last->sermons_count);
     }
 
     #[Test]


### PR DESCRIPTION
💡 **What:** Replaced brittle `Cache::has()` assertions with behavior-based verification using the database query log.
🎯 **Why:** Future refactors of cache keys or internal memoization would have broken the old assertions. Behavioral testing ensures the cache actually reduces database load.
🔄 **Coverage:** Same code paths tested, more robust assertions.
✅ **Stability:** Ran 5x in a row, all passes. Verified with PHPStan and Pint.

---
*PR created automatically by Jules for task [7486479603078653425](https://jules.google.com/task/7486479603078653425) started by @GarethClarridge*