### PR TITLE
D3: begin decomposing SermonViewPresenter (dates, meta, URLs)

### DIFF
--- a/app/Presenters/SermonDateFormatter.php
+++ b/app/Presenters/SermonDateFormatter.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presenters;
+
+use App\Models\Sermon;
+use App\Support\SermonContentFormatter;
+
+/**
+ * Formats a sermon's date and duration for display.
+ *
+ * Extracted from SermonViewPresenter so the date/duration cluster lives behind a
+ * single-responsibility collaborator. Duration formatting delegates to the pure
+ * SermonContentFormatter; date formatting is memoized by the sermon's date
+ * timestamp so that multiple sermons sharing a date in a listing format it once.
+ *
+ * The presenter owns one instance per request and delegates its public
+ * date/duration accessors here, so this collaborator is the single home for the
+ * date memo (cleared via clearCache() when the presenter clears its caches).
+ */
+class SermonDateFormatter
+{
+    /**
+     * Memoized date strings keyed by the sermon's date timestamp.
+     *
+     * @var array<int, array{human: string, iso: string, short: string}>
+     */
+    private array $memoizedDates = [];
+
+    /**
+     * Get the human-friendly formatted duration of the sermon (e.g. "1h 30m").
+     */
+    public function formattedDuration(Sermon $sermon): ?string
+    {
+        return SermonContentFormatter::humanDuration($this->durationInSeconds($sermon));
+    }
+
+    /**
+     * Get the ISO 8601 duration string (e.g. PT45M) for the sermon.
+     */
+    public function durationIso8601(Sermon $sermon): ?string
+    {
+        return SermonContentFormatter::iso8601Duration($this->durationInSeconds($sermon));
+    }
+
+    /**
+     * Get various formatted date strings for the sermon.
+     *
+     * Performance Optimization: Memoizes date formatting results by timestamp
+     * to avoid redundant object calls and string formatting across multiple
+     * sermons sharing the same date in a listing. Returns human-friendly,
+     * ISO 8601, and short display formats.
+     *
+     * @return array{human: string, iso: string, short: string}
+     */
+    public function formattedDates(Sermon $sermon): array
+    {
+        $timestamp = $sermon->date->getTimestamp();
+
+        return $this->memoizedDates[$timestamp] ??= [
+            'human' => $sermon->date->format('F j, Y'),
+            'iso' => $sermon->date->toDateString(),
+            'short' => $sermon->date->format('j F Y'),
+        ];
+    }
+
+    /**
+     * Get the human-friendly date of the sermon.
+     */
+    public function humanDate(Sermon $sermon): string
+    {
+        return $this->formattedDates($sermon)['human'];
+    }
+
+    /**
+     * Clear the memoized date cache.
+     *
+     * Called by the presenter's clearInternalCaches() so a single reset covers
+     * every cache the presenter and its collaborators hold.
+     */
+    public function clearCache(): void
+    {
+        $this->memoizedDates = [];
+    }
+
+    /**
+     * Normalize the float-cast `duration` column to an integer number of seconds.
+     */
+    private function durationInSeconds(Sermon $sermon): ?int
+    {
+        return $sermon->duration === null ? null : (int) $sermon->duration;
+    }
+}

--- a/app/Presenters/SermonMetaPresenter.php
+++ b/app/Presenters/SermonMetaPresenter.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presenters;
+
+use App\Models\Sermon;
+use App\Services\Sermon\SermonExposurePolicy;
+use App\Support\SermonContentFormatter;
+
+/**
+ * Builds the SEO/meta surface for a sermon: the meta description and the image
+ * alt-text variants.
+ *
+ * Like SermonPresentationAssembler, this collaborator reads already-resolved
+ * facts (preacher name, human date, scripture reference, service label) back
+ * through the presenter so the presenter remains the single memoization layer.
+ * The meta description's own pure string assembly lives in SermonContentFormatter;
+ * this class only gathers the inputs and applies the database-stored-description
+ * short-circuit.
+ */
+class SermonMetaPresenter
+{
+    public function __construct(
+        private readonly SermonExposurePolicy $exposurePolicy,
+    ) {}
+
+    /**
+     * Get the descriptive alt text for a sermon thumbnail image.
+     */
+    public function imageAlt(SermonViewPresenter $presenter, Sermon $sermon): string
+    {
+        $preacherName = $presenter->displayPreacherName($sermon);
+
+        return 'Sermon: '.$sermon->title.($preacherName ? ' by '.$preacherName : '');
+    }
+
+    /**
+     * Get the descriptive alt text for a Children's Corner talk thumbnail image.
+     */
+    public function childrensTalkImageAlt(SermonViewPresenter $presenter, Sermon $sermon): string
+    {
+        $preacherName = $presenter->displayPreacherName($sermon);
+
+        return "Children's Corner: ".$sermon->title.($preacherName ? ' by '.$preacherName : '');
+    }
+
+    /**
+     * Generate the SEO meta description for a sermon.
+     *
+     * Prefers an explicit database-stored description; otherwise assembles one
+     * from the sermon's resolved facts via SermonContentFormatter.
+     */
+    public function metaDescription(SermonViewPresenter $presenter, Sermon $sermon): string
+    {
+        $attributes = $sermon->getAttributes();
+        if (filled($attributes['meta_description'] ?? null)) {
+            return (string) $attributes['meta_description'];
+        }
+
+        $summary = ($sermon->show_summary && filled($sermon->summary))
+            ? strip_tags((string) $sermon->summary)
+            : null;
+
+        return SermonContentFormatter::metaDescription(
+            title: (string) $sermon->title,
+            preacherName: $presenter->displayPreacherName($sermon) ?? 'Unknown preacher',
+            humanDate: $presenter->humanDate($sermon),
+            reference: $presenter->displayReference($sermon),
+            series: filled($sermon->series) ? (string) $sermon->series : null,
+            serviceLabel: $presenter->serviceLabel($sermon),
+            hasVideo: $this->exposurePolicy->shouldExposeVideo($sermon),
+            hasAudio: filled($sermon->audio_file_path),
+            summary: $summary,
+        );
+    }
+}

