### PR TITLE
🏛️ Warden: Add composite index to sermons(preacher_id, date)

### DIFF
--- a/database/migrations/2026_06_19_054923_add_preacher_id_date_index_to_sermons_table.php
+++ b/database/migrations/2026_06_19_054923_add_preacher_id_date_index_to_sermons_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sermons', function (Blueprint $table) {
+            $table->index(['preacher_id', 'date'], 'sermons_preacher_id_date_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sermons', function (Blueprint $table) {
+            $table->dropIndex('sermons_preacher_id_date_index');
+        });
+    }
+};

--- a/tests/Feature/DataIntegrity/SermonPreacherIndexTest.php
+++ b/tests/Feature/DataIntegrity/SermonPreacherIndexTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Feature\DataIntegrity;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class SermonPreacherIndexTest extends TestCase
 {
+    use RefreshDatabase;
+
     #[Test]
     public function it_has_the_preacher_id_and_date_composite_index(): void
     {

--- a/tests/Feature/DataIntegrity/SermonPreacherIndexTest.php
+++ b/tests/Feature/DataIntegrity/SermonPreacherIndexTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\DataIntegrity;
+
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonPreacherIndexTest extends TestCase
+{
+    #[Test]
+    public function it_has_the_preacher_id_and_date_composite_index(): void
+    {
+        $this->assertTrue(
+            Schema::hasIndex('sermons', 'sermons_preacher_id_date_index'),
+            'The sermons table should have a composite index on [preacher_id, date].'
+        );
+    }
+}


### PR DESCRIPTION
💡 **What:** Added a composite index on `(preacher_id, date)` to the `sermons` table.
🎯 **Why:** This optimizes preacher-specific sermon listings and improves the performance of relationship resolution, such as `Preacher::latestSermon()`.
🗄️ **Migration:** `database/migrations/2026_06_19_054923_add_preacher_id_date_index_to_sermons_table.php`
✅ **Verification:** Added `tests/Feature/DataIntegrity/SermonPreacherIndexTest.php` to verify index existence. Ran full test suite.
⚠️ **Rollback:** `php8.4 artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [11063836961144598939](https://jules.google.com/task/11063836961144598939) started by @GarethClarridge*