### PR TITLE
♿ Aria: [a11y improvement] - Accessible buttons, landmarks, and charts

### DIFF
--- a/resources/views/church/songs/show.blade.php
+++ b/resources/views/church/songs/show.blade.php
@@ -77,7 +77,13 @@
 
                 <div class="w-full max-w-sm">
                     <div class="w-full rounded-xl bg-gradient-teal p-[1.5px]">
-                        <x-button link="{{ route('church.songs.index') }}" variant="secondary" size="lg" class="w-full rounded-[11px]">
+                        <x-button
+                            link="{{ route('church.songs.index') }}"
+                            variant="secondary"
+                            size="lg"
+                            class="w-full rounded-[11px]"
+                            aria-label="Back to song catalogue"
+                        >
                             Back to Songs
                         </x-button>
                     </div>

--- a/resources/views/components/admin/list-shell.blade.php
+++ b/resources/views/components/admin/list-shell.blade.php
@@ -38,9 +38,9 @@
         </div>
 
         @isset($pagination)
-            <div class="mt-4">
+            <nav class="mt-4" aria-label="Pagination">
                 {{ $pagination }}
-            </div>
+            </nav>
         @endisset
     </x-card>
 </x-admin.page>

--- a/resources/views/components/childrens-talk-card.blade.php
+++ b/resources/views/components/childrens-talk-card.blade.php
@@ -16,7 +16,7 @@
         >
             <img
                 src="{{ $cardThumbnailUrl }}"
-                alt="Children's Corner: {{ $sermon->title }}"
+                alt="Children's talk: {{ $sermon->title }}"
                 class="h-full w-full object-cover brightness-110 contrast-105 transition duration-500 ease-out group-hover:scale-105 group-hover:brightness-115"
                 loading="lazy"
             >

--- a/resources/views/livewire/admin/church-services/show-song.blade.php
+++ b/resources/views/livewire/admin/church-services/show-song.blade.php
@@ -83,9 +83,29 @@
                         class="mt-6 w-full"
                         aria-label="Bar chart of song usage by year">
                         @php $maxCount = max(array_column($usageByYear, 'count')); @endphp
+
+                        <table class="sr-only">
+                            <caption>Song usage by year</caption>
+                            <thead>
+                                <tr>
+                                    <th scope="col">Year</th>
+                                    <th scope="col">Uses</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($usageByYear as $entry)
+                                    <tr>
+                                        <td>{{ $entry['year'] }}</td>
+                                        <td>{{ $entry['count'] }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+
                         <div
                             class="overflow-x-auto"
-                            x-init="$el.scrollLeft = $el.scrollWidth">
+                            x-init="$el.scrollLeft = $el.scrollWidth"
+                            aria-hidden="true">
                             <div class="relative flex items-end gap-2" style="height: 120px; min-width: max-content;">
                                 @foreach($usageByYear as $entry)
                                     @php $heightPx = $maxCount > 0 ? round(($entry['count'] / $maxCount) * 120) : 0; @endphp

--- a/resources/views/livewire/admin/pages/list-pages.blade.php
+++ b/resources/views/livewire/admin/pages/list-pages.blade.php
@@ -73,7 +73,7 @@
                     <td class="px-4 py-3">
                         @if($page->hasMedia('headings'))
                             <img src="{{ $page->getFirstMediaUrl('headings', 'thumbnail') }}"
-                                 alt="Header image for {{ $page->heading }}"
+                                 alt="Thumbnail for {{ $page->heading }}"
                                  class="w-10 h-10 object-cover rounded-lg"
                                  loading="lazy" />
                         @else

--- a/resources/views/sermons/index.blade.php
+++ b/resources/views/sermons/index.blade.php
@@ -38,7 +38,10 @@
 
     @if (auth()->user()?->canAccessAdmin())
         <div class="px-6 max-w-2xl mx-auto mt-6 my-12">
-            <x-button link="{{ route('admin.services.upload-recording') }}">
+            <x-button
+                link="{{ route('admin.services.upload-recording') }}"
+                aria-label="Upload a new sermon recording"
+            >
                 Upload a new sermon
             </x-button>
         </div>


### PR DESCRIPTION
💡 **What:** Improved accessibility across several key surfaces. Added accessible names to icon-adjacent buttons, established a pagination landmark in admin lists, implemented an accessible table alternative for song usage bar charts, and refined image alt text.
🎯 **Who:** Benefits screen reader users (descriptive labels, landmarks, data tables), keyboard users (landmarks), and low-vision users (clearer context).
🧪 **How to verify:** Inspected markup via read_file, ran full test suite (php artisan test --parallel), and verified static analysis (phpstan).
🔄 **Behavior:** Same visible behaviour — accessibility metadata and hidden content for assistive tech only.

---
*PR created automatically by Jules for task [13835883075691879265](https://jules.google.com/task/13835883075691879265) started by @GarethClarridge*