--- a/app/Presenters/SermonUrlBuilder.php
+++ b/app/Presenters/SermonUrlBuilder.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presenters;
+
+use App\Models\Sermon;
+use App\Services\Sermon\SermonExposurePolicy;
+use App\Services\Sermon\SermonStorageService;
+
+/**
+ * Builds the delivery and route URLs for a sermon's media and pages.
+ *
+ * Extracted from SermonViewPresenter so the URL/thumbnail cluster lives behind a
+ * single-responsibility collaborator. Following the SermonPresentationAssembler
+ * pattern, each method receives the presenter so cross-cutting reads (e.g. the
+ * plain-thumbnail fallback to the primary thumbnail) flow back through the
+ * presenter's single memoization layer; this collaborator adds no caching of its
+ * own and is a pure function of the sermon plus the storage and exposure services.
+ */
+class SermonUrlBuilder
+{
+    public function __construct(
+        private readonly SermonStorageService $storageService,
+        private readonly SermonExposurePolicy $exposurePolicy,
+    ) {}
+
+    public function audioUrl(SermonViewPresenter $presenter, Sermon $sermon): ?string
+    {
+        return filled($sermon->audio_file_path)
+            ? $this->storageService->getAudioDeliveryUrl($sermon)
+            : null;
+    }
+
+    public function videoUrl(SermonViewPresenter $presenter, Sermon $sermon): ?string
+    {
+        if (! $this->exposurePolicy->shouldExposeVideo($sermon)) {
+            return null;
+        }
+
+        return $this->storageService->getVideoDeliveryUrl($sermon);
+    }
+
+    public function canonicalUrl(SermonViewPresenter $presenter, Sermon $sermon): string
+    {
+        return $this->exposurePolicy->canonicalUrl($sermon);
+    }
+
+    public function publicUrl(SermonViewPresenter $presenter, Sermon $sermon): string
+    {
+        return $this->exposurePolicy->publicUrl($sermon);
+    }
+
+    public function thumbnailUrl(SermonViewPresenter $presenter, Sermon $sermon): ?string
+    {
+        if (! $this->exposurePolicy->shouldExposeThumbnail($sermon)) {
+            return null;
+        }
+
+        if (! $sermon->hasThumbnail()) {
+            return null;
+        }
+
+        return $this->storageService->getThumbnailDeliveryUrl($sermon);
+    }
+
+    /**
+     * Get the card variant thumbnail URL for a sermon.
+     *
+     * Performance Optimization: Returns null when the thumbnail_metadata column
+     * is not loaded (e.g. in listings) to avoid N+1 queries for large JSON metadata.
+     */
+    public function cardThumbnailUrl(SermonViewPresenter $presenter, Sermon $sermon): ?string
+    {
+        if (! $this->exposurePolicy->shouldExposeThumbnail($sermon)) {
+            return null;
+        }
+
+        if (! isset($sermon->getAttributes()['thumbnail_metadata'])) {
+            return null;
+        }
+
+        if (! $sermon->hasPlainThumbnail()) {
+            return null;
+        }
+
+        return $this->storageService->getCardThumbnailDeliveryUrl($sermon);
+    }
+
+    /**
+     * Get the plain variant thumbnail URL for a sermon.
+     *
+     * Performance Optimization: Falls back to the primary thumbnail (resolved
+     * through the presenter, so its memoized result is reused) for listings where
+     * the thumbnail_metadata column is not selected.
+     */
+    public function plainThumbnailUrl(SermonViewPresenter $presenter, Sermon $sermon): ?string
+    {
+        if (! $this->exposurePolicy->shouldExposeThumbnail($sermon)) {
+            return null;
+        }
+
+        // Fallback for listings where metadata is not selected: use primary thumbnail
+        if (! isset($sermon->getAttributes()['thumbnail_metadata']) && $sermon->hasThumbnail()) {
+            return $presenter->thumbnailUrl($sermon);
+        }
+
+        if (! $sermon->hasPlainThumbnail()) {
+            return null;
+        }
+
+        return $this->storageService->getPlainThumbnailDeliveryUrl($sermon);
+    }
+
+    public function transcriptUrl(SermonViewPresenter $presenter, Sermon $sermon): ?string
+    {
+        if (! $sermon->hasTranscript()) {
+            return null;
+        }
+
+        return route('sermons.transcript', ['sermon' => $sermon->slug]);
+    }
+}

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -43,13 +43,21 @@ class SermonViewPresenter
      */
     private array $computed = [];
 
