### PR TITLE
📜 Herald: Document livestream metadata shape and analysis exceptions

### DIFF
--- a/app/Contracts/SermonAnalysisInterface.php
+++ b/app/Contracts/SermonAnalysisInterface.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Contracts;
 
 use App\Data\SermonAnalysis;
+use OpenAI\Exceptions\ErrorException;
+use OpenAI\Exceptions\TransporterException;
 
 interface SermonAnalysisInterface
 {
@@ -15,6 +17,10 @@ interface SermonAnalysisInterface
      * @param  array<int, string>  $existingSeries  Existing sermon series for context
      * @param  string|null  $processingId  Processing run identifier used for log correlation
      * @return SermonAnalysis The analyzed sermon data
+     *
+     * @throws \Exception
+     * @throws ErrorException
+     * @throws TransporterException
      */
     public function analyzeSermon(string $transcript, array $existingSeries = [], ?string $processingId = null): SermonAnalysis;
 }

--- a/app/Data/SermonCreationOptions.php
+++ b/app/Data/SermonCreationOptions.php
@@ -122,7 +122,13 @@ class SermonCreationOptions
     /**
      * Create options for livestream processing
      *
-     * @param  array<string, mixed>  $metadata
+     * @param  array{
+     *     original_filename?: string,
+     *     video_file_path?: string|null,
+     *     livestream_processing_id?: string,
+     *     segment_start_time?: float|null,
+     *     segment_end_time?: float|null,
+     * }  $metadata
      */
     public static function fromLivestream(MediaProcessingLog $log, array $metadata): self
     {


### PR DESCRIPTION
I have improved the inline documentation and developer experience by addressing two significant documentation gaps in the media processing pipeline:

1.  **SermonCreationOptions**: The `fromLivestream` method previously used a generic `array<string, mixed>` for its `$metadata` parameter. I have replaced this with a precise array shape (`array{original_filename?: string, video_file_path?: string|null, ...}`) which improves IDE autocompletion and allows PHPStan to perform better static analysis on livestream processing results.
2.  **SermonAnalysisInterface**: The `analyzeSermon` method now includes explicit `@throws` annotations for `\Exception`, `\OpenAI\Exceptions\ErrorException`, and `\OpenAI\Exceptions\TransporterException`. This clarifies the contract for callers of the AI-driven analysis service, ensuring they are aware of potential failure modes (validation errors, API errors, or network issues).

These changes were verified by running Laravel Pint, PHPStan (which confirmed the new array shapes), and the full parallel test suite (5659 tests passed).

---
*PR created automatically by Jules for task [13156138446052689769](https://jules.google.com/task/13156138446052689769) started by @GarethClarridge*