### PR TITLE
🧹 Tidy: standardise string sanitisation and blank checks

### DIFF
--- a/app/Data/SermonAnalysis.php
+++ b/app/Data/SermonAnalysis.php
@@ -121,10 +121,10 @@ class SermonAnalysis extends Data implements ArrayAccess
     public static function fromAiAnalysis(array $analysisData): self
     {
         $title = $analysisData['title'] ?? 'Untitled Sermon';
-        $series = ! empty($analysisData['series']) ? $analysisData['series'] : null;
-        $reference = ! empty($analysisData['reference']) ? $analysisData['reference'] : null;
+        $series = filled($analysisData['series'] ?? null) ? $analysisData['series'] : null;
+        $reference = filled($analysisData['reference'] ?? null) ? $analysisData['reference'] : null;
         $points = $analysisData['points'] ?? [];
-        $summary = ! empty($analysisData['summary']) ? $analysisData['summary'] : null;
+        $summary = filled($analysisData['summary'] ?? null) ? $analysisData['summary'] : null;
         $transcript = $analysisData['transcript'] ?? '';
 
         return self::create($title, $series, $reference, $points, $summary, $transcript);

--- a/app/Services/Public/SermonRepository.php
+++ b/app/Services/Public/SermonRepository.php
@@ -239,8 +239,8 @@ class SermonRepository
         string|int|null $preacherId,
         string|int|null $series,
     ): array {
-        $book = is_string($book) && trim($book) !== '' ? trim($book) : null;
-        $series = is_string($series) && trim($series) !== '' ? trim($series) : null;
+        $book = filled($book) ? trim((string) $book) : null;
+        $series = filled($series) ? trim((string) $series) : null;
         $preacherId = filter_var($preacherId, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) ?: null;
         $chapter = filter_var($chapter, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) ?: null;
 

--- a/app/Services/Sermon/SermonAnalysisValidator.php
+++ b/app/Services/Sermon/SermonAnalysisValidator.php
@@ -80,9 +80,9 @@ class SermonAnalysisValidator
 
         // Validate points (must be array of strings)
         $points = [];
-        if (isset($analysisData['points']) && is_array($analysisData['points'])) {
+        if (filled($analysisData['points'] ?? null) && is_array($analysisData['points'])) {
             foreach ($analysisData['points'] as $point) {
-                if (is_string($point) && ! empty(trim($point))) {
+                if (filled($point) && is_string($point)) {
                     $cleanPoint = $this->britishEnglishConverter->convert(trim($point));
                     $points[] = $cleanPoint;
                 }
@@ -118,11 +118,11 @@ class SermonAnalysisValidator
      */
     public function validateAndCleanTitle(string $title): string
     {
-        $title = trim($title);
-
-        if (empty($title)) {
+        if (blank($title)) {
             return 'Untitled sermon';
         }
+
+        $title = trim($title);
 
         // Remove quotes if present
         $title = trim($title, '"\'');
@@ -182,11 +182,11 @@ class SermonAnalysisValidator
      */
     public function validateAndCleanSummary(string $summary): ?string
     {
-        $summary = trim($summary);
-
-        if (empty($summary)) {
+        if (blank($summary)) {
             return null;
         }
+
+        $summary = trim($summary);
 
         // Remove quotes if present
         $summary = trim($summary, '"\'');

--- a/app/Services/Sermon/SermonCreationService.php
+++ b/app/Services/Sermon/SermonCreationService.php
@@ -313,7 +313,7 @@ class SermonCreationService
      */
     private function fillIfBlank(Sermon $existing, array &$updates, string $field, ?string $incoming): void
     {
-        if ($incoming !== null && $incoming !== '' && empty($existing->{$field})) {
+        if (filled($incoming) && blank($existing->{$field})) {
             $updates[$field] = $incoming;
         }
     }
@@ -323,13 +323,13 @@ class SermonCreationService
      */
     private function fillSeriesIfBlank(Sermon $existing, SermonCreationOptions $options, array &$updates): void
     {
-        if (! empty($existing->series)) {
+        if (filled($existing->series)) {
             return;
         }
 
         $value = $options->id3Series ?? ($options->aiAnalysis['series'] ?? null);
 
-        if (is_string($value) && $value !== '') {
+        if (filled($value)) {
             $updates['series'] = $value;
         }
     }
@@ -339,13 +339,13 @@ class SermonCreationService
      */
     private function fillReferenceIfBlank(Sermon $existing, SermonCreationOptions $options, array &$updates): void
     {
-        if (! empty($existing->reference)) {
+        if (filled($existing->reference)) {
             return;
         }
 
         $value = $options->id3Reference ?? ($options->aiAnalysis['reference'] ?? null);
 
-        if (is_string($value) && $value !== '') {
+        if (filled($value)) {
             $updates['reference'] = $value;
         }
     }
@@ -355,11 +355,11 @@ class SermonCreationService
      */
     private function fillPointsIfBlank(Sermon $existing, SermonCreationOptions $options, array &$updates): void
     {
-        if (! empty($existing->points)) {
+        if (filled($existing->points)) {
             return;
         }
 
-        if (isset($options->aiAnalysis['points'])) {
+        if (filled($options->aiAnalysis['points'] ?? null)) {
             $updates['points'] = $options->aiAnalysis['points'];
         }
     }
@@ -369,7 +369,7 @@ class SermonCreationService
      */
     private function refreshAiField(Sermon $existing, array &$updates, string $field, mixed $value): void
     {
-        if (! is_string($value) || $value === '') {
+        if (blank($value)) {
             return;
         }
 
@@ -615,13 +615,13 @@ class SermonCreationService
     {
         // Priority 1: ID3 tag title (if present)
         $id3Title = $context['id3_title'] ?? null;
-        if ($id3Title && ! empty(trim($id3Title))) {
+        if (filled($id3Title)) {
             return Str::limit($id3Title, 100, '');
         }
 
         // Priority 2: AI-generated title (if available)
         $aiAnalysis = $context['ai_analysis'] ?? null;
-        if ($aiAnalysis && ! empty($aiAnalysis['title'])) {
+        if (filled($aiAnalysis['title'] ?? null)) {
             return $aiAnalysis['title'];
         }
 


### PR DESCRIPTION
Standardised string sanitisation and blank/filled checks across the codebase. replaced manual `empty()` and `null` checks with Laravel's `filled()` and `blank()` helpers in `SermonCreationService`, `SermonRepository`, `SermonAnalysisValidator`, and `SermonAnalysis`. Verified with tests and code review.

---
*PR created automatically by Jules for task [14012371006067989242](https://jules.google.com/task/14012371006067989242) started by @GarethClarridge*