### PR TITLE
📜 Herald: Add PHPDoc type aliases to processing registry

### DIFF
--- a/.Jules/herald.md
+++ b/.Jules/herald.md
@@ -21,3 +21,7 @@
 ## 2026-06-15 - Documenting Log Parsing and Performance Summaries
 **Learning:** Documenting services that parse unstructured logs into structured data (like `ProcessingLogService`) requires precise return shapes to ensure downstream consumers (like status dashboards) can safely access nested metrics. Identifying that `timestamp` might be null in `step_metrics` (if a log entry lacks a timestamp but has performance data) was a critical catch for PHPStan accuracy.
 **Action:** Use nullable types in array shapes (`type|null`) for keys derived from logs or external inputs that might be malformed or missing.
+
+## 2026-06-18 - Centralizing Complex Array Shapes with PHPStan Types
+**Learning:** For complex data structures reused across the processing pipeline (like `RetryPlan` and `ProcessingPhase`), defining `@phpstan-type` aliases in a central registry (e.g., `ProcessingPhaseRegistry`) and leveraging `@phpstan-import-type` in consuming services ensures documentation consistency and improves static analysis precision.
+**Action:** Use `@phpstan-type` and `@phpstan-import-type` whenever a complex array shape is shared between services to prevent documentation rot. Note that `@phpstan-import-type` must be placed in the class-level PHPDoc block.

--- a/app/Services/Processing/ProcessingPhaseRegistry.php
+++ b/app/Services/Processing/ProcessingPhaseRegistry.php
@@ -13,6 +13,25 @@ use App\Models\MediaProcessingLog;
  * This class serves as the central source of truth for mapping discrete processing
  * steps to progress percentages and defining how a failed or cancelled pipeline
  * should be retried based on its last known state.