+    /**
+     * Builds the SEO/meta surface; defaults to one backed by the exposure policy.
+     */
+    private readonly SermonMetaPresenter $metaPresenter;
+
     public function __construct(
         private readonly SermonExposurePolicy $exposurePolicy,
         private readonly SermonStorageService $storageService,
         private readonly SermonTranscriptReader $transcriptReader,
         private readonly SermonPresentationAssembler $assembler = new SermonPresentationAssembler,
         private readonly SermonDateFormatter $dateFormatter = new SermonDateFormatter,
-    ) {}
+        ?SermonMetaPresenter $metaPresenter = null,
+    ) {
+        $this->metaPresenter = $metaPresenter ?? new SermonMetaPresenter($this->exposurePolicy);
+    }
 
     /**
      * Get the human-friendly formatted duration of the sermon (e.g. "1h 30m").
@@ -580,21 +588,11 @@ class SermonViewPresenter
     }
 
     /**
-     * Generate the SEO meta description for a sermon.
-     *
-     * Performance Optimization: Memoizes generated meta descriptions to avoid
-     * redundant assembly logic for the same sermon within a single request.
-     * Checks for existing database-stored descriptions before falling back
-     * to dynamic generation.
-     */
-    /**
      * Get the descriptive alt text for a sermon thumbnail image.
      */
     public function imageAlt(Sermon $sermon): string
     {
-        $preacherName = $this->displayPreacherName($sermon);
-
-        return 'Sermon: '.$sermon->title.($preacherName ? ' by '.$preacherName : '');
+        return $this->metaPresenter->imageAlt($this, $sermon);
     }
 
     /**
@@ -602,35 +600,18 @@ class SermonViewPresenter
      */
     public function childrensTalkImageAlt(Sermon $sermon): string
     {
-        $preacherName = $this->displayPreacherName($sermon);
-
-        return "Children's Corner: ".$sermon->title.($preacherName ? ' by '.$preacherName : '');
+        return $this->metaPresenter->childrensTalkImageAlt($this, $sermon);
     }
 
+    /**
+     * Generate the SEO meta description for a sermon.
+     *
+     * The description shape lives on SermonMetaPresenter; this method adds only
+     * request-level memoization of the assembled result.
+     */
     public function metaDescription(Sermon $sermon): string
     {
-        return $this->memoize($sermon, 'meta_desc', 'memoized', function () use ($sermon): string {
-            $attributes = $sermon->getAttributes();
-            if (filled($attributes['meta_description'] ?? null)) {
-                return (string) $attributes['meta_description'];
-            }
-
-            $summary = ($sermon->show_summary && filled($sermon->summary))
-                ? strip_tags((string) $sermon->summary)
-                : null;
-
-            return SermonContentFormatter::metaDescription(
-                title: (string) $sermon->title,
-                preacherName: $this->displayPreacherName($sermon) ?? 'Unknown preacher',
-                humanDate: $this->humanDate($sermon),
-                reference: $this->displayReference($sermon),
-                series: filled($sermon->series) ? (string) $sermon->series : null,
-                serviceLabel: $this->serviceLabel($sermon),
-                hasVideo: $this->exposurePolicy->shouldExposeVideo($sermon),
-                hasAudio: filled($sermon->audio_file_path),
-                summary: $summary,
-            );
-        });
+        return $this->memoize($sermon, 'meta_desc', 'memoized', fn (): string => $this->metaPresenter->metaDescription($this, $sermon));
     }
 
     public function videoUrl(Sermon $sermon): ?string

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -37,13 +37,6 @@ class SermonViewPresenter
     private array $memoizedPresents = [];
 
     /**
-     * Memoization for formatted dates.
-     *
-     * @var array<int, array{human: string, iso: string, short: string}>
-     */
-    private array $memoizedDates = [];
-
-    /**
      * Tracks which keys have been computed, allowing null to be a legitimate cached result.
      *
      * @var array<string, true>
@@ -55,6 +48,7 @@ class SermonViewPresenter
         private readonly SermonStorageService $storageService,
         private readonly SermonTranscriptReader $transcriptReader,
         private readonly SermonPresentationAssembler $assembler = new SermonPresentationAssembler,
+        private readonly SermonDateFormatter $dateFormatter = new SermonDateFormatter,
     ) {}
 
     /**
@@ -62,7 +56,7 @@ class SermonViewPresenter
      */
     public function formattedDuration(Sermon $sermon): ?string
     {
-        return SermonContentFormatter::humanDuration($this->durationInSeconds($sermon));
+        return $this->dateFormatter->formattedDuration($sermon);
     }
 
     /**
@@ -70,36 +64,17 @@ class SermonViewPresenter
      */
     public function durationIso8601(Sermon $sermon): ?string
     {
-        return SermonContentFormatter::iso8601Duration($this->durationInSeconds($sermon));
-    }
-
-    /**
-     * Normalize the float-cast `duration` column to an integer number of seconds.
-     */
-    private function durationInSeconds(Sermon $sermon): ?int
-    {
-        return $sermon->duration === null ? null : (int) $sermon->duration;
+        return $this->dateFormatter->durationIso8601($sermon);
     }
 
     /**
      * Get various formatted date strings for the sermon.
      *
-     * Performance Optimization: Memoizes date formatting results by timestamp
-     * to avoid redundant object calls and string formatting across multiple
-     * sermons sharing the same date in a listing. Returns human-friendly,
-     * ISO 8601, and short display formats.
-     *
      * @return array{human: string, iso: string, short: string}
      */
     public function formattedDates(Sermon $sermon): array
     {
-        $timestamp = $sermon->date->getTimestamp();
-
-        return $this->memoizedDates[$timestamp] ??= [
-            'human' => $sermon->date->format('F j, Y'),
-            'iso' => $sermon->date->toDateString(),
-            'short' => $sermon->date->format('j F Y'),
-        ];
+        return $this->dateFormatter->formattedDates($sermon);
     }
 
     /**
@@ -107,7 +82,7 @@ class SermonViewPresenter
      */
     public function humanDate(Sermon $sermon): string
     {
-        return $this->formattedDates($sermon)['human'];
+        return $this->dateFormatter->humanDate($sermon);
     }
 
     /**
@@ -119,8 +94,8 @@ class SermonViewPresenter
         $this->memoized = [];
         $this->memoizedUrls = [];
         $this->memoizedPresents = [];
-        $this->memoizedDates = [];
         $this->computed = [];
+        $this->dateFormatter->clearCache();
     }
 
     public function audioUrl(Sermon $sermon): ?string

--- a/app/Presenters/SermonViewPresenter.php
+++ b/app/Presenters/SermonViewPresenter.php
@@ -48,15 +48,23 @@ class SermonViewPresenter
      */
     private readonly SermonMetaPresenter $metaPresenter;
 
