### PR TITLE
🎨 Palette: Improve empty state guidance in sermon browse

### DIFF
--- a/app/Livewire/Sermons/BrowseSermons.php
+++ b/app/Livewire/Sermons/BrowseSermons.php
@@ -111,6 +111,8 @@ class BrowseSermons extends Component
         if ($filter === 'book') {
             $this->bookFilter = null;
             $this->chapterFilter = null;
+        } elseif ($filter === 'chapter') {
+            $this->chapterFilter = null;
         } elseif ($filter === 'preacher') {
             $this->preacherFilter = null;
         } elseif ($filter === 'series') {

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -167,9 +167,17 @@
                         title="No sermons match these filters"
                         description="Try another book, chapter, preacher, or series, or clear the filters to return to the full sermon archive."
                     >
-                        <x-form-button type="button" variant="outline" size="sm" icon="x-mark" wire:click="clearFilters">
-                            Clear filters
-                        </x-form-button>
+                        <div class="flex flex-wrap justify-center gap-3">
+                            @if($bookFilter && $chapterFilter)
+                                <x-form-button type="button" variant="secondary" size="sm" icon="book-open" wire:click="removeFilter('chapter')">
+                                    Try searching all of {{ $bookFilter }}
+                                </x-form-button>
+                            @endif
+
+                            <x-form-button type="button" variant="outline" size="sm" icon="x-mark" wire:click="clearFilters">
+                                Clear all filters
+                            </x-form-button>
+                        </div>
                     </x-empty-state>
                 @else
                     <x-empty-state


### PR DESCRIPTION
This PR adds a contextual "Try searching all of [Book]" button to the sermon browse empty state when both book and chapter filters are active but return no results. It also updates the `BrowseSermons` Livewire component to support clearing just the chapter filter.

💡 **What:** Added a contextual "Try searching all of [Book]" button to the sermon browse empty state when both book and chapter filters are active but return no results.
🎯 **Why:** Helps users quickly broaden their search without losing their current book selection, making the interface more intuitive and helpful when results are missing.
♿ **Accessibility:** Follows existing patterns using semantic button roles and accessible labels.
📱 **Responsive:** The new button is wrapped in a flex-wrap container for mobile friendliness.

---
*PR created automatically by Jules for task [432808048564905263](https://jules.google.com/task/432808048564905263) started by @GarethClarridge*