### PR TITLE
Fix deploy migration failure when explicit index backs the FK

### DIFF
--- a/database/migrations/2026_06_18_120000_drop_redundant_church_service_items_livestream_index.php
+++ b/database/migrations/2026_06_18_120000_drop_redundant_church_service_items_livestream_index.php
@@ -11,16 +11,22 @@ return new class extends Migration
     /**
      * Drop the redundant explicit index on church_service_items.livestream_service_section_id.
      *
-     * The column is the local side of a foreign key to service_sections, and MySQL/MariaDB
-     * automatically create a backing index (church_service_items_livestream_service_section_id_foreign)
-     * for every foreign key. The separately added church_service_items_livestream_service_section_id_index
-     * therefore duplicates that coverage on the production engine, adding write and storage overhead for
-     * no read benefit. The guard keeps this a no-op on engines (e.g. SQLite) where the duplicate was the
-     * only index, or where the original migration was never applied.
+     * The column is the local side of a foreign key to service_sections. When MySQL creates that
+     * foreign key it only adds its own backing index (church_service_items_livestream_service_section_id_foreign)
+     * if no suitable index already exists. Where that auto-created `_foreign` index is present, the separately
+     * added church_service_items_livestream_service_section_id_index duplicates its coverage and can be dropped.
+     *
+     * Where the `_foreign` index is absent, MySQL adopted the explicit `_index` as the foreign key's sole
+     * backing index, so it is not redundant and dropping it fails with errno 1553
+     * ("needed in a foreign key constraint"). Guarding on the `_foreign` index keeps this a safe no-op in
+     * that case, and on engines (e.g. SQLite) that do not auto-index foreign-key columns.
      */
     public function up(): void
     {
-        if (Schema::hasIndex('church_service_items', 'church_service_items_livestream_service_section_id_index')) {
+        if (
+            Schema::hasIndex('church_service_items', 'church_service_items_livestream_service_section_id_index')
+            && Schema::hasIndex('church_service_items', 'church_service_items_livestream_service_section_id_foreign')
+        ) {
             Schema::table('church_service_items', function (Blueprint $table): void {
                 $table->dropIndex('church_service_items_livestream_service_section_id_index');
             });

--- a/database/migrations/2026_06_18_130000_drop_redundant_fk_indexes_from_media_processing_logs_and_speaker_samples.php
+++ b/database/migrations/2026_06_18_130000_drop_redundant_fk_indexes_from_media_processing_logs_and_speaker_samples.php
@@ -9,36 +9,42 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration
 {
     /**
-     * Indexes that duplicate a foreign-key backing index, keyed by table.
+     * Explicit indexes that may duplicate a foreign-key backing index, keyed by table.
      *
-     * Each listed column is the local side of a foreign key, so MySQL/MariaDB already
-     * maintain a `<table>_<column>_foreign` index for it. The matching `<table>_<column>_index`
-     * added by 2026_06_14_200000_add_missing_fk_indexes_to_media_processing_logs_and_speaker_samples
-     * therefore duplicates that coverage on the production engine for no read benefit. (The earlier
-     * "missing FK index" premise only held on SQLite, which does not auto-index FK columns.)
+     * Each listed column is the local side of a foreign key. MySQL only adds its own
+     * `<table>_<column>_foreign` backing index when no suitable index already exists, so the matching
+     * `<table>_<column>_index` added by
+     * 2026_06_14_200000_add_missing_fk_indexes_to_media_processing_logs_and_speaker_samples
+     * is only a true duplicate where that `_foreign` index is also present. (The earlier "missing FK index"
+     * premise only held on SQLite, which does not auto-index FK columns.)
      *
-     * @var array<string, list<string>>
+     * Each value maps the explicit index name to the foreign-key backing index that must also exist
+     * before the explicit one can be safely dropped. Where the `_foreign` index is absent, MySQL adopted
+     * the explicit `_index` as the foreign key's sole backing index, so dropping it fails with errno 1553
+     * ("needed in a foreign key constraint"); the guard below keeps that case a no-op.
+     *
+     * @var array<string, array<string, string>>
      */
     private array $redundantIndexes = [
         'media_processing_logs' => [
-            'media_processing_logs_sermon_id_index',
-            'media_processing_logs_owner_user_id_index',
-            'media_processing_logs_church_service_id_index',
+            'media_processing_logs_sermon_id_index' => 'media_processing_logs_sermon_id_foreign',
+            'media_processing_logs_owner_user_id_index' => 'media_processing_logs_owner_user_id_foreign',
+            'media_processing_logs_church_service_id_index' => 'media_processing_logs_church_service_id_foreign',
         ],
         'speaker_samples' => [
-            'speaker_samples_media_processing_log_id_index',
+            'speaker_samples_media_processing_log_id_index' => 'speaker_samples_media_processing_log_id_foreign',
         ],
     ];
 
     /**
-     * Drop the redundant foreign-key duplicate indexes where present.
+     * Drop the redundant foreign-key duplicate indexes where the foreign key retains its own backing index.
      */
     public function up(): void
     {
         foreach ($this->redundantIndexes as $table => $indexes) {
             Schema::table($table, function (Blueprint $blueprint) use ($table, $indexes): void {
-                foreach ($indexes as $index) {
-                    if (Schema::hasIndex($table, $index)) {
+                foreach ($indexes as $index => $foreignIndex) {
+                    if (Schema::hasIndex($table, $index) && Schema::hasIndex($table, $foreignIndex)) {
                         $blueprint->dropIndex($index);
                     }
                 }

--- a/tests/Feature/Database/CorrectiveSchemaMigrationsTest.php
+++ b/tests/Feature/Database/CorrectiveSchemaMigrationsTest.php
@@ -212,6 +212,33 @@ class CorrectiveSchemaMigrationsTest extends TestCase
     }
 
     #[Test]
+    public function it_leaves_the_livestream_index_in_place_when_it_is_the_foreign_keys_only_backing_index(): void
+    {
+        if (! $this->isMySql()) {
+            $this->markTestSkipped('Foreign-key auto-indexing behaviour requires MySQL.');
+        }
+
+        // Reproduce the production state: the explicit index exists and the foreign key has adopted it
+        // as its sole backing index (no auto-created `_foreign` index). Adding the explicit index, then
+        // dropping the `_foreign` one, makes MySQL reassign the foreign key to the explicit index.
+        if (! Schema::hasIndex('church_service_items', 'church_service_items_livestream_service_section_id_index')) {
+            Schema::table('church_service_items', function (Blueprint $table): void {
+                $table->index('livestream_service_section_id', 'church_service_items_livestream_service_section_id_index');
+            });
+        }
+        DB::statement('ALTER TABLE church_service_items DROP INDEX church_service_items_livestream_service_section_id_foreign');
+
+        $this->assertFalse(Schema::hasIndex('church_service_items', 'church_service_items_livestream_service_section_id_foreign'));
+        $this->assertTrue(Schema::hasIndex('church_service_items', 'church_service_items_livestream_service_section_id_index'));
+
+        // Dropping the explicit index here would fail with errno 1553, so the migration must skip it.
+        $this->redundantLivestreamIndexMigration()->up();
+
+        $this->assertTrue($this->hasForeignKey('church_service_items', 'livestream_service_section_id', 'service_sections'));
+        $this->assertTrue(Schema::hasIndex('church_service_items', 'church_service_items_livestream_service_section_id_index'));
+    }
+
+    #[Test]
     public function it_drops_redundant_fk_duplicate_indexes_while_retaining_foreign_key_coverage(): void
     {
         if (! $this->isMySql()) {
@@ -251,6 +278,41 @@ class CorrectiveSchemaMigrationsTest extends TestCase
         $this->redundantFkIndexesMigration()->down();
 
         foreach ($cases as [$table, , , $explicitIndex]) {
+            $this->assertTrue(Schema::hasIndex($table, $explicitIndex));
+        }
+    }
+
+    #[Test]
+    public function it_leaves_fk_duplicate_indexes_in_place_when_they_are_the_foreign_keys_only_backing_index(): void
+    {
+        if (! $this->isMySql()) {
+            $this->markTestSkipped('Foreign-key auto-indexing behaviour requires MySQL.');
+        }
+
+        $cases = [
+            ['media_processing_logs', 'sermon_id', 'sermons', 'media_processing_logs_sermon_id_index', 'media_processing_logs_sermon_id_foreign'],
+            ['speaker_samples', 'media_processing_log_id', 'media_processing_logs', 'speaker_samples_media_processing_log_id_index', 'speaker_samples_media_processing_log_id_foreign'],
+        ];
+
+        // Reproduce the production state for each foreign key: the explicit index exists and the foreign
+        // key has adopted it as its sole backing index (no auto-created `_foreign` index).
+        foreach ($cases as [$table, $column, , $explicitIndex, $foreignIndex]) {
+            if (! Schema::hasIndex($table, $explicitIndex)) {
+                Schema::table($table, function (Blueprint $blueprint) use ($column, $explicitIndex): void {
+                    $blueprint->index($column, $explicitIndex);
+                });
+            }
+            DB::statement("ALTER TABLE {$table} DROP INDEX {$foreignIndex}");
+
+            $this->assertFalse(Schema::hasIndex($table, $foreignIndex));
+            $this->assertTrue(Schema::hasIndex($table, $explicitIndex));
+        }
+
+        // Dropping any explicit index here would fail with errno 1553, so the migration must skip them.
+        $this->redundantFkIndexesMigration()->up();
+
+        foreach ($cases as [$table, $column, $referencedTable, $explicitIndex]) {
+            $this->assertTrue($this->hasForeignKey($table, $column, $referencedTable));
             $this->assertTrue(Schema::hasIndex($table, $explicitIndex));
         }
     }


### PR DESCRIPTION
## What was failing

The most recent `Deploy` runs on `master` failed at the **Deploy to server** step. Despite the step name, the SSH connection succeeded — the failure was *inside* the remote deploy script, on `php artisan migrate --force`:

```
2026_06_18_120000_drop_redundant_church_service_items_livestream_index  FAIL
SQLSTATE[HY000]: General error: 1553 Cannot drop index
'church_service_items_livestream_service_section_id_index': needed in a foreign key constraint
```

## Root cause

The migration assumed every FK has its own auto-created `<table>_<column>_foreign` backing index, making the separately-added `_index` a droppable duplicate. That holds in CI (migrations run from scratch, so the FK creates `_foreign` first) and matches the committed schema dump — but **not on production**.

MySQL only creates a `_foreign` backing index when no suitable index already exists. On production, MySQL had adopted the explicit `_index` as the FK's *sole* backing index, so dropping it is rejected with errno 1553. Production runs MySQL 8.0, which auto-reassigns a FK to an alternative index when one exists — the fact that it didn't proves no alternative was present.

The sibling migration `2026_06_18_130000_drop_redundant_fk_indexes_from_media_processing_logs_and_speaker_samples` shared the same flawed assumption and would have failed the next deploy too.

## The fix

Both corrective migrations now drop the explicit `_index` **only when the FK's own `_foreign` backing index also exists** — i.e. when it is genuinely redundant. Where `_foreign` is absent (production), the drop is skipped as a safe no-op and the FK keeps its coverage.

- `database/migrations/2026_06_18_120000_...` — guard added on the `_foreign` index.
- `database/migrations/2026_06_18_130000_...` — each index mapped to its `_foreign` counterpart and guarded.
- `tests/Feature/Database/CorrectiveSchemaMigrationsTest.php` — added two tests reproducing the production state (FK backed solely by the explicit index) and asserting each migration is a safe no-op that leaves the index and FK intact.

This does not change the end state in CI (both indexes exist mid-run, so the drop still happens), so the schema-dump-freshness guard stays satisfied.

## Validation

Pint passes and the changed files are syntax-clean. The MySQL-backed tests could not run in the sandbox (no Docker/MySQL); they execute in CI's `master-validation` job against MySQL 8.0, which is part of this deploy pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Htf1S3aQSwbxMcCcQdimT2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Htf1S3aQSwbxMcCcQdimT2)_