+ *
+ * @phpstan-type ProcessingPhase array{
+ *     key: string,
+ *     progress: int,
+ *     job_offset: int,
+ *     steps: list<string>,
+ *     retry_action?: 'dispatch_chain'|'dispatch_livestream_chain'|'restart_livestream',
+ *     rerun_strategy?: 'safe_to_rerun'|'targeted_reset'|'full_restart',
+ *     reset_scope?: 'analyze_segments'|'submit_to_processing'|'none'
+ * }
+ * @phpstan-type RetryPlan array{
+ *     action: 'dispatch_chain'|'dispatch_livestream_chain'|'restart_livestream'|'manual_review',
+ *     pipeline?: 'audio'|'video'|'video_auto_trim'|'livestream',
+ *     job_offset?: int,
+ *     rerun_strategy?: 'safe_to_rerun'|'targeted_reset'|'full_restart',
+ *     reset_scope?: 'analyze_segments'|'submit_to_processing'|'none',
+ *     reason_code?: string,
+ *     reason_message?: string
+ * }
  */
 class ProcessingPhaseRegistry
 {
@@ -20,15 +39,7 @@ class ProcessingPhaseRegistry
      * Retrieve the ordered collection of phases for a specific pipeline profile.
      *
      * @param  string  $pipeline  The pipeline profile (audio, video, video_auto_trim, livestream)
-     * @return list<array{
-     *     key: string,
-     *     progress: int,
-     *     job_offset: int,
-     *     steps: list<string>,
-     *     retry_action?: 'dispatch_chain'|'dispatch_livestream_chain'|'restart_livestream',
-     *     rerun_strategy?: 'safe_to_rerun'|'targeted_reset'|'full_restart',
-     *     reset_scope?: 'analyze_segments'|'submit_to_processing'|'none'
-     * }>
+     * @return list<ProcessingPhase>
      */
     public function phasesForPipeline(string $pipeline): array
     {
@@ -102,15 +113,7 @@ class ProcessingPhaseRegistry
      * or requires manual administrative review.
      *
      * @param  MediaProcessingLog  $processingLog  The failed or cancelled log
-     * @return array{
-     *     action: 'dispatch_chain'|'dispatch_livestream_chain'|'restart_livestream'|'manual_review',
-     *     pipeline?: 'audio'|'video'|'video_auto_trim'|'livestream',
-     *     job_offset?: int,
-     *     rerun_strategy?: 'safe_to_rerun'|'targeted_reset'|'full_restart',
-     *     reset_scope?: 'analyze_segments'|'submit_to_processing'|'none',
-     *     reason_code?: string,
-     *     reason_message?: string
-     * }
+     * @return RetryPlan
      */
     public function retryPlanFor(MediaProcessingLog $processingLog): array
     {
@@ -161,11 +164,7 @@ class ProcessingPhaseRegistry
     }
 
     /**
-     * @return array{
-     *     action: 'manual_review',
-     *     reason_code: string,
-     *     reason_message: string
-     * }
+     * @return RetryPlan
      */
     private function manualReviewPlan(string $reasonCode, string $reasonMessage): array
     {
@@ -176,6 +175,13 @@ class ProcessingPhaseRegistry
         ];
     }
 
+    /**
+     * Normalize processing step identifiers.
+     *
+     * Ensures that legacy or variant step formats (like those prefixed with
+     * livestream source metadata) are resolved to their canonical phase keys
+     * for registry lookup.
+     */
     private function normalizeStep(?string $step): ?string
     {
         if ($step === null || $step === '') {
@@ -204,15 +210,7 @@ class ProcessingPhaseRegistry
     }
 
     /**
-     * @return array{
-     *     key: string,
-     *     progress: int,
-     *     job_offset: int,
-     *     steps: list<string>,
-     *     retry_action?: 'dispatch_chain'|'dispatch_livestream_chain'|'restart_livestream',
-     *     rerun_strategy?: 'safe_to_rerun'|'targeted_reset'|'full_restart',
-     *     reset_scope?: 'analyze_segments'|'submit_to_processing'|'none'
-     * }|null
+     * @return ProcessingPhase|null
      */
     private function phaseForPipelineStep(string $pipeline, ?string $step): ?array
     {
@@ -230,12 +228,7 @@ class ProcessingPhaseRegistry
     }
 
     /**
-     * @return list<array{
-     *     key: string,
-     *     progress: int,
-     *     job_offset: int,
-     *     steps: list<string>
-     * }>
+     * @return list<ProcessingPhase>
      */
     private function audioPhases(): array
     {
@@ -338,12 +331,7 @@ class ProcessingPhaseRegistry
     }
 
     /**
-     * @return list<array{
-     *     key: string,
-     *     progress: int,
-     *     job_offset: int,
-     *     steps: list<string>
-     * }>
+     * @return list<ProcessingPhase>
      */
     private function videoPhases(): array
     {
@@ -469,15 +457,7 @@ class ProcessingPhaseRegistry
     }
 
     /**
-     * @return list<array{
-     *     key: string,
-     *     progress: int,
-     *     job_offset: int,
-     *     steps: list<string>,
-     *     retry_action?: 'dispatch_chain'|'dispatch_livestream_chain'|'restart_livestream',
-     *     rerun_strategy?: 'safe_to_rerun'|'targeted_reset'|'full_restart',
-     *     reset_scope?: 'analyze_segments'|'submit_to_processing'|'none'
-     * }>
+     * @return list<ProcessingPhase>
      */
     private function videoAutoTrimPhases(): array
     {
@@ -707,12 +687,7 @@ class ProcessingPhaseRegistry
     }
 
     /**
-     * @return list<array{
-     *     key: string,
-     *     progress: int,
-     *     job_offset: int,
-     *     steps: list<string>
-     * }>
+     * @return list<ProcessingPhase>
      */
     private function livestreamPhases(): array
     {

--- a/app/Services/Processing/ProcessingPhaseResetService.php
+++ b/app/Services/Processing/ProcessingPhaseResetService.php
@@ -7,18 +7,13 @@ namespace App\Services\Processing;
 use App\Models\MediaProcessingLog;
 use App\Models\Sermon;
 
+/**
+ * @phpstan-import-type RetryPlan from ProcessingPhaseRegistry
+ */
 class ProcessingPhaseResetService
 {
     /**
-     * @param  array{
-     *     action: 'dispatch_chain'|'dispatch_livestream_chain'|'restart_livestream'|'manual_review',
-     *     pipeline?: 'audio'|'video'|'video_auto_trim'|'livestream',
-     *     job_offset?: int,
-     *     rerun_strategy?: 'safe_to_rerun'|'targeted_reset'|'full_restart',
-     *     reset_scope?: 'analyze_segments'|'submit_to_processing'|'none',
-     *     reason_code?: string,
-     *     reason_message?: string
-     * }  $retryPlan
+     * @param  RetryPlan  $retryPlan
      */
     public function resetForRetry(MediaProcessingLog $processingLog, array $retryPlan): void
     {

--- a/app/Services/Processing/ProcessingRunOrchestrator.php
+++ b/app/Services/Processing/ProcessingRunOrchestrator.php
@@ -20,6 +20,8 @@ use Illuminate\Support\Facades\Log;
  * job chains or batches to their appropriate queues based on the media type.
  * Handles the logic for starting fresh runs, resuming after manual review,
  * retrying failed/cancelled runs, and user-initiated cancellations.
+ *
+ * @phpstan-import-type RetryPlan from ProcessingPhaseRegistry
  */
 class ProcessingRunOrchestrator
 {
@@ -140,6 +142,7 @@ class ProcessingRunOrchestrator
                 );
             }
 
+            /** @var RetryPlan $retryPlan */
             $retryPlan = $this->phaseRegistry->retryPlanFor($processingLog);
 
             return match ($retryPlan['action']) {
@@ -307,15 +310,7 @@ class ProcessingRunOrchestrator
     }
 
     /**
-     * @param  array{
-     *     action: 'dispatch_chain'|'dispatch_livestream_chain',
-     *     pipeline?: 'audio'|'video'|'video_auto_trim'|'livestream',
-     *     job_offset?: int,
-     *     rerun_strategy?: 'safe_to_rerun'|'targeted_reset'|'full_restart',
-     *     reset_scope?: 'analyze_segments'|'submit_to_processing'|'none',
-     *     reason_code?: string,
-     *     reason_message?: string
-     * }  $retryPlan
+     * @param  RetryPlan  $retryPlan
      */
     private function retryWithChainFromPlan(MediaProcessingLog $processingLog, array $retryPlan): ProcessingResult
     {
@@ -366,15 +361,7 @@ class ProcessingRunOrchestrator
     }
 
     /**
-     * @param  array{
-     *     action: 'manual_review',
-     *     pipeline?: 'audio'|'video'|'video_auto_trim'|'livestream',
-     *     job_offset?: int,
-     *     rerun_strategy?: 'safe_to_rerun'|'targeted_reset'|'full_restart',
-     *     reset_scope?: 'analyze_segments'|'submit_to_processing'|'none',
-     *     reason_code?: string,
-     *     reason_message?: string
-     * }  $retryPlan
+     * @param  RetryPlan  $retryPlan
      */
     private function markForManualReviewFromPlan(MediaProcessingLog $processingLog, array $retryPlan): ProcessingResult
     {


### PR DESCRIPTION
- 💡 **What:** Consistently defined complex array shapes (`RetryPlan`, `ProcessingPhase`) using `@phpstan-type` in `ProcessingPhaseRegistry` and imported them into `ProcessingRunOrchestrator` and `ProcessingPhaseResetService`.
- 🎯 **Why:** Replaces fragile, redundant inline array shapes with a single source of truth, improving static analysis and reducing documentation rot.
- 🔄 **Behavior:** No functional changes — documentation only.

---
*PR created automatically by Jules for task [15879200053704335498](https://jules.google.com/task/15879200053704335498) started by @GarethClarridge*