### PR TITLE
♿ Aria: [a11y improvement] fix hidden card headings and navigation links

### DIFF
--- a/resources/views/components/childrens-talk-card.blade.php
+++ b/resources/views/components/childrens-talk-card.blade.php
@@ -11,9 +11,8 @@
         <a
             href="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}"
             wire:navigate
-            tabindex="-1"
-            aria-hidden="true"
-            class="relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
+            aria-label="{{ $sermon->title }}"
+            class="relative z-10 block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
         >
             <img
                 src="{{ $cardThumbnailUrl }}"
@@ -38,9 +37,8 @@
                 <a
                     href="{{ route('childrens-corner.show', ['sermon' => $sermon->slug]) }}"
                     wire:navigate
-                    tabindex="-1"
-                    aria-hidden="true"
-                    class="block rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
+                    aria-label="{{ $sermon->title }}"
+                    class="relative z-10 block rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
                 >
                     <h2 class="font-display text-2xl leading-tight text-gray-900 transition-colors hover:text-cbc-teal-dark">
                         {{ $sermon->title }}

--- a/resources/views/components/page-card.blade.php
+++ b/resources/views/components/page-card.blade.php
@@ -24,7 +24,7 @@
     }
 @endphp
 <div class="group relative mb-4 flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
-    <a class="relative block aspect-video overflow-hidden bg-slate-200" href="{{ $pageUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
+    <a class="relative z-10 block aspect-video overflow-hidden bg-slate-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2" href="{{ $pageUrl }}" wire:navigate aria-label="{{ $pageHeading }}">
         <img class="h-full w-full object-cover brightness-110 contrast-105 transition duration-500 ease-out group-hover:scale-105 group-hover:brightness-115" src="{{ $pageImageUrl }}" alt="{{ $pageHeading }}" onerror="this.onerror=null;this.src='/images/headings/small/default.webp';" loading="lazy" width="300" height="169">
         <div class="absolute inset-0 bg-gradient-to-t from-black/35 via-black/10 to-transparent"></div>
         <h2 class="absolute inset-x-5 top-1/2 -translate-y-1/2 text-center font-display text-3xl leading-[0.95] text-white [text-shadow:0_2px_8px_rgba(0,0,0,0.45)] sm:text-4xl">

--- a/resources/views/components/sermon-card.blade.php
+++ b/resources/views/components/sermon-card.blade.php
@@ -24,10 +24,8 @@
     <a
       href="{{ $sermonUrl }}"
       wire:navigate
-      tabindex="-1"
-      aria-hidden="true"
       data-sermon-card-thumbnail
-      class="relative block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200"
+      class="relative z-10 block aspect-video overflow-hidden border-b border-gray-100 bg-slate-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2"
     >
       <img
         src="{{ $thumbnailUrl }}"
@@ -47,13 +45,13 @@
 
   <div class="flex flex-col flex-1 p-6">
     @if (($sermon->title != null) && ! $thumbnailUrl)
-      <a class="group" href="{{ $sermonUrl }}" wire:navigate tabindex="-1" aria-hidden="true">
+      <a class="relative z-10 group rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2" href="{{ $sermonUrl }}" wire:navigate aria-label="{{ $sermon->title }}">
         <h2 class="font-display text-2xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
           {{$sermon->title}}
         </h2>
       </a>
     @elseif ($sermon->title != null)
-      <a class="group hidden" href="{{ $sermonUrl }}" wire:navigate data-sermon-card-title-fallback>
+      <a class="relative z-10 group hidden rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2" href="{{ $sermonUrl }}" wire:navigate data-sermon-card-title-fallback aria-label="{{ $sermon->title }}">
         <h2 class="font-display text-2xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
           {{$sermon->title}}
         </h2>

--- a/resources/views/livewire/church/songs/browse-songs.blade.php
+++ b/resources/views/livewire/church/songs/browse-songs.blade.php
@@ -105,7 +105,7 @@
                         <div class="flex flex-col flex-1 p-6 @if (!empty($snippetsBySongId[$song->id])) pb-0 @endif">
                             <div class="flex items-start justify-between gap-4">
                                 <div class="flex flex-col gap-2">
-                                    <a class="group" href="{{ $songUrl }}" wire:navigate tabindex="-1">
+                                    <a class="relative z-10 group rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-cbc-teal focus-visible:ring-offset-2" href="{{ $songUrl }}" wire:navigate aria-label="{{ $song->title }}">
                                         <h2 class="font-display text-3xl text-gray-900 group-hover:underline decoration-cbc-teal-light underline-offset-4">
                                             {{ $song->title }}
                                         </h2>


### PR DESCRIPTION
💡 **What:** Fixed accessibility violations in several card components where primary navigation links and headings were hidden from keyboard users and screen readers via `tabindex="-1"` and `aria-hidden="true"`.
🎯 **Who:** Screen reader users (who can now navigate via headings) and keyboard-only users (who can now focus and activate these links).
🧪 **How to verify:** Tab through the sermon list, song list, or page cards on the home page. Use a screen reader or accessibility inspector to verify that `h2` headings are no longer inside `aria-hidden` elements.
🔄 **Behavior:** Same visible behaviour — accessibility metadata and keyboard reachability improved. Added `focus-visible` rings for visual feedback during navigation.

---
*PR created automatically by Jules for task [773233013500286137](https://jules.google.com/task/773233013500286137) started by @GarethClarridge*