### PR TITLE
📜 Herald: Add PHPDoc to SermonProcessingStepTransitions

### DIFF
--- a/app/Services/Processing/SermonProcessingStepTransitions.php
+++ b/app/Services/Processing/SermonProcessingStepTransitions.php
@@ -7,8 +7,28 @@ namespace App\Services\Processing;
 use App\Enums\ProcessingStatus;
 use App\Models\SermonProcessingStep;
 
+/**
+ * Service for managing the lifecycle and state transitions of individual
+ * processing steps within a media processing run.
+ *
+ * Provides a structured API for recording the progress of discrete pipeline
+ * operations (e.g. extraction, transcription, analysis) into the
+ * `sermon_processing_steps` table. These records provide granular
+ * observability beyond the high-level status of the `MediaProcessingLog`.
+ */
 class SermonProcessingStepTransitions
 {
+    /**
+     * Record that a specific processing step has started.
+     *
+     * Creates a new step record or updates an existing one, setting its status
+     * to 'started' and recording the current timestamp.
+     *
+     * @param  string  $processingId  The unique processing identifier
+     * @param  string  $step  The identifier for the step being recorded
+     * @param  string|null  $message  Optional context or details about the start
+     * @return SermonProcessingStep The updated or created step record
+     */
     public function markAsStarted(string $processingId, string $step, ?string $message = null): SermonProcessingStep
     {
         return SermonProcessingStep::query()->updateOrCreate(
@@ -25,6 +45,14 @@ class SermonProcessingStepTransitions
         );
     }
 
+    /**
+     * Record that a specific processing step has completed successfully.
+     *
+     * @param  string  $processingId  The unique processing identifier
+     * @param  string  $step  The identifier for the step being recorded
+     * @param  string|null  $message  Optional completion details
+     * @return SermonProcessingStep The updated step record
+     */
     public function markAsCompleted(string $processingId, string $step, ?string $message = null): SermonProcessingStep
     {
         return $this->fillAndSave(
@@ -35,6 +63,14 @@ class SermonProcessingStepTransitions
         );
     }
 
+    /**
+     * Record that a specific processing step has failed.
+     *
+     * @param  string  $processingId  The unique processing identifier
+     * @param  string  $step  The identifier for the step being recorded
+     * @param  string  $errorMessage  Descriptive error message for the failure
+     * @return SermonProcessingStep The updated step record
+     */
     public function markAsFailed(string $processingId, string $step, string $errorMessage): SermonProcessingStep
     {
         return $this->fillAndSave(
@@ -45,6 +81,17 @@ class SermonProcessingStepTransitions
         );
     }
 
+    /**
+     * Record that a specific processing step was intentionally skipped.
+     *
+     * Used when a step is not required for a specific media type or when
+     * cached results are already available.
+     *
+     * @param  string  $processingId  The unique processing identifier
+     * @param  string  $step  The identifier for the step being recorded
+     * @param  string|null  $message  Optional reason for skipping the step
+     * @return SermonProcessingStep The updated step record
+     */
     public function markAsSkipped(string $processingId, string $step, ?string $message = null): SermonProcessingStep
     {
         return $this->fillAndSave(
@@ -55,6 +102,14 @@ class SermonProcessingStepTransitions
         );
     }
 
+    /**
+     * Record that a specific processing step was cancelled.
+     *
+     * @param  string  $processingId  The unique processing identifier
+     * @param  string  $step  The identifier for the step being recorded
+     * @param  string|null  $message  Optional cancellation reason (defaults to 'Cancelled by user')
+     * @return SermonProcessingStep The updated step record
+     */
     public function markAsCancelled(string $processingId, string $step, ?string $message = null): SermonProcessingStep
     {
         $stepLog = SermonProcessingStep::query()->firstOrNew([


### PR DESCRIPTION
💡 **What:** Added comprehensive PHPDoc to the `SermonProcessingStepTransitions` service.
🎯 **Why:** This core service was completely undocumented, making it harder for developers to understand how discrete media processing steps are tracked and transitioned. These docblocks provide essential context on its role in pipeline observability.
🔄 **Behavior:** No functional changes — documentation only.

---
*PR created automatically by Jules for task [10220794616313493435](https://jules.google.com/task/10220794616313493435) started by @GarethClarridge*