### PR TITLE
🔦 Lighthouse: Enrich and synchronize sermon structured data

### DIFF
--- a/app/Seo/PreacherItemListPresenter.php
+++ b/app/Seo/PreacherItemListPresenter.php
@@ -22,7 +22,7 @@ class PreacherItemListPresenter
         $orgId = $appUrl.'/#organization';
 
         $worksFor = [
-            '@type' => 'Organization',
+            '@type' => 'Church',
             'name' => $orgName,
             '@id' => $orgId,
         ];

--- a/app/Seo/SeriesItemListPresenter.php
+++ b/app/Seo/SeriesItemListPresenter.php
@@ -39,7 +39,7 @@ class SeriesItemListPresenter
                         'url' => $seriesUrl,
                         'inLanguage' => 'en-GB',
                         'publisher' => [
-                            '@type' => 'Organization',
+                            '@type' => 'Church',
                             'name' => $orgName,
                             '@id' => $orgId,
                             'logo' => [

--- a/app/Seo/SermonItemListPresenter.php
+++ b/app/Seo/SermonItemListPresenter.php
@@ -84,7 +84,7 @@ class SermonItemListPresenter
     private function buildPublisher(string $orgName, string $logoUrl, string $orgId): array
     {
         return [
-            '@type' => 'Organization',
+            '@type' => 'Church',
             'name' => $orgName,
             '@id' => $orgId,
             'logo' => [
@@ -113,7 +113,7 @@ class SermonItemListPresenter
     private function buildWorksFor(string $orgName, string $orgId): array
     {
         return [
-            '@type' => 'Organization',
+            '@type' => 'Church',
             'name' => $orgName,
             '@id' => $orgId,
         ];
@@ -221,6 +221,8 @@ class SermonItemListPresenter
 
     /**
      * @param  array<string, mixed>  $sermonView
+     * @param  array<string, mixed>  $author
+     * @param  array<string, mixed>  $publisher
      * @return array<string, mixed>
      */
     private function buildVideoObject(
@@ -228,15 +230,21 @@ class SermonItemListPresenter
         array $sermonView,
         string $datePublished,
         string $metaDescription,
-        string $logoUrl
+        string $logoUrl,
+        array $author,
+        array $publisher,
     ): array {
         $video = [
             '@type' => 'VideoObject',
             'name' => $sermon->title,
+            'url' => $sermonView['video_url'],
             'description' => $metaDescription,
             'thumbnailUrl' => $sermonView['thumbnail_url'] ?: $logoUrl,
             'uploadDate' => $datePublished,
             'contentUrl' => $sermonView['video_url'],
+            'author' => $author,
+            'publisher' => $publisher,
+            'inLanguage' => 'en-GB',
         ];
 
         if ($sermonView['duration_iso8601']) {
@@ -248,21 +256,29 @@ class SermonItemListPresenter
 
     /**
      * @param  array<string, mixed>  $sermonView
+     * @param  array<string, mixed>  $author
+     * @param  array<string, mixed>  $publisher
      * @return array<string, mixed>
      */
     private function buildAudioObject(
         Sermon $sermon,
         array $sermonView,
         string $datePublished,
-        string $metaDescription
+        string $metaDescription,
+        array $author,
+        array $publisher,
     ): array {
         $audio = [
             '@type' => 'AudioObject',
             'name' => $sermon->title,
+            'url' => $sermonView['audio_url'],
             'contentUrl' => $sermonView['audio_url'],
             'description' => $metaDescription,
             'encodingFormat' => 'audio/mpeg',
             'uploadDate' => $datePublished,
+            'author' => $author,
+            'publisher' => $publisher,
+            'inLanguage' => 'en-GB',
         ];
 
         if ($sermonView['duration_iso8601']) {
@@ -312,7 +328,9 @@ class SermonItemListPresenter
                 $sermonView,
                 $datePublished,
                 $metaDescription,
-                $logoUrl
+                $logoUrl,
+                $author,
+                $publisher
             );
         }
 
@@ -321,7 +339,9 @@ class SermonItemListPresenter
                 $sermon,
                 $sermonView,
                 $datePublished,
-                $metaDescription
+                $metaDescription,
+                $author,
+                $publisher
             );
         }
 

--- a/resources/views/components/schema/sermon.blade.php
+++ b/resources/views/components/schema/sermon.blade.php
@@ -23,7 +23,7 @@
         'url' => $sermonView['preacher_url'],
         'jobTitle' => 'Preacher',
         'worksFor' => [
-            '@type' => 'Organization',
+            '@type' => 'Church',
             'name' => config('organization.name'),
             '@id' => config('app.url').'/#organization',
         ],
@@ -35,11 +35,25 @@
 
     $articleBody = $transcript ?: (($sermon->show_summary && $sermon->summary) ? strip_tags($sermon->summary) : null);
 
+    $publisher = [
+        '@type' => 'Church',
+        'name' => config('organization.name'),
+        '@id' => config('app.url').'/#organization',
+        'logo' => [
+            '@type' => 'ImageObject',
+            'url' => asset('images/Primary.png'),
+            'width' => 444,
+            'height' => 481,
+        ],
+    ];
+
     $schema = [
         '@' . 'context' => 'https://schema.org',
         '@type' => 'Article',
         '@id' => $sermonView['canonical_url'] . '#sermon',
         'headline' => $sermon->title,
+        'name' => $sermon->title,
+        'url' => $sermonView['canonical_url'],
         'description' => $metaDescription,
         'articleBody' => $articleBody,
         'image' => $thumbnailUrl,
@@ -48,17 +62,7 @@
         'inLanguage' => 'en-GB',
         'genre' => 'Sermon',
         'author' => $author,
-        'publisher' => [
-            '@type' => 'Organization',
-            'name' => config('organization.name'),
-            '@id' => config('app.url').'/#organization',
-            'logo' => [
-                '@type' => 'ImageObject',
-                'url' => asset('images/Primary.png'),
-                'width' => 444,
-                'height' => 481,
-            ],
-        ],
+        'publisher' => $publisher,
         'mainEntityOfPage' => [
             '@type' => 'WebPage',
             '@id' => $sermonView['canonical_url'] . '#webpage',
@@ -93,10 +97,14 @@
         $schema['video'] = [
             '@type' => 'VideoObject',
             'name' => $sermon->title,
+            'url' => $sermonView['video_url'],
             'description' => $metaDescription,
             'thumbnailUrl' => $thumbnailUrl,
             'uploadDate' => $datePublished,
             'contentUrl' => $sermonView['video_url'],
+            'author' => $author,
+            'publisher' => $publisher,
+            'inLanguage' => 'en-GB',
         ];
 
         if ($duration) {
@@ -112,10 +120,14 @@
         $schema['audio'] = [
             '@type' => 'AudioObject',
             'name' => $sermon->title,
+            'url' => $sermonView['audio_url'],
             'contentUrl' => $sermonView['audio_url'],
             'description' => $metaDescription,
             'encodingFormat' => 'audio/mpeg',
             'uploadDate' => $datePublished,
+            'author' => $author,
+            'publisher' => $publisher,
+            'inLanguage' => 'en-GB',
         ];
 
         if ($duration) {


### PR DESCRIPTION
This improvement synchronizes and enriches the JSON-LD structured data for sermons across the entire site.

💡 **What:**
- Replaced the generic `Organization` type with the more specific `Church` type in all sermon-related schemas (publisher, worksFor).
- Enriched `AudioObject` and `VideoObject` with `url`, `author`, `publisher`, and `inLanguage` properties.
- Added the `url` property to the main `Article` schema for sermons.
- Standardized these changes across `SermonItemListPresenter`, `SeriesItemListPresenter`, `PreacherItemListPresenter`, and the individual sermon schema component.

🎯 **Why:**
- Provides search engines with more precise and consistent information about the church and its media content.
- Using the specific `Church` schema type is recommended for religious organizations.
- Including author and publisher data directly within media objects (Audio/Video) improves the quality of rich results.

📊 **Impact:**
- All public sermon listing pages and individual sermon views now provide higher-quality, consistent metadata.
- Improved semantic accuracy for the church's identity in search results.

🔍 **Verification:**
- Verified with existing integration tests (`SermonItemListPresenterTest`, `SermonSchemaTest`, `SermonJsonLdTest`).
- Confirmed with a full parallel test run and static analysis (`phpstan`).
- Manual inspection of JSON-LD outputs confirms the correct enrichment and synchronization.

---
*PR created automatically by Jules for task [9022657168213286462](https://jules.google.com/task/9022657168213286462) started by @GarethClarridge*