### PR TITLE
🧹 Tidy: Standardise presence checks using filled() and blank()

### DIFF
--- a/.Jules/tidy.md
+++ b/.Jules/tidy.md
@@ -7,3 +7,7 @@
 ## 2026-06-13 - Detailed PHPDoc Array Shapes for Complex Returns
 **Learning:** Standard `array<string, mixed>` return hints hide the internal structure of complex service results, making them brittle and hard to maintain without deep file exploration.
 **Action:** Use detailed array shape annotations (e.g., `array{key: string, sub: array{...}}`) in PHPDocs for private/internal methods that initialize or return complex structures. This provides immediate clarity for developers and enhances PHPStan's ability to catch property access errors.
+
+## 2026-06-21 - Standardising presence and absence checks
+**Learning:** Using explicit `!== null`, `=== null`, `=== []`, and `empty()`/`!empty()` comparisons on strings, arrays, and models is less expressive and can lead to subtle inconsistencies (e.g., whitespace-only strings being treated as "present").
+**Action:** Prefer Laravel's `filled()` and `blank()` helpers. They provide a unified, expressive API for checking "meaningful" presence across strings (handles whitespace), arrays, and models, improving readability and robustness.

--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -304,7 +304,7 @@ class Sermon extends Model implements Sitemapable
             get: function (): ?string {
                 $metadata = $this->thumbnail_metadata;
 
-                if ($metadata === null) {
+                if (blank($metadata)) {
                     return null;
                 }
 
@@ -425,30 +425,30 @@ class Sermon extends Model implements Sitemapable
 
     public function hasPlainThumbnail(): bool
     {
-        return $this->plain_thumbnail_file_path !== null;
+        return filled($this->plain_thumbnail_file_path);
     }
 
     public function hasCardThumbnail(): bool
     {
-        return $this->card_thumbnail_file_path !== null;
+        return filled($this->card_thumbnail_file_path);
     }
 
     public function hasThumbnailCandidates(): bool
     {
-        return $this->thumbnail_candidates !== [];
+        return filled($this->thumbnail_candidates);
     }
 
     public function hasVideoGeneratedThumbnail(): bool
     {
         $metadata = $this->thumbnail_metadata;
 
-        if ($metadata === null) {
+        if (blank($metadata)) {
             return false;
         }
 
-        return $metadata->videoDuration !== null
-            || $metadata->thumbnailCandidates !== []
-            || $metadata->selectedThumbnailCandidateId !== null;
+        return filled($metadata->videoDuration)
+            || filled($metadata->thumbnailCandidates)
+            || filled($metadata->selectedThumbnailCandidateId);
     }
 
     /**
@@ -500,7 +500,7 @@ class Sermon extends Model implements Sitemapable
          * We prioritize latestProcessingLog as it is more commonly eager-loaded in listing views.
          */
         if ($this->relationLoaded('latestProcessingLog')) {
-            return $this->latestProcessingLog !== null;
+            return filled($this->latestProcessingLog);
         }
 
         if ($this->relationLoaded('processingLogs')) {

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -124,7 +124,7 @@ class Song extends Model
         $uniqueCanonicalKey = function (string $attribute, mixed $value, \Closure $fail) use ($ignoreId): void {
             $normalised = self::canonicalizeKey((string) $value);
             $query = self::query()->where('canonical_key', $normalised);
-            if ($ignoreId !== null) {
+            if (filled($ignoreId)) {
                 $query->where('id', '!=', $ignoreId);
             }
             if ($query->exists()) {
@@ -242,7 +242,7 @@ class Song extends Model
     public function displayVideo(): ?SongVideo
     {
         $featured = $this->featuredVideo()->first();
-        if ($featured !== null) {
+        if (filled($featured)) {
             return $featured;
         }
 

--- a/app/Services/BritishEnglishConverter.php
+++ b/app/Services/BritishEnglishConverter.php
@@ -36,10 +36,10 @@ class BritishEnglishConverter
      */
     public function convert(string $text): string
     {
-        if ($this->patterns === null || $this->replacements === null) {
+        if (blank($this->patterns) || blank($this->replacements)) {
             $corrections = $this->getCorrections();
 
-            if (empty($corrections)) {
+            if (blank($corrections)) {
                 return $text;
             }
 
@@ -72,7 +72,7 @@ class BritishEnglishConverter
         // Load from external word list if available, otherwise use built-in
         $wordList = $this->loadWordList();
 
-        if (! empty($wordList)) {
+        if (filled($wordList)) {
             return $this->buildCorrectionsFromWordList($wordList);
         }
 

--- a/app/Services/Sermon/SermonCreationService.php
+++ b/app/Services/Sermon/SermonCreationService.php
@@ -58,7 +58,7 @@ class SermonCreationService
             $options->contentType,
         );
 
-        if ($existing === null) {
+        if (blank($existing)) {
             return $this->createFresh($processingLog, $options, $sermonDate, $service);
         }
 
@@ -115,11 +115,11 @@ class SermonCreationService
 
     private function detectExistingRichness(Sermon $existing): RichnessLevel
     {
-        if ($existing->livestream_processing_id !== null) {
+        if (filled($existing->livestream_processing_id)) {
             return RichnessLevel::Livestream;
         }
 
-        if (! empty($existing->video_file_path)) {
+        if (filled($existing->video_file_path)) {
             return RichnessLevel::Video;
         }
 
@@ -164,19 +164,19 @@ class SermonCreationService
     ): Sermon {
         $updates = [];
 
-        if ($options->videoFilePath) {
+        if (filled($options->videoFilePath)) {
             $updates['video_file_path'] = $options->videoFilePath;
         }
 
-        if ($options->livestreamProcessingId) {
+        if (filled($options->livestreamProcessingId)) {
             $updates['livestream_processing_id'] = $options->livestreamProcessingId;
         }
 
-        if ($options->segmentStartTime !== null) {
+        if (filled($options->segmentStartTime)) {
             $updates['segment_start_time'] = $options->segmentStartTime;
         }
 
-        if ($options->segmentEndTime !== null) {
+        if (filled($options->segmentEndTime)) {
             $updates['segment_end_time'] = $options->segmentEndTime;
         }
 
@@ -191,7 +191,7 @@ class SermonCreationService
         $this->fillReferenceIfBlank($existing, $options, $updates);
         $this->fillPointsIfBlank($existing, $options, $updates);
 
-        if (empty($existing->duration) && $options->duration !== null) {
+        if (blank($existing->duration) && filled($options->duration)) {
             $updates['duration'] = $options->duration;
         }
 
@@ -208,7 +208,7 @@ class SermonCreationService
             }
         }
 
-        if ($updates !== []) {
+        if (filled($updates)) {
             $existing->fill($updates);
             $existing->save();
         }
@@ -242,25 +242,25 @@ class SermonCreationService
             $updates['video_file_path'] = $options->videoFilePath;
         }
 
-        if ($options->transcriptFilePath) {
+        if (filled($options->transcriptFilePath)) {
             $updates['transcript_file_path'] = $options->transcriptFilePath;
         }
 
         if ($incoming === MediaType::Livestream) {
-            if ($options->livestreamProcessingId) {
+            if (filled($options->livestreamProcessingId)) {
                 $updates['livestream_processing_id'] = $options->livestreamProcessingId;
             }
 
-            if ($options->segmentStartTime !== null) {
+            if (filled($options->segmentStartTime)) {
                 $updates['segment_start_time'] = $options->segmentStartTime;
             }
 
-            if ($options->segmentEndTime !== null) {
+            if (filled($options->segmentEndTime)) {
                 $updates['segment_end_time'] = $options->segmentEndTime;
             }
         }
 
-        if ($options->duration !== null) {
+        if (filled($options->duration)) {
             $updates['duration'] = $options->duration;
         }
 
@@ -282,7 +282,7 @@ class SermonCreationService
             $updates['needs_preacher_review'] = $resolved['needs_review'];
         }
 
-        if ($updates !== []) {
+        if (filled($updates)) {
             $existing->fill($updates);
             $existing->save();
         }
@@ -466,7 +466,7 @@ class SermonCreationService
     {
         $explicitPreacher = $this->normalizePreacherInput($options->preacher);
 
-        if ($explicitPreacher !== null) {
+        if (filled($explicitPreacher)) {
             $preacherModel = $this->resolveExplicitPreacher($explicitPreacher, $options->preacherId);
 
             return [
@@ -480,7 +480,7 @@ class SermonCreationService
 
         $id3Preacher = $this->normalizePreacherInput($options->id3Preacher);
         $preacherName = $id3Preacher ?? 'Visiting Speaker';
-        $preacherSource = $id3Preacher !== null ? PreacherSource::Id3 : PreacherSource::Default;
+        $preacherSource = filled($id3Preacher) ? PreacherSource::Id3 : PreacherSource::Default;
 
         return [
             'preacher_name' => $preacherName,
@@ -493,7 +493,7 @@ class SermonCreationService
 
     private function resolveExplicitPreacher(string $preacherName, ?int $preacherId): Preacher
     {
-        if ($preacherId !== null) {
+        if (filled($preacherId)) {
             $preacher = Preacher::query()->find($preacherId);
 
             if ($preacher instanceof Preacher) {
@@ -506,7 +506,7 @@ class SermonCreationService
 
     private function normalizePreacherInput(?string $name): ?string
     {
-        if ($name === null) {
+        if (blank($name)) {
             return null;
         }
 
@@ -522,7 +522,7 @@ class SermonCreationService
         MediaProcessingLog $processingLog,
         string $filename
     ): string {
-        if ($processingLog->extracted_date !== null) {
+        if (filled($processingLog->extracted_date)) {
             $extractedDate = $processingLog->extracted_date->toDateString();
             $processingMetadata = $processingLog->processing_metadata?->toArray() ?? [];
 
@@ -645,7 +645,7 @@ class SermonCreationService
         /** @var MediaProcessingLog|null $processingLog */
         $processingLog = $context['processing_log'] ?? null;
 
-        if (empty($filename)) {
+        if (blank($filename)) {
             return 'Sermon - '.now()->format('F j, Y');
         }
 
@@ -661,7 +661,7 @@ class SermonCreationService
         $title = trim($title ?? '');
 
         // If title is empty or too short, use a default
-        if (empty($title) || strlen($title) < 3 || $this->looksLikeFilenameFragment($title)) {
+        if (blank($title) || strlen($title) < 3 || $this->looksLikeFilenameFragment($title)) {
             // Try to build from context
             $date = $context['date'] ?? $this->filenameParser->extractDateFromFilename($filename)->toDateString();
 

--- a/app/Services/Sermon/SermonCreationService.php
+++ b/app/Services/Sermon/SermonCreationService.php
@@ -191,7 +191,9 @@ class SermonCreationService
         $this->fillReferenceIfBlank($existing, $options, $updates);
         $this->fillPointsIfBlank($existing, $options, $updates);
 
-        if (blank($existing->duration) && filled($options->duration)) {
+        // A stored duration of 0 (or null) counts as missing, so a richer
+        // livestream/video source can still backfill the real length.
+        if (($existing->duration === null || $existing->duration <= 0) && filled($options->duration)) {
             $updates['duration'] = $options->duration;
         }
 


### PR DESCRIPTION
Standardise presence and absence checks across core models and services by replacing explicit null, empty string, and empty array comparisons with Laravel's `filled()` and `blank()` helpers.

This refactor improves readability and maintainability while adhering to modern Laravel standards. It also fixes a subtle logic bug in `Sermon::hasThumbnailCandidates()` where a `null` value would previously have returned `true`.

Modified files:
- `app/Models/Sermon.php`: Updated `cardThumbnailFilePath`, `hasPlainThumbnail`, `hasCardThumbnail`, `hasThumbnailCandidates`, `hasVideoGeneratedThumbnail`, and `isAutomated`.
- `app/Models/Song.php`: Updated `validationRules` and `displayVideo`.
- `app/Services/Sermon/SermonCreationService.php`: Updated `createSermon`, `detectExistingRichness`, `enrichExisting`, `replaceExisting`, `resolvePreacherAssignment`, `resolveExplicitPreacher`, `normalizePreacherInput`, `extractDate`, and `generateTitleFromFilename`.
- `app/Services/BritishEnglishConverter.php`: Updated `convert` and `buildCorrections`.

All existing tests pass unchanged.

---
*PR created automatically by Jules for task [11635520665980518072](https://jules.google.com/task/11635520665980518072) started by @GarethClarridge*