### PR TITLE
🏛️ Warden: Add index to sermons.duration

### DIFF
--- a/database/migrations/2026_06_18_054230_add_index_to_sermons_duration.php
+++ b/database/migrations/2026_06_18_054230_add_index_to_sermons_duration.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sermons', function (Blueprint $table) {
+            $table->index('duration');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sermons', function (Blueprint $table) {
+            $table->dropIndex(['duration']);
+        });
+    }
+};

--- a/tests/Feature/WardenSermonDurationIndexTest.php
+++ b/tests/Feature/WardenSermonDurationIndexTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class WardenSermonDurationIndexTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function test_it_has_an_index_on_sermons_duration(): void
+    {
+        $this->assertTrue(
+            Schema::hasIndex('sermons', 'sermons_duration_index'),
+            'Index sermons_duration_index does not exist on sermons table.'
+        );
+    }
+}


### PR DESCRIPTION
🏛️ Warden: Add index to sermons.duration

Added an index to the `duration` column in the `sermons` table to improve performance for queries filtering or sorting by sermon length. Verified the change with a new feature test.

💡 **What:** Added a database index to `sermons.duration`.
🎯 **Why:** To optimize queries that sort or filter sermons by their duration.
🗄️ **Migration:** `2026_06_18_054230_add_index_to_sermons_duration.php`
✅ **Verification:** `tests/Feature/WardenSermonDurationIndexTest.php` proving the index exists.
⚠️ **Rollback:** `php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [11938445642248667832](https://jules.google.com/task/11938445642248667832) started by @GarethClarridge*