### PR TITLE
🧪 Steward: Harden log mocking and job retry timing

### DIFF
--- a/.Jules/steward.md
+++ b/.Jules/steward.md
@@ -22,3 +22,8 @@
 **Pattern:** Internal cache key assertion
 **Cause:** Previous tests used `Cache::has('key')` which is brittle and doesn't guarantee the cache is actually used by the code path.
 **Fix:** Replaced with behavioral verification using `DB::enableQueryLog()` and asserting zero subsequent queries to the 'preachers' table after cache warming.
+
+## 2026-08-15 - Harden log mocking and job retry timing
+**Pattern:** Strict log mocking and approximate timestamp assertions.
+**Cause:** `Log::shouldReceive()` creates a strict mock that fails on any un-mocked log call (even at different levels), causing brittleness when unrelated code paths log information. Job `retryUntil` tests used `assertEqualsWithDelta` which is fragile and slow if execution hangs.
+**Fix:** Introduced `Log::partialMock()` to isolate the specific logs under test while allowing the rest of the logging system to function naturally. Replaced approximate time assertions with deterministic checks using `Carbon::setTestNow()`.

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -202,6 +202,7 @@ class LoginTest extends TestCase
             'password' => bcrypt('correct-password'),
         ]);
 
+        Log::partialMock();
         Log::shouldReceive('warning')
             ->once()
             ->withArgs(fn ($message, $context) => str_contains($message, 'Admin logged in') &&
@@ -218,17 +219,18 @@ class LoginTest extends TestCase
     #[Test]
     public function failed_admin_login_is_logged_as_warning(): void
     {
+        $admin = User::factory()->create([
+            'is_admin' => true,
+            'password' => bcrypt('correct-password'),
+        ]);
+
+        Log::partialMock();
         Log::shouldReceive('warning')
             ->once()
             ->withArgs(fn ($message, $context) => str_contains($message, 'Admin login attempt failed') &&
                 isset($context['admin_id']) &&
                 isset($context['email']) &&
                 isset($context['ip']));
-
-        $admin = User::factory()->create([
-            'is_admin' => true,
-            'password' => bcrypt('correct-password'),
-        ]);
 
         Livewire::test(LoginComponent::class)
             ->set('email', $admin->email)
@@ -240,6 +242,7 @@ class LoginTest extends TestCase
     #[Test]
     public function failed_regular_user_login_is_not_logged_as_warning(): void
     {
+        Log::partialMock();
         Log::shouldReceive('warning')
             ->never();
 

--- a/tests/Integration/GenerateThumbnailJobTest.php
+++ b/tests/Integration/GenerateThumbnailJobTest.php
@@ -94,6 +94,7 @@ class GenerateThumbnailJobTest extends TestCase
                 ]
             ));
 
+        Log::partialMock();
         Log::shouldReceive('info')->atLeast()->once();
         Log::shouldReceive('warning')->never();
 
@@ -123,6 +124,7 @@ class GenerateThumbnailJobTest extends TestCase
             ->with($this->callback(fn (Sermon $model): bool => $model->is($sermon)), 'sermons/1/video.mp4', 'public')
             ->willReturn(ThumbnailResult::skipped('Test failure'));
 
+        Log::partialMock();
         Log::shouldReceive('info')->atLeast()->once();
         Log::shouldReceive('warning')->atLeast()->once();
 
@@ -148,6 +150,7 @@ class GenerateThumbnailJobTest extends TestCase
         $mockService = $this->createMock(ThumbnailGenerationService::class);
         $mockService->expects($this->never())->method('generateThumbnail');
 
+        Log::partialMock();
         Log::shouldReceive('error')->once()->with(
             'Missing sermon ID or video path for thumbnail generation',
             \Mockery::any()
@@ -168,6 +171,7 @@ class GenerateThumbnailJobTest extends TestCase
         $mockService = $this->createMock(ThumbnailGenerationService::class);
         $mockService->expects($this->never())->method('generateThumbnail');
 
+        Log::partialMock();
         Log::shouldReceive('info')->once();
         Log::shouldReceive('warning')->once()->with(
             'Video file not found for thumbnail generation',
@@ -196,6 +200,7 @@ class GenerateThumbnailJobTest extends TestCase
         $mockService = $this->createMock(ThumbnailGenerationService::class);
         $mockService->expects($this->never())->method('generateThumbnail');
 
+        Log::partialMock();
         Log::shouldReceive('info')->twice();
         Log::shouldReceive('warning')->never();
 
@@ -222,6 +227,7 @@ class GenerateThumbnailJobTest extends TestCase
             ->with($this->callback(fn (Sermon $model): bool => $model->is($sermon)), 'sermons/1/video.mp4', 'public')
             ->willThrowException(new \Exception('Service error'));
 
+        Log::partialMock();
         Log::shouldReceive('info')->atLeast()->once();
         Log::shouldReceive('warning')->atLeast()->once();
 
@@ -255,6 +261,7 @@ class GenerateThumbnailJobTest extends TestCase
             ->with($this->callback(fn (Sermon $model): bool => $model->is($sermon)), 'sermons/1/final-video.mp4', 'public')
             ->willReturn(ThumbnailResult::skipped('Not needed for this test'));
 
+        Log::partialMock();
         Log::shouldReceive('debug')->atLeast()->once();
         Log::shouldReceive('info')->atLeast()->once();
         Log::shouldReceive('warning')->atLeast()->once();
@@ -279,16 +286,17 @@ class GenerateThumbnailJobTest extends TestCase
     #[Test]
     public function it_has_correct_retry_until_time(): void
     {
+        \Illuminate\Support\Carbon::setTestNow('2026-05-27 12:00:00');
         $job = new GenerateThumbnail(MediaProcessingLog::factory()->video()->processing()->create());
 
         $retryUntil = $job->retryUntil();
 
         $this->assertInstanceOf(\DateTime::class, $retryUntil);
-        $this->assertEqualsWithDelta(
+        $this->assertEquals(
             now()->addDay()->timestamp,
-            $retryUntil->getTimestamp(),
-            120
+            $retryUntil->getTimestamp()
         );
+        \Illuminate\Support\Carbon::setTestNow();
     }
 
     #[Test]
@@ -299,6 +307,7 @@ class GenerateThumbnailJobTest extends TestCase
         ]);
         $job = new GenerateThumbnail($this->createProcessingLog($sermon, 'sermons/1/video.mp4'));
 
+        Log::partialMock();
         Log::shouldReceive('warning')->once()->with(
             'GenerateThumbnail job failed permanently',
             \Mockery::on(function (array $context) use ($sermon): bool {
@@ -322,6 +331,7 @@ class GenerateThumbnailJobTest extends TestCase
         $mockService = $this->createMock(ThumbnailGenerationService::class);
         $mockService->expects($this->never())->method('generateThumbnail');
 
+        Log::partialMock();
         Log::shouldReceive('info')->once()->with('GenerateThumbnail job skipped: processing cancelled', \Mockery::any());
 
         $job = new GenerateThumbnail($log);


### PR DESCRIPTION
Hardened tests in LoginTest and GenerateThumbnailJobTest by using Log::partialMock() for resilient log assertions and Carbon::setTestNow() for deterministic timestamp verification in job retry logic. Added a journal entry to .Jules/steward.md documenting the patterns.

---
*PR created automatically by Jules for task [3275153189460898732](https://jules.google.com/task/3275153189460898732) started by @GarethClarridge*