### PR TITLE
🧪 Steward: Harden CreateMeeting log assertion

### DIFF
--- a/tests/Feature/Livewire/Admin/Meetings/CreateMeetingTest.php
+++ b/tests/Feature/Livewire/Admin/Meetings/CreateMeetingTest.php
@@ -54,15 +54,10 @@ class CreateMeetingTest extends TestCase
     #[Test]
     public function it_can_create_a_meeting(): void
     {
+        Log::spy();
+
         $this->actingAs($this->admin);
         $page = Page::factory()->create();
-
-        Log::shouldReceive('warning')
-            ->once()
-            ->with('New meeting created by admin', \Mockery::on(function ($args) {
-                return $args['admin_id'] === $this->admin->id &&
-                       $args['slug'] === 'new-meeting-test';
-            }));
 
         Livewire::test(CreateMeeting::class)
             ->set('form.slug', 'new-meeting-test')
@@ -74,6 +69,12 @@ class CreateMeetingTest extends TestCase
             ->call('save')
             ->assertHasNoErrors()
             ->assertRedirect(route('admin.meetings.index'));
+
+        Log::assertLogged('warning', function ($message, $context) {
+            return str_contains($message, 'New meeting created by admin') &&
+                   $context['admin_id'] === $this->admin->id &&
+                   $context['slug'] === 'new-meeting-test';
+        });
 
         $this->assertDatabaseHas('meetings', [
             'slug' => 'new-meeting-test',


### PR DESCRIPTION
Hardened the log assertion in CreateMeetingTest by replacing a brittle exact-string Mockery expectation with a more robust Log::spy() and assertLogged() call using partial string matching and context verification.

---
*PR created automatically by Jules for task [12868078389874562827](https://jules.google.com/task/12868078389874562827) started by @GarethClarridge*