### PR TITLE
Add GA4 consent, pageview correctness, and event tracking

### DIFF
--- a/docs/operations/SEO_SETUP_GUIDE.md
+++ b/docs/operations/SEO_SETUP_GUIDE.md
@@ -124,6 +124,60 @@ Google Analytics 4 (GA4) provides insights into user behavior on your website.
 2. In GA4, go to "Reports" > "Realtime"
 3. You should see your visit appear within a few seconds
 
+### 8. Cookie Consent (Consent Mode v2)
+
+Analytics cookies are **not** "strictly necessary" under UK PECR/ICO guidance, so
+they require opt-in consent. The site implements this with Google Consent Mode v2,
+no third-party package:
+
+- On every page where `GOOGLE_ANALYTICS_ID` is set, `analytics_storage` defaults
+  to **`denied`**. GA still loads and sends cookieless, modelled pings.
+- A bespoke banner (`<x-cookie-consent>`) asks the visitor to **Accept** or
+  **Decline**. The choice is stored in `localStorage` (`cbc_analytics_consent`)
+  and persists across visits; the banner does not reappear once a choice is made.
+- **Accept** calls `gtag('consent', 'update', { analytics_storage: 'granted' })`
+  and switches GA to cookie-based measurement. **Decline** keeps storage denied.
+- No banner and no GA renders when `GOOGLE_ANALYTICS_ID` is unset (e.g. locally).
+
+The whole client-side integration lives in `resources/js/analytics.js`.
+
+### 9. Custom Events
+
+GA4 Enhanced Measurement does not track native `<audio>`/`<video>` players or our
+extension-less asset routes, so the site emits these explicitly:
+
+| Event | Fires when |
+|-------|-----------|
+| `page_view` | Each navigation (incl. `wire:navigate` hops — fired on `livewire:navigated`, not the one-time `config`) |
+| `sermon_play` | A sermon/children's-talk `<audio>`/`<video>` starts playing (once per element) |
+| `sermon_download` | The "Download audio" link is clicked |
+| `transcript_download` | An automated transcript is opened and fetched |
+| `share` | A copy-to-clipboard button annotated with `analytics` succeeds |
+| `podcast_subscribe` | Reserved — wired in JS, but no visible subscribe link exists yet (podcast pickup is better measured server-side; see the GA5 plan phase) |
+
+**Mark as key events (conversions)** in GA4 admin → Events: `sermon_play` and
+`podcast_subscribe` (confirm with stakeholders before enabling).
+
+### 10. Custom Dimensions (required for reporting)
+
+`sermon_play` and `page_view` carry these event params. They are collected
+immediately but **only reportable once registered** as event-scoped custom
+dimensions. In GA4: **Admin → Custom definitions → Create custom dimensions**, scope
+**Event**, for each:
+
+| Dimension name | Event parameter |
+|----------------|-----------------|
+| Preacher | `preacher` |
+| Series | `series` |
+| Service | `service` |
+| Content type | `content_type` |
+
+`content_group` is also set per page (`Sermons` / `Children's Corner`) and is
+reportable via the built-in **Content group** dimension without registration.
+
+After registering, confirm values populate in **Admin → DebugView** (the source of
+truth for verifying events and dimensions land).
+
 ---
 
 ## Google Business Profile Setup

