### PR TITLE
T7: Replace remaining placeholder assertions (testing remediation)

### DIFF
--- a/docs/plans/TESTING-REMEDIATION-PLAN.md
+++ b/docs/plans/TESTING-REMEDIATION-PLAN.md
@@ -242,15 +242,20 @@ Net: −4 test methods (1 Database, 3 Schema); column-list assertions collapsed 
 `tests/Unit/ExampleTest`, `tests/Unit/StorageAdapterHelperTest`, `tests/Unit/Services/AudioExtractionServiceTest`, `MediaValidationServiceTest`, `FrameExtractionServiceTest`, `OpenLpDecompressionBombTest`, `AudioChunkingServiceTest`, `AudioEnhancementServiceTest`, `tests/Integration/Models/PageTest`, `tests/Integration/Livewire/Traits/WithAdminAuthorizationTest`, plus the SEO files touched in T3.
 
 ### Tasks
-- [ ] For each `assertTrue(true)`, either replace it with the real assertion the test name implies, or delete the test if it proves nothing.
-- [ ] Delete `tests/Unit/ExampleTest.php` and `tests/Browser/ExampleTest.php` (scaffolding) unless intentionally kept.
-- [ ] Do not remove a test file without confirming it has no other meaningful assertions (per the repo rule on not deleting tests without approval — flag any deletions for sign-off).
+- [x] For each `assertTrue(true)`, either replace it with the real assertion the test name implies, or delete the test if it proves nothing.
+- [x] Delete `tests/Unit/ExampleTest.php` and `tests/Browser/ExampleTest.php` (scaffolding) unless intentionally kept.
+- [x] Do not remove a test file without confirming it has no other meaningful assertions (per the repo rule on not deleting tests without approval — flag any deletions for sign-off).
 
 ### Verification
-- [ ] Re-run each touched file; confirm assertions now fail if the behaviour regresses (spot-check by temporarily breaking one path).
+- [x] Re-run each touched file; confirm assertions now fail if the behaviour regresses (spot-check by temporarily breaking one path). *(Suite not runnable in the web session — no `vendor/`, no Docker daemon; `php -l` lints clean and CI runs the full suite on the PR.)*
+
+### What changed
+Most of T7 was already done in earlier phases; this pass closed the last two placeholders, in [tests/Unit/Rules/TrimmedTextTest.php](../../tests/Unit/Rules/TrimmedTextTest.php). `it_passes_for_null_values` and `it_passes_for_valid_trimmed_strings` previously ended in `assertTrue(true)` with a `$this->fail(...)` callback that only fired on the unhappy path, so the happy path asserted nothing (PHPUnit "risky"). Both now track a `$failed` flag the validator callback flips and assert `assertFalse($failed, ...)`, mirroring the negative tests in the same file — a real, counted assertion every run. A repo-wide grep confirms **no `assertTrue(true)` placeholder remains** in `tests/`.
+
+**Deletions — none.** `tests/Unit/ExampleTest.php` was already removed in an earlier phase. `tests/Browser/ExampleTest.php` is **intentionally kept**: it is no longer scaffolding but a genuine Dusk smoke test that visits `/` and asserts the homepage renders "Crockenhill Baptist Church", so the plan's "unless intentionally kept" clause applies and no sign-off-requiring deletion was needed.
 
 ### Exit criteria
-- No `assertTrue(true)` placeholder remains; every test asserts the behaviour in its name.
+- [x] No `assertTrue(true)` placeholder remains; every test asserts the behaviour in its name.
 
 ---
 
@@ -314,7 +319,7 @@ Pure-logic tests under `tests/Unit/Services` and `tests/Unit/Support` — e.g. `
 - [x] `Http::preventStrayRequests()` guards the suite; no stray Laravel-`Http` calls (T4).
 - [x] Thumbnail-render cost audited: no redundant variants existed (caching already maximal); dead helpers removed without fidelity loss (T5).
 - [x] One schema-guardrail test per table; MySQL constraint tests retained (T6).
-- [ ] No `assertTrue(true)` placeholder assertions remain (T7).
+- [x] No `assertTrue(true)` placeholder assertions remain (T7).
 - [ ] Consistent DB trait per directory; deprecations at zero, notices minimised (T8).
 - [ ] Pure-function unit tests run on bare PHPUnit (T9).
 - [ ] Full `--parallel` suite is green, faster, and free of external-service dependencies; required quality gates pass for each delivered phase.

--- a/tests/Unit/Rules/TrimmedTextTest.php
+++ b/tests/Unit/Rules/TrimmedTextTest.php
@@ -21,11 +21,12 @@ class TrimmedTextTest extends TestCase
     #[Test]
     public function it_passes_for_null_values(): void
     {
-        $this->rule->validate('attribute', null, function ($message) {
-            $this->fail('Validation should have passed for null: '.$message);
+        $failed = false;
+        $this->rule->validate('attribute', null, function () use (&$failed) {
+            $failed = true;
         });
 
-        $this->assertTrue(true);
+        $this->assertFalse($failed, 'Validation should have passed for null.');
     }
 
     #[Test]
@@ -40,12 +41,13 @@ class TrimmedTextTest extends TestCase
         ];
 
         foreach ($validStrings as $value) {
-            $this->rule->validate('attribute', $value, function ($message) use ($value) {
-                $this->fail("Validation should have passed for '{$value}': ".$message);
+            $failed = false;
+            $this->rule->validate('attribute', $value, function () use (&$failed) {
+                $failed = true;
             });
-        }
 
-        $this->assertTrue(true);
+            $this->assertFalse($failed, "Validation should have passed for '{$value}'.");
+        }
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Completes **T7** of the [Testing Remediation Plan](docs/plans/TESTING-REMEDIATION-PLAN.md) — "Replace placeholder assertions". Most of T7 was already done in earlier phases; this closes the last two `assertTrue(true)` placeholders so a repo-wide grep now returns **none**.

Separate from PR #962 (T1/T2/T4/T9) — branched off `master`, touches only `TrimmedTextTest` and the T7 section of the plan tracker.

## What changed

`tests/Unit/Rules/TrimmedTextTest.php` — the two happy-path tests (`it_passes_for_null_values`, `it_passes_for_valid_trimmed_strings`) ended in `assertTrue(true)` with a `$this->fail(...)` callback that only fired on the *unhappy* path, so the happy path asserted nothing (PHPUnit flagged them risky). Both now track a `$failed` flag the validator callback flips and assert `assertFalse($failed, ...)`, mirroring the negative tests already in the file — a real, counted assertion on every run.

## Deletions — none

- `tests/Unit/ExampleTest.php` was already removed in an earlier phase.
- `tests/Browser/ExampleTest.php` is **intentionally kept**: it's no longer scaffolding but a genuine Dusk smoke test that visits `/` and asserts the homepage renders "Crockenhill Baptist Church". The plan's "unless intentionally kept" clause applies, so no sign-off-requiring test deletion was needed.

## Verification

`php -l` passes; a repo-wide grep confirms no `assertTrue(true)` placeholder remains in `tests/`. The full suite was **not** runnable in this environment (no `vendor/`, no Docker daemon), so behavioural confirmation rides on the PR's CI — noted honestly in the plan rather than claiming a local green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fesb3PK4f3xwiXvHCkPxbK)_