### PR TITLE
📖 Editor: capitalise Baptist on church info page

### DIFF
--- a/resources/views/full-width-pages/church.blade.php
+++ b/resources/views/full-width-pages/church.blade.php
@@ -4,7 +4,7 @@
 Church
 @stop
 
-@section('meta_description', 'Learn about Crockenhill Baptist Church - who we are, when we meet, and what kind of church we are. An independent evangelical church in Kent.')
+@section('meta_description', 'Learn about Crockenhill Baptist Church - who we are, when we meet, and what kind of church we are. An independent evangelical Baptist church in Kent.')
 
 @section('canonical')
 <link rel="canonical" href="{{ url('/church') }}">
@@ -13,13 +13,13 @@ Church
 @section('meta_tags')
 <x-meta-tags
     title="Church"
-    description="Learn about Crockenhill Baptist Church - who we are, when we meet, and what kind of church we are. An independent evangelical baptist church in Kent."
+    description="Learn about Crockenhill Baptist Church - who we are, when we meet, and what kind of church we are. An independent evangelical Baptist church in Kent."
     :image="asset('/images/homepage/may2024wide.webp')"
     image-alt="Crockenhill Baptist Church members outside the church building"
 />
 <x-schema.webpage
     heading="Church"
-    description="Learn about Crockenhill Baptist Church - who we are, when we meet, and what kind of church we are. An independent evangelical baptist church in Kent."
+    description="Learn about Crockenhill Baptist Church - who we are, when we meet, and what kind of church we are. An independent evangelical Baptist church in Kent."
     :image="asset('/images/homepage/may2024wide.webp')"
 />
 
@@ -232,7 +232,7 @@ Church
     </p>
   </x-text>
 
-  <x-h3>A <i>baptist</i> church</x-h3>
+  <x-h3>A <i>Baptist</i> church</x-h3>
 
   <x-text>
     <p>


### PR DESCRIPTION
* 💡 **What:** Capitalised "Baptist" in the meta description, JSON-LD schema, and page headings in `church.blade.php`.
* 🎯 **Why:** "Baptist" is a proper noun referring to the denomination and was inconsistently lowercase in several user-facing strings.
* 🔄 **Behavior:** No functional changes — copy only.
* 📍 **Where:** `resources/views/full-width-pages/church.blade.php`.

---
*PR created automatically by Jules for task [12967336015927192788](https://jules.google.com/task/12967336015927192788) started by @GarethClarridge*