### PR TITLE
🧪 Steward: Harden unit test hygiene

### DIFF
--- a/tests/Unit/Presenters/SermonPresentationAssemblerTest.php
+++ b/tests/Unit/Presenters/SermonPresentationAssemblerTest.php
@@ -7,7 +7,6 @@ namespace Tests\Unit\Presenters;
 use App\Models\Sermon;
 use App\Presenters\SermonPresentationAssembler;
 use App\Presenters\SermonViewPresenter;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Mockery;
 use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
@@ -15,8 +14,6 @@ use Tests\TestCase;
 
 class SermonPresentationAssemblerTest extends TestCase
 {
-    use DatabaseTransactions;
-
     private SermonViewPresenter&MockInterface $presenter;
 
     private SermonPresentationAssembler $assembler;

--- a/tests/Unit/Presenters/SermonViewPresenterTest.php
+++ b/tests/Unit/Presenters/SermonViewPresenterTest.php
@@ -13,7 +13,6 @@ use App\Services\Media\Audio\SermonTranscriptReader;
 use App\Services\Sermon\SermonExposurePolicy;
 use App\Services\Sermon\SermonStorageService;
 use Carbon\Carbon;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Mockery;
 use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
@@ -21,8 +20,6 @@ use Tests\TestCase;
 
 class SermonViewPresenterTest extends TestCase
 {
-    use DatabaseTransactions;
-
     private SermonExposurePolicy&MockInterface $exposurePolicy;
 
     private SermonStorageService&MockInterface $storageService;
@@ -238,7 +235,11 @@ class SermonViewPresenterTest extends TestCase
     #[Test]
     public function it_memoizes_results(): void
     {
-        $sermon = Sermon::factory()->create(['audio_file_path' => 'original.mp3']);
+        $sermon = Sermon::factory()->make([
+            'id' => 123,
+            'updated_at' => now(),
+            'audio_file_path' => 'original.mp3',
+        ]);
 
         $this->storageService->shouldReceive('getAudioDeliveryUrl')->once()->with($sermon)->andReturn('https://cdn.example.com/url1');
 
@@ -258,7 +259,11 @@ class SermonViewPresenterTest extends TestCase
     #[Test]
     public function it_clears_internal_caches(): void
     {
-        $sermon = Sermon::factory()->create(['series' => 'Cache Clear Test']);
+        $sermon = Sermon::factory()->make([
+            'id' => 456,
+            'updated_at' => now(),
+            'series' => 'Cache Clear Test',
+        ]);
 
         $url1 = $this->presenter->seriesUrl($sermon);
 

--- a/tests/Unit/Services/OpenAIResponseLoggerSecurityTest.php
+++ b/tests/Unit/Services/OpenAIResponseLoggerSecurityTest.php
@@ -11,30 +11,36 @@ use Tests\TestCase;
 
 class OpenAIResponseLoggerSecurityTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Log::spy();
+    }
+
     #[Test]
     public function it_sanitizes_processing_id_and_response_preview_in_log_response(): void
     {
-        Log::shouldReceive('warning')
+        OpenAIResponseLogger::logResponse("proc-123\n", 1, "malicious\nresponse\r\t");
+
+        Log::shouldHaveReceived('warning')
             ->once()
             ->withArgs(function (string $message, array $context) {
                 return $context['processing_id'] === 'proc-123'
                     && $context['response_content_preview'] === 'malicious response';
             });
-
-        OpenAIResponseLogger::logResponse("proc-123\n", 1, "malicious\nresponse\r\t");
     }
 
     #[Test]
     public function it_sanitizes_processing_id_and_error_message_and_body_preview_in_log_transport_error(): void
     {
-        Log::shouldReceive('error')
+        OpenAIResponseLogger::logTransportError("proc-123\r", 1, "transport\nerror\t", 500, "error\nbody\r");
+
+        Log::shouldHaveReceived('error')
             ->once()
             ->withArgs(function (string $message, array $context) {
                 return $context['processing_id'] === 'proc-123'
                     && $context['error_message'] === 'transport error'
                     && $context['response_body_preview'] === 'error body';
             });
-
-        OpenAIResponseLogger::logTransportError("proc-123\r", 1, "transport\nerror\t", 500, "error\nbody\r");
     }
 }

--- a/tests/Unit/Services/OpenAIResponseLoggerTest.php
+++ b/tests/Unit/Services/OpenAIResponseLoggerTest.php
@@ -11,10 +11,18 @@ use Tests\TestCase;
 
 class OpenAIResponseLoggerTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Log::spy();
+    }
+
     #[Test]
     public function it_logs_response_analysis_for_strings(): void
     {
-        Log::shouldReceive('warning')
+        OpenAIResponseLogger::logResponse('test-id', 1, 'test content', 'test-hint');
+
+        Log::shouldHaveReceived('warning')
             ->once()
             ->with('OpenAI API response type analysis', [
                 'processing_id' => 'test-id',
@@ -25,34 +33,32 @@ class OpenAIResponseLoggerTest extends TestCase
                 'response_length' => 12,
                 'is_json' => 'no',
             ]);
-
-        OpenAIResponseLogger::logResponse('test-id', 1, 'test content', 'test-hint');
     }
 
     #[Test]
     public function it_detects_likely_errors_in_string_responses(): void
     {
-        Log::shouldReceive('warning')
+        OpenAIResponseLogger::logResponse('test-id', 1, '<html> unauthorized rate limit </html>');
+
+        Log::shouldHaveReceived('warning')
             ->once()
             ->with('OpenAI API response type analysis', \Mockery::on(function ($data) {
                 return $data['likely_html_error'] === true &&
                        $data['likely_auth_error'] === true &&
                        $data['likely_rate_limit'] === true;
             }));
-
-        OpenAIResponseLogger::logResponse('test-id', 1, '<html> unauthorized rate limit </html>');
     }
 
     #[Test]
     public function it_detects_json_in_string_responses(): void
     {
-        Log::shouldReceive('warning')
+        OpenAIResponseLogger::logResponse('test-id', 1, json_encode(['foo' => 'bar']));
+
+        Log::shouldHaveReceived('warning')
             ->once()
             ->with('OpenAI API response type analysis', \Mockery::on(function ($data) {
                 return $data['is_json'] === 'yes';
             }));
-
-        OpenAIResponseLogger::logResponse('test-id', 1, json_encode(['foo' => 'bar']));
     }
 
     #[Test]
@@ -60,14 +66,14 @@ class OpenAIResponseLoggerTest extends TestCase
     {
         $longString = str_repeat('a', 600);
 
-        Log::shouldReceive('warning')
+        OpenAIResponseLogger::logResponse('test-id', 1, $longString);
+
+        Log::shouldHaveReceived('warning')
             ->once()
             ->with('OpenAI API response type analysis', \Mockery::on(function ($data) {
                 return strlen($data['response_content_preview']) === 500 &&
                        $data['response_length'] === 600;
             }));
-
-        OpenAIResponseLogger::logResponse('test-id', 1, $longString);
     }
 
     #[Test]
@@ -75,7 +81,9 @@ class OpenAIResponseLoggerTest extends TestCase
     {
         $responseData = ['foo' => 'bar', 'baz' => 'qux'];
 
-        Log::shouldReceive('warning')
+        OpenAIResponseLogger::logResponse('test-id', 1, $responseData);
+
+        Log::shouldHaveReceived('warning')
             ->once()
             ->with('OpenAI API response type analysis', [
                 'processing_id' => 'test-id',
@@ -85,14 +93,14 @@ class OpenAIResponseLoggerTest extends TestCase
                 'response_keys' => ['foo', 'baz'],
                 'response_structure_valid' => true,
             ]);
-
-        OpenAIResponseLogger::logResponse('test-id', 1, $responseData);
     }
 
     #[Test]
     public function it_logs_transport_errors_without_body(): void
     {
-        Log::shouldReceive('error')
+        OpenAIResponseLogger::logTransportError('test-id', 1, 'Network failure', 500);
+
+        Log::shouldHaveReceived('error')
             ->once()
             ->with('OpenAI API transport layer error', [
                 'processing_id' => 'test-id',
@@ -100,22 +108,20 @@ class OpenAIResponseLoggerTest extends TestCase
                 'error_message' => 'Network failure',
                 'status_code' => 500,
             ]);
-
-        OpenAIResponseLogger::logTransportError('test-id', 1, 'Network failure', 500);
     }
 
     #[Test]
     public function it_logs_transport_errors_with_non_json_body(): void
     {
-        Log::shouldReceive('error')
+        OpenAIResponseLogger::logTransportError('test-id', 1, 'Error', 404, 'Not found');
+
+        Log::shouldHaveReceived('error')
             ->once()
             ->with('OpenAI API transport layer error', \Mockery::on(function ($data) {
                 return $data['response_body_preview'] === 'Not found' &&
                        $data['response_body_length'] === 9 &&
                        $data['response_is_not_json'] === true;
             }));
-
-        OpenAIResponseLogger::logTransportError('test-id', 1, 'Error', 404, 'Not found');
     }
 
     #[Test]
@@ -123,13 +129,13 @@ class OpenAIResponseLoggerTest extends TestCase
     {
         $jsonBody = json_encode(['error' => ['message' => 'Invalid key']]);
 
-        Log::shouldReceive('error')
+        OpenAIResponseLogger::logTransportError('test-id', 1, 'Error', 401, $jsonBody);
+
+        Log::shouldHaveReceived('error')
             ->once()
             ->with('OpenAI API transport layer error', \Mockery::on(function ($data) {
                 return $data['error_response_json'] === ['error' => ['message' => 'Invalid key']];
             }));
-
-        OpenAIResponseLogger::logTransportError('test-id', 1, 'Error', 401, $jsonBody);
     }
 
     #[Test]
@@ -137,13 +143,13 @@ class OpenAIResponseLoggerTest extends TestCase
     {
         $longBody = str_repeat('b', 600);
 
-        Log::shouldReceive('error')
+        OpenAIResponseLogger::logTransportError('test-id', 1, 'Error', 500, $longBody);
+
+        Log::shouldHaveReceived('error')
             ->once()
             ->with('OpenAI API transport layer error', \Mockery::on(function ($data) {
                 return strlen($data['response_body_preview']) === 500 &&
                        $data['response_body_length'] === 600;
             }));
-
-        OpenAIResponseLogger::logTransportError('test-id', 1, 'Error', 500, $longBody);
     }
 }


### PR DESCRIPTION
Hardened several unit tests by removing unnecessary database transactions and refactoring log assertions to use the AAA pattern. This makes the tests faster and more robust against implementation details.

---
*PR created automatically by Jules for task [11235391386613822358](https://jules.google.com/task/11235391386613822358) started by @GarethClarridge*