### PR TITLE
🔦 Lighthouse: Enrich sermon metadata with author and publisher info

### DIFF
--- a/app/Seo/SermonItemListPresenter.php
+++ b/app/Seo/SermonItemListPresenter.php
@@ -221,6 +221,8 @@ class SermonItemListPresenter
 
     /**
      * @param  array<string, mixed>  $sermonView
+     * @param  array<string, mixed>  $author
+     * @param  array<string, mixed>  $publisher
      * @return array<string, mixed>
      */
     private function buildVideoObject(
@@ -228,7 +230,9 @@ class SermonItemListPresenter
         array $sermonView,
         string $datePublished,
         string $metaDescription,
-        string $logoUrl
+        string $logoUrl,
+        array $author,
+        array $publisher,
     ): array {
         $video = [
             '@type' => 'VideoObject',
@@ -237,6 +241,8 @@ class SermonItemListPresenter
             'thumbnailUrl' => $sermonView['thumbnail_url'] ?: $logoUrl,
             'uploadDate' => $datePublished,
             'contentUrl' => $sermonView['video_url'],
+            'author' => $author,
+            'publisher' => $publisher,
         ];
 
         if ($sermonView['duration_iso8601']) {
@@ -248,13 +254,17 @@ class SermonItemListPresenter
 
     /**
      * @param  array<string, mixed>  $sermonView
+     * @param  array<string, mixed>  $author
+     * @param  array<string, mixed>  $publisher
      * @return array<string, mixed>
      */
     private function buildAudioObject(
         Sermon $sermon,
         array $sermonView,
         string $datePublished,
-        string $metaDescription
+        string $metaDescription,
+        array $author,
+        array $publisher,
     ): array {
         $audio = [
             '@type' => 'AudioObject',
@@ -263,6 +273,8 @@ class SermonItemListPresenter
             'description' => $metaDescription,
             'encodingFormat' => 'audio/mpeg',
             'uploadDate' => $datePublished,
+            'author' => $author,
+            'publisher' => $publisher,
         ];
 
         if ($sermonView['duration_iso8601']) {
@@ -312,7 +324,9 @@ class SermonItemListPresenter
                 $sermonView,
                 $datePublished,
                 $metaDescription,
-                $logoUrl
+                $logoUrl,
+                $author,
+                $publisher,
             );
         }
 
@@ -321,7 +335,9 @@ class SermonItemListPresenter
                 $sermon,
                 $sermonView,
                 $datePublished,
-                $metaDescription
+                $metaDescription,
+                $author,
+                $publisher,
             );
         }
 

--- a/resources/views/components/schema/sermon.blade.php
+++ b/resources/views/components/schema/sermon.blade.php
@@ -39,6 +39,7 @@
         '@' . 'context' => 'https://schema.org',
         '@type' => 'Article',
         '@id' => $sermonView['canonical_url'] . '#sermon',
+        'url' => $sermonView['canonical_url'],
         'headline' => $sermon->title,
         'description' => $metaDescription,
         'articleBody' => $articleBody,
@@ -97,6 +98,8 @@
             'thumbnailUrl' => $thumbnailUrl,
             'uploadDate' => $datePublished,
             'contentUrl' => $sermonView['video_url'],
+            'author' => $author,
+            'publisher' => $schema['publisher'],
         ];
 
         if ($duration) {
@@ -116,6 +119,8 @@
             'description' => $metaDescription,
             'encodingFormat' => 'audio/mpeg',
             'uploadDate' => $datePublished,
+            'author' => $author,
+            'publisher' => $schema['publisher'],
         ];
 
         if ($duration) {


### PR DESCRIPTION
💡 **What:** Enriched the Schema.org structured data for sermons across the application.

🎯 **Why:** To improve the site's discoverability and rich result appearance in search engines by providing complete context (author, publisher, canonical URLs) for both the primary sermon articles and their nested media (audio/video).

📊 **Impact:** All sermon listing pages (index, preacher, series, service) and individual sermon pages benefit from more robust, consistent metadata.

🔍 **Verification:**
- Verified with `SermonItemListPresenterTest` and `SermonControllerTest`.
- Ran full test suite (5,635 tests passed).
- Confirmed that large transcripts are NOT embedded in list views to maintain performance.

---
*PR created automatically by Jules for task [12726592742628744024](https://jules.google.com/task/12726592742628744024) started by @GarethClarridge*