### PR TITLE
♿ Aria: Improve card heading visibility and form error association

### DIFF
--- a/resources/views/components/childrens-talk-card.blade.php
+++ b/resources/views/components/childrens-talk-card.blade.php
@@ -11,13 +11,12 @@
         <a
             href="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}"
             wire:navigate
-            tabindex="-1"
-            aria-hidden="true"
-            class="relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
+            class="relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-inset"
         >
             <img
                 src="{{ $cardThumbnailUrl }}"
-                alt="Children's Corner: {{ $sermon->title }}"
+                alt=""
+                role="presentation"
                 class="h-full w-full object-cover brightness-110 contrast-105 transition duration-500 ease-out group-hover:scale-105 group-hover:brightness-115"
                 loading="lazy"
             >
@@ -38,9 +37,7 @@
                 <a
                     href="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}"
                     wire:navigate
-                    tabindex="-1"
-                    aria-hidden="true"
-                    class="block rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
+                    class="block rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal"
                 >
                     <h2 class="font-display text-2xl leading-tight text-gray-900 transition-colors hover:text-cbc-teal-dark">
                         {{ $sermon->title }}

--- a/resources/views/components/page-card.blade.php
+++ b/resources/views/components/page-card.blade.php
@@ -24,8 +24,8 @@
     }
 @endphp
 <div class="group relative mb-4 flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
-    <a class="relative block aspect-video overflow-hidden bg-slate-200" href="{{ $pageUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
-        <img class="h-full w-full object-cover brightness-110 contrast-105 transition duration-500 ease-out group-hover:scale-105 group-hover:brightness-115" src="{{ $pageImageUrl }}" alt="{{ $pageHeading }}" onerror="this.onerror=null;this.src='/images/headings/small/default.webp';" loading="lazy" width="300" height="169">
+    <a class="relative block aspect-video overflow-hidden bg-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-inset" href="{{ $pageUrl }}" wire:navigate>
+        <img class="h-full w-full object-cover brightness-110 contrast-105 transition duration-500 ease-out group-hover:scale-105 group-hover:brightness-115" src="{{ $pageImageUrl }}" alt="" role="presentation" onerror="this.onerror=null;this.src='/images/headings/small/default.webp';" loading="lazy" width="300" height="169">
         <div class="absolute inset-0 bg-gradient-to-t from-black/35 via-black/10 to-transparent"></div>
         <h2 class="absolute inset-x-5 top-1/2 -translate-y-1/2 text-center font-display text-3xl leading-[0.95] text-white [text-shadow:0_2px_8px_rgba(0,0,0,0.45)] sm:text-4xl">
             {{ $pageHeading }}

--- a/resources/views/components/sermon-card.blade.php
+++ b/resources/views/components/sermon-card.blade.php
@@ -24,14 +24,13 @@
     <a
       href="{{ $sermonUrl }}"
       wire:navigate
-      tabindex="-1"
-      aria-hidden="true"
       data-sermon-card-thumbnail
-      class="relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200"
+      class="relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-inset"
     >
       <img
         src="{{ $thumbnailUrl }}"
-        alt="Sermon: {{ $sermon->title }}"
+        alt=""
+        role="presentation"
         class="h-full w-full object-cover brightness-110 contrast-105 transition duration-500 ease-out group-hover:scale-105 group-hover:brightness-115"
         loading="lazy"
         onerror="this.onerror=null; const card = this.closest('[data-sermon-card]'); card?.querySelector('[data-sermon-card-thumbnail]')?.remove(); card?.querySelector('[data-sermon-card-title-fallback]')?.classList.remove('hidden');"
@@ -47,13 +46,13 @@
 
   <div class="flex flex-col flex-1 p-6">
     @if (($sermon->title != null) && ! $thumbnailUrl)
-      <a class="group" href="{{ $sermonUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
+      <a class="group focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal rounded" href="{{ $sermonUrl }}" wire:navigate>
         <h2 class="font-display text-2xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
           {{$sermon->title}}
         </h2>
       </a>
     @elseif ($sermon->title != null)
-      <a class="group hidden" href="{{ $sermonUrl }}" wire:navigate data-sermon-card-title-fallback>
+      <a class="group hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal rounded" href="{{ $sermonUrl }}" wire:navigate data-sermon-card-title-fallback>
         <h2 class="font-display text-2xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
           {{$sermon->title}}
         </h2>

--- a/resources/views/livewire/media-upload/form.blade.php
+++ b/resources/views/livewire/media-upload/form.blade.php
@@ -65,9 +65,6 @@
                                 ]"
                             />
                             <p class="mt-2 text-sm text-gray-600">Which service this recording is for. We pre-select based on the media type — change it if it's wrong.</p>
-                            @error('serviceOverride')
-                                <p class="mt-1 text-sm text-red-600" role="alert">{{ $message }}</p>
-                            @enderror
                         </div>
                     @endif
 
@@ -94,13 +91,13 @@
                         <div>
                             <label class="block text-sm font-medium text-gray-700 mb-2" for="media-file">
                                 @if($mediaType === 'audio')
-                                    Upload sermon audio file <span class="text-red-500">*</span>
+                                    Upload sermon audio file <span class="text-red-500" aria-hidden="true">*</span>
                                 @elseif($mediaType === 'video')
-                                    Upload sermon video file <span class="text-red-500">*</span>
+                                    Upload sermon video file <span class="text-red-500" aria-hidden="true">*</span>
                                 @elseif($mediaType === 'livestream')
-                                    Upload full livestream file <span class="text-red-500">*</span>
+                                    Upload full livestream file <span class="text-red-500" aria-hidden="true">*</span>
                                 @else
-                                    Upload media file <span class="text-red-500">*</span>
+                                    Upload media file <span class="text-red-500" aria-hidden="true">*</span>
                                 @endif
                             </label>
 
@@ -147,6 +144,7 @@
                                     class="sr-only"
                                     accept="{{ $acceptAttribute }}"
                                     x-on:change="handleFileInputChange($event)"
+                                    @if($errors->has('mediaFile')) aria-describedby="media-file-error" aria-invalid="true" @endif
                                 />
                                 <input type="hidden" x-model="fileModifiedDate" />
                                 <label for="media-file" class="cursor-pointer inline-block align-middle">
@@ -157,7 +155,7 @@
                             </div>
 
                             @error('mediaFile')
-                                <p class="mt-1 text-sm text-red-600" role="alert">{{ $message }}</p>
+                                <p class="mt-1 text-sm text-red-600" id="media-file-error" role="alert">{{ $message }}</p>
                             @enderror
                         </div>
 


### PR DESCRIPTION
This PR improves accessibility across several key components of the site, specifically focusing on screen-reader navigation and form validation feedback.

### 💡 What:
1.  **Card Heading Visibility**: Restored the visibility of headings in `sermon-card`, `childrens-talk-card`, and `page-card`. Previously, these were wrapped in `aria-hidden="true"` links, making them invisible to screen readers' heading navigation.
2.  **Keyboard Navigation**: Added `focus-visible:ring-2` to these card links to ensure keyboard users have a clear visual indicator of where focus is.
3.  **Form Error Association**: In the manual media upload form, I've correctly associated the file input with its error message using `aria-describedby` and `aria-invalid`.
4.  **Required Field Indicators**: Wrapped visible asterisks in `<span aria-hidden="true">*</span>` to prevent redundant announcements by screen readers that already announce the field as required.
5.  **Refactored Redundant Blocks**: Removed manual error display blocks for `serviceOverride` as the base `<x-select>` component already handles both the display and the ARIA association for errors.

### 🎯 Who:
- **Screen Reader Users**: Benefit from being able to find sermon titles in the heading list and receiving correct error feedback in forms.
- **Keyboard Users**: Benefit from visible focus indicators on interactive elements.
- **Low Vision Users**: Benefit from high-contrast focus rings.

### 🧪 How to verify:
- Tab through the sermon listing and verify that the titles receive focus with a teal ring.
- Use an accessibility inspector (like Chrome DevTools) to verify that the `h2` elements within cards are not hidden from the accessibility tree.
- Attempt to upload a file in the admin media upload form without selecting a file and verify that the error message is correctly associated with the input.

### 🔄 Behavior:
No changes to visual layout. Accessibility metadata and focus indicators are improved.

---
*PR created automatically by Jules for task [6031467670403845777](https://jules.google.com/task/6031467670403845777) started by @GarethClarridge*