### PR TITLE
🪦 Mortician: Document dead sermon update artefacts

### DIFF
--- a/docs/issues/2026-06-20-dead-sermon-update-artefacts.md
+++ b/docs/issues/2026-06-20-dead-sermon-update-artefacts.md
@@ -1,0 +1,45 @@
+# 🪦 Mortician: Possibly dead — Legacy Sermon Update Artefacts
+
+## 1. Dead Job: `App\Jobs\UpdateSermonRecord`
+
+**Artefact:** `app/Jobs/UpdateSermonRecord.php`
+
+**Evidence:**
+Project-wide grep for `UpdateSermonRecord` in production directories (`app/`, `resources/`, `routes/`, `config/`) returns **zero** callers.
+
+```bash
+grep -r "UpdateSermonRecord" app/ resources/ routes/ config/
+# Result: 0 matches (excluding the file itself)
+```
+
+**Reality:**
+This job appears to be a legacy orchestrator from an older version of the media processing pipeline. It has been superseded by the `UnifiedMediaProcessor` and the granular jobs coordinated by `ProcessingRunOrchestrator` (e.g., `ProcessTranscriptWithAI`, `CreateSermonRecord`). While several integration tests still exercise this job, they represent coverage for a legacy path that is no longer reachable in production.
+
+**Risk:**
+Low — The job is isolated and has no production callers.
+
+**Recommendation:**
+Safe to remove once the corresponding legacy tests are also retired or migrated.
+
+---
+
+## 2. Dead Form Request: `App\Http\Requests\UpdateSermonRequest`
+
+**Artefact:** `app/Http/Requests/UpdateSermonRequest.php`
+
+**Evidence:**
+Project-wide grep for `UpdateSermonRequest` in production directories returns **zero** callers.
+
+```bash
+grep -r "UpdateSermonRequest" app/ resources/ routes/ config/
+# Result: 0 matches
+```
+
+**Reality:**
+This Form Request was likely used by a traditional controller-based sermon update action. Sermon editing has since been refactored into the `App\Livewire\Admin\Sermons\EditSermon` Livewire component, which uses its own internal validation logic or Form Objects.
+
+**Risk:**
+Low — Unreferenced class.
+
+**Recommendation:**
+Safe to remove.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -58,6 +58,20 @@ at the same target — correct redirect behaviour.
 
 ---
 
+### O8 · Legacy sermon update artefacts (`UpdateSermonRecord` & `UpdateSermonRequest`)
+
+**Artefacts:** `app/Jobs/UpdateSermonRecord.php`, `app/Http/Requests/UpdateSermonRequest.php`
+
+These artefacts have been superseded by the `UnifiedMediaProcessor` and Livewire-based
+admin forms. Grep search returns zero production callers in `app/`, `resources/`,
+`routes/`, or `config/`.
+
+**Risk:** Low — isolated classes with no callers.
+
+**Action:** Remove both classes and retire/migrate legacy tests that still exercise them.
+
+---
+
 ## ✅ Recently resolved (2026-06-18 unless noted)
 
 - **O1 — Dead mailable `App\Mail\LivestreamProcessingCompleted`** — removed (class, view, test, `AGENTS.md` reference).


### PR DESCRIPTION
I have documented two clearly-dead pieces of code that were identified during a project-wide audit for the Mortician mission:

1. **`App\Jobs\UpdateSermonRecord`**: A legacy orchestrator job superseded by the `UnifiedMediaProcessor` pipeline. It has no remaining callers in production.
2. **`App\Http\Requests\UpdateSermonRequest`**: An orphaned Form Request likely from a legacy controller-based update path, now handled by Livewire components.

**Actions taken:**
- Performed deep, project-wide grep verification across `app/`, `resources/`, `routes/`, and `config/` to confirm zero production references.
- Verified that existing tests still pass.
- Created a detailed issue report at `docs/issues/2026-06-20-dead-sermon-update-artefacts.md`.
- Updated the main issue tracker in `docs/issues/README.md` (Issue O8).

No functional code was removed in this step, adhering to the "default to issues" guideline for Mortician.

---
*PR created automatically by Jules for task [6724190995384012180](https://jules.google.com/task/6724190995384012180) started by @GarethClarridge*