### PR TITLE
🏛️ Warden: fortify Meeting validation and synchronize Livewire form

### DIFF
--- a/.Jules/warden.md
+++ b/.Jules/warden.md
@@ -10,3 +10,7 @@
 1.  Application-level validation (e.g., `lowercase` rule).
 2.  Model-level normalization (e.g., Eloquent Attribute mutators) to gracefully handle and fix data before it reaches the database.
 3.  Defensive testing that asserts both DB rejection and validation-level handling.
+
+## 2026-06-21 - Centralized Model Validation Synchronization
+**Learning:** Validation rules for models (e.g., Meeting) were incomplete and duplicated between the model and Livewire form objects. Centralizing these in a static `validationRules()` method on the model and consuming them in form objects ensures consistency and reduces technical debt.
+**Action:** When fortifying model validation, always check corresponding Livewire forms or Form Requests and refactor them to use the model's `validationRules()`. Ensure rules that reference other fields (e.g. `after_or_equal:start_time`) are correctly mapped to their form property equivalents (e.g. `after_or_equal:startTime`).

--- a/app/Livewire/Forms/MeetingFormData.php
+++ b/app/Livewire/Forms/MeetingFormData.php
@@ -84,19 +84,25 @@ class MeetingFormData extends Form
 
         return [
             'slug' => $modelRules['slug'],
-            'type' => ['required', Rule::enum(MeetingType::class)],
-            'startTime' => 'nullable|date_format:H:i:s,H:i',
-            'endTime' => 'nullable|date_format:H:i:s,H:i|after_or_equal:startTime',
+            'type' => $modelRules['type'],
+            'startTime' => $modelRules['start_time'],
+            'endTime' => array_map(
+                fn ($rule) => $rule === 'after_or_equal:start_time' ? 'after_or_equal:startTime' : $rule,
+                $modelRules['end_time']
+            ),
             'day' => $modelRules['day'],
             'location' => $modelRules['location'],
             'who' => $modelRules['who'],
-            'pictures' => 'boolean',
+            'pictures' => $modelRules['pictures'],
             'leadersPhone' => $modelRules['leaders_phone'],
             'leadersEmail' => $modelRules['leaders_email'],
-            'meetingDate' => 'nullable|date_format:Y-m-d',
-            'isRecurring' => 'boolean',
-            'frequency' => ['nullable', 'required_if:isRecurring,true', Rule::enum(MeetingFrequency::class)],
-            'pageId' => ['nullable', 'integer', 'exists:pages,id', Rule::unique('meetings', 'page_id')->ignore($this->meeting)],
+            'meetingDate' => $modelRules['meeting_date'],
+            'isRecurring' => $modelRules['is_recurring'],
+            'frequency' => array_map(
+                fn ($rule) => $rule === 'required_if:is_recurring,true' ? 'required_if:isRecurring,true' : $rule,
+                $modelRules['frequency']
+            ),
+            'pageId' => $modelRules['page_id'],
         ];
     }
 

--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -182,12 +182,16 @@ class Meeting extends Model implements HasMedia, Sitemapable
         return [
             'slug' => $slugRule,
             'type' => ['required', Rule::enum(MeetingType::class)],
+            'start_time' => ['nullable', 'date_format:H:i:s,H:i'],
+            'end_time' => ['nullable', 'date_format:H:i:s,H:i', 'after_or_equal:start_time'],
             'day' => ['nullable', 'string', 'max:75', new TrimmedText],
             'location' => ['nullable', 'string', 'max:255', new TrimmedText],
             'who' => ['required', 'string', 'max:255', new TrimmedText],
+            'pictures' => ['boolean'],
             'leaders_phone' => ['nullable', 'string', 'max:255', new TrimmedText],
             'leaders_email' => ['nullable', 'email', 'max:255', new TrimmedText],
-            'is_recurring' => ['nullable', 'boolean'],
+            'meeting_date' => ['nullable', 'date_format:Y-m-d'],
+            'is_recurring' => ['boolean'],
             'frequency' => ['nullable', 'required_if:is_recurring,true', Rule::enum(MeetingFrequency::class)],
             'page_id' => $pageIdRule,
         ];

