### PR TITLE
🧹 Tidy: Standardize sermon analysis types and clean up validator logic

### DIFF
--- a/app/Services/Sermon/SermonAnalysisService.php
+++ b/app/Services/Sermon/SermonAnalysisService.php
@@ -17,6 +17,24 @@ use OpenAI\Exceptions\TransporterException;
 use OpenAI\Laravel\Facades\OpenAI;
 use OpenAI\Responses\Chat\CreateResponse;
 
+/**
+ * @phpstan-type SermonAnalysisResult array{
+ *     title: string,
+ *     series: string|null,
+ *     reference: string|null,
+ *     points: list<string>,
+ *     summary: string|null,
+ *     transcript: string,
+ * }
+ * @phpstan-type RawAiAnalysisData array{
+ *     title?: mixed,
+ *     series?: mixed,
+ *     reference?: mixed,
+ *     points?: mixed,
+ *     summary?: mixed,
+ *     transcript?: mixed,
+ * }
+ */
 class SermonAnalysisService implements SermonAnalysisInterface
 {
     use SanitizesLogData;
@@ -102,14 +120,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
      * @param  string  $transcript  The sermon transcript
      * @param  array<int, string>  $existingSeries  Array of existing series names
      * @param  string  $processingId  Processing ID for logging
-     * @return array{
-     *     title: string,
-     *     series: string|null,
-     *     reference: string|null,
-     *     points: list<string>,
-     *     summary: string|null,
-     *     transcript: string,
-     * } The parsed analysis results
+     * @return SermonAnalysisResult The parsed analysis results
      *
      * @throws Exception|ErrorException|TransporterException
      */
@@ -142,14 +153,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
      * Execute a single AI analysis attempt.
      *
      * @param  array<int, string>  $existingSeries
-     * @return array{
-     *     title: string,
-     *     series: string|null,
-     *     reference: string|null,
-     *     points: list<string>,
-     *     summary: string|null,
-     *     transcript: string,
-     * }
+     * @return SermonAnalysisResult
      *
      * @throws Exception|\TypeError|ErrorException|TransporterException
      */
@@ -278,14 +282,7 @@ class SermonAnalysisService implements SermonAnalysisInterface
     /**
      * Parse and validate OpenAI API response.
      *
-     * @return array{
-     *     title?: string,
-     *     series?: string|null,
-     *     reference?: string|null,
-     *     points?: array<int, string>,
-     *     summary?: string|null,
-     *     transcript?: string,
-     * }
+     * @return RawAiAnalysisData
      *
      * @throws Exception If the response structure is invalid or JSON parsing fails
      */

--- a/app/Services/Sermon/SermonAnalysisValidator.php
+++ b/app/Services/Sermon/SermonAnalysisValidator.php
@@ -9,6 +9,10 @@ use App\Services\BritishEnglishConverter;
 use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 
+/**
+ * @phpstan-import-type SermonAnalysisResult from SermonAnalysisService
+ * @phpstan-import-type RawAiAnalysisData from SermonAnalysisService
+ */
 class SermonAnalysisValidator
 {
     use SanitizesLogData;
@@ -56,16 +60,9 @@ class SermonAnalysisValidator
      * Normalises types, applies British English spelling corrections, enforces
      * word limits on titles, and ensures a valid structure for the SermonAnalysis DTO.
      *
-     * @param  array{title?: mixed, series?: mixed, reference?: mixed, points?: mixed, summary?: mixed}  $analysisData  Raw analysis data from AI
+     * @param  RawAiAnalysisData  $analysisData  Raw analysis data from AI
      * @param  string  $originalTranscript  Original transcript for fallback
-     * @return array{
-     *     title: string,
-     *     series: string|null,
-     *     reference: string|null,
-     *     points: list<string>,
-     *     summary: string|null,
-     *     transcript: string,
-     * } Validated and cleaned analysis data
+     * @return SermonAnalysisResult Validated and cleaned analysis data
      */
     public function validateAndCleanAnalysisData(array $analysisData, string $originalTranscript): array
     {
@@ -231,13 +228,13 @@ class SermonAnalysisValidator
      */
     private function sanitizeAiNullableString(mixed $value): ?string
     {
-        if (! is_string($value)) {
+        if (! filled($value) || ! is_string($value)) {
             return null;
         }
 
         $trimmed = trim($value);
 
-        if ($trimmed === '' || strtolower($trimmed) === 'null' || strtolower($trimmed) === 'none') {
+        if (in_array(strtolower($trimmed), ['null', 'none'], true)) {
             return null;
         }
 


### PR DESCRIPTION
🧹 Tidy: Standardize sermon analysis types and clean up validator logic

This refactor addresses the "Data Clump" and "Duplication" smells in the sermon analysis services by consolidating complex array shape definitions into reusable PHPStan type aliases.

💡 **What:** 
- Defined `@phpstan-type SermonAnalysisResult` and `RawAiAnalysisData` in `SermonAnalysisService`.
- Updated `performAiAnalysis`, `runAnalysisAttempt`, and `parseAiResponse` to use these aliases.
- Imported aliases into `SermonAnalysisValidator` and updated `validateAndCleanAnalysisData`.
- Refactored `sanitizeAiNullableString` to use the `filled()` helper.

🎯 **Why:** 
- Improves maintainability by providing a single source of truth for the analysis result shape.
- Enhances developer experience with better IDE autocompletion and static analysis precision.
- Reduces cognitive load by using standard Laravel helpers for string presence checks.

🔄 **Behavior:** 
Explicitly state: No functional changes. Behavior is preserved and verified by existing tests.

✅ **Tests:** 
- `php vendor/bin/phpstan analyse app/Services/Sermon/SermonAnalysisService.php app/Services/Sermon/SermonAnalysisValidator.php` -> OK
- `php vendor/bin/phpunit tests/Integration/Services/SermonAnalysisServiceTest.php` -> OK (6 tests, 12 assertions)
- `php vendor/bin/phpunit tests/Integration/Services/SermonCreationServiceTest.php` -> OK (40 tests, 120 assertions)

---
*PR created automatically by Jules for task [13479376887751813531](https://jules.google.com/task/13479376887751813531) started by @GarethClarridge*