### PR TITLE
🧹 Tidy: standardize presence and absence checks

### DIFF
--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -232,7 +232,7 @@ class Meeting extends Model implements HasMedia, Sitemapable
      */
     public function hasContent(): bool
     {
-        return $this->page !== null;
+        return filled($this->page);
     }
 
     /**
@@ -245,7 +245,7 @@ class Meeting extends Model implements HasMedia, Sitemapable
     {
         return Attribute::make(
             get: function (): ?string {
-                if ($this->meeting_date) {
+                if (filled($this->meeting_date)) {
                     $dateTime = $this->meeting_date;
                     // If start_time is a Carbon instance (due to cast) and represents a valid time
                     if ($this->start_time instanceof Carbon) {
@@ -312,7 +312,7 @@ class Meeting extends Model implements HasMedia, Sitemapable
     {
         $meetingDate = $this->meeting_date;
 
-        if (! $this->is_recurring || ! $meetingDate instanceof Carbon || ! $this->frequency) {
+        if (! $this->is_recurring || ! $meetingDate instanceof Carbon || blank($this->frequency)) {
             return null;
         }
 

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -68,7 +68,7 @@ class Page extends Model implements HasMedia, Sitemapable
 
             $heading = trim($page->heading);
 
-            $page->description = $heading !== '' ? $heading : 'No description provided.';
+            $page->description = filled($heading) ? $heading : 'No description provided.';
         });
     }
 
@@ -166,7 +166,7 @@ class Page extends Model implements HasMedia, Sitemapable
     {
         return Attribute::make(
             get: function (): ?string {
-                if ($this->slug !== '') {
+                if (filled($this->slug)) {
                     return '/'.trim($this->area->value, '/').'/'.trim($this->slug, '/');
                 }
 
@@ -244,7 +244,7 @@ class Page extends Model implements HasMedia, Sitemapable
             get: function (): string {
                 $description = trim(strip_tags($this->description ?? ''));
 
-                if (empty($description)) {
+                if (blank($description)) {
                     $description = $this->heading;
                 }
 

--- a/app/Models/Preacher.php
+++ b/app/Models/Preacher.php
@@ -114,7 +114,7 @@ class Preacher extends Model implements Sitemapable
     {
         return Attribute::make(
             get: function (): ?string {
-                if (! $this->image_path) {
+                if (blank($this->image_path)) {
                     return null;
                 }
 

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -182,7 +182,7 @@ class Song extends Model
     {
         $key = self::canonicalizeKey($value);
 
-        if ($key === '') {
+        if (blank($key)) {
             return [];
         }
 

--- a/app/Services/Sermon/SermonCreationService.php
+++ b/app/Services/Sermon/SermonCreationService.php
@@ -518,7 +518,7 @@ class SermonCreationService
 
         $normalized = $this->preacherResolutionService->normalizeWhitespace($name);
 
-        return $normalized === '' ? null : $normalized;
+        return filled($normalized) ? $normalized : null;
     }
 
     /**
@@ -712,7 +712,7 @@ class SermonCreationService
     {
         $normalized = trim($title);
 
-        if ($normalized === '') {
+        if (blank($normalized)) {
             return true;
         }
 


### PR DESCRIPTION
Standardized presence and absence checks in `Page`, `Meeting`, `Preacher`, and `Song` models, as well as `SermonCreationService`, by replacing manual checks with Laravel's `filled()` and `blank()` helpers. Verified with existing tests and full suite run.

---
*PR created automatically by Jules for task [12238089482348249170](https://jules.google.com/task/12238089482348249170) started by @GarethClarridge*