--- a/tests/Feature/Admin/MeetingValidationTest.php
+++ b/tests/Feature/Admin/MeetingValidationTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Meeting;
+use App\Models\Page;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MeetingValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_validates_meeting_date_format(): void
+    {
+        $rules = Meeting::validationRules();
+
+        $this->assertTrue(Validator::make(['meeting_date' => '2023-01-15'], ['meeting_date' => $rules['meeting_date']])->passes());
+        $this->assertFalse(Validator::make(['meeting_date' => '15-01-2023'], ['meeting_date' => $rules['meeting_date']])->passes());
+        $this->assertFalse(Validator::make(['meeting_date' => '2023/01/15'], ['meeting_date' => $rules['meeting_date']])->passes());
+    }
+
+    #[Test]
+    public function it_validates_time_formats(): void
+    {
+        $rules = Meeting::validationRules();
+
+        $this->assertTrue(Validator::make(['start_time' => '10:30'], ['start_time' => $rules['start_time']])->passes());
+        $this->assertTrue(Validator::make(['start_time' => '10:30:00'], ['start_time' => $rules['start_time']])->passes());
+        $this->assertFalse(Validator::make(['start_time' => '10:30 AM'], ['start_time' => $rules['start_time']])->passes());
+    }
+
+    #[Test]
+    public function it_ensures_end_time_is_after_or_equal_to_start_time(): void
+    {
+        $rules = Meeting::validationRules();
+
+        $this->assertTrue(Validator::make(
+            ['start_time' => '10:00', 'end_time' => '11:00'],
+            ['start_time' => $rules['start_time'], 'end_time' => $rules['end_time']]
+        )->passes());
+
+        $this->assertTrue(Validator::make(
+            ['start_time' => '10:00', 'end_time' => '10:00'],
+            ['start_time' => $rules['start_time'], 'end_time' => $rules['end_time']]
+        )->passes());
+
+        $this->assertFalse(Validator::make(
+            ['start_time' => '10:00', 'end_time' => '09:00'],
+            ['start_time' => $rules['start_time'], 'end_time' => $rules['end_time']]
+        )->passes());
+    }
+
+    #[Test]
+    public function it_validates_boolean_fields(): void
+    {
+        $rules = Meeting::validationRules();
+
+        $this->assertTrue(Validator::make(['pictures' => true], ['pictures' => $rules['pictures']])->passes());
+        $this->assertTrue(Validator::make(['pictures' => 0], ['pictures' => $rules['pictures']])->passes());
+        $this->assertFalse(Validator::make(['pictures' => 'yes'], ['pictures' => $rules['pictures']])->passes());
+
+        $this->assertTrue(Validator::make(['is_recurring' => false], ['is_recurring' => $rules['is_recurring']])->passes());
+        $this->assertFalse(Validator::make(['is_recurring' => 'no'], ['is_recurring' => $rules['is_recurring']])->passes());
+    }
+
+    #[Test]
+    public function it_validates_page_id_uniqueness_and_existence(): void
+    {
+        $page = Page::factory()->create();
+        $otherPage = Page::factory()->create();
+        $meeting = Meeting::factory()->create(['page_id' => $page->id]);
+
+        $rules = Meeting::validationRules();
+
+        // Valid: existing page_id that is not used
+        $this->assertTrue(Validator::make(['page_id' => $otherPage->id], ['page_id' => $rules['page_id']])->passes());
+
+        // Invalid: page_id that does not exist
+        $this->assertFalse(Validator::make(['page_id' => 999], ['page_id' => $rules['page_id']])->passes());
+
+        // Invalid: page_id that is already used by another meeting
+        $this->assertFalse(Validator::make(['page_id' => $page->id], ['page_id' => $rules['page_id']])->passes());
+
+        // Valid: ignoring current meeting's page_id
+        $updateRules = Meeting::validationRules($meeting);
+        $this->assertTrue(Validator::make(['page_id' => $page->id], ['page_id' => $updateRules['page_id']])->passes());
+    }
+}


### PR DESCRIPTION
💡 **What:** Fortified validation rules for the `Meeting` model and synchronized them with the `MeetingFormData` Livewire form.

🎯 **Why:** Ensures data integrity by centralizing validation rules in the model and maintaining a single source of truth across the application. This prevents "validation drift" where the UI allows data that the backend or other parts of the system might find invalid.

🗄️ **Changes:**
- Updated \`Meeting::validationRules()\` to include previously missing rules for \`start_time\`, \`end_time\`, \`meeting_date\`, \`pictures\`, and \`is_recurring\`.
- Refactored \`MeetingFormData::rules()\` to consume the model's rules directly.
- Implemented rule mapping in the form to translate database attribute names in rules (e.g., \`start_time\`) to Livewire property names (e.g., \`startTime\`) for relative rules like \`after_or_equal\`.

✅ **Verification:**
- Created \`tests/Feature/Admin/MeetingValidationTest.php\` with 5 new tests verifying date formats, time comparisons, boolean types, and unique/existence constraints.
- Ran the full test suite (5584 tests), all of which passed.
- Verified that \`MeetingFormData\` correctly applies the model-defined rules.

⚠️ **Rollback:** Standard git revert. No database migrations were added in this PR as the schema already supported these constraints.

---
*PR created automatically by Jules for task [7767762514794821230](https://jules.google.com/task/7767762514794821230) started by @GarethClarridge*