--- a/docs/plans/GOOGLE-ANALYTICS-ENHANCEMENT-2026-06-19.md
+++ b/docs/plans/GOOGLE-ANALYTICS-ENHANCEMENT-2026-06-19.md
@@ -1,0 +1,369 @@
+# Google Analytics Enhancement (2026-06-19)
+
+Created 2026-06-19 from an assessment of the current GA4 integration. Turns the
+"better use of Google Analytics" backlog into ordered, independently-shippable
+phases (`GA1…GA6`).
+
+## Recommendation
+
+The site has a clean but **minimal** GA4 install: one deferred `gtag('config', …)`
+call and nothing else. That yields automatic pageviews and zero insight into the
+content that defines a church website — sermon listens, downloads, podcast pickup,
+and which preacher/series drives engagement. Two of those pageviews are also
+**counted wrongly** because of the SPA navigation model (see Background).
+
+This plan does six things, in priority order:
+
+1. **GA1 — Consent.** Add a cookie-consent banner + Google Consent Mode v2 so
+   analytics cookies only fire after opt-in. *(Compliance, not just an
+   enhancement — see Privacy & Compliance.)*
+2. **GA2 — Pageview correctness.** Fire `page_view` on `livewire:navigated` and
+   extract the inline snippet into a testable `resources/js/analytics.js` module.
+   **Technical prerequisite for GA3–GA4.**
+3. **GA3 — Event tracking.** `sermon_play`, `sermon_download`,
+   `transcript_download`, `podcast_subscribe`, `share`.
+4. **GA4 — Content grouping & custom dimensions.** Attach `preacher`, `series`,
+   `service`, `content_type` to events and set `content_group`.
+5. **GA5 — Server-side Measurement Protocol** for podcast / direct-download
+   listens that never touch browser JS. *(Higher effort, optional.)*
+6. **GA6 — GA4 property configuration & docs.** Register custom dimensions, mark
+   key events as conversions, update the SEO guide. *(No app code; without it the
+   data from GA3–GA5 is collected but not reportable.)*
+
+GA2–GA4 are the value sweet-spot: modest effort, and they convert GA from a
+hit-counter into something that answers real questions about the preaching
+archive. GA1 is the highest *priority* (legal), and is technically independent of
+the rest, so it can land in parallel.
+
+## Background — current state (measured 2026-06-19)
+
+- **The whole integration** is one block in
+  [resources/views/layouts/main.blade.php:66-87](../../resources/views/layouts/main.blade.php#L66-L87).
+  It reads `config('services.google_analytics.measurement_id')`
+  ([config/services.php:49-51](../../config/services.php#L49-L51), from
+  `GOOGLE_ANALYTICS_ID`), defers the `gtag.js` load until after `window load`
+  + 100 ms (a deliberate, good LCP optimisation — **keep it**), then fires a bare
+  `gtag('config', …)`.
+- **CSP already allows the Google hosts** —
+  [app/Http/Middleware/SecurityHeaders.php:68-71](../../app/Http/Middleware/SecurityHeaders.php#L68-L71)
+  permits `googletagmanager.com` (`script-src`, `img-src`) and
+  `*.google-analytics.com` (`connect-src`). No CSP change is needed for any
+  *client-side* phase here. (GA5 is server-side and not subject to CSP.)
+- **Existing tests:**
+  [tests/Feature/SeoMetaTagsTest.php:123-143](../../tests/Feature/SeoMetaTagsTest.php#L123-L143)
+  assert the tag appears when configured and is absent otherwise. These must keep
+  passing through every phase.
+- **Production-only:** `GOOGLE_ANALYTICS_ID` is commented out in `.env` /
+  `.env.example`, so GA is inert locally. All client phases must stay no-ops when
+  the ID is unset.
+
+### The two correctness problems a bare `config` call leaves behind
+
+1. **Pageviews are undercounted.** The site navigates via `wire:navigate`
+   (61 uses across 32 files, 16 in the nav alone), so internally it behaves like
+   an SPA — Livewire swaps the `<body>` with no full document load. The GA snippet
+   fires on `window load`, which happens **once**. A visitor who browses five
+   sermons registers as **one** pageview. The codebase already solves this exact
+   problem for a different script:
+   [resources/js/scripture-fums.js:8-15,48](../../resources/js/scripture-fums.js#L8-L15)
+   listens to `livewire:navigated` precisely because it "covers both the initial
+   page load and all subsequent wire:navigate transitions" and documents how to
+   avoid double-counting the first render. GA must follow that precedent.
+
+2. **The content events are invisible.** GA4 Enhanced Measurement only auto-tracks
+   *embedded YouTube*, never native `<audio>`/`<video>`. The sermon players are
+   native elements
+   ([resources/views/sermons/sermon.blade.php:86,92](../../resources/views/sermons/sermon.blade.php#L86-L98)),
+   so **sermon listens — the single most important metric — are untracked**.
+   Likewise, auto `file_download` matches on URL *extension*; audio/transcript are
+   served by extension-less controller routes
+   (`/{sermon}/audio`, `/{sermon}/transcript` →
+   [app/Http/Controllers/SermonAssetController.php:35,59](../../app/Http/Controllers/SermonAssetController.php#L35-L93)),
+   so downloads never fire either.
+
+## Quality Gates (run for every phase that touches the relevant area)
+
+1. `vendor/bin/sail bin pint --dirty --format agent`
+2. `vendor/bin/sail composer phpstan` — must stay at 0 errors.
+3. `vendor/bin/sail artisan test --compact --parallel <focused paths>`, then a full
+   `--parallel` run before merge.
+4. `vendor/bin/sail artisan dusk` — for GA1 (consent banner) and any phase touching
+   public sermon routes or the layout. Run `vendor/bin/sail npm run build` before
+   Dusk for phases that change `resources/js`.
+
+## Privacy & Compliance (drives GA1)
+
+Under UK PECR / ICO guidance, analytics cookies are **not** "strictly necessary",
+so they require **opt-in consent**. The site currently sets GA cookies with no
+banner and no Consent Mode — a real compliance gap for a UK church, independent of
+the data-quality work. GA1 is therefore the highest-priority phase even though it
+adds the least analytical value. The recommended approach is **bespoke** (Alpine
+banner + Google Consent Mode v2, no new dependency); `spatie/laravel-cookie-consent`
+is an alternative but predates Consent Mode v2 and would need dependency approval
+per `AGENTS.md`.
+
+## Decisions to confirm before starting
+
+1. **Consent UX (GA1):** accept/reject banner wording, and whether a "reject"
+   choice is remembered for the same duration as "accept". *Recommended:* simple
+   two-button banner ("Accept" / "Decline"), choice stored 12 months.
+2. **Conversions (GA6):** which events count as "key events" in GA4. *Recommended:*
+   `sermon_play` and `podcast_subscribe`.
+3. **Server-side tracking (GA5):** do we want podcast/direct-download listens
+   measured at all? It needs a GA4 Measurement Protocol API secret and careful
+   Range-request handling. *Recommended:* yes, but ship it last and behind a flag.
+
+---
+
+## Phase GA1 — Consent banner + Google Consent Mode v2
+
+**Priority: Highest (compliance) · Risk: Low · Effort: M · Status: ☐ Not started**
+Technically independent of GA2–GA6; can land first or in parallel.
+
+### Rationale
+Analytics cookies need opt-in consent (see Privacy & Compliance). Consent Mode v2
+is the Google-native mechanism: GA loads but is told storage is `denied` until the
+user opts in, at which point we update to `granted`.
+
+### Approach
+- Set `gtag('consent', 'default', { analytics_storage: 'denied' })` **before** the
+  `gtag('config', …)` call (ordering matters — default consent must be registered
+  before config runs). This slots into the existing deferred loader.
+- A small Alpine banner component persists the choice (localStorage + a first-party
+  cookie for server awareness if needed) and, on "Accept", calls
+  `gtag('consent', 'update', { analytics_storage: 'granted' })`.
+- Banner is suppressed once a choice exists. No banner renders when
+  `GOOGLE_ANALYTICS_ID` is unset (nothing to consent to).
+
+### Target files
+- `resources/views/components/cookie-consent.blade.php` — **new** Alpine banner.
+- `resources/js/analytics.js` — **new** (shared with GA2); houses the
+  `grantConsent()` / `denyConsent()` helpers and the default-consent bootstrap.
+- [resources/views/layouts/main.blade.php](../../resources/views/layouts/main.blade.php)
+  — set `consent` default before `config`; render `<x-cookie-consent />`.
+
+### Tasks
+- [ ] Build `<x-cookie-consent>` (brand tokens via the `frontend-design` skill;
+      dismissible, keyboard-accessible, `x-cloak` to avoid flash).
+- [ ] Emit `consent default … denied` ahead of `config` in the deferred loader.
+- [ ] On Accept → `consent update … granted` + persist; on Decline → persist denial.
+- [ ] Guard everything behind `@if(config('services.google_analytics.measurement_id'))`.
+
+### Verification
+- [ ] Dusk: banner shows on first visit; Accept hides it and persists across reload;
+      Decline persists and leaves `analytics_storage` denied.
+- [ ] Feature test: banner markup present when ID set, absent when unset.
+
+---
+
+## Phase GA2 — Pageview correctness + analytics module extraction
+
+**Priority: High · Risk: Low · Effort: S · Status: ☐ Not started**
+**Prerequisite for GA3 and GA4.**
+
+### Root cause
+The snippet fires once on `window load`; `wire:navigate` transitions never
+re-trigger it (see Background → correctness problem 1).
+
+### Approach
+- Add `send_page_view: false` to the `gtag('config', …)` options so the initial
+  automatic pageview doesn't fire.
+- Move the GA bootstrap + a `sendPageView()` into `resources/js/analytics.js`, and
+  fire `page_view` on `livewire:navigated` — mirroring `scripture-fums.js`, which
+  fires on initial render too, giving exactly one pageview per navigation.
+- Pass `page_path: location.pathname + location.search` and
+  `page_title: document.title` explicitly (the title changes on wire:navigate).
+- Keep the deferred-load timing and the `config('…measurement_id')` guard.
+
+### Target files
+- `resources/js/analytics.js` — **new** (shared with GA1).
+- [resources/js/app.js](../../resources/js/app.js) — `import './analytics';`.
+- [resources/views/layouts/main.blade.php:66-87](../../resources/views/layouts/main.blade.php#L66-L87)
+  — pass the measurement ID to JS (e.g. `window.__gaId`), thin the inline script to
+  just the deferred bootstrap, add `send_page_view: false`.
+
+### Tasks
+- [ ] Extract bootstrap to `analytics.js`; expose `sendPageView()`.
+- [ ] `document.addEventListener('livewire:navigated', sendPageView)`.
+- [ ] No-op cleanly when `window.__gaId` is falsy.
+
+### Verification
+- [ ] Existing `SeoMetaTagsTest` still passes (tag present/absent).
+- [ ] Manual/Dusk: `dataLayer` receives one `page_view` per `wire:navigate` hop in
+      GA4 DebugView / realtime.
+
+---
+
+## Phase GA3 — Client-side event tracking
+
+**Priority: High · Risk: Low · Effort: M · Status: ☐ Not started · Depends on GA2.**
+
+### Rationale
+Native players and extension-less routes mean the core engagement is invisible
+(Background → correctness problem 2). Add explicit events.
+
+### Events & hooks
+| Event | Trigger | Hook |
+|-------|---------|------|
+| `sermon_play` | `play` on the sermon `<audio>`/`<video>` | delegated listener on `data-analytics="sermon-media"` |
+| `sermon_download` | click on a "Download audio" link | `data-analytics="sermon-download"` |
+| `transcript_download` | transcript fetch/open | `data-analytics="transcript"` |
+| `podcast_subscribe` | click on a feed/subscribe link | `data-analytics="podcast-subscribe"` |
+| `share` | clipboard copy succeeds | hook in the copy `.then()` |
+
+### Approach
+- Add `data-analytics="…"` (+ data-* params, see GA4) to the existing markup; a
+  single delegated listener in `analytics.js` reads them and calls `gtag('event', …)`.
+  Delegation means it survives `wire:navigate` DOM swaps without re-binding.
+- For `<audio>`/`<video>`, listen for the `play` event once per element (guard a
+  `dataset.played` flag so seeking doesn't re-fire).
+- For `share`, add an optional `analytics` prop to
+  [resources/views/components/clipboard-button.blade.php:50](../../resources/views/components/clipboard-button.blade.php#L50)
+  and call `gtag('event','share', …)` inside the existing `writeText().then()`.
+
+### Target files
+- [resources/views/sermons/sermon.blade.php:86-98](../../resources/views/sermons/sermon.blade.php#L86-L98)
+  — `data-analytics` on the players; a Download link if one isn't already present.
+- [resources/views/components/clipboard-button.blade.php](../../resources/views/components/clipboard-button.blade.php)
+  — optional `share` event in the copy handler.
+- [resources/views/components/podcast-discovery.blade.php](../../resources/views/components/podcast-discovery.blade.php)
+  and any visible subscribe links — `data-analytics="podcast-subscribe"`.
+- `resources/js/analytics.js` — the delegated event dispatcher.
+
+### Tasks
+- [ ] Delegated `click`/`play` listener reading `data-analytics` + params.
+- [ ] Annotate players, download/transcript links, subscribe links, share button.
+- [ ] Respect consent (no events before `granted` — Consent Mode handles transport,
+      but skip queuing where sensible).
+
+### Verification
+- [ ] Feature/HTTP test: sermon page renders the `data-analytics` attributes
+      (asserts the *wiring*, which is PHP-testable even though the JS isn't).
+- [ ] Dusk smoke: clicking the share button pushes a `share` event to `dataLayer`.
+- [ ] Manual: events appear in GA4 DebugView.
+
+---
+
+## Phase GA4 — Content grouping & custom dimensions
+
+**Priority: Medium · Risk: Low · Effort: S–M · Status: ☐ Not started · Depends on GA2/GA3.**
+
+### Rationale
+Turns "page X got 200 views" into "Pastor Y is the most-listened preacher" and
+"the Romans series drives the most plays" — without manual URL parsing. The data is
+already on the page: `$sermonView['preacher_name']`, `$sermon->series`,
+`$sermon->service`, `$sermon->content_type`
+([sermon.blade.php:4-7,42-44](../../resources/views/sermons/sermon.blade.php#L4-L44),
+via `App\Presenters\SermonViewPresenter`).
+
+### Approach
+- Set `content_group` on the sermon `page_view` (e.g. `Sermons`, `Children's Corner`).
+- Emit `preacher`, `series`, `service`, `content_type` as **event params** on
+  `page_view` and `sermon_play`, sourced from `data-*` attributes on a page-level
+  element so JS needs no Blade-embedded scripts.
+- These params become reportable only after GA6 registers them as event-scoped
+  custom dimensions in the GA4 admin — call that dependency out in GA6.
+
+### Target files
+- `resources/views/sermons/sermon.blade.php` — `data-ga-*` attributes on a wrapper.
+- `resources/js/analytics.js` — read the wrapper's dataset into event params.
+- (Optional) a small `<x-analytics-context>` partial so other content types
+  (children's corner, songs) can supply the same dimensions consistently.
+
+### Tasks
+- [ ] Emit `data-ga-preacher/series/service/content-type` on sermon pages.
+- [ ] Merge dataset into `page_view` + `sermon_play` params.
+- [ ] Set `content_group` per content type.
+
+### Verification
+- [ ] HTTP test: attributes present with correct values for a sermon vs a
+      children's talk (factory states).
+- [ ] Manual: dimensions populate in GA4 DebugView after GA6 registration.
+
+---
+
+## Phase GA5 — Server-side Measurement Protocol (podcast & direct downloads)
+
+**Priority: Low · Risk: Medium · Effort: L · Status: ☐ Not started · Optional, ship last.**
+
+### Rationale
+Podcast apps fetch the RSS enclosure server-side and direct media hits may bypass
+the page entirely — invisible to any browser JS. The only way to count them is to
+emit GA4 Measurement Protocol events from the controller that serves the bytes.
+
+### Approach
+- A `GoogleAnalyticsMeasurementProtocol` service POSTs to
+  `https://www.google-analytics.com/mp/collect` via Laravel's HTTP client (a
+  server-to-server call — **not** subject to CSP).
+- Fire from
+  [SermonAssetController::serveAudio()/serveVideo()](../../app/Http/Controllers/SermonAssetController.php#L59-L130)
+  with a `sermon_listen` event carrying the same dimensions as GA4.
+- **Range-request guard (critical):** browsers issue many partial `Range` requests
+  per media file; only emit on the first request (no `Range` header, or
+  `Range: bytes=0-…`) to avoid one "listen" becoming dozens. Dispatch on a queued
+  job so serving latency is unaffected.
+- New env: `GOOGLE_ANALYTICS_MP_API_SECRET` (+ config under
+  `services.google_analytics.mp_api_secret`). No-op when unset.
+
+### Target files
+- `app/Services/Analytics/GoogleAnalyticsMeasurementProtocol.php` — **new**.
+- `app/Jobs/RecordSermonListen.php` — **new** (queued).
+- [config/services.php:49-51](../../config/services.php#L49-L51) — add `mp_api_secret`.
+- [app/Http/Controllers/SermonAssetController.php](../../app/Http/Controllers/SermonAssetController.php)
+  — dispatch on first (non-Range) hit.
+
+### Tasks
+- [ ] MP client with `Http::fake`-able transport; no-op without secret.
+- [ ] Range-aware dispatch + queued job.
+- [ ] Reuse the same `client_id` strategy where a cookie exists; generate otherwise.
+
+### Verification
+- [ ] Unit test (`Http::fake`): correct payload shape; **no** call without the secret.
+- [ ] Unit test: a `Range: bytes=200-` request does **not** dispatch; a fresh GET does.
+
+---
+
+## Phase GA6 — GA4 property configuration & documentation
+
+**Priority: Medium (do alongside GA3–GA5) · Risk: None (no app code) · Status: ☐ Not started.**
+
+### Rationale
+Custom event params are collected but **not reportable** until registered as
+custom dimensions in the GA4 admin, and key events aren't conversions until marked.
+This is dashboard work, but the data from GA3–GA5 is wasted without it.
+
+### Tasks
+- [ ] Register event-scoped custom dimensions: `preacher`, `series`, `service`,
+      `content_type`.
+- [ ] Mark key events as conversions (confirm list — see Decisions: likely
+      `sermon_play`, `podcast_subscribe`).
+- [ ] Confirm Enhanced Measurement settings (scroll, outbound clicks) are on and not
+      duplicating our explicit events.
+- [ ] Update
+      [docs/operations/SEO_SETUP_GUIDE.md:70-126](../../docs/operations/SEO_SETUP_GUIDE.md#L70)
+      with the event/dimension catalogue, the consent behaviour, and the
+      `GOOGLE_ANALYTICS_MP_API_SECRET` step (if GA5 ships).
+
+---
+
+## Testing strategy
+
+- **PHP/HTTP (primary):** the *wiring* is PHP-testable even though the JS isn't —
+  assert `data-analytics`/`data-ga-*` attributes render with correct values, that
+  the consent banner and GA tag appear only when the ID is set, and (GA5) test the
+  MP service with `Http::fake`. Extend `SeoMetaTagsTest` rather than duplicating it.
+- **Dusk (targeted):** consent Accept/Decline flow (GA1) and a `dataLayer` push on
+  the share button (GA3). Keep it to the flows that genuinely need a browser.
+- **Manual:** GA4 **DebugView** is the source of truth for confirming events and
+  dimensions land — list the expected events per page in the PR description.
+
+## Sequencing
+
+```
+GA1 (consent)  ─────────────┐  (independent; land first or parallel)
+GA2 (pageview fix + module) ─┴─→ GA3 (events) ─→ GA4 (dimensions) ─→ GA6 (GA admin/docs)
+GA5 (Measurement Protocol)  ───────────────────────────────────────→ (optional, last)
+```
+
+One phase per PR, each independently revertable. GA6 is partly continuous (register
+each dimension as the phase that emits it merges).

--- a/resources/js/analytics.js
+++ b/resources/js/analytics.js
@@ -119,13 +119,23 @@ function paramsFromDataset(el) {
     return params;
 }
 
+// Tracks the path of the most recent page_view so that opting in to analytics
+// does not replay a page_view that navigation has already counted.
+let lastPageViewPath = null;
+
+function pagePath() {
+    return window.location.pathname + window.location.search;
+}
+
 function sendPageView() {
     if (!window.gtag) {
         return;
     }
 
+    lastPageViewPath = pagePath();
+
     window.gtag('event', 'page_view', {
-        page_path: window.location.pathname + window.location.search,
+        page_path: lastPageViewPath,
         page_title: document.title,
         ...contentDimensions(),
     });
@@ -220,8 +230,12 @@ function grantConsent() {
     persistConsent('granted');
     if (window.gtag) {
         window.gtag('consent', 'update', { analytics_storage: 'granted' });
-        // Capture the current page now that storage is permitted.
-        sendPageView();
+        // Capture the current page now that storage is permitted, but only if
+        // navigation hasn't already counted it — otherwise opting in would
+        // double-count this page_view.
+        if (lastPageViewPath !== pagePath()) {
+            sendPageView();
+        }
     }
 }
 

--- a/resources/js/analytics.js
+++ b/resources/js/analytics.js
@@ -1,0 +1,275 @@
+/**
+ * Google Analytics 4 integration.
+ *
+ * The measurement ID is injected as `window.__gaId` by layouts/main.blade.php and
+ * only when `GOOGLE_ANALYTICS_ID` is configured, so this module is a clean no-op
+ * locally and on any environment without GA configured. The data-* annotations it
+ * reads still render in that case — they are simply inert.
+ *
+ * Responsibilities:
+ *   - Consent (GA1): Google Consent Mode v2. `analytics_storage` defaults to
+ *     'denied' until the visitor opts in through <x-cookie-consent>. The banner
+ *     calls the `window.grantConsent()` / `window.denyConsent()` helpers exposed
+ *     here.
+ *   - Pageviews (GA2): the site browses via wire:navigate, so the document only
+ *     loads once. We disable the config-time pageview (`send_page_view: false`)
+ *     and instead fire one `page_view` per navigation on `livewire:navigated`,
+ *     which also fires on the initial render — mirroring scripture-fums.js, and
+ *     giving exactly one pageview per navigation without double-counting.
+ *   - Events (GA3): a single delegated listener turns `data-analytics`
+ *     annotations on links and media elements into gtag events, surviving
+ *     wire:navigate DOM swaps without re-binding.
+ *   - Dimensions (GA4): `data-ga-*` attributes on the page's [data-ga-context]
+ *     marker are merged into `page_view` and `sermon_play` so GA4 reporting can
+ *     group by preacher / series / service / content type. These become
+ *     reportable once registered as event-scoped custom dimensions in the GA4
+ *     admin (see docs/operations/SEO_SETUP_GUIDE.md).
+ *
+ * Consent note: with Consent Mode v2, events still fire while consent is denied —
+ * Google sends cookieless, modelled pings. Granting consent switches transport to
+ * cookie-based measurement. We therefore do not gate event dispatch on consent;
+ * Consent Mode governs storage for us.
+ */
+
+// Shared with the <x-cookie-consent> Alpine banner. Keep both in sync.
+const CONSENT_STORAGE_KEY = 'cbc_analytics_consent';
+
+// Maps a `data-analytics` token (used in markup) to its GA4 event name.
+const CLICK_EVENTS = {
+    'sermon-download': 'sermon_download',
+    transcript: 'transcript_download',
+    'podcast-subscribe': 'podcast_subscribe',
+};
+
+function gaIsConfigured() {
+    return typeof window.__gaId === 'string' && window.__gaId !== '';
+}
+
+function consentChoice() {
+    try {
+        return window.localStorage.getItem(CONSENT_STORAGE_KEY);
+    } catch (e) {
+        return null;
+    }
+}
+
+function persistConsent(value) {
+    try {
+        window.localStorage.setItem(CONSENT_STORAGE_KEY, value);
+    } catch (e) {
+        // localStorage unavailable (private mode / disabled): the choice simply
+        // isn't remembered and the banner reappears next visit. Acceptable.
+    }
+}
+
+/**
+ * Reads the page-level [data-ga-context] marker (rendered by
+ * <x-analytics-context>) so page_view and sermon_play carry the same custom
+ * dimensions. Returns {} when no marker is present (e.g. non-sermon pages).
+ */
+function contentDimensions() {
+    const el = document.querySelector('[data-ga-context]');
+    if (!el) {
+        return {};
+    }
+
+    const params = {};
+    const { gaPreacher, gaSeries, gaService, gaContentType, gaContentGroup } = el.dataset;
+
+    if (gaPreacher) {
+        params.preacher = gaPreacher;
+    }
+    if (gaSeries) {
+        params.series = gaSeries;
+    }
+    if (gaService) {
+        params.service = gaService;
+    }
+    if (gaContentType) {
+        params.content_type = gaContentType;
+    }
+    if (gaContentGroup) {
+        params.content_group = gaContentGroup;
+    }
+
+    return params;
+}
+
+/**
+ * Extracts `data-ga-*` attributes from an annotated element into event params,
+ * e.g. data-ga-sermon-slug="x" -> { sermon_slug: 'x' }.
+ */
+function paramsFromDataset(el) {
+    const params = {};
+
+    Object.entries(el.dataset).forEach(([key, value]) => {
+        if (!value || !key.startsWith('ga') || key === 'gaContext') {
+            return;
+        }
+
+        const name = key
+            .slice(2)
+            .replace(/([A-Z])/g, '_$1')
+            .replace(/^_/, '')
+            .toLowerCase();
+
+        params[name] = value;
+    });
+
+    return params;
+}
+
+function sendPageView() {
+    if (!window.gtag) {
+        return;
+    }
+
+    window.gtag('event', 'page_view', {
+        page_path: window.location.pathname + window.location.search,
+        page_title: document.title,
+        ...contentDimensions(),
+    });
+}
+
+function dispatchEvent(eventName, el, extra = {}) {
+    if (!window.gtag) {
+        return;
+    }
+
+    window.gtag('event', eventName, {
+        ...contentDimensions(),
+        ...paramsFromDataset(el),
+        ...extra,
+    });
+}
+
+function loadGtagScript() {
+    if (window.__gaScriptRequested) {
+        return;
+    }
+    window.__gaScriptRequested = true;
+
+    // Defer the heavy library download to protect LCP. The gtag() shim already
+    // queues our consent/config commands on dataLayer, so they replay in order
+    // once the library loads.
+    const inject = () => {
+        setTimeout(() => {
+            const script = document.createElement('script');
+            script.src =
+                'https://www.googletagmanager.com/gtag/js?id=' + encodeURIComponent(window.__gaId);
+            script.async = true;
+            document.head.appendChild(script);
+        }, 100);
+    };
+
+    if (document.readyState === 'complete') {
+        inject();
+    } else {
+        window.addEventListener('load', inject, { once: true });
+    }
+}
+
+function registerListeners() {
+    if (window.__gaListenersBound) {
+        return;
+    }
+    window.__gaListenersBound = true;
+
+    // One page_view per navigation. Fires on the initial render too (Livewire
+    // emits livewire:navigated on first load), so config's send_page_view:false
+    // avoids a double count.
+    document.addEventListener('livewire:navigated', sendPageView);
+
+    // Delegated click events for annotated links.
+    document.addEventListener('click', (event) => {
+        const target = event.target.closest('[data-analytics]');
+        if (!target) {
+            return;
+        }
+
+        const eventName = CLICK_EVENTS[target.dataset.analytics];
+        if (eventName) {
+            dispatchEvent(eventName, target);
+        }
+    });
+
+    // sermon_play on native <audio>/<video>. The `play` event does not bubble,
+    // so we listen in the capture phase; a per-element flag keeps seeking/replay
+    // from re-firing.
+    document.addEventListener(
+        'play',
+        (event) => {
+            const el = event.target;
+            if (!el.matches || !el.matches('[data-analytics="sermon-media"]')) {
+                return;
+            }
+            if (el.dataset.analyticsPlayed === 'true') {
+                return;
+            }
+            el.dataset.analyticsPlayed = 'true';
+
+            dispatchEvent('sermon_play', el, {
+                media_type: el.tagName.toLowerCase() === 'video' ? 'video' : 'audio',
+            });
+        },
+        true
+    );
+}
+
+function grantConsent() {
+    persistConsent('granted');
+    if (window.gtag) {
+        window.gtag('consent', 'update', { analytics_storage: 'granted' });
+        // Capture the current page now that storage is permitted.
+        sendPageView();
+    }
+}
+
+function denyConsent() {
+    persistConsent('denied');
+    if (window.gtag) {
+        window.gtag('consent', 'update', { analytics_storage: 'denied' });
+    }
+}
+
+// Exposed for the consent banner and for the clipboard "share" hook. These are
+// safe no-ops when GA isn't configured (window.gtag is undefined).
+window.grantConsent = grantConsent;
+window.denyConsent = denyConsent;
+window.gaTrackEvent = (name, params = {}) => {
+    if (window.gtag) {
+        window.gtag('event', name, { ...contentDimensions(), ...params });
+    }
+};
+
+function bootstrap() {
+    if (!gaIsConfigured()) {
+        return;
+    }
+
+    window.dataLayer = window.dataLayer || [];
+    window.gtag =
+        window.gtag ||
+        function gtag() {
+            window.dataLayer.push(arguments);
+        };
+
+    // Consent default must be registered BEFORE config (ordering matters).
+    window.gtag('consent', 'default', {
+        analytics_storage: 'denied',
+        wait_for_update: 500,
+    });
+
+    // Honour a stored opt-in from a previous visit.
+    if (consentChoice() === 'granted') {
+        window.gtag('consent', 'update', { analytics_storage: 'granted' });
+    }
+
+    window.gtag('js', new Date());
+    window.gtag('config', window.__gaId, { send_page_view: false });
+
+    loadGtagScript();
+    registerListeners();
+}
+
+bootstrap();

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -2,5 +2,6 @@ import '../css/app.css';
 import './bootstrap';
 import './livewire/media-upload-controller';
 import './scripture-fums';
+import './analytics';
 
 // Alpine.js is automatically loaded by Livewire 3, no need to import it separately

--- a/resources/views/childrens-corner/show.blade.php
+++ b/resources/views/childrens-corner/show.blade.php
@@ -47,6 +47,8 @@
     @endphp
 
     <section class="space-y-8">
+        <x-analytics-context :sermon="$sermon" :preacher-name="$speakerName ?? null" />
+
         <div class="overflow-hidden rounded-2xl border border-cbc-teal/15 bg-[linear-gradient(135deg,rgba(36,154,151,0.12)_0%,rgba(29,104,106,0.08)_50%,rgba(20,85,87,0.16)_100%)] p-8 shadow-sm">
             <div class="flex flex-wrap items-start justify-between gap-6">
                 <div class="space-y-5">
@@ -110,6 +112,8 @@
                         src="{{ $sermonView['video_url'] }}"
                         class="w-full rounded-xl bg-slate-950"
                         controls
+                        data-analytics="sermon-media"
+                        data-ga-sermon-slug="{{ $sermon->slug }}"
                         @if($sermonView['thumbnail_url']) poster="{{ $sermonView['thumbnail_url'] }}" @endif
                     >
                         Your browser does not support the <code>video</code> element.
@@ -121,7 +125,12 @@
         @if ($hasAudio)
             <x-card heading="Listen">
                 <div class="not-prose">
-                    <audio src="{{ $sermonView['audio_url'] }}" class="w-full" controls>
+                    <audio
+                        src="{{ $sermonView['audio_url'] }}"
+                        class="w-full"
+                        controls
+                        data-analytics="sermon-media"
+                        data-ga-sermon-slug="{{ $sermon->slug }}">
                         Your browser does not support the <code>audio</code> element.
                     </audio>
                 </div>

--- a/resources/views/components/analytics-context.blade.php
+++ b/resources/views/components/analytics-context.blade.php
@@ -1,0 +1,42 @@
+{{--
+    Analytics context marker (GA4).
+
+    Emits a single hidden element whose data-ga-* attributes describe the content
+    on the page. resources/js/analytics.js reads [data-ga-context] and merges these
+    into page_view and sermon_play as event params / content_group, so GA4 can
+    group by preacher, series, service, and content type once the matching custom
+    dimensions are registered (see docs/operations/SEO_SETUP_GUIDE.md).
+
+    Shared across content types (sermons, children's corner) so every player page
+    supplies the same dimensions consistently.
+--}}
+@props([
+    'sermon',
+    'preacherName' => null,
+    'serviceLabel' => null,
+])
+
+@php
+    $isChildrensTalk = $sermon->content_type === \App\Enums\SermonContentType::ChildrensTalk;
+
+    $preacher = filled($preacherName) ? $preacherName : $sermon->preacher;
+
+    $service = $serviceLabel;
+    if ($service === null && $sermon->service !== null) {
+        $service = $sermon->service instanceof \App\Enums\SermonService
+            ? $sermon->service->label()
+            : \Illuminate\Support\Str::title((string) $sermon->service);
+    }
+
+    $contentGroup = $isChildrensTalk ? "Children's Corner" : 'Sermons';
+@endphp
+
+<div
+    data-ga-context
+    @if(filled($preacher)) data-ga-preacher="{{ $preacher }}" @endif
+    @if(filled($sermon->series)) data-ga-series="{{ $sermon->series }}" @endif
+    @if(filled($service)) data-ga-service="{{ $service }}" @endif
+    data-ga-content-type="{{ $sermon->content_type->value }}"
+    data-ga-content-group="{{ $contentGroup }}"
+    hidden
+></div>

--- a/resources/views/components/clipboard-button.blade.php
+++ b/resources/views/components/clipboard-button.blade.php
@@ -8,6 +8,9 @@
     'icon' => 'link',
     'copiedIcon' => 'check',
     'size' => 'sm',
+    // When set, a successful copy fires a GA `share` event carrying this value as
+    // its content_type (GA3). Leave null to opt out of analytics for this button.
+    'analytics' => null,
 ])
 
 @php
@@ -50,6 +53,11 @@ $resolvedIconSize = $iconSizeClasses[$hideLabel ? 'xs' : $size] ?? $iconSizeClas
         navigator.clipboard.writeText(textToCopy).then(() => {
             copied = true;
             setTimeout(() => copied = false, 2000);
+            @if($analytics)
+            if (window.gaTrackEvent) {
+                window.gaTrackEvent('share', { method: 'clipboard', content_type: {{ \Illuminate\Support\Js::from($analytics) }} });
+            }
+            @endif
         });
     "
     {{ $attributes->merge(['class' => $classes]) }}

--- a/resources/views/components/cookie-consent.blade.php
+++ b/resources/views/components/cookie-consent.blade.php
@@ -1,0 +1,80 @@
+{{--
+    Cookie consent banner (GA1).
+
+    Renders only when Google Analytics is configured — there is nothing to consent
+    to otherwise. Google Consent Mode v2 defaults analytics_storage to 'denied' in
+    resources/js/analytics.js; this banner persists the visitor's choice and calls
+    the grantConsent()/denyConsent() helpers that module exposes.
+
+    The localStorage key must match CONSENT_STORAGE_KEY in resources/js/analytics.js.
+--}}
+@if(config('services.google_analytics.measurement_id'))
+<div
+    x-data="{
+        show: false,
+        init() {
+            try {
+                this.show = ! window.localStorage.getItem('cbc_analytics_consent');
+            } catch (e) {
+                this.show = true;
+            }
+        },
+        accept() {
+            if (window.grantConsent) { window.grantConsent(); }
+            this.show = false;
+        },
+        decline() {
+            if (window.denyConsent) { window.denyConsent(); }
+            this.show = false;
+        },
+    }"
+    x-show="show"
+    x-cloak
+    x-transition:enter="transition ease-out duration-300"
+    x-transition:enter-start="opacity-0 translate-y-4"
+    x-transition:enter-end="opacity-100 translate-y-0"
+    x-transition:leave="transition ease-in duration-200"
+    x-transition:leave-start="opacity-100 translate-y-0"
+    x-transition:leave-end="opacity-0 translate-y-4"
+    role="dialog"
+    aria-modal="false"
+    aria-labelledby="cookie-consent-heading"
+    aria-describedby="cookie-consent-body"
+    class="fixed inset-x-0 bottom-0 z-[120] px-4 pb-4 sm:px-6 sm:pb-6"
+>
+    <div class="mx-auto max-w-3xl rounded-xl border border-gray-200 bg-white p-5 shadow-lg sm:p-6">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
+            <div class="flex items-start gap-3">
+                <x-heroicon-o-shield-check class="mt-0.5 h-6 w-6 shrink-0 text-cbc-teal" aria-hidden="true" />
+                <div class="space-y-1">
+                    <h2 id="cookie-consent-heading" class="font-display text-lg text-gray-900">
+                        Cookies &amp; analytics
+                    </h2>
+                    <p id="cookie-consent-body" class="text-sm text-gray-600">
+                        We'd like to use analytics cookies to understand how people use the site so we
+                        can improve it. These are optional and off until you accept. See our
+                        <a href="/church/privacy-notice" wire:navigate class="text-cbc-teal-dark underline decoration-cbc-teal/40 underline-offset-2 hover:text-cbc-teal">privacy notice</a>.
+                    </p>
+                </div>
+            </div>
+
+            <div class="flex shrink-0 gap-3 sm:ml-auto">
+                <button
+                    type="button"
+                    @click="decline()"
+                    class="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
+                >
+                    Decline
+                </button>
+                <button
+                    type="button"
+                    @click="accept()"
+                    class="inline-flex items-center justify-center rounded-md bg-[linear-gradient(120deg,var(--color-cbc-teal)_0%,var(--color-cbc-teal-dark)_55%,#0e3a3c_100%)] px-5 py-2 text-sm font-medium text-white transition-all hover:brightness-110 active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
+                >
+                    Accept
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+@endif

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -63,26 +63,12 @@
   <link rel="shortcut icon" href="/favicon.ico?v=GvJNbAA7Wv">
   <meta name="theme-color" content="#16324f">
 
-  {{-- Google Analytics 4 - Deferred to improve LCP --}}
+  {{-- Google Analytics 4 — bootstrapped (deferred for LCP), consent-gated, and
+       pageview/event-aware in resources/js/analytics.js. The inline script only
+       hands the measurement ID to JS so the module can no-op when GA is unset. --}}
   @if(config('services.google_analytics.measurement_id'))
   <script>
-    // Load GA after page becomes interactive to avoid blocking LCP
-    window.addEventListener('load', function() {
-      setTimeout(function() {
-        var script = document.createElement('script');
-        script.src = 'https://www.googletagmanager.com/gtag/js?id={{ config('services.google_analytics.measurement_id') }}';
-        script.async = true;
-        document.head.appendChild(script);
-
-        script.onload = function() {
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          window.gtag = gtag;
-          gtag('js', new Date());
-          gtag('config', '{{ config('services.google_analytics.measurement_id') }}');
-        };
-      }, 100); // Small delay to ensure page is fully rendered
-    });
+    window.__gaId = @json(config('services.google_analytics.measurement_id'));
   </script>
   @endif
 
@@ -136,6 +122,8 @@
   </footer>
 
   <x-back-to-top />
+
+  <x-cookie-consent />
 
   {{-- Livewire Scripts --}}
   @livewireScripts

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -56,6 +56,11 @@
 
     <article class="space-y-6">
 
+        <x-analytics-context
+            :sermon="$sermon"
+            :preacher-name="$sermonView['preacher_name']"
+            :service-label="$sermonView['service_label'] ?? null" />
+
         {{-- ══ Row 1: Hero thumbnail / Media (full width) ══════════ --}}
 
         @if(! $hasPublicVideo && $sermonView['thumbnail_url'])
@@ -83,15 +88,33 @@
             </div>
             <div class="p-6 space-y-6">
                 @if ($hasPublicAudio)
-                <audio src="{{ $sermonView['audio_url'] }}" class="w-full rounded-lg" controls>
+                <audio
+                    src="{{ $sermonView['audio_url'] }}"
+                    class="w-full rounded-lg"
+                    controls
+                    data-analytics="sermon-media"
+                    data-ga-sermon-slug="{{ $sermon->slug }}">
                     Your browser does not support the <code>audio</code> element.
                 </audio>
+                <div>
+                    <a
+                        href="{{ $sermonView['audio_url'] }}"
+                        download
+                        data-analytics="sermon-download"
+                        data-ga-sermon-slug="{{ $sermon->slug }}"
+                        class="inline-flex items-center gap-1.5 text-sm font-medium text-cbc-teal-dark underline decoration-cbc-teal/40 underline-offset-2 transition-colors hover:text-cbc-teal focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2 rounded">
+                        <x-heroicon-o-arrow-down-tray class="h-4 w-4" aria-hidden="true" />
+                        Download audio
+                    </a>
+                </div>
                 @endif
 
                 @if ($hasPublicVideo)
                 <video src="{{ $sermonView['video_url'] }}"
                     class="w-full rounded-lg"
                     controls
+                    data-analytics="sermon-media"
+                    data-ga-sermon-slug="{{ $sermon->slug }}"
                     @if($sermonView['thumbnail_url']) poster="{{ $sermonView['thumbnail_url'] }}" @endif>
                     Your browser does not support the <code>video</code> element.
                 </video>
@@ -203,6 +226,9 @@
                                     }
                                     this.html = await response.text();
                                     this.loaded = true;
+                                    if (window.gaTrackEvent) {
+                                        window.gaTrackEvent('transcript_download', { sermon_slug: @js($sermon->slug) });
+                                    }
                                 } catch (e) {
                                     this.error = 'Transcript could not be loaded.';
                                 } finally {
@@ -352,6 +378,7 @@
                                     label="Copy reference"
                                     title="Copy Bible reference to clipboard"
                                     icon="clipboard-document"
+                                    analytics="scripture_reference"
                                 />
                             </div>
                         </div>

--- a/tests/Feature/SeoMetaTagsTest.php
+++ b/tests/Feature/SeoMetaTagsTest.php
@@ -120,26 +120,30 @@ class SeoMetaTagsTest extends TestCase
     }
 
     #[Test]
-    public function google_analytics_tag_appears_when_configured(): void
+    public function google_analytics_id_and_consent_banner_appear_when_configured(): void
     {
         config(['services.google_analytics.measurement_id' => 'G-TEST123456']);
 
         $response = $this->get('/');
 
         $response->assertStatus(200);
-        $response->assertSee('https://www.googletagmanager.com/gtag/js?id=G-TEST123456', false);
-        $response->assertSee('gtag(\'config\', \'G-TEST123456\');', false);
+        // The bootstrap now lives in resources/js/analytics.js; the layout only
+        // hands it the measurement ID. The gtag library is loaded from there.
+        $response->assertSee('window.__gaId', false);
+        $response->assertSee('G-TEST123456', false);
+        // Consent banner (GA1) only renders when there is analytics to consent to.
+        $response->assertSee('id="cookie-consent-heading"', false);
     }
 
     #[Test]
-    public function google_analytics_tag_does_not_appear_when_not_configured(): void
+    public function google_analytics_id_and_consent_banner_are_absent_when_not_configured(): void
     {
         config(['services.google_analytics.measurement_id' => null]);
 
         $response = $this->get('/');
 
         $response->assertStatus(200);
-        $response->assertDontSee('googletagmanager.com/gtag/js', false);
-        $response->assertDontSee('gtag(', false);
+        $response->assertDontSee('window.__gaId', false);
+        $response->assertDontSee('id="cookie-consent-heading"', false);
     }
 }

--- a/tests/Feature/SermonAnalyticsTrackingTest.php
+++ b/tests/Feature/SermonAnalyticsTrackingTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\SermonContentType;
+use App\Models\Sermon;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * Wiring smoke tests for the client-side Google Analytics event tracking (GA3)
+ * and content dimensions (GA4). The JavaScript itself isn't exercised here, but
+ * the data-analytics / data-ga-* attributes it reads are PHP-rendered, so we can
+ * prove the markup is wired correctly.
+ */
+class SermonAnalyticsTrackingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function sermon_page_annotates_audio_player_and_download_for_analytics(): void
+    {
+        $sermon = Sermon::factory()->withAudio()->create();
+
+        $response = $this->followingRedirects()->get(route('sermons.show', $sermon->slug));
+
+        $response->assertStatus(200);
+        $response->assertSee('data-analytics="sermon-media"', false);
+        $response->assertSee('data-analytics="sermon-download"', false);
+        $response->assertSee('data-ga-sermon-slug="'.$sermon->slug.'"', false);
+    }
+
+    #[Test]
+    public function sermon_page_emits_content_dimensions_for_a_sermon(): void
+    {
+        $sermon = Sermon::factory()->byPreacher('Mark Evans')->create([
+            'series' => 'Letters to Rome',
+            'content_type' => SermonContentType::Sermon,
+        ]);
+
+        $response = $this->followingRedirects()->get(route('sermons.show', $sermon->slug));
+
+        $response->assertStatus(200);
+        $response->assertSee('data-ga-context', false);
+        $response->assertSee('data-ga-content-type="sermon"', false);
+        $response->assertSee('data-ga-content-group="Sermons"', false);
+        $response->assertSee('data-ga-preacher="Mark Evans"', false);
+        $response->assertSee('data-ga-series="Letters to Rome"', false);
+    }
+
+    #[Test]
+    public function sermon_page_opts_in_the_reference_copy_button_as_a_share(): void
+    {
+        $sermon = Sermon::factory()->create([
+            'reference' => 'Romans 8:28',
+            'scripture_passage_id' => null,
+        ]);
+
+        $response = $this->followingRedirects()->get(route('sermons.show', $sermon->slug));
+
+        $response->assertStatus(200);
+        $response->assertSee("window.gaTrackEvent('share'", false);
+    }
+
+    #[Test]
+    public function childrens_corner_page_emits_childrens_content_group(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $talk = Sermon::factory()->withAudio()->create([
+            'content_type' => SermonContentType::ChildrensTalk,
+        ]);
+
+        $response = $this->get(route('childrens-corner.show', $talk->slug));
+
+        $response->assertStatus(200);
+        $response->assertSee('data-ga-content-type="childrens_talk"', false);
+        $response->assertSee('data-ga-content-group="Children&#039;s Corner"', false);
+    }
+}


### PR DESCRIPTION
Implements phases GA1–GA4 (plus GA6 docs) of the Google Analytics enhancement plan, turning the minimal GA4 install into a consent-gated, SPA-aware, event-rich integration.

- GA1: Google Consent Mode v2 + bespoke <x-cookie-consent> banner; analytics_storage defaults to denied until opt-in, choice persisted in localStorage. Banner only renders when GOOGLE_ANALYTICS_ID is set.
- GA2: extract the deferred bootstrap into resources/js/analytics.js, disable the config-time pageview (send_page_view: false), and fire one page_view per wire:navigate hop on livewire:navigated.
- GA3: delegated listener turns data-analytics annotations into events — sermon_play (native audio/video), sermon_download, transcript_download, share (clipboard), podcast_subscribe.
- GA4: <x-analytics-context> emits data-ga-* dimensions (preacher, series, service, content_type) and content_group, merged into page_view and sermon_play.
- GA6: SEO_SETUP_GUIDE documents consent, the event catalogue, and the custom dimensions to register in the GA4 admin.

The layout now only hands the measurement ID to JS so the whole module no-ops cleanly when GA is unconfigured. SeoMetaTagsTest updated for the new bootstrap; SermonAnalyticsTrackingTest covers the PHP-rendered wiring.