### PR TITLE
📜 Herald: Add PHPDoc to SectionPublication handlers

### DIFF
--- a/app/Services/ChurchService/SectionPublication/SermonPublicationHandler.php
+++ b/app/Services/ChurchService/SectionPublication/SermonPublicationHandler.php
@@ -19,10 +19,25 @@ use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
+/**
+ * Handler for promoting and publishing sermon segments extracted from livestreams.
+ *
+ * This handler manages the "livestream-to-sermon" pipeline, ensuring that extracted
+ * audio and video clips are correctly promoted to public storage, sermon metadata
+ * is resolved from the processing identity, and a canonical Sermon record is
+ * created or enriched via the SermonCreationService.
+ */
 class SermonPublicationHandler implements SectionPublicationHandler
 {
     use SanitizesLogData;
 
+    /**
+     * @param  ChildrensTalkSpeakerService  $childrensTalkSpeakerService  Service for detecting speakers in children's talks
+     * @param  SermonCreationService  $sermonCreationService  Service for richness-aware sermon upserts
+     * @param  MediaProcessingIdentityResolver  $identityResolver  Service for resolving date/service from processing logs
+     * @param  ServiceSectionPublicationTransitionService  $publicationTransitions  Service for managing section state transitions
+     * @param  ExtractedSectionMediaChecker  $mediaChecker  Service for verifying existence of extracted assets
+     */
     public function __construct(
         private readonly ChildrensTalkSpeakerService $childrensTalkSpeakerService,
         private readonly SermonCreationService $sermonCreationService,
@@ -31,16 +46,32 @@ class SermonPublicationHandler implements SectionPublicationHandler
         private readonly ExtractedSectionMediaChecker $mediaChecker,
     ) {}
 
+    /**
+     * {@inheritDoc}
+     */
     public function requiresAudioExtraction(): bool
     {
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function hasReusableExtractedMedia(ServiceSection $section): bool
     {
         return $this->mediaChecker->hasExtractedMedia($section);
     }
 
+    /**
+     * Determine if a sermon section is eligible for automated publication.
+     *
+     * Enforces the high-confidence requirement for automated sermon publication
+     * to prevent low-confidence segments from being published without administrative
+     * review.
+     *
+     * @param  ServiceSection  $section  The section to evaluate
+     * @return bool True if the section meets confidence thresholds or if requirements are disabled
+     */
     public function isEligible(ServiceSection $section): bool
     {
         $requireHighConfidence = (bool) config('media-processing.section_publishing.require_high_confidence', true);
@@ -48,6 +79,9 @@ class SermonPublicationHandler implements SectionPublicationHandler
         return ! $requireHighConfidence || ($section->confidence ?? 0.0) >= ServiceSectionConfidence::HIGH_THRESHOLD;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function afterExtraction(ServiceSection $section): void
     {
         if ($section->section_type === ServiceSectionType::ChildrensTalk) {
@@ -55,11 +89,26 @@ class SermonPublicationHandler implements SectionPublicationHandler
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function requiresApproval(): bool
     {
         return true;
     }
 
+    /**
+     * Publish an approved sermon section to the public sermon repository.
+     *
+     * Promotes extracted audio and video assets to permanent storage, resolves the
+     * sermon's identity (date/service) from the parent processing log, and
+     * initiates a richness-aware upsert of the Sermon record.
+     *
+     * @param  ServiceSection  $section  The approved section to publish
+     *
+     * @throws \RuntimeException If assets are missing, identity cannot be resolved,
+     *                           or state transitions fail.
+     */
     public function publish(ServiceSection $section): void
     {
         $processingLog = $section->processingLog;
@@ -134,6 +183,11 @@ class SermonPublicationHandler implements SectionPublicationHandler
         $section->save();
     }
 
+    /**
+     * Handle the removal of a section by logging a warning if it was already published.
+     *
+     * @param  ServiceSection  $section  The removed section
+     */
     public function onSectionRemoved(ServiceSection $section): void
     {
         if ($section->published_sermon_id === null) {

--- a/app/Services/ChurchService/SectionPublication/SongPublicationHandler.php
+++ b/app/Services/ChurchService/SectionPublication/SongPublicationHandler.php
@@ -17,10 +17,24 @@ use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
+/**
+ * Handler for enhancing and publishing song segments extracted from livestreams.
+ *
+ * This handler manages the "livestream-to-song" pipeline, which includes downloading
+ * extracted video clips, applying audio enhancement (normalization) if possible,
+ * and promoting the final video asset to the public sermon disk where it is
+ * linked to a canonical Song model.
+ */
 class SongPublicationHandler implements SectionPublicationHandler
 {
     use SanitizesLogData;
 
+    /**
+     * @param  SongVideoService  $songVideoService  Service for managing song video records
+     * @param  ServiceSectionPublicationTransitionService  $publicationTransitions  Service for managing section state transitions
+     * @param  AudioEnhancementService  $audioEnhancement  Service for normalizing audio in video files
+     * @param  StorageAdapterHelper  $storageHelper  Service for cross-disk storage operations
+     */
     public function __construct(
         private readonly SongVideoService $songVideoService,
         private readonly ServiceSectionPublicationTransitionService $publicationTransitions,
@@ -28,11 +42,17 @@ class SongPublicationHandler implements SectionPublicationHandler
         private readonly StorageAdapterHelper $storageHelper,
     ) {}
 
+    /**
+     * {@inheritDoc}
+     */
     public function requiresAudioExtraction(): bool
     {
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function hasReusableExtractedMedia(ServiceSection $section): bool
     {
         $videoPath = $section->extracted_video_path;
@@ -44,6 +64,15 @@ class SongPublicationHandler implements SectionPublicationHandler
         return Storage::disk($section->extractedAssetDisk($videoPath))->exists($videoPath);
     }
 
+    /**
+     * Determine if a song section is eligible for automated publication.
+     *
+     * Song publication requires either a confirmed song match or a high-confidence
+     * inferred match linked to a canonical Song record in the database.
+     *
+     * @param  ServiceSection  $section  The section to evaluate
+     * @return bool True if the section is linked to a valid song
+     */
     public function isEligible(ServiceSection $section): bool
     {
         if (! $section->hasConfirmedSongMatch() && ! $section->hasInferredSongMatch()) {
@@ -55,16 +84,34 @@ class SongPublicationHandler implements SectionPublicationHandler
         return $item !== null && $item->song_id !== null;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function afterExtraction(ServiceSection $section): void
     {
         // No post-extraction enrichment needed for songs.
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function requiresApproval(): bool
     {
         return false;
     }
 
+    /**
+     * Publish a song section by enhancing its audio and promoting the asset.
+     *
+     * Downloads the extracted video to local temp storage, applies normalization
+     * via the AudioEnhancementService, and promotes the final MP4 to the public
+     * sermon disk before creating the SongVideo record.
+     *
+     * @param  ServiceSection  $section  The section to publish
+     *
+     * @throws \RuntimeException If assets are missing, song links are broken,
+     *                           or storage promotion fails.
+     */
     public function publish(ServiceSection $section): void
     {
         // Idempotent: skip if a SongVideo already exists for this section.
@@ -136,6 +183,11 @@ class SongPublicationHandler implements SectionPublicationHandler
         $section->save();
     }
 
+    /**
+     * Handle removal of a section by deleting its associated SongVideo and file.
+     *
+     * @param  ServiceSection  $section  The removed section
+     */
     public function onSectionRemoved(ServiceSection $section): void
     {
         $songVideo = SongVideo::query()


### PR DESCRIPTION
### 💡 What: Documentation added or corrected
Added comprehensive PHPDoc blocks to `SermonPublicationHandler` and `SongPublicationHandler` classes in `app/Services/ChurchService/SectionPublication/`.

### 🎯 Why: What was unclear and how this helps
These handlers manage the critical transition from extracted livestream segments to canonical sermon and song records. They were previously undocumented, making it difficult to understand the requirements for eligibility (confidence thresholds) and the side effects of publication (asset promotion and audio enhancement).

### 🔄 Behavior: Explicitly state "No functional changes — documentation only"
No functional changes — documentation only. Verified with Pint, PHPStan, and the full test suite.

---
*PR created automatically by Jules for task [5264331260079112129](https://jules.google.com/task/5264331260079112129) started by @GarethClarridge*