### PR TITLE
📖 Editor: standardise "Sync calendar" button text

### DIFF
--- a/resources/views/admin/calendar/uncategorized.blade.php
+++ b/resources/views/admin/calendar/uncategorized.blade.php
@@ -14,7 +14,7 @@
         <form method="POST" action="{{ route('admin.calendar.sync') }}" class="inline">
             @csrf
             <x-form-button variant="secondary" inline>
-                Sync Calendar
+                Sync calendar
             </x-form-button>
         </form>
     </x-slot:actions>

--- a/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
+++ b/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
@@ -106,7 +106,7 @@
                 >
                     @if(!$hasFilters)
                         <x-button link="{{ route('admin.calendar.sync') }}" variant="primary" icon="arrow-path" inline>
-                            Sync Calendar
+                            Sync calendar
                         </x-button>
                     @endif
                 </x-admin.empty-state>


### PR DESCRIPTION
### 💡 What:
Standardised the "Sync Calendar" button text to "Sync calendar" (sentence case) in two admin views.

### 🎯 Why:
To maintain consistency with the project's house style for button labels (sentence case) and to match the existing "Sync calendar" button in the same interface area.

### 🔄 Behavior:
No functional changes — copy only.

### 📍 Where:
- `resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php`: Updated the empty state button.
- `resources/views/admin/calendar/uncategorized.blade.php`: Updated the sync button in the header actions.

---
*PR created automatically by Jules for task [7902290676743331889](https://jules.google.com/task/7902290676743331889) started by @GarethClarridge*