### PR TITLE
♿ Aria: Fix accessible required field indicators

### DIFF
--- a/resources/views/components/checkbox.blade.php
+++ b/resources/views/components/checkbox.blade.php
@@ -31,6 +31,7 @@ $describedBy = implode(' ', $describedBy);
         <div class="text-sm leading-5">
             <label @if($id) id="{{ $id }}-label" for="{{ $id }}" @endif class="cursor-pointer font-medium text-gray-700">
                 {{ $label }}
+                @if($required) <span class="text-red-500" aria-hidden="true">*</span> @endif
             </label>
             @if($hint)
                 <p @if($id) id="{{ $id }}-hint" @endif class="text-gray-500">{{ $hint }}</p>

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -38,7 +38,7 @@ $clearLabel = 'Clear ' . ($label ?: ($attributes->get('placeholder') ?: 'input')
     @if($label)
         <label @if($id) for="{{ $id }}" @endif class="block text-sm font-medium text-gray-700 mb-1">
             {{ $label }}
-            @if($required) <span class="text-red-500">*</span> @endif
+            @if($required) <span class="text-red-500" aria-hidden="true">*</span> @endif
         </label>
     @endif
 

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -17,7 +17,7 @@ $describedBy = implode(' ', $describedBy);
     @if($label)
         <label @if($id) for="{{ $id }}" @endif class="block text-sm font-medium text-gray-700 mb-1">
             {{ $label }}
-            @if($required) <span class="text-red-500">*</span> @endif
+            @if($required) <span class="text-red-500" aria-hidden="true">*</span> @endif
         </label>
     @endif
 

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -48,7 +48,7 @@ $describedBy = implode(' ', $describedBy);
     @if($label)
         <label @if($id) for="{{ $id }}" @endif class="block text-sm font-medium text-gray-700 mb-1">
             {{ $label }}
-            @if($required) <span class="text-red-500">*</span> @endif
+            @if($required) <span class="text-red-500" aria-hidden="true">*</span> @endif
         </label>
     @endif
 


### PR DESCRIPTION
This PR improves accessibility by hiding decorative required indicators (asterisks) from screen readers. Since the input elements already have `required` or `aria-required="true"` attributes, screen readers already announce the required state. Announcing the asterisk as well is redundant and noisy.

Changes:
- Added `aria-hidden="true"` to the `*` span in `input.blade.php`, `textarea.blade.php`, and `select.blade.php`.
- Added the required asterisk (with `aria-hidden="true"`) to `checkbox.blade.php` when the `required` prop is present, ensuring UI consistency across form components.

These changes maintain the same visual appearance while providing a cleaner experience for assistive technology users.

---
*PR created automatically by Jules for task [3595847582160433234](https://jules.google.com/task/3595847582160433234) started by @GarethClarridge*