### PR TITLE
🏛️ Warden: Harden Sermon validation bounds to match DB capacities

### DIFF
--- a/app/Models/Sermon.php
+++ b/app/Models/Sermon.php
@@ -256,13 +256,13 @@ class Sermon extends Model implements Sitemapable
             'reference' => ['nullable', 'string', 'max:255', new NotEmptyString],
             'preacher' => ['required', 'string', 'max:255'], // Matches database varchar length and non-empty constraint
             // Security: integer bounding on ID and counter fields adds defence in depth against malformed input and overflow.
-            'preacher_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:preachers,id'],
+            'preacher_id' => ['nullable', 'integer', 'min:1', 'max:9223372036854775807', 'exists:preachers,id'],
             'preacher_source' => ['nullable', Rule::enum(PreacherSource::class)],
             'preacher_confidence' => ['nullable', 'numeric', 'min:0', 'max:1'],
             'segment_start_time' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
             'segment_end_time' => ['nullable', 'numeric', 'min:0', 'max:9999999.999', 'gte:segment_start_time'],
-            'scripture_passage_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:scripture_passages,id'],
-            'download_count' => ['nullable', 'integer', 'min:0', 'max:2147483647'],
+            'scripture_passage_id' => ['nullable', 'integer', 'min:1', 'max:9223372036854775807', 'exists:scripture_passages,id'],
+            'download_count' => ['nullable', 'integer', 'min:0', 'max:4294967295'],
             'duration' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
             'summary' => ['nullable', 'string', 'max:1000'],
             'points' => ['nullable', 'array', 'max:100'],

--- a/tests/Feature/WardenSermonValidationTest.php
+++ b/tests/Feature/WardenSermonValidationTest.php
@@ -111,14 +111,14 @@ class WardenSermonValidationTest extends TestCase
 
         // download_count has no exists rule, so a failure here can only come from the max bound.
         $validator = Validator::make([
-            'download_count' => 2147483648,
+            'download_count' => 4294967296,
         ], [
             'download_count' => $rules['download_count'],
         ]);
 
         $this->assertTrue($validator->fails());
         $this->assertEquals(
-            'The download count field must not be greater than 2147483647.',
+            'The download count field must not be greater than 4294967295.',
             $validator->errors()->first('download_count')
         );
     }
@@ -129,7 +129,7 @@ class WardenSermonValidationTest extends TestCase
         $rules = Sermon::validationRules();
 
         $validator = Validator::make([
-            'download_count' => 2147483647,
+            'download_count' => 4294967295,
         ], [
             'download_count' => $rules['download_count'],
         ]);


### PR DESCRIPTION
💡 **What:** Hardened integer validation bounds in the `Sermon` model.
🎯 **Why:** To ensure application-layer validation exactly mirrors the database schema's capacities, preventing potential overflows or silent truncation while providing a consistent safety net.
🗄️ **Migration:** No schema changes (validation-only fortification).
✅ **Verification:** Updated and executed `WardenSermonValidationTest`, and ran the full test suite (`php artisan test --parallel --compact`) with 100% success.
⚠️ **Rollback:** Revert the changes in `app/Models/Sermon.php` and `tests/Feature/WardenSermonValidationTest.php`.

---
*PR created automatically by Jules for task [11854340666185036065](https://jules.google.com/task/11854340666185036065) started by @GarethClarridge*