### PR TITLE
📝 Scribe: Add tests for SermonBuilder scopes and SermonSourceType enum

### DIFF
--- a/tests/Feature/Models/SermonBuilderScopesTest.php
+++ b/tests/Feature/Models/SermonBuilderScopesTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Enums\SermonSourceType;
+use App\Models\Preacher;
+use App\Models\Sermon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonBuilderScopesTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function scope_by_preacher_finds_by_denormalized_name_or_profile_relationship(): void
+    {
+        $preacher = Preacher::factory()->create(['name' => 'John Profile']);
+
+        $sermonByDenormalized = Sermon::factory()->create([
+            'preacher' => 'John Denormalized',
+            'preacher_id' => null,
+        ]);
+
+        $sermonByProfile = Sermon::factory()->create([
+            'preacher' => 'Different Name',
+            'preacher_id' => $preacher->id,
+        ]);
+
+        $sermonUnrelated = Sermon::factory()->create([
+            'preacher' => 'Someone Else',
+            'preacher_id' => null,
+        ]);
+
+        // Search by denormalized name
+        $resultsDenormalized = Sermon::byPreacher('John Denormalized')->get();
+        $this->assertTrue($resultsDenormalized->contains($sermonByDenormalized));
+        $this->assertFalse($resultsDenormalized->contains($sermonByProfile));
+
+        // Search by profile name
+        $resultsProfile = Sermon::byPreacher('John Profile')->get();
+        $this->assertTrue($resultsProfile->contains($sermonByProfile));
+        $this->assertFalse($resultsProfile->contains($sermonByDenormalized));
+    }
+
+    #[Test]
+    public function scope_by_source_type_filters_correctly(): void
+    {
+        $manual = Sermon::factory()->create(['source_type' => SermonSourceType::Manual]);
+        $livestream = Sermon::factory()->create(['source_type' => SermonSourceType::Livestream]);
+
+        $results = Sermon::bySourceType(SermonSourceType::Manual)->get();
+
+        $this->assertTrue($results->contains($manual));
+        $this->assertFalse($results->contains($livestream));
+    }
+
+    #[Test]
+    public function scope_from_livestream_filters_correctly(): void
+    {
+        $manual = Sermon::factory()->create(['source_type' => SermonSourceType::Manual]);
+        $livestream = Sermon::factory()->create(['source_type' => SermonSourceType::Livestream]);
+
+        $results = Sermon::fromLivestream()->get();
+
+        $this->assertFalse($results->contains($manual));
+        $this->assertTrue($results->contains($livestream));
+    }
+
+    #[Test]
+    public function scope_with_video_filters_correctly(): void
+    {
+        $withVideo = Sermon::factory()->create(['video_file_path' => 'videos/sermon.mp4']);
+        $withoutVideo = Sermon::factory()->create(['video_file_path' => null]);
+
+        $results = Sermon::withVideo()->get();
+
+        $this->assertTrue($results->contains($withVideo));
+        $this->assertFalse($results->contains($withoutVideo));
+    }
+
+    #[Test]
+    public function scope_with_thumbnail_filters_correctly(): void
+    {
+        $withThumbnail = Sermon::factory()->create(['thumbnail_file_path' => 'thumbnails/sermon.webp']);
+        $withoutThumbnail = Sermon::factory()->create(['thumbnail_file_path' => null]);
+
+        $results = Sermon::withThumbnail()->get();
+
+        $this->assertTrue($results->contains($withThumbnail));
+        $this->assertFalse($results->contains($withoutThumbnail));
+    }
+
+    #[Test]
+    public function scope_needs_preacher_review_filters_correctly(): void
+    {
+        $needsReview = Sermon::factory()->create(['needs_preacher_review' => true]);
+        $noReview = Sermon::factory()->create(['needs_preacher_review' => false]);
+
+        $results = Sermon::needsPreacherReview()->get();
+
+        $this->assertTrue($results->contains($needsReview));
+        $this->assertFalse($results->contains($noReview));
+    }
+
+    #[Test]
+    public function scope_for_podcast_filters_and_orders_correctly(): void
+    {
+        $older = Sermon::factory()->create([
+            'audio_file_path' => 'audio/older.mp3',
+            'date' => now()->subDays(2),
+        ]);
+        $newer = Sermon::factory()->create([
+            'audio_file_path' => 'audio/newer.mp3',
+            'date' => now()->subDay(),
+        ]);
+        $noAudio = Sermon::factory()->create([
+            'audio_file_path' => null,
+            'date' => now(),
+        ]);
+
+        $results = Sermon::forPodcast()->get();
+
+        $this->assertCount(2, $results);
+        $this->assertEquals($newer->id, $results[0]->id);
+        $this->assertEquals($older->id, $results[1]->id);
+        $this->assertFalse($results->contains($noAudio));
+    }
+}

