### PR TITLE
🛡️ Sentinel: [security improvement] Harden log sanitization and documentation

### DIFF
--- a/app/Http/Controllers/Api/MediaController.php
+++ b/app/Http/Controllers/Api/MediaController.php
@@ -9,6 +9,7 @@ use App\Actions\GetMediaProcessingStatus;
 use App\Contracts\ProvidesSafeMessage;
 use App\Data\VideoProcessingOptions;
 use App\Enums\MediaType;
+use App\Exceptions\InvalidFileException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\CancelMediaProcessingRequest;
 use App\Http\Requests\ConfirmMediaSegmentRequest;
@@ -19,6 +20,7 @@ use App\Http\Requests\RetryMediaProcessingRequest;
 use App\Models\User;
 use App\Services\Processing\UnifiedMediaProcessor;
 use App\Traits\SanitizesLogData;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\StreamedEvent;
 use Illuminate\Support\Facades\Log;
@@ -37,6 +39,10 @@ class MediaController extends Controller
      *
      * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
      * Stack traces are sanitized to prevent information leakage.
+     *
+     * @throws UniqueConstraintViolationException If a duplicate race occurs
+     * @throws InvalidFileException If the file fails initial validation
+     * @throws \Exception For underlying service or storage failures
      */
     public function upload(ProcessMediaRequest $request, string $type): JsonResponse
     {
@@ -85,6 +91,8 @@ class MediaController extends Controller
      *
      * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
      * Stack traces are sanitized to prevent information leakage.
+     *
+     * @throws \Exception If the status check fails
      */
     public function status(MediaStatusRequest $request, string $processingId): JsonResponse
     {
@@ -160,6 +168,8 @@ class MediaController extends Controller
      *
      * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
      * Stack traces are sanitized to prevent information leakage.
+     *
+     * @throws \Exception If the cancellation fails
      */
     public function cancel(CancelMediaProcessingRequest $request, string $processingId): JsonResponse
     {
@@ -187,6 +197,9 @@ class MediaController extends Controller
      *
      * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
      * Stack traces are sanitized to prevent information leakage.
+     *
+     * @throws \InvalidArgumentException If parameters are invalid
+     * @throws \Exception If the confirmation fails
      */
     public function confirmSegment(ConfirmMediaSegmentRequest $request, string $processingId, ConfirmLivestreamSermonSegment $action): JsonResponse
     {
@@ -226,6 +239,8 @@ class MediaController extends Controller
      *
      * Security: Log data is sanitized to prevent log injection from user-controlled metadata.
      * Stack traces are sanitized to prevent information leakage.
+     *
+     * @throws \Exception If the retry initiation fails
      */
     public function retry(RetryMediaProcessingRequest $request, string $processingId): JsonResponse
     {

--- a/app/Services/Sermon/SermonCreationService.php
+++ b/app/Services/Sermon/SermonCreationService.php
@@ -44,6 +44,7 @@ class SermonCreationService
      * @return Sermon The created or updated sermon model
      *
      * @throws SermonRichnessDowngradeException When attempting to overwrite a richer record
+     * @throws \Exception For underlying service or repository failures
      */
     public function createSermon(
         MediaProcessingLog $processingLog,
@@ -80,6 +81,9 @@ class SermonCreationService
         };
     }
 
+    /**
+     * @throws SermonRichnessDowngradeException
+     */
     private function rejectOrForce(
         Sermon $existing,
         MediaProcessingLog $processingLog,
@@ -89,22 +93,22 @@ class SermonCreationService
         RichnessLevel $incomingLevel,
     ): Sermon {
         if ($options->forceOverwrite) {
-            Log::warning('SermonCreationService: forceOverwrite bypassed richness downgrade rejection', [
+            Log::warning('SermonCreationService: forceOverwrite bypassed richness downgrade rejection', $this->sanitizeArrayForLog([
                 'sermon_id' => $existing->id,
-                'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
+                'processing_id' => $processingLog->processing_id,
                 'existing_level' => $existingLevel->name,
                 'incoming_level' => $incomingLevel->name,
-            ]);
+            ]));
 
             return $this->replaceExisting($existing, $processingLog, $options);
         }
 
-        Log::warning('SermonCreationService: rejecting richness downgrade', [
+        Log::warning('SermonCreationService: rejecting richness downgrade', $this->sanitizeArrayForLog([
             'sermon_id' => $existing->id,
-            'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
+            'processing_id' => $processingLog->processing_id,
             'existing_level' => $existingLevel->name,
             'incoming_level' => $incomingLevel->name,
-        ]);
+        ]));
 
         throw SermonRichnessDowngradeException::forExisting(
             $existing,
@@ -213,11 +217,11 @@ class SermonCreationService
             $existing->save();
         }
 
-        Log::info('SermonCreationService: enriched existing sermon', [
+        Log::info('SermonCreationService: enriched existing sermon', $this->sanitizeArrayForLog([
             'sermon_id' => $existing->id,
-            'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
-            'fields_updated' => array_map(fn (string $key) => $this->sanitizeForLog($key), array_keys($updates)),
-        ]);
+            'processing_id' => $processingLog->processing_id,
+            'fields_updated' => array_keys($updates),
+        ]));
 
         return $existing->refresh();
     }
@@ -287,11 +291,11 @@ class SermonCreationService
             $existing->save();
         }
 
-        Log::info('SermonCreationService: replaced existing sermon media', [
+        Log::info('SermonCreationService: replaced existing sermon media', $this->sanitizeArrayForLog([
             'sermon_id' => $existing->id,
-            'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
-            'fields_updated' => array_map(fn (string $key) => $this->sanitizeForLog($key), array_keys($updates)),
-        ]);
+            'processing_id' => $processingLog->processing_id,
+            'fields_updated' => array_keys($updates),
+        ]));
 
         return $existing->refresh();
     }
@@ -526,22 +530,22 @@ class SermonCreationService
             $extractedDate = $processingLog->extracted_date->toDateString();
             $processingMetadata = $processingLog->processing_metadata?->toArray() ?? [];
 
-            Log::info('SermonCreationService: Using date extracted from file metadata', [
-                'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
-                'extracted_date' => $this->sanitizeForLog($extractedDate),
-                'extraction_method' => $this->sanitizeForLog((string) ($processingMetadata['date_extraction_method'] ?? 'unknown')),
-            ]);
+            Log::info('SermonCreationService: Using date extracted from file metadata', $this->sanitizeArrayForLog([
+                'processing_id' => $processingLog->processing_id,
+                'extracted_date' => $extractedDate,
+                'extraction_method' => (string) ($processingMetadata['date_extraction_method'] ?? 'unknown'),
+            ]));
 
             return $extractedDate;
         }
 
         $filenameDate = $this->filenameParser->extractDateFromFilename($filename)->toDateString();
 
-        Log::info('SermonCreationService: Using date extracted from filename', [
-            'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
-            'filename' => $this->sanitizeForLog($filename),
-            'extracted_date' => $this->sanitizeForLog($filenameDate),
-        ]);
+        Log::info('SermonCreationService: Using date extracted from filename', $this->sanitizeArrayForLog([
+            'processing_id' => $processingLog->processing_id,
+            'filename' => $filename,
+            'extracted_date' => $filenameDate,
+        ]));
 
         return $filenameDate;
     }
