### PR TITLE
🔗 Pathfinder: Fix broken podcast transcript and admin links

### DIFF
--- a/app/Services/Public/PodcastFeedService.php
+++ b/app/Services/Public/PodcastFeedService.php
@@ -82,7 +82,7 @@ class PodcastFeedService
             publishedAt: $sermon->date->toRfc2822String(),
             sermonId: $sermon->id,
             title: $sermon->title,
-            transcriptUrl: $this->buildTranscriptUrl($sermon),
+            transcriptUrl: $this->sermonViewPresenter->transcriptUrl($sermon),
         );
     }
 
@@ -117,14 +117,6 @@ class PodcastFeedService
         return ! empty($parts) ? implode(' ', $parts).'.' : $sermon->title;
     }
 
-    private function buildTranscriptUrl(Sermon $sermon): ?string
-    {
-        if (! $sermon->transcript_file_path) {
-            return null;
-        }
-
-        return route('sermons.transcript', ['sermon' => $sermon->slug]);
-    }
 
     /**
      * Get feed metadata for a service type

--- a/app/Services/Public/PodcastFeedService.php
+++ b/app/Services/Public/PodcastFeedService.php
@@ -123,7 +123,7 @@ class PodcastFeedService
             return null;
         }
 
-        return url("/christ/sermons/{$sermon->date->format('Y')}/{$sermon->date->format('m')}/{$sermon->slug}/transcript");
+        return route('sermons.transcript', ['sermon' => $sermon->slug]);
     }
 
     /**

--- a/resources/views/components/edit-buttons.blade.php
+++ b/resources/views/components/edit-buttons.blade.php
@@ -1,17 +1,12 @@
 @if (isset($slug))
 @if (auth()->user()?->canAccessAdmin())
-<form class="m-6" action="/church/members/pages/{{$slug}}" method="POST">
-  <input type="hidden" name="_method" value="DELETE">
-  <input type="hidden" name="_token" value="{{ csrf_token() }}">
-  <x-button link="/church/members/pages/{{$slug}}/edit">
+<div class="m-6">
+  <x-button link="{{ route('admin.pages.edit', ['page' => $slug]) }}">
     <div class="flex items-center justify-center">
       <x-heroicon-s-pencil-square class="h-6 w-6 mr-2" aria-hidden="true" />
-
-
-
       Edit page
     </div>
   </x-button>
-</form>
+</div>
 @endif
 @endif


### PR DESCRIPTION
This PR addresses two link integrity issues identified during a diagnostic crawl of the site:

1. **Broken Transcript URLs in Podcast Feeds**: The `PodcastFeedService` was generating date-based URLs (e.g., `/christ/sermons/2024/11/slug/transcript`) that did not exist in the router. These have been updated to use the canonical `sermons.transcript` named route.
2. **Dead Admin Links**: The `x-edit-buttons` Blade component contained hardcoded legacy paths (`/church/members/pages/...`) that returned 404s. These have been updated to use the correct `admin.pages.edit` named route. Additionally, a non-functional legacy delete form was removed from the component, as page deletion is now handled through the main admin list view.

All related tests pass, and manual verification confirms the URLs now resolve correctly.

---
*PR created automatically by Jules for task [7803378696675339450](https://jules.google.com/task/7803378696675339450) started by @GarethClarridge*