--- a/tests/Feature/Models/SermonBuilderScopesTest.php
+++ b/tests/Feature/Models/SermonBuilderScopesTest.php
@@ -20,17 +20,11 @@ class SermonBuilderScopesTest extends TestCase
     {
         $preacher = Preacher::factory()->create(['name' => 'John Profile']);
 
-        $sermonByDenormalized = Sermon::factory()->byPreacher('John Denormalized')->create([
-            'preacher_id' => null,
-        ]);
+        $sermonByDenormalized = Sermon::factory()->byPreacher('John Denormalized')->create();
 
-        $sermonByProfile = Sermon::factory()->withPreacher($preacher)->create([
-            'preacher' => 'Different Name', // Override the factory's name-sync to test specific query branch
-        ]);
+        $sermonByProfile = Sermon::factory()->withPreacher($preacher)->byPreacher('Different Name')->create();
 
-        $sermonUnrelated = Sermon::factory()->byPreacher('Someone Else')->create([
-            'preacher_id' => null,
-        ]);
+        $sermonUnrelated = Sermon::factory()->byPreacher('Someone Else')->create();
 
         // Search by denormalized name
         $resultsDenormalized = Sermon::byPreacher('John Denormalized')->get();

--- a/tests/Feature/Models/SermonBuilderScopesTest.php
+++ b/tests/Feature/Models/SermonBuilderScopesTest.php
@@ -18,23 +18,30 @@ class SermonBuilderScopesTest extends TestCase
     #[Test]
     public function scope_by_preacher_finds_by_denormalized_name_or_profile_relationship(): void
     {
-        $preacher = Preacher::factory()->create(['name' => 'John Profile']);
+        // 1. Match via denormalized name column (even if preacher_id is null)
+        $sermonByDenormalized = Sermon::factory()->byPreacher('Denormalized Name')->create([
+            'preacher_id' => null,
+        ]);
 
-        $sermonByDenormalized = Sermon::factory()->byPreacher('John Denormalized')->create();
+        $this->assertTrue(Sermon::byPreacher('Denormalized Name')->get()->contains($sermonByDenormalized));
 
-        $sermonByProfile = Sermon::factory()->withPreacher($preacher)->byPreacher('Different Name')->create();
+        // 2. Match via linked preacher profile name (even if denormalized column is stale)
+        $preacher = Preacher::factory()->create(['name' => 'Profile Name']);
 
-        $sermonUnrelated = Sermon::factory()->byPreacher('Someone Else')->create();
+        // We use createQuietly to bypass the SermonIdentityObserver which would otherwise
+        // sync the 'preacher' string back to the profile name on save.
+        $sermonWithProfile = Sermon::factory()->withPreacher($preacher)->createQuietly([
+            'preacher' => 'Stale Name',
+        ]);
 
-        // Search by denormalized name
-        $resultsDenormalized = Sermon::byPreacher('John Denormalized')->get();
-        $this->assertTrue($resultsDenormalized->contains($sermonByDenormalized));
-        $this->assertFalse($resultsDenormalized->contains($sermonByProfile));
+        // Test matching via denormalized column
+        $this->assertTrue(Sermon::byPreacher('Stale Name')->get()->contains($sermonWithProfile));
 
-        // Search by profile name
-        $resultsProfile = Sermon::byPreacher('John Profile')->get();
-        $this->assertTrue($resultsProfile->contains($sermonByProfile));
-        $this->assertFalse($resultsProfile->contains($sermonByDenormalized));
+        // Test matching via profile relationship
+        $this->assertTrue(Sermon::byPreacher('Profile Name')->get()->contains($sermonWithProfile));
+
+        // Verify no false positives
+        $this->assertFalse(Sermon::byPreacher('Profile Name')->get()->contains($sermonByDenormalized));
     }
 
     #[Test]

--- a/tests/Feature/Models/SermonBuilderScopesTest.php
+++ b/tests/Feature/Models/SermonBuilderScopesTest.php
@@ -20,18 +20,15 @@ class SermonBuilderScopesTest extends TestCase
     {
         $preacher = Preacher::factory()->create(['name' => 'John Profile']);
 
-        $sermonByDenormalized = Sermon::factory()->create([
-            'preacher' => 'John Denormalized',
+        $sermonByDenormalized = Sermon::factory()->byPreacher('John Denormalized')->create([
             'preacher_id' => null,
         ]);
 
-        $sermonByProfile = Sermon::factory()->create([
-            'preacher' => 'Different Name',
-            'preacher_id' => $preacher->id,
+        $sermonByProfile = Sermon::factory()->withPreacher($preacher)->create([
+            'preacher' => 'Different Name', // Override the factory's name-sync to test specific query branch
         ]);
 
-        $sermonUnrelated = Sermon::factory()->create([
-            'preacher' => 'Someone Else',
+        $sermonUnrelated = Sermon::factory()->byPreacher('Someone Else')->create([
             'preacher_id' => null,
         ]);
 

--- a/tests/Unit/Enums/SermonSourceTypeTest.php
+++ b/tests/Unit/Enums/SermonSourceTypeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\SermonSourceType;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonSourceTypeTest extends TestCase
+{
+    #[Test]
+    public function it_returns_correct_labels(): void
+    {
+        $this->assertSame('Manual', SermonSourceType::Manual->label());
+        $this->assertSame('Audio Upload', SermonSourceType::AudioUpload->label());
+        $this->assertSame('Video Upload', SermonSourceType::VideoUpload->label());
+        $this->assertSame('Livestream', SermonSourceType::Livestream->label());
+    }
+
+    #[Test]
+    public function it_correctly_identifies_livestream_source(): void
+    {
+        $this->assertTrue(SermonSourceType::Livestream->isFromLivestream());
+        $this->assertFalse(SermonSourceType::Manual->isFromLivestream());
+        $this->assertFalse(SermonSourceType::AudioUpload->isFromLivestream());
+        $this->assertFalse(SermonSourceType::VideoUpload->isFromLivestream());
+    }
+}


### PR DESCRIPTION
🎯 **Coverage:** Added tests for several previously untested or under-tested code paths in `SermonBuilder` and `SermonSourceType`.

📋 **Tests added:**
- `SermonBuilderScopesTest.php`:
    - `scope_by_preacher_finds_by_denormalized_name_or_profile_relationship`: Verifies both denormalized and profile-based preacher filtering.
    - `scope_by_source_type_filters_correctly`: Verifies filtering by source type enum.
    - `scope_from_livestream_filters_correctly`: Verifies specific livestream filtering.
    - `scope_with_video_filters_correctly`: Verifies video file path presence filtering.
    - `scope_with_thumbnail_filters_correctly`: Verifies thumbnail file path presence filtering.
    - `scope_needs_preacher_review_filters_correctly`: Verifies review status filtering.
    - `scope_for_podcast_filters_and_orders_correctly`: Verifies audio presence filtering and date-based ordering.
- `SermonSourceTypeTest.php`:
    - `it_returns_correct_labels`: Verifies human-readable labels for all enum cases.
    - `it_correctly_identifies_livestream_source`: Verifies the `isFromLivestream()` helper method.

🔍 **Why:** These code paths are critical for the public-facing sermon index, podcast feed, and admin review workflow. Ensuring their integrity prevents regressions in how sermons are discovered and displayed to users.

✅ **Results:** All 9 new tests pass (along with relevant existing tests), Pint formatting is applied, and PHPStan remains at 0 errors.

---
*PR created automatically by Jules for task [15788881407281233521](https://jules.google.com/task/15788881407281233521) started by @GarethClarridge*