@@ -556,22 +560,22 @@ class SermonCreationService
         if ($processingLog->extracted_service instanceof SermonService) {
             $processingMetadata = $processingLog->processing_metadata?->toArray() ?? [];
 
-            Log::info('SermonCreationService: Using service extracted from file metadata', [
-                'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
+            Log::info('SermonCreationService: Using service extracted from file metadata', $this->sanitizeArrayForLog([
+                'processing_id' => $processingLog->processing_id,
                 'extracted_service' => $processingLog->extracted_service->value,
-                'extraction_method' => $this->sanitizeForLog((string) ($processingMetadata['service_extraction_method'] ?? 'unknown')),
-            ]);
+                'extraction_method' => (string) ($processingMetadata['service_extraction_method'] ?? 'unknown'),
+            ]));
 
             return $processingLog->extracted_service;
         }
 
         $service = $this->filenameParser->determineServiceFromFilename($filename);
 
-        Log::info('SermonCreationService: Using service detected from filename', [
-            'processing_id' => $this->sanitizeForLog($processingLog->processing_id),
-            'filename' => $this->sanitizeForLog($filename),
+        Log::info('SermonCreationService: Using service detected from filename', $this->sanitizeArrayForLog([
+            'processing_id' => $processingLog->processing_id,
+            'filename' => $filename,
             'service' => $service->value,
-        ]);
+        ]));
 
         return $service;
     }

--- a/tests/Integration/Services/SermonProcessingLoggerTest.php
+++ b/tests/Integration/Services/SermonProcessingLoggerTest.php
@@ -250,6 +250,26 @@ class SermonProcessingLoggerTest extends TestCase
     // --- logHealthCheck() ---
 
     #[Test]
+    public function it_sanitizes_log_data_to_prevent_log_injection(): void
+    {
+        Log::spy();
+
+        // Input with control characters (potential log injection)
+        $maliciousFilename = "sermon\ntitle\r.mp3";
+
+        $this->logger->logProcessingStart('proc-001', $maliciousFilename);
+
+        Log::shouldHaveReceived('info')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                // The newline and carriage return should be replaced by spaces
+                return ! str_contains($context['filename'], "\n")
+                    && ! str_contains($context['filename'], "\r")
+                    && str_contains($context['filename'], 'sermon title');
+            });
+    }
+
+    #[Test]
     public function it_logs_healthy_check_as_info(): void
     {
         Log::shouldReceive('log')


### PR DESCRIPTION
This PR implements additive security hardening by standardizing log sanitization and improving exception documentation in the media processing and sermon creation layers.

Key changes:
- **Log Sanitization**: Standardized `SermonCreationService` to use `sanitizeArrayForLog()` for all context data passed to `Log::*` calls. This ensures comprehensive protection against log injection by stripping control characters from all user-controlled or metadata-derived strings.
- **Documentation**: Added explicit `@throws` PHPDoc annotations to `MediaController` and `SermonCreationService` public methods to improve transparency for security-conscious development.
- **Verification**: Added an integration test in `SermonProcessingLoggerTest` to verify that control characters are correctly sanitized in log contexts.

These changes strictly follow the Sentinel mission of additive hardening within a narrowed scope.

---
*PR created automatically by Jules for task [17403645158558344801](https://jules.google.com/task/17403645158558344801) started by @GarethClarridge*