### PR TITLE
📝 Scribe: Add unit tests for SermonViewPresenter and SermonPresentationAssembler

### DIFF
--- a/.Jules/scribe.md
+++ b/.Jules/scribe.md
@@ -13,3 +13,7 @@
 ## 2026-06-15 - [Model Precedence Testing]
 **Learning:** Testing methods like `semanticSectionType` which combine explicit property checks, type mapping, and fuzzy inference requires multiple test cases to verify the correct precedence order (Explicit property > Type match > Fuzzy inference).
 **Action:** Write separate test methods for each level of precedence in the model to ensure behavior is exactly as intended and protected against refactoring.
+
+## 2026-06-16 - [Presenter Memoization Testing]
+**Learning:** Testing memoization in presenters that use model identity (ID + `updated_at`) for cache keys requires either using `factory()->create()` or manually setting the `updated_at` timestamp. Without a persisted state or explicit timestamp, consecutive calls might yield different cache keys if the object hash or internal state changes.
+**Action:** Use `factory()->create()` for memoization tests that rely on `cacheKey()` logic, or explicitly mock the storage service to verify that it is only called once.

--- a/tests/Unit/Presenters/SermonPresentationAssemblerTest.php
+++ b/tests/Unit/Presenters/SermonPresentationAssemblerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Presenters;
+
+use App\Models\Sermon;
+use App\Presenters\SermonPresentationAssembler;
+use App\Presenters\SermonViewPresenter;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonPresentationAssemblerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private SermonViewPresenter&MockInterface $presenter;
+
+    private SermonPresentationAssembler $assembler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->presenter = Mockery::mock(SermonViewPresenter::class);
+        $this->assembler = new SermonPresentationAssembler;
+    }
+
+    #[Test]
+    public function for_api_returns_expected_shape(): void
+    {
+        $sermon = Sermon::factory()->make();
+
+        $this->presenter->shouldReceive('audioUrl')->with($sermon)->andReturn('audio_url');
+        $this->presenter->shouldReceive('displayReference')->with($sermon)->andReturn('ref');
+        $this->presenter->shouldReceive('durationIso8601')->with($sermon)->andReturn('iso_duration');
+        $this->presenter->shouldReceive('formattedDuration')->with($sermon)->andReturn('human_duration');
+        $this->presenter->shouldReceive('humanDate')->with($sermon)->andReturn('human_date');
+        $this->presenter->shouldReceive('preacherImageUrl')->with($sermon)->andReturn('preacher_img');
+        $this->presenter->shouldReceive('displayPreacherName')->with($sermon)->andReturn('preacher_name');
+        $this->presenter->shouldReceive('preacherUrl')->with($sermon)->andReturn('preacher_url');
+        $this->presenter->shouldReceive('seriesUrl')->with($sermon)->andReturn('series_url');
+        $this->presenter->shouldReceive('thumbnailUrl')->with($sermon)->andReturn('thumb_url');
+        $this->presenter->shouldReceive('videoUrl')->with($sermon)->andReturn('video_url');
+
+        $result = $this->assembler->forApi($this->presenter, $sermon);
+
+        $this->assertSame([
+            'audio_url' => 'audio_url',
+            'display_reference' => 'ref',
+            'duration_iso8601' => 'iso_duration',
+            'formatted_duration' => 'human_duration',
+            'human_date' => 'human_date',
+            'preacher_image_url' => 'preacher_img',
+            'preacher_name' => 'preacher_name',
+            'preacher_url' => 'preacher_url',
+            'series_url' => 'series_url',
+            'thumbnail_url' => 'thumb_url',
+            'video_url' => 'video_url',
+        ], $result);
+    }
+
+    #[Test]
+    public function for_list_returns_expected_shape(): void
+    {
+        $sermon = Sermon::factory()->make(['slug' => 'test-sermon', 'transcript_file_path' => 'transcript.txt']);
+
+        $this->presenter->shouldReceive('formattedDates')->with($sermon)->andReturn([
+            'iso' => '2024-03-10',
+            'short' => '10 March 2024',
+            'human' => 'March 10, 2024',
+        ]);
+        $this->presenter->shouldReceive('audioUrl')->with($sermon)->andReturn('audio_url');
+        $this->presenter->shouldReceive('canonicalUrl')->with($sermon)->andReturn('canonical_url');
+        $this->presenter->shouldReceive('cardThumbnailUrl')->with($sermon)->andReturn('card_thumb');
+        $this->presenter->shouldReceive('displayReference')->with($sermon)->andReturn('ref');
+        $this->presenter->shouldReceive('durationIso8601')->with($sermon)->andReturn('iso_duration');
+        $this->presenter->shouldReceive('formattedDuration')->with($sermon)->andReturn('human_duration');
+        $this->presenter->shouldReceive('plainThumbnailUrl')->with($sermon)->andReturn('plain_thumb');
+        $this->presenter->shouldReceive('preacherImageUrl')->with($sermon)->andReturn('preacher_img');
+        $this->presenter->shouldReceive('displayPreacherName')->with($sermon)->andReturn('preacher_name');
+        $this->presenter->shouldReceive('preacherUrl')->with($sermon)->andReturn('preacher_url');
+        $this->presenter->shouldReceive('publicUrl')->with($sermon)->andReturn('public_url');
+        $this->presenter->shouldReceive('seriesUrl')->with($sermon)->andReturn('series_url');
+        $this->presenter->shouldReceive('serviceLabel')->with($sermon)->andReturn('service_label');
+        $this->presenter->shouldReceive('thumbnailUrl')->with($sermon)->andReturn('thumb_url');
+        $this->presenter->shouldReceive('videoUrl')->with($sermon)->andReturn('video_url');
+
+        $result = $this->assembler->forList($this->presenter, $sermon);
+
+        $this->assertSame([
+            'audio_url' => 'audio_url',
+            'canonical_url' => 'canonical_url',
+            'card_thumbnail_url' => 'card_thumb',
+            'date_iso' => '2024-03-10',
+            'date_string' => '10 March 2024',
+            'display_reference' => 'ref',
+            'duration_iso8601' => 'iso_duration',
+            'formatted_duration' => 'human_duration',
+            'has_transcript' => true,
+            'human_date' => 'March 10, 2024',
+            'plain_thumbnail_url' => 'plain_thumb',
+            'preacher_image_url' => 'preacher_img',
+            'preacher_name' => 'preacher_name',
+            'preacher_url' => 'preacher_url',
+            'public_url' => 'public_url',
+            'series_url' => 'series_url',
+            'service_label' => 'service_label',
+            'thumbnail_url' => 'thumb_url',
+            'transcript_url' => route('sermons.transcript', ['sermon' => 'test-sermon']),
+            'video_url' => 'video_url',
+        ], $result);
+    }
+
+    #[Test]
+    public function for_full_returns_expected_shape(): void
+    {
+        $sermon = Sermon::factory()->make();
+        $listData = ['key' => 'value'];
+
+        $this->presenter->shouldReceive('presentForList')->with($sermon)->andReturn($listData);
+        $this->presenter->shouldReceive('transcript')->with($sermon)->andReturn('transcript_content');
+        $this->presenter->shouldReceive('plainTextOutline')->with($sermon)->andReturn('outline_content');
+
+        $result = $this->assembler->forFull($this->presenter, $sermon);
+
+        $this->assertSame([
+            'key' => 'value',
+            'transcript' => 'transcript_content',
+            'plain_text_outline' => 'outline_content',
+        ], $result);
+    }
+}

--- a/tests/Unit/Presenters/SermonViewPresenterTest.php
+++ b/tests/Unit/Presenters/SermonViewPresenterTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Presenters;
+
+use App\Enums\SermonService;
+use App\Models\Preacher;
+use App\Models\ScripturePassage;
+use App\Models\Sermon;
+use App\Presenters\SermonViewPresenter;
+use App\Services\Media\Audio\SermonTranscriptReader;
+use App\Services\Sermon\SermonExposurePolicy;
+use App\Services\Sermon\SermonStorageService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonViewPresenterTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private SermonExposurePolicy&MockInterface $exposurePolicy;
+
+    private SermonStorageService&MockInterface $storageService;
+
+    private SermonTranscriptReader&MockInterface $transcriptReader;
+
+    private SermonViewPresenter $presenter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->exposurePolicy = Mockery::mock(SermonExposurePolicy::class);
+        $this->storageService = Mockery::mock(SermonStorageService::class);
+        $this->transcriptReader = Mockery::mock(SermonTranscriptReader::class);
+
+        $this->presenter = new SermonViewPresenter(
+            $this->exposurePolicy,
+            $this->storageService,
+            $this->transcriptReader
+        );
+    }
+
+    #[Test]
+    public function it_formats_duration_as_human_readable_string(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => 2705]); // 45m (floored)
+
+        $this->assertSame('45m', $this->presenter->formattedDuration($sermon));
+    }
+
+    #[Test]
+    public function it_formats_duration_as_iso8601_string(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => 2705]);
+
+        $this->assertSame('PT45M5S', $this->presenter->durationIso8601($sermon));
+    }
+
+    #[Test]
+    public function it_returns_formatted_dates(): void
+    {
+        $sermon = Sermon::factory()->make(['date' => Carbon::parse('2024-03-10')]);
+
+        $dates = $this->presenter->formattedDates($sermon);
+
+        $this->assertSame('March 10, 2024', $dates['human']);
+        $this->assertSame('2024-03-10', $dates['iso']);
+        $this->assertSame('10 March 2024', $dates['short']);
+    }
+
+    #[Test]
+    public function it_returns_human_date(): void
+    {
+        $sermon = Sermon::factory()->make(['date' => Carbon::parse('2024-03-10')]);
+
+        $this->assertSame('March 10, 2024', $this->presenter->humanDate($sermon));
+    }
+
+    #[Test]
+    public function it_resolves_preacher_name_from_profile_if_loaded(): void
+    {
+        $preacher = Preacher::factory()->make(['name' => 'John Profile']);
+        $sermon = Sermon::factory()->make(['preacher' => 'Legacy Name']);
+        $sermon->setRelation('preacherProfile', $preacher);
+
+        $this->assertSame('John Profile', $this->presenter->displayPreacherName($sermon));
+    }
+
+    #[Test]
+    public function it_resolves_preacher_name_from_legacy_column_if_profile_not_loaded(): void
+    {
+        $sermon = Sermon::factory()->make(['preacher' => 'Legacy Name']);
+
+        $this->assertSame('Legacy Name', $this->presenter->displayPreacherName($sermon));
+    }
+
+    #[Test]
+    public function it_resolves_preacher_image_url_from_profile_if_loaded(): void
+    {
+        $preacher = Preacher::factory()->make(['image_path' => 'preachers/john.webp']);
+        $sermon = Sermon::factory()->make();
+        $sermon->setRelation('preacherProfile', $preacher);
+
+        $this->assertSame($preacher->profile_image_url, $this->presenter->preacherImageUrl($sermon));
+    }
+
+    #[Test]
+    public function it_returns_null_preacher_image_url_if_profile_not_loaded(): void
+    {
+        $sermon = Sermon::factory()->make();
+
+        $this->assertNull($this->presenter->preacherImageUrl($sermon));
+    }
+
+    #[Test]
+    public function it_returns_preacher_url_from_profile_slug_if_loaded(): void
+    {
+        $preacher = Preacher::factory()->make(['slug' => 'john-profile']);
+        $sermon = Sermon::factory()->make();
+        $sermon->setRelation('preacherProfile', $preacher);
+
+        $this->assertSame(route('sermons.preacher', ['preacher' => 'john-profile']), $this->presenter->preacherUrl($sermon));
+    }
+
+    #[Test]
+    public function it_returns_preacher_url_from_legacy_name_if_profile_not_loaded(): void
+    {
+        $sermon = Sermon::factory()->make(['preacher' => 'Legacy Name']);
+
+        $this->assertSame(route('sermons.preacher', ['preacher' => 'legacy-name']), $this->presenter->preacherUrl($sermon));
+    }
+
+    #[Test]
+    public function it_resolves_display_reference_from_passage_if_loaded(): void
+    {
+        $passage = ScripturePassage::factory()->make(['display_reference' => 'John 3:16']);
+        $sermon = Sermon::factory()->make(['reference' => 'Legacy Ref']);
+        $sermon->setRelation('scripturePassage', $passage);
+
+        $this->assertSame('John 3:16', $this->presenter->displayReference($sermon));
+    }
+
+    #[Test]
+    public function it_resolves_display_reference_from_legacy_column_if_passage_not_loaded(): void
+    {
+        $sermon = Sermon::factory()->make(['reference' => 'Legacy Ref']);
+
+        $this->assertSame('Legacy Ref', $this->presenter->displayReference($sermon));
+    }
+
+    #[Test]
+    public function it_returns_service_label(): void
+    {
+        $sermon = Sermon::factory()->make(['service' => SermonService::Morning]);
+
+        $this->assertSame('Morning', $this->presenter->serviceLabel($sermon));
+    }
+
+    #[Test]
+    public function it_returns_series_url(): void
+    {
+        $sermon = Sermon::factory()->make(['series' => 'Life Of David']);
+
+        $this->assertSame(route('sermons.series.show', ['series' => 'life-of-david']), $this->presenter->seriesUrl($sermon));
+    }
+
+    #[Test]
+    public function it_returns_audio_url_when_available(): void
+    {
+        $sermon = Sermon::factory()->make(['audio_file_path' => 'sermons/audio.mp3']);
+        $this->storageService->shouldReceive('getAudioDeliveryUrl')->with($sermon)->andReturn('https://cdn.example.com/audio.mp3');
+
+        $this->assertSame('https://cdn.example.com/audio.mp3', $this->presenter->audioUrl($sermon));
+    }
+
+    #[Test]
+    public function it_returns_video_url_when_exposed(): void
+    {
+        $sermon = Sermon::factory()->make();
+        $this->exposurePolicy->shouldReceive('shouldExposeVideo')->with($sermon)->andReturn(true);
+        $this->storageService->shouldReceive('getVideoDeliveryUrl')->with($sermon)->andReturn('https://cdn.example.com/video.mp4');
+
+        $this->assertSame('https://cdn.example.com/video.mp4', $this->presenter->videoUrl($sermon));
+    }
+
+    #[Test]
+    public function it_returns_null_video_url_when_not_exposed(): void
+    {
+        $sermon = Sermon::factory()->make();
+        $this->exposurePolicy->shouldReceive('shouldExposeVideo')->with($sermon)->andReturn(false);
+
+        $this->assertNull($this->presenter->videoUrl($sermon));
+    }
+
+    #[Test]
+    public function it_returns_thumbnail_url_when_exposed(): void
+    {
+        $sermon = Sermon::factory()->make([
+            'video_file_path' => 'video.mp4',
+            'thumbnail_file_path' => 'thumb.webp',
+        ]);
+        $this->exposurePolicy->shouldReceive('shouldExposeThumbnail')->with($sermon)->andReturn(true);
+        $this->storageService->shouldReceive('getThumbnailDeliveryUrl')->with($sermon)->andReturn('https://cdn.example.com/thumb.webp');
+
+        $this->assertSame('https://cdn.example.com/thumb.webp', $this->presenter->thumbnailUrl($sermon));
+    }
+
+    #[Test]
+    public function it_generates_meta_description(): void
+    {
+        $sermon = Sermon::factory()->make([
+            'title' => 'Test Sermon',
+            'preacher' => 'John Smith',
+            'date' => Carbon::parse('2024-03-10'),
+            'reference' => 'John 3:16',
+            'service' => SermonService::Morning,
+            'series' => null, // Keep it short so summary fits
+            'show_summary' => true,
+            'summary' => 'This is a summary.',
+        ]);
+        $this->exposurePolicy->shouldReceive('shouldExposeVideo')->andReturn(false);
+
+        $description = $this->presenter->metaDescription($sermon);
+
+        $this->assertStringContainsString('Test Sermon', $description);
+        $this->assertStringContainsString('John Smith', $description);
+        $this->assertStringContainsString('March 10, 2024', $description);
+        $this->assertStringContainsString('John 3:16', $description);
+        $this->assertStringContainsString('This is a summary.', $description);
+    }
+
+    #[Test]
+    public function it_memoizes_results(): void
+    {
+        $sermon = Sermon::factory()->create(['audio_file_path' => 'original.mp3']);
+
+        $this->storageService->shouldReceive('getAudioDeliveryUrl')->once()->with($sermon)->andReturn('https://cdn.example.com/url1');
+
+        // First call computes and should call storage service
+        $url1 = $this->presenter->audioUrl($sermon);
+
+        // Modify sermon - audioUrl is memoized by sermon ID + updated_at
+        $sermon->audio_file_path = 'changed.mp3';
+
+        // Second call should return memoized result without calling storage service again
+        $url2 = $this->presenter->audioUrl($sermon);
+
+        $this->assertSame($url1, $url2);
+        $this->assertSame('https://cdn.example.com/url1', $url2);
+    }
+
+    #[Test]
+    public function it_clears_internal_caches(): void
+    {
+        $sermon = Sermon::factory()->create(['series' => 'Cache Clear Test']);
+
+        $url1 = $this->presenter->seriesUrl($sermon);
+
+        $this->presenter->clearInternalCaches();
+
+        $sermon->series = 'New Series';
+        $url2 = $this->presenter->seriesUrl($sermon);
+
+        $this->assertNotSame($url1, $url2);
+        $this->assertStringContainsString('new-series', $url2);
+    }
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests for the `SermonViewPresenter` and `SermonPresentationAssembler` classes. These tests ensure that the logic for formatting sermon data, resolving preacher and scripture information (including fallbacks for legacy data), and generating media URLs is correct and robust. It also verifies that the presenters' memoization behavior works as intended to optimize performance.

Key improvements:
- Verified date and duration formatting logic.
- Tested relationship-based resolution vs. legacy string fallbacks for preachers and scripture.
- Ensured media URLs are correctly generated and respect exposure policies.
- Validated the array shapes returned for API and listing consumers.
- Confirmed that internal memoization and cache clearing function correctly.

All tests were run locally and in parallel, and the codebase remains PHPStan-clean.

---
*PR created automatically by Jules for task [14240615516616924807](https://jules.google.com/task/14240615516616924807) started by @GarethClarridge*