### PR TITLE
📝 Scribe: Add tests for sermon analysis summary truncation

### DIFF
--- a/tests/Unit/Services/SermonAnalysisValidatorTest.php
+++ b/tests/Unit/Services/SermonAnalysisValidatorTest.php
@@ -126,6 +126,80 @@ class SermonAnalysisValidatorTest extends TestCase
     }
 
     #[Test]
+    public function it_truncates_summary_to_200_words_and_ends_on_a_period(): void
+    {
+        // 200 words followed by a 201st word containing a period at the end of the block.
+        $words = array_fill(0, 199, 'word');
+        $words[] = 'last.';
+        $words[] = 'extra';
+        $summary = implode(' ', $words);
+
+        $result = $this->validator->validateAndCleanSummary($summary);
+
+        $this->assertNotNull($result);
+        $this->assertStringEndsWith('.', $result);
+        $this->assertEquals(200, count(explode(' ', $result)));
+    }
+
+    #[Test]
+    public function it_truncates_summary_to_200_words_and_ends_on_an_exclamation_mark(): void
+    {
+        $words = array_fill(0, 199, 'word');
+        $words[] = 'last!';
+        $words[] = 'extra';
+        $summary = implode(' ', $words);
+
+        $result = $this->validator->validateAndCleanSummary($summary);
+
+        $this->assertNotNull($result);
+        $this->assertStringEndsWith('!', $result);
+    }
+
+    #[Test]
+    public function it_truncates_summary_to_200_words_and_ends_on_a_question_mark(): void
+    {
+        $words = array_fill(0, 199, 'word');
+        $words[] = 'last?';
+        $words[] = 'extra';
+        $summary = implode(' ', $words);
+
+        $result = $this->validator->validateAndCleanSummary($summary);
+
+        $this->assertNotNull($result);
+        $this->assertStringEndsWith('?', $result);
+    }
+
+    #[Test]
+    public function it_truncates_summary_to_exactly_200_words_if_no_sentence_boundary_within_threshold(): void
+    {
+        // Period at word 100 (50% mark), which is < 80% threshold of the 200-word block.
+        $words = array_fill(0, 99, 'word');
+        $words[] = 'mid.';
+        $words = array_merge($words, array_fill(0, 100, 'word'));
+        $words[] = 'extra';
+        $summary = implode(' ', $words);
+
+        $result = $this->validator->validateAndCleanSummary($summary);
+
+        $this->assertNotNull($result);
+        $this->assertStringEndsWith('word', $result);
+        $this->assertEquals(200, count(explode(' ', $result)));
+    }
+
+    #[Test]
+    public function it_truncates_summary_to_exactly_200_words_if_no_sentence_boundary_at_all(): void
+    {
+        $words = array_fill(0, 210, 'word');
+        $summary = implode(' ', $words);
+
+        $result = $this->validator->validateAndCleanSummary($summary);
+
+        $this->assertNotNull($result);
+        $this->assertEquals(200, count(explode(' ', $result)));
+        $this->assertStringEndsWith('word', $result);
+    }
+
+    #[Test]
     public function it_normalises_null_and_none_values_in_analysis_data(): void
     {
         $transcript = 'Sample transcript content for testing purposes with enough words to pass validation.';


### PR DESCRIPTION
I identified that the `validateAndCleanSummary` method in `SermonAnalysisValidator` had limited test coverage for its smart truncation logic. I added five new test methods to `tests/Unit/Services/SermonAnalysisValidatorTest.php` to verify that the method correctly truncates summaries to 200 words while attempting to end on a complete sentence boundary (period, exclamation mark, or question mark) if one exists within the final 20% of the truncated block. I also covered the fallback scenarios where no boundary is found within the threshold or no punctuation is present at all. All tests passed, and the full test suite was verified in parallel.

---
*PR created automatically by Jules for task [6098296660554493712](https://jules.google.com/task/6098296660554493712) started by @GarethClarridge*