+    /**
+     * Builds media and page URLs; defaults to one backed by the storage and
+     * exposure services.
+     */
+    private readonly SermonUrlBuilder $urlBuilder;
+
     public function __construct(
-        private readonly SermonExposurePolicy $exposurePolicy,
-        private readonly SermonStorageService $storageService,
+        SermonExposurePolicy $exposurePolicy,
+        SermonStorageService $storageService,
         private readonly SermonTranscriptReader $transcriptReader,
         private readonly SermonPresentationAssembler $assembler = new SermonPresentationAssembler,
         private readonly SermonDateFormatter $dateFormatter = new SermonDateFormatter,
         ?SermonMetaPresenter $metaPresenter = null,
+        ?SermonUrlBuilder $urlBuilder = null,
     ) {
-        $this->metaPresenter = $metaPresenter ?? new SermonMetaPresenter($this->exposurePolicy);
+        $this->metaPresenter = $metaPresenter ?? new SermonMetaPresenter($exposurePolicy);
+        $this->urlBuilder = $urlBuilder ?? new SermonUrlBuilder($storageService, $exposurePolicy);
     }
 
     /**
@@ -108,9 +116,7 @@ class SermonViewPresenter
 
     public function audioUrl(Sermon $sermon): ?string
     {
-        return $this->memoize($sermon, 'audio', 'memoizedUrls', fn (): ?string => filled($sermon->audio_file_path)
-            ? $this->storageService->getAudioDeliveryUrl($sermon)
-            : null);
+        return $this->memoize($sermon, 'audio', 'memoizedUrls', fn (): ?string => $this->urlBuilder->audioUrl($this, $sermon));
     }
 
     /**
@@ -146,60 +152,23 @@ class SermonViewPresenter
 
     public function canonicalUrl(Sermon $sermon): string
     {
-        return $this->memoize($sermon, 'canonical', 'memoizedUrls', fn (): string => $this->exposurePolicy->canonicalUrl($sermon));
+        return $this->memoize($sermon, 'canonical', 'memoizedUrls', fn (): string => $this->urlBuilder->canonicalUrl($this, $sermon));
     }
 
     /**
      * Get the card variant thumbnail URL for a sermon.
-     *
-     * Performance Optimization: Implements fallback logic to use the primary
-     * thumbnail path if metadata is not loaded (e.g. in listings) to avoid
-     * N+1 queries for large JSON metadata.
      */
     public function cardThumbnailUrl(Sermon $sermon): ?string
     {
-        return $this->memoize($sermon, 'card_thumb', 'memoizedUrls', function () use ($sermon): ?string {
-            if (! $this->exposurePolicy->shouldExposeThumbnail($sermon)) {
-                return null;
-            }
-
-            if (! isset($sermon->getAttributes()['thumbnail_metadata'])) {
-                return null;
-            }
-
-            if (! $sermon->hasPlainThumbnail()) {
-                return null;
-            }
-
-            return $this->storageService->getCardThumbnailDeliveryUrl($sermon);
-        });
+        return $this->memoize($sermon, 'card_thumb', 'memoizedUrls', fn (): ?string => $this->urlBuilder->cardThumbnailUrl($this, $sermon));
     }
 
     /**
      * Get the plain variant thumbnail URL for a sermon.
-     *
-     * Performance Optimization: Implements fallback logic to use the primary
-     * thumbnail path if metadata is not loaded (e.g. in listings) to avoid
-     * N+1 queries for large JSON metadata.
      */
     public function plainThumbnailUrl(Sermon $sermon): ?string
     {
-        return $this->memoize($sermon, 'plain_thumb', 'memoizedUrls', function () use ($sermon): ?string {
-            if (! $this->exposurePolicy->shouldExposeThumbnail($sermon)) {
-                return null;
-            }
-
-            // Fallback for listings where metadata is not selected: use primary thumbnail
-            if (! isset($sermon->getAttributes()['thumbnail_metadata']) && $sermon->hasThumbnail()) {
-                return $this->thumbnailUrl($sermon);
-            }
-
-            if (! $sermon->hasPlainThumbnail()) {
-                return null;
-            }
-
-            return $this->storageService->getPlainThumbnailDeliveryUrl($sermon);
-        });
+        return $this->memoize($sermon, 'plain_thumb', 'memoizedUrls', fn (): ?string => $this->urlBuilder->plainThumbnailUrl($this, $sermon));
     }
 
     /**
@@ -394,22 +363,12 @@ class SermonViewPresenter
 
     public function publicUrl(Sermon $sermon): string
     {
-        return $this->memoize($sermon, 'public', 'memoizedUrls', fn (): string => $this->exposurePolicy->publicUrl($sermon));
+        return $this->memoize($sermon, 'public', 'memoizedUrls', fn (): string => $this->urlBuilder->publicUrl($this, $sermon));
     }
 
     public function thumbnailUrl(Sermon $sermon): ?string
     {
-        return $this->memoize($sermon, 'thumb', 'memoizedUrls', function () use ($sermon): ?string {
-            if (! $this->exposurePolicy->shouldExposeThumbnail($sermon)) {
-                return null;
-            }
-
-            if (! $sermon->hasThumbnail()) {
-                return null;
-            }
-
-            return $this->storageService->getThumbnailDeliveryUrl($sermon);
-        });
+        return $this->memoize($sermon, 'thumb', 'memoizedUrls', fn (): ?string => $this->urlBuilder->thumbnailUrl($this, $sermon));
     }
 
     public function transcript(Sermon $sermon): ?string
@@ -419,13 +378,7 @@ class SermonViewPresenter
 
     public function transcriptUrl(Sermon $sermon): ?string
     {
-        return $this->memoize($sermon, 'transcript_url', 'memoizedUrls', function () use ($sermon): ?string {
-            if (! $sermon->hasTranscript()) {
-                return null;
-            }
-
-            return route('sermons.transcript', ['sermon' => $sermon->slug]);
-        });
+        return $this->memoize($sermon, 'transcript_url', 'memoizedUrls', fn (): ?string => $this->urlBuilder->transcriptUrl($this, $sermon));
     }
 
     /**
@@ -616,13 +569,7 @@ class SermonViewPresenter
 
     public function videoUrl(Sermon $sermon): ?string
     {
-        return $this->memoize($sermon, 'video', 'memoizedUrls', function () use ($sermon): ?string {
-            if (! $this->exposurePolicy->shouldExposeVideo($sermon)) {
-                return null;
-            }
-
-            return $this->storageService->getVideoDeliveryUrl($sermon);
-        });
+        return $this->memoize($sermon, 'video', 'memoizedUrls', fn (): ?string => $this->urlBuilder->videoUrl($this, $sermon));
     }
 
     /**

--- a/docs/plans/TECHNICAL-DEBT-REMEDIATION-2026-06-18.md
+++ b/docs/plans/TECHNICAL-DEBT-REMEDIATION-2026-06-18.md
@@ -145,17 +145,27 @@ Suggested seams (confirm names against existing conventions in `app/Support`, `a
   - [tests/Integration/Presenters/SermonViewPresenterTest.php](../../tests/Integration/Presenters/SermonViewPresenterTest.php)
   - [tests/Integration/Presenters/SermonPresentationAssemblerTest.php](../../tests/Integration/Presenters/SermonPresentationAssemblerTest.php)
 
+### Progress (2026-06-26)
+First decomposition pass landed (presenter **748 → 651 lines**), extracting three cohesive clusters behind the unchanged public facade, each as its own commit with focused unit coverage:
+- `SermonDateFormatter` — the date/duration cluster (owns its date-timestamp memo).
+- `SermonMetaPresenter` — the meta-description / image-alt cluster (the named seam above).
+- `SermonUrlBuilder` — the URL/thumbnail cluster (the plain-thumbnail fallback still resolves through the presenter, preserving its memoized result).
+
+The `SermonPresentationAssembler` (present/forApi/forList shaping) was extracted in an earlier pass. Caching was deliberately **left as the single `memoize()`/`cacheKey()` seam on the presenter** — collaborators are pure and the presenter wraps them — so cache behaviour is byte-for-byte unchanged; `clearInternalCaches()` now also resets the date formatter's cache.
+
+Still outstanding for this phase: the entangled **preacher-name resolution** cluster (`displayPreacherName`/`preacherUrl`/`preacherImageUrl`/`resolvePreacherAttribute`) and the identity-keyed `displayReference`/`seriesUrl`/`serviceLabel` methods, plus the final push under the ~300-line target.
+
 ### Tasks
-- [ ] Characterise the current caching behaviour first (what `memoize`/`cacheKey` actually key on) so the extracted decorator reproduces it exactly.
-- [ ] Extract one responsibility cluster per commit; after each, run the two presenter tests above plus `SermonDisplayTest`/`SermonSeoTest`.
-- [ ] Move memoization into a single seam; confirm `clearInternalCaches()` still resets all caches (it is called between requests/tests).
-- [ ] Add focused unit tests for each extracted collaborator (cheaper than the current full-presenter integration tests).
-- [ ] Target: `SermonViewPresenter` < ~300 lines, each collaborator single-responsibility.
+- [x] Characterise the current caching behaviour first (what `memoize`/`cacheKey` actually key on) so the extracted decorator reproduces it exactly.
+- [~] Extract one responsibility cluster per commit; after each, run the two presenter tests above plus `SermonDisplayTest`/`SermonSeoTest`. *(3 clusters done: dates, meta, URLs; preacher-resolution cluster remains.)*
+- [~] Move memoization into a single seam; confirm `clearInternalCaches()` still resets all caches (it is called between requests/tests). *(Kept as the single `memoize()` seam on the presenter; `clearInternalCaches()` now also clears the date formatter.)*
+- [~] Add focused unit tests for each extracted collaborator (cheaper than the current full-presenter integration tests). *(Added for `SermonDateFormatter`, `SermonMetaPresenter`, `SermonUrlBuilder`.)*
+- [ ] Target: `SermonViewPresenter` < ~300 lines, each collaborator single-responsibility. *(651 lines so far.)*
 
 ### Verification
-- [ ] `vendor/bin/sail artisan test --compact --parallel tests/Integration/Presenters tests/Integration/Models/SermonDisplayTest.php tests/Integration/Models/SermonSeoTest.php tests/Feature/SermonPagesTest.php`
-- [ ] `vendor/bin/sail artisan dusk` for the public sermon page (presenter output is rendered there).
-- [ ] `vendor/bin/sail composer phpstan` — 0 errors, no new baseline entries.
+- [x] `tests/Integration/Presenters tests/Integration/Models/SermonDisplayTest.php tests/Integration/Models/SermonSeoTest.php tests/Feature/SermonPagesTest.php` — green (plus `tests/Unit/Presenters`, sitemap and API-controller suites: 202 passing across presenter consumers).
+- [ ] `vendor/bin/sail artisan dusk` for the public sermon page — not run for this pass; the server-rendered `SermonPagesTest` exercises the same presenter output and is green.
+- [x] `composer phpstan` — 0 errors, no new baseline entries.
 
 ### Exit criteria
 - Public facade unchanged; presenter is an orchestrator under ~300 lines; each extracted collaborator is independently unit-tested; full suite + Dusk green.

--- a/tests/Unit/Presenters/SermonDateFormatterTest.php
+++ b/tests/Unit/Presenters/SermonDateFormatterTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Presenters;
+
+use App\Models\Sermon;
+use App\Presenters\SermonDateFormatter;
+use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonDateFormatterTest extends TestCase
+{
+    private SermonDateFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->formatter = new SermonDateFormatter;
+    }
+
+    #[Test]
+    public function it_formats_duration_as_human_readable_string(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => 2705]); // 45m (floored)
+
+        $this->assertSame('45m', $this->formatter->formattedDuration($sermon));
+    }
+
+    #[Test]
+    public function it_returns_null_duration_when_absent(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => null]);
+
+        $this->assertNull($this->formatter->formattedDuration($sermon));
+        $this->assertNull($this->formatter->durationIso8601($sermon));
+    }
+
+    #[Test]
+    public function it_formats_duration_as_iso8601_string(): void
+    {
+        $sermon = Sermon::factory()->make(['duration' => 2705]);
+
+        $this->assertSame('PT45M5S', $this->formatter->durationIso8601($sermon));
+    }
+
+    #[Test]
+    public function it_returns_formatted_dates(): void
+    {
+        $sermon = Sermon::factory()->make(['date' => Carbon::parse('2024-03-10')]);
+
+        $dates = $this->formatter->formattedDates($sermon);
+
+        $this->assertSame('March 10, 2024', $dates['human']);
+        $this->assertSame('2024-03-10', $dates['iso']);
+        $this->assertSame('10 March 2024', $dates['short']);
+    }
+
+    #[Test]
+    public function it_returns_human_date(): void
+    {
+        $sermon = Sermon::factory()->make(['date' => Carbon::parse('2024-03-10')]);
+
+        $this->assertSame('March 10, 2024', $this->formatter->humanDate($sermon));
+    }
+
+    #[Test]
+    public function it_memoizes_formatted_dates_by_timestamp(): void
+    {
+        $sermon = Sermon::factory()->make(['date' => Carbon::parse('2024-03-10')]);
+
+        $first = $this->formatter->formattedDates($sermon);
+
+        // Same timestamp resolves to the cached array, so a later mutation to a
+        // sermon sharing the timestamp is not re-read.
+        $second = $this->formatter->formattedDates($sermon);
+
+        $this->assertSame($first, $second);
+    }
+
+    #[Test]
+    public function it_clears_the_date_cache(): void
+    {
+        $sermon = Sermon::factory()->make(['date' => Carbon::parse('2024-03-10')]);
+        $this->formatter->formattedDates($sermon);
+
+        $this->formatter->clearCache();
+
+        $sermon->date = Carbon::parse('2024-03-10');
+        $this->assertSame('March 10, 2024', $this->formatter->humanDate($sermon));
+    }
+}

--- a/tests/Unit/Presenters/SermonMetaPresenterTest.php
+++ b/tests/Unit/Presenters/SermonMetaPresenterTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Presenters;
+
+use App\Models\Sermon;
+use App\Presenters\SermonMetaPresenter;
+use App\Presenters\SermonViewPresenter;
+use App\Services\Sermon\SermonExposurePolicy;
+use Carbon\Carbon;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonMetaPresenterTest extends TestCase
+{
+    private SermonExposurePolicy&MockInterface $exposurePolicy;
+
+    private SermonViewPresenter&MockInterface $presenter;
+
+    private SermonMetaPresenter $metaPresenter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->exposurePolicy = Mockery::mock(SermonExposurePolicy::class);
+        $this->presenter = Mockery::mock(SermonViewPresenter::class);
+        $this->metaPresenter = new SermonMetaPresenter($this->exposurePolicy);
+    }
+
+    #[Test]
+    public function it_builds_sermon_image_alt_text_with_preacher(): void
+    {
+        $sermon = Sermon::factory()->make(['title' => 'Grace Abounding']);
+        $this->presenter->shouldReceive('displayPreacherName')->with($sermon)->andReturn('John Smith');
+
+        $this->assertSame(
+            'Sermon: Grace Abounding by John Smith',
+            $this->metaPresenter->imageAlt($this->presenter, $sermon),
+        );
+    }
+
+    #[Test]
+    public function it_builds_sermon_image_alt_text_without_preacher(): void
+    {
+        $sermon = Sermon::factory()->make(['title' => 'Grace Abounding']);
+        $this->presenter->shouldReceive('displayPreacherName')->with($sermon)->andReturn(null);
+
+        $this->assertSame(
+            'Sermon: Grace Abounding',
+            $this->metaPresenter->imageAlt($this->presenter, $sermon),
+        );
+    }
+
+    #[Test]
+    public function it_builds_childrens_talk_image_alt_text(): void
+    {
+        $sermon = Sermon::factory()->make(['title' => 'The Lost Sheep']);
+        $this->presenter->shouldReceive('displayPreacherName')->with($sermon)->andReturn('Jane Doe');
+
+        $this->assertSame(
+            "Children's Corner: The Lost Sheep by Jane Doe",
+            $this->metaPresenter->childrensTalkImageAlt($this->presenter, $sermon),
+        );
+    }
+
+    #[Test]
+    public function it_prefers_the_stored_meta_description(): void
+    {
+        $sermon = Sermon::factory()->make(['meta_description' => 'A hand-written description.']);
+
+        $this->assertSame(
+            'A hand-written description.',
+            $this->metaPresenter->metaDescription($this->presenter, $sermon),
+        );
+    }
+
+    #[Test]
+    public function it_assembles_a_meta_description_from_resolved_facts(): void
+    {
+        $sermon = Sermon::factory()->make([
+            'title' => 'Test Sermon',
+            'meta_description' => null,
+            'date' => Carbon::parse('2024-03-10'),
+            'series' => null,
+            'show_summary' => true,
+            'summary' => 'This is a summary.',
+        ]);
+
+        $this->presenter->shouldReceive('displayPreacherName')->with($sermon)->andReturn('John Smith');
+        $this->presenter->shouldReceive('humanDate')->with($sermon)->andReturn('March 10, 2024');
+        $this->presenter->shouldReceive('displayReference')->with($sermon)->andReturn('John 3:16');
+        $this->presenter->shouldReceive('serviceLabel')->with($sermon)->andReturn('Morning');
+        $this->exposurePolicy->shouldReceive('shouldExposeVideo')->with($sermon)->andReturn(false);
+
+        $description = $this->metaPresenter->metaDescription($this->presenter, $sermon);
+
+        $this->assertStringContainsString('Test Sermon', $description);
+        $this->assertStringContainsString('John Smith', $description);
+        $this->assertStringContainsString('March 10, 2024', $description);
+        $this->assertStringContainsString('John 3:16', $description);
+        $this->assertStringContainsString('This is a summary.', $description);
+    }
+}

--- a/tests/Unit/Presenters/SermonUrlBuilderTest.php
+++ b/tests/Unit/Presenters/SermonUrlBuilderTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Presenters;
+
+use App\Models\Sermon;
+use App\Presenters\SermonUrlBuilder;
+use App\Presenters\SermonViewPresenter;
+use App\Services\Sermon\SermonExposurePolicy;
+use App\Services\Sermon\SermonStorageService;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonUrlBuilderTest extends TestCase
+{
+    private SermonStorageService&MockInterface $storageService;
+
+    private SermonExposurePolicy&MockInterface $exposurePolicy;
+
+    private SermonViewPresenter&MockInterface $presenter;
+
+    private SermonUrlBuilder $builder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->storageService = Mockery::mock(SermonStorageService::class);
+        $this->exposurePolicy = Mockery::mock(SermonExposurePolicy::class);
+        $this->presenter = Mockery::mock(SermonViewPresenter::class);
+        $this->builder = new SermonUrlBuilder($this->storageService, $this->exposurePolicy);
+    }
+
+    #[Test]
+    public function it_returns_audio_url_when_a_file_is_present(): void
+    {
+        $sermon = Sermon::factory()->make(['audio_file_path' => 'sermons/audio.mp3']);
+        $this->storageService->shouldReceive('getAudioDeliveryUrl')->with($sermon)->andReturn('https://cdn.example.com/audio.mp3');
+
+        $this->assertSame('https://cdn.example.com/audio.mp3', $this->builder->audioUrl($this->presenter, $sermon));
+    }
+
+    #[Test]
+    public function it_returns_null_audio_url_when_no_file_is_present(): void
+    {
+        $sermon = Sermon::factory()->make(['audio_file_path' => null]);
+
+        $this->assertNull($this->builder->audioUrl($this->presenter, $sermon));
+    }
+
+    #[Test]
+    public function it_returns_video_url_only_when_exposed(): void
+    {
+        $sermon = Sermon::factory()->make();
+        $this->exposurePolicy->shouldReceive('shouldExposeVideo')->with($sermon)->andReturn(true);
+        $this->storageService->shouldReceive('getVideoDeliveryUrl')->with($sermon)->andReturn('https://cdn.example.com/video.mp4');
+
+        $this->assertSame('https://cdn.example.com/video.mp4', $this->builder->videoUrl($this->presenter, $sermon));
+    }
+
+    #[Test]
+    public function it_returns_null_video_url_when_not_exposed(): void
+    {
+        $sermon = Sermon::factory()->make();
+        $this->exposurePolicy->shouldReceive('shouldExposeVideo')->with($sermon)->andReturn(false);
+
+        $this->assertNull($this->builder->videoUrl($this->presenter, $sermon));
+    }
+
+    #[Test]
+    public function it_returns_thumbnail_url_when_exposed_and_present(): void
+    {
+        $sermon = Sermon::factory()->make(['thumbnail_file_path' => 'thumb.webp']);
+        $this->exposurePolicy->shouldReceive('shouldExposeThumbnail')->with($sermon)->andReturn(true);
+        $this->storageService->shouldReceive('getThumbnailDeliveryUrl')->with($sermon)->andReturn('https://cdn.example.com/thumb.webp');
+
+        $this->assertSame('https://cdn.example.com/thumb.webp', $this->builder->thumbnailUrl($this->presenter, $sermon));
+    }
+
+    #[Test]
+    public function it_falls_back_to_the_primary_thumbnail_via_the_presenter_when_metadata_is_unloaded(): void
+    {
+        // A sermon whose thumbnail_metadata column was not selected (listing query)
+        // but which has a primary thumbnail.
+        $sermon = Sermon::factory()->make(['thumbnail_file_path' => 'thumb.webp']);
+        $sermon->offsetUnset('thumbnail_metadata');
+
+        $this->exposurePolicy->shouldReceive('shouldExposeThumbnail')->with($sermon)->andReturn(true);
+        $this->presenter->shouldReceive('thumbnailUrl')->with($sermon)->andReturn('https://cdn.example.com/thumb.webp');
+
+        $this->assertSame(
+            'https://cdn.example.com/thumb.webp',
+            $this->builder->plainThumbnailUrl($this->presenter, $sermon),
+        );
+    }
+
+    #[Test]
+    public function it_returns_transcript_url_when_a_transcript_exists(): void
+    {
+        $sermon = Sermon::factory()->make(['slug' => 'a-sermon', 'transcript_file_path' => 'transcripts/a-sermon.txt']);
+        $this->exposurePolicy->shouldNotReceive('shouldExposeThumbnail');
+
+        $this->assertSame(
+            route('sermons.transcript', ['sermon' => 'a-sermon']),
+            $this->builder->transcriptUrl($this->presenter, $sermon),
+        );
+    }
+}


### PR DESCRIPTION
## What & why

First decomposition pass for **D3** of the [Technical Debt Remediation Plan](docs/plans/TECHNICAL-DEBT-REMEDIATION-2026-06-18.md) — the highest-priority *outstanding* phase. (D1's CVE patch and D2's PR-gate audit are already in the code; their plan checkboxes were just stale.)

`SermonViewPresenter` is the repo's worst churn × complexity file. This PR extracts three cohesive responsibility clusters into focused collaborators **behind the unchanged public facade**, shrinking the presenter **748 → 651 lines** with no behavioural change.

## Commits (one cluster each)

1. **`SermonDateFormatter`** — date/duration cluster (`formattedDuration`, `durationIso8601`, `formattedDates`, `humanDate`). Owns its own date-timestamp memo.
2. **`SermonMetaPresenter`** — SEO/meta cluster (`metaDescription`, `imageAlt`, `childrensTalkImageAlt`). A named seam in the plan; mirrors the existing `SermonPresentationAssembler` pattern.
3. **`SermonUrlBuilder`** — URL/thumbnail cluster (`audioUrl`, `videoUrl`, `canonicalUrl`, `publicUrl`, `thumbnailUrl`, `cardThumbnailUrl`, `plainThumbnailUrl`, `transcriptUrl`).
4. Plan tracker update.

## Guardrails honoured

- **Public facade unchanged** — `present()`/`presentForApi()`/`presentForList()` and every accessor keep their exact signatures; callers (controllers, Blade, API resources, SEO/sitemap) are untouched.
- **Caching byte-for-byte** — `memoize()`/`cacheKey()` stay as the single seam on the presenter; collaborators are pure and the presenter wraps them. The plain-thumbnail fallback still resolves the primary thumbnail *through the presenter*, preserving its memoized result. `clearInternalCaches()` now also clears the date formatter.
- **Re-shape, not re-cover** — no existing assertion touched; added focused unit tests for each new collaborator.
- **PHPStan stays at 0**, no new baseline entries.

## Verification

- `tests/Unit/Presenters`, `tests/Integration/Presenters`, `SermonDisplayTest`, `SermonSeoTest`, `SermonPagesTest`, sitemap + API-controller suites — **202 passing** across presenter consumers.
- `pint --dirty` clean; `composer phpstan` → **0 errors**.
- Dusk not run in this environment; the server-rendered `SermonPagesTest` exercises the same presenter output and is green.

## Still outstanding for D3 (follow-up)

The entangled **preacher-name resolution** cluster (`displayPreacherName`/`preacherUrl`/`preacherImageUrl`/`resolvePreacherAttribute`) and identity-keyed `displayReference`/`seriesUrl`/`serviceLabel`, plus the final push under the ~300-line target — deliberately left for a separate increment per the plan's "small, individually-green steps" guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVqPuvy3x6fpgkf14jC5xN)_