### PR TITLE
T9: Move 10 pure-function unit tests off the Laravel TestCase

### DIFF
--- a/docs/plans/TESTING-REMEDIATION-PLAN.md
+++ b/docs/plans/TESTING-REMEDIATION-PLAN.md
@@ -285,15 +285,32 @@ Net: −4 test methods (1 Database, 3 Schema); column-list assertions collapsed 
 Pure-logic tests under `tests/Unit/Services` and `tests/Unit/Support` — e.g. `SermonFilenameParserTest`, `SermonContentFormatterTest`, `BibleCanonTest`, `PathTest`, `ScriptureHtmlSanitizerTest`, `SafeMarkdownRendererTest`, `ThumbnailTextHelperTest` (color/wrap math), `SongLyricSnippetBuilderTest`. Exclude anything using `config()`, facades, `app()`, factories, or `Storage`/`Cache`.
 
 ### Tasks
-- [ ] For each candidate, confirm it uses no facade/container/config/DB. If clean, change `extends Tests\TestCase` → `extends PHPUnit\Framework\TestCase` and drop the `CreatesApplication`/`WithCachedConfig` reliance.
-- [ ] Keep any test that touches `config()` or facades on the Laravel `TestCase` — the bootstrap is load-bearing there.
-- [ ] Note the `ThumbnailCanvasComposerTest` is **not** a candidate (it uses Intervention's `Image` facade and `Sermon` models).
+- [x] For each candidate, confirm it uses no facade/container/config/DB. If clean, change `extends Tests\TestCase` → `extends PHPUnit\Framework\TestCase` and drop the `CreatesApplication`/`WithCachedConfig` reliance.
+- [x] Keep any test that touches `config()` or facades on the Laravel `TestCase` — the bootstrap is load-bearing there.
+- [x] Note the `ThumbnailCanvasComposerTest` is **not** a candidate (it uses Intervention's `Image` facade and `Sermon` models).
 
 ### Verification
-- [ ] `vendor/bin/sail artisan test --compact tests/Unit/Services tests/Unit/Support` — all pass; confirm the converted files no longer boot the app (faster).
+- [x] `vendor/bin/sail artisan test --compact tests/Unit/Services tests/Unit/Support` — all pass; confirm the converted files no longer boot the app (faster). *(Suite not runnable in the web session — no `vendor/`, no Docker daemon; each converted file was instead `php -l`-linted and audited statically, and CI runs the full suite on the PR.)*
+
+### What changed
+Both the **test** and its **class-under-test** were audited for any container/config/facade/DB/model/`now()` use; a candidate was converted only when both are provably bootstrap-free, then `use Tests\TestCase;` was swapped for `use PHPUnit\Framework\TestCase;` (import order kept Pint-correct).
+
+**Converted to bare PHPUnit (10 files):** `Support/PathTest`, `Support/SermonContentFormatterTest`, `Support/OpenAiChatPayloadTest`, `Services/ScriptureHtmlSanitizerTest`, `Services/ScriptureReferenceResolverTest`, `Services/SongLyricSnippetBuilderTest`, `Services/SongTitleHintExtractorTest`, `Services/OpenLpLyricsParserTest`, `Services/FrameQualityScorerTest`, `Services/ProcessingReportTest`. (`collect()` / `Illuminate\Support\Str` / `Collection` used by these are autoloaded helpers/pure value classes, not container-bound.)
+
+**Already on bare PHPUnit (no action):** `Support/ServiceSectionConfidenceTest`, `Support/ParallelTestingProcessLimiterTest`, `Services/ChurchServiceReviewStateServiceTest`, `Services/SectionAlignmentBaselineRestorerTest`.
+
+**Kept on the Laravel `TestCase` (bootstrap is load-bearing):**
+- `Support/BibleCanonTest` — asserts the container singleton via `app(BibleCanon::class)`.
+- `Services/ThumbnailTextHelperTest` — SUT logs via the `Log` facade.
+- `Services/SafeMarkdownRendererTest` — SUT reads `config('markdown.safe_options')`.
+- `Services/SermonFilenameParserTest` — SUT calls the `now()` helper (resolves the `Date` facade).
+- `Services/SongClusteringServiceTest` — SUT logs via the `Log` facade on its main path.
+- `Services/CalendarCategorizationResultTest` / `Services/PresentationItemClassifierTest` — instantiate Eloquent models.
+
+Scope was the `deps=0` pure-logic candidates under `tests/Unit/{Services,Support}`; the remaining `deps≥1` files there have genuine framework coupling and stay put. Further candidates can be converted incrementally (the phase is explicitly safe to interleave).
 
 ### Exit criteria
-- Pure-function unit tests run on bare PHPUnit; framework-dependent ones stay on the Laravel base.
+- [x] Pure-function unit tests run on bare PHPUnit; framework-dependent ones stay on the Laravel base.
 
 ---
 
@@ -316,6 +333,6 @@ Pure-logic tests under `tests/Unit/Services` and `tests/Unit/Support` — e.g. `
 - [x] One schema-guardrail test per table; MySQL constraint tests retained (T6).
 - [ ] No `assertTrue(true)` placeholder assertions remain (T7).
 - [ ] Consistent DB trait per directory; deprecations at zero, notices minimised (T8).
-- [ ] Pure-function unit tests run on bare PHPUnit (T9).
+- [x] Pure-function unit tests run on bare PHPUnit (T9).
 - [ ] Full `--parallel` suite is green, faster, and free of external-service dependencies; required quality gates pass for each delivered phase.
 ```

--- a/tests/Unit/Services/FrameQualityScorerTest.php
+++ b/tests/Unit/Services/FrameQualityScorerTest.php
@@ -6,7 +6,7 @@ namespace Tests\Unit\Services;
 
 use App\Services\Media\Video\FrameQualityScorer;
 use PHPUnit\Framework\Attributes\Test;
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class FrameQualityScorerTest extends TestCase
 {

--- a/tests/Unit/Services/OpenLpLyricsParserTest.php
+++ b/tests/Unit/Services/OpenLpLyricsParserTest.php
@@ -6,7 +6,7 @@ namespace Tests\Unit\Services;
 
 use App\Services\Song\OpenLpLyricsParser;
 use PHPUnit\Framework\Attributes\Test;
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class OpenLpLyricsParserTest extends TestCase
 {

--- a/tests/Unit/Services/ProcessingReportTest.php
+++ b/tests/Unit/Services/ProcessingReportTest.php
@@ -7,7 +7,7 @@ namespace Tests\Unit\Services;
 use App\Data\ProcessingReport;
 use App\Enums\ProcessingStatus;
 use PHPUnit\Framework\Attributes\Test;
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class ProcessingReportTest extends TestCase
 {

--- a/tests/Unit/Services/ScriptureHtmlSanitizerTest.php
+++ b/tests/Unit/Services/ScriptureHtmlSanitizerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Services;
 
 use App\Services\Scripture\ScriptureHtmlSanitizer;
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class ScriptureHtmlSanitizerTest extends TestCase
 {

--- a/tests/Unit/Services/ScriptureReferenceResolverTest.php
+++ b/tests/Unit/Services/ScriptureReferenceResolverTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\Unit\Services;
 
 use App\Services\Scripture\ScriptureReferenceResolver;
+use PHPUnit\Framework\TestCase;
 use TechWilk\BibleVerseParser\BiblePassageParser;
-use Tests\TestCase;
 
 class ScriptureReferenceResolverTest extends TestCase
 {

--- a/tests/Unit/Services/SongLyricSnippetBuilderTest.php
+++ b/tests/Unit/Services/SongLyricSnippetBuilderTest.php
@@ -6,7 +6,7 @@ namespace Tests\Unit\Services;
 
 use App\Services\Song\SongLyricSnippetBuilder;
 use PHPUnit\Framework\Attributes\Test;
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class SongLyricSnippetBuilderTest extends TestCase
 {

--- a/tests/Unit/Services/SongTitleHintExtractorTest.php
+++ b/tests/Unit/Services/SongTitleHintExtractorTest.php
@@ -8,7 +8,7 @@ use App\Enums\ServiceSectionType;
 use App\Services\Song\SongTitleHintExtractor;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class SongTitleHintExtractorTest extends TestCase
 {

--- a/tests/Unit/Support/OpenAiChatPayloadTest.php
+++ b/tests/Unit/Support/OpenAiChatPayloadTest.php
@@ -7,7 +7,7 @@ namespace Tests\Unit\Support;
 use App\Support\OpenAiChatPayload;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class OpenAiChatPayloadTest extends TestCase
 {

--- a/tests/Unit/Support/PathTest.php
+++ b/tests/Unit/Support/PathTest.php
@@ -6,7 +6,7 @@ namespace Tests\Unit\Support;
 
 use App\Support\Path;
 use PHPUnit\Framework\Attributes\Test;
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class PathTest extends TestCase
 {

--- a/tests/Unit/Support/SermonContentFormatterTest.php
+++ b/tests/Unit/Support/SermonContentFormatterTest.php
@@ -6,7 +6,7 @@ namespace Tests\Unit\Support;
 
 use App\Support\SermonContentFormatter;
 use PHPUnit\Framework\Attributes\Test;
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class SermonContentFormatterTest extends TestCase
 {


### PR DESCRIPTION
## Summary

Implements **T9** of the [Testing Remediation Plan](docs/plans/TESTING-REMEDIATION-PLAN.md) — "Move pure-function unit tests off the Laravel `TestCase`". This is the actual code work that wasn't part of the merged PR #962 (which turned out to be the doc-tracker change only); splitting it onto its own PR.

Switches 10 container-free unit tests under `tests/Unit/{Services,Support}` from `Tests\TestCase` to `PHPUnit\Framework\TestCase` so they no longer boot the framework on every test.

## Audit method

Each test **and its class-under-test** was audited for any facade/container/config/DB/model/`now()` use; a candidate was converted only when **both** are provably bootstrap-free, then `use Tests\TestCase;` was swapped for `use PHPUnit\Framework\TestCase;` (import order kept Pint-correct).

## Converted (10)

`Support/PathTest`, `Support/SermonContentFormatterTest`, `Support/OpenAiChatPayloadTest`, `Services/ScriptureHtmlSanitizerTest`, `Services/ScriptureReferenceResolverTest`, `Services/SongLyricSnippetBuilderTest`, `Services/SongTitleHintExtractorTest`, `Services/OpenLpLyricsParserTest`, `Services/FrameQualityScorerTest`, `Services/ProcessingReportTest`.

(`collect()` / `Illuminate\Support\Str` / `Collection` used by these are autoloaded helpers / pure value classes, not container-bound.)

## Kept on the Laravel `TestCase` (bootstrap is load-bearing)

- `Support/BibleCanonTest` — asserts the container singleton via `app(BibleCanon::class)`.
- `Services/ThumbnailTextHelperTest` / `Services/SongClusteringServiceTest` — SUT logs via the `Log` facade.
- `Services/SafeMarkdownRendererTest` — SUT reads `config('markdown.safe_options')`.
- `Services/SermonFilenameParserTest` — SUT calls the `now()` helper (resolves the `Date` facade).
- `Services/CalendarCategorizationResultTest` / `Services/PresentationItemClassifierTest` — instantiate Eloquent models.

## Verification

All 10 files pass `php -l`; no residual `Tests\TestCase` or Laravel-only test helpers; import ordering kept Pint-correct. The full suite was **not** runnable in this environment (no `vendor/`, no Docker daemon), so behavioural confirmation rides on the PR's CI — noted honestly in the plan rather than claiming a local green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fesb3PK4f3xwiXvHCkPxbK)_