### PR TITLE
🐛 Fix flaky LivestreamSegment factory timing (derive end_time)

### DIFF
--- a/database/factories/LivestreamSegmentFactory.php
+++ b/database/factories/LivestreamSegmentFactory.php
@@ -11,17 +11,31 @@ class LivestreamSegmentFactory extends Factory
 {
     protected $model = LivestreamSegment::class;
 
+    /**
+     * Keep end_time consistent with start_time + duration unless the caller sets
+     * it explicitly. Without this, overriding start_time/duration on their own (a
+     * common pattern in tests) leaves end_time at the random definition value,
+     * which can fall below start_time and violate livestream_segments_timing_check.
+     */
+    public function configure(): static
+    {
+        return $this->afterMaking(function (LivestreamSegment $segment): void {
+            if ($segment->end_time === null && is_numeric($segment->start_time) && is_numeric($segment->duration)) {
+                $segment->end_time = (float) $segment->start_time + (float) $segment->duration;
+            }
+        });
+    }
+
     public function definition(): array
     {
         $startTime = $this->faker->numberBetween(0, 5400); // Up to 1.5 hours
         $duration = $this->faker->numberBetween(60, 1800); // 1 minute to 30 minutes
-        $endTime = $startTime + $duration;
 
         return [
             'media_processing_log_id' => 1, // Will be overridden in tests
             'segment_index' => $this->faker->unique()->numberBetween(0, 5000),
             'start_time' => $startTime,
-            'end_time' => $endTime,
+            // end_time is derived in configure() so it always tracks start_time + duration.
             'duration' => $duration,
             'classification' => $this->faker->randomElement(['song', 'speech', 'silence']),
             'avg_rms' => $this->faker->randomFloat(2, 0.1, 1.0),

--- a/tests/Feature/DataIntegrity/LivestreamSegmentIntegrityTest.php
+++ b/tests/Feature/DataIntegrity/LivestreamSegmentIntegrityTest.php
@@ -52,6 +52,37 @@ class LivestreamSegmentIntegrityTest extends TestCase
     }
 
     #[Test]
+    public function the_factory_keeps_end_time_consistent_when_start_time_and_duration_are_overridden(): void
+    {
+        $log = MediaProcessingLog::factory()->create();
+
+        // Overriding start_time/duration without end_time must not leave a stale
+        // end_time that violates livestream_segments_timing_check (end_time >= start_time).
+        $segment = LivestreamSegment::factory()->create([
+            'media_processing_log_id' => $log->id,
+            'start_time' => 1000.0,
+            'duration' => 1500.0,
+        ]);
+
+        $this->assertSame(2500.0, (float) $segment->end_time);
+    }
+
+    #[Test]
+    public function the_factory_respects_an_explicitly_provided_end_time(): void
+    {
+        $log = MediaProcessingLog::factory()->create();
+
+        $segment = LivestreamSegment::factory()->create([
+            'media_processing_log_id' => $log->id,
+            'start_time' => 100.0,
+            'duration' => 50.0,
+            'end_time' => 200.0,
+        ]);
+
+        $this->assertSame(200.0, (float) $segment->end_time);
+    }
+
+    #[Test]
     public function it_allows_same_segment_index_for_different_processing_logs(): void
     {
         $log1 = MediaProcessingLog::factory()->create();


### PR DESCRIPTION
## What

Make `LivestreamSegmentFactory` derive `end_time` from `start_time + duration` (in `configure()->afterMaking()`) instead of baking a random `end_time` into `definition()`.

## Why

The factory computed `end_time = start_time + duration` once in `definition()` using the *random* start/duration. When a test overrides `start_time` and/or `duration` **without** also setting `end_time` — a common pattern — `end_time` kept its stale random value, which could fall below the overridden `start_time` and violate the DB check constraint:

```
livestream_segments_timing_check: start_time >= 0 AND end_time >= start_time AND duration >= 0
```

This surfaced as an intermittent CI failure in `SermonCandidateConfidenceServiceTest::it_identifies_a_clear_sermon_candidate_from_the_database` (`start_time => 1000.0, duration => 1500.0`, but a random `end_time` of e.g. `606`). The same latent bug affected the `sermon()` state, which overrides `duration` alone.

## How

- `end_time` is now derived after attributes are merged, so it always tracks `start_time + duration`.
- Callers that pass an explicit `end_time` (e.g. constraint-violation tests) are respected — the hook only fills it when unset.
- Added regression tests for both the derived and the explicit paths.

## Verification

- `vendor/bin/pint` clean.
- Docker/MySQL wasn't available locally, so the suite runs via CI (the constraint is MySQL-specific). Logic verified by reasoning; new tests cover both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYBPJW7V6Vnt9Hmq7bTrqh)_