### PR TITLE
⚡ Bolt: [performance improvement] Optimize Sitemap and Page queries

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -36,7 +36,17 @@ class PageController extends Controller
         }
 
         // Fetch the landing page for this area (where slug equals area)
-        $page = Page::query()->where('slug', $area)->where('area', $area)->first();
+        /**
+         * Performance Optimization: Limits retrieved columns for the page to required
+         * fields for visibility checks, read models, and view rendering to reduce
+         * memory usage and DB I/O.
+         */
+        $page = Page::query()
+            ->select(['id', 'slug', 'heading', 'area', 'admin', 'navigation', 'description', 'created_at', 'updated_at', 'body', 'markdown'])
+            ->where('slug', $area)
+            ->where('area', $area)
+            ->first();
+
         if (! $page instanceof Page) {
             if ($area === PageArea::Members->value && ! Auth::check()) {
                 // Even if no landing page exists, protect the members area by default
@@ -70,7 +80,16 @@ class PageController extends Controller
      */
     public function show(string $area, string $slug): Response
     {
-        $page = Page::query()->where('slug', $slug)->where('area', $area)->firstOrFail();
+        /**
+         * Performance Optimization: Limits retrieved columns for the page to required
+         * fields for visibility checks, read models, and view rendering to reduce
+         * memory usage and DB I/O.
+         */
+        $page = Page::query()
+            ->select(['id', 'slug', 'heading', 'area', 'admin', 'navigation', 'description', 'created_at', 'updated_at', 'body', 'markdown'])
+            ->where('slug', $slug)
+            ->where('area', $area)
+            ->firstOrFail();
 
         if ($redirect = $this->publicPageVisibilityGuard->enforce($page)) {
             return $redirect;

--- a/app/Services/Public/SitemapService.php
+++ b/app/Services/Public/SitemapService.php
@@ -132,7 +132,7 @@ class SitemapService
          * keeping memory usage low for sites with large numbers of sermons.
          */
         $sermons = Sermon::query()
-            ->select(['id', 'title', 'date', 'slug', 'updated_at', 'audio_file_path', 'video_file_path', 'video_quality_status', 'video_visibility_override', 'thumbnail_file_path', 'thumbnail_generated_at', 'thumbnail_metadata', 'summary', 'show_summary', 'duration', 'preacher', 'preacher_id', 'reference', 'series', 'meta_description', 'content_type', 'scripture_passage_id'])
+            ->select(['id', 'title', 'date', 'slug', 'service', 'updated_at', 'audio_file_path', 'video_file_path', 'video_quality_status', 'video_visibility_override', 'thumbnail_file_path', 'thumbnail_generated_at', 'thumbnail_metadata', 'summary', 'show_summary', 'duration', 'preacher', 'preacher_id', 'reference', 'series', 'meta_description', 'content_type', 'scripture_passage_id'])
             ->with([
                 'preacherProfile:id,name,slug,image_path',
                 'scripturePassage:id,display_reference,normalized_reference',
@@ -167,6 +167,7 @@ class SitemapService
                 'sermons.title',
                 'sermons.date',
                 'sermons.slug',
+                'sermons.service',
                 'sermons.thumbnail_file_path',
                 'sermons.thumbnail_generated_at',
                 'sermons.thumbnail_metadata',
@@ -291,9 +292,11 @@ class SitemapService
                         'sermons.title',
                         'sermons.date',
                         'sermons.slug',
+                        'sermons.service',
                         'sermons.audio_file_path',
                         'sermons.thumbnail_file_path',
                         'sermons.thumbnail_generated_at',
+                        'sermons.thumbnail_metadata',
                         'sermons.video_file_path',
                         'sermons.video_visibility_override',
                         'sermons.video_quality_status',
@@ -327,6 +330,7 @@ class SitemapService
                 'title',
                 'date',
                 'slug',
+                'service',
                 'series',
                 'thumbnail_file_path',
                 'thumbnail_generated_at',


### PR DESCRIPTION
This PR implements two performance improvements:

1. **SitemapService Optimization**: Added missing 'service' and 'thumbnail_metadata' columns to Sermon queries in `app/Services/Public/SitemapService.php`. This ensures that the presenters and SEO metadata generators (like `SermonViewPresenter::metaDescription`) have the required data upfront, preventing silent missing-data fallbacks or potential lazy-loading during sitemap generation.

2. **PageController Optimization**: Implemented column limiting in `app/Http/Controllers/PageController.php` for the `showPage` and `show` methods. This reduces memory usage and DB I/O by only fetching columns required for visibility checks, read models, and view rendering.

Verification:
- Ran `php artisan test --compact tests/Feature/SitemapTest.php tests/Feature/PageControllerTest.php` (All 34 tests passed).
- Ran `vendor/bin/pint --dirty` (0 files modified).
- Ran `composer phpstan` (0 errors).

---
*PR created automatically by Jules for task [15812314981256201095](https://jules.google.com/task/15812314981256201095) started by @GarethClarridge*