### PR TITLE
🧪 Steward: Harden PreventRequestForgeryConfigTest

### DIFF
--- a/tests/Feature/Middleware/PreventRequestForgeryConfigTest.php
+++ b/tests/Feature/Middleware/PreventRequestForgeryConfigTest.php
@@ -10,7 +10,6 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Session\TokenMismatchException;
 use PHPUnit\Framework\Attributes\Test;
-use ReflectionClass;
 use Tests\TestCase;
 
 /**
@@ -20,10 +19,9 @@ use Tests\TestCase;
  * Notes on the test design:
  *  - The framework's `PreventRequestForgery::handle()` short-circuits to
  *    "accept" when `app->runningUnitTests()` is true, so HTTP-level tests
- *    cannot exercise the real CSRF path. We invoke `handle()` directly and
- *    stub `runningUnitTests` via the protected static `$skipsRunningTests`
- *    workaround — there isn't one, so we exercise the underlying
- *    `hasValidOrigin()` method through reflection instead.
+ *    cannot exercise the real CSRF path. We invoke `handle()` directly on an
+ *    anonymous subclass that stubs `runningUnitTests()` to return false,
+ *    allowing us to exercise the real CSRF flow behaviorally without reflection.
  *  - The middleware reads its `allowSameSite` flag from a protected static
  *    property set by `PreventRequestForgery::allowSameSite()`. Bootstrap
  *    runs once per test process, so by the time this test executes the
@@ -34,12 +32,15 @@ class PreventRequestForgeryConfigTest extends TestCase
     #[Test]
     public function bootstrap_enables_allow_same_site(): void
     {
-        $reflection = new ReflectionClass(PreventRequestForgery::class);
-        $property = $reflection->getProperty('allowSameSite');
-        $property->setAccessible(true);
+        $request = Request::create('/admin/sermons', 'POST');
+        $request->setLaravelSession($this->app['session.store']);
+        $request->headers->set('Sec-Fetch-Site', 'same-site');
 
-        $this->assertTrue(
-            $property->getValue(),
+        $response = $this->callMiddlewareDirectly($request);
+
+        $this->assertEquals(
+            'ok',
+            $response->getContent(),
             'bootstrap/app.php must call preventRequestForgery(allowSameSite: true) so '
             .'browsers signalling Sec-Fetch-Site: same-site are accepted as origin-verified.'
         );
@@ -48,24 +49,23 @@ class PreventRequestForgeryConfigTest extends TestCase
     #[Test]
     public function same_site_request_is_treated_as_having_a_valid_origin(): void
     {
-        $middleware = $this->app->make(PreventRequestForgery::class);
-
-        $hasValidOrigin = (new ReflectionClass($middleware))->getMethod('hasValidOrigin');
-        $hasValidOrigin->setAccessible(true);
-
         $sameSiteRequest = Request::create('/admin/sermons', 'POST');
+        $sameSiteRequest->setLaravelSession($this->app['session.store']);
         $sameSiteRequest->headers->set('Sec-Fetch-Site', 'same-site');
 
-        $this->assertTrue(
-            $hasValidOrigin->invoke($middleware, $sameSiteRequest),
+        $this->assertEquals(
+            'ok',
+            $this->callMiddlewareDirectly($sameSiteRequest)->getContent(),
             'With allowSameSite enabled, same-site requests must be accepted without a token fallback.'
         );
 
         $sameOriginRequest = Request::create('/admin/sermons', 'POST');
+        $sameOriginRequest->setLaravelSession($this->app['session.store']);
         $sameOriginRequest->headers->set('Sec-Fetch-Site', 'same-origin');
 
-        $this->assertTrue(
-            $hasValidOrigin->invoke($middleware, $sameOriginRequest),
+        $this->assertEquals(
+            'ok',
+            $this->callMiddlewareDirectly($sameOriginRequest)->getContent(),
             'Same-origin requests must always be accepted, regardless of allowSameSite.'
         );
     }
@@ -73,26 +73,24 @@ class PreventRequestForgeryConfigTest extends TestCase
     #[Test]
     public function cross_site_request_without_token_is_rejected(): void
     {
-        $middleware = $this->app->make(PreventRequestForgery::class);
-
         $request = Request::create('/admin/sermons', 'POST');
         $request->setLaravelSession($this->app['session.store']);
         $request->headers->set('Sec-Fetch-Site', 'cross-site');
 
         $this->expectException(TokenMismatchException::class);
 
-        $this->callMiddlewareDirectly($middleware, $request);
+        $this->callMiddlewareDirectly($request);
     }
 
     /**
      * Invoke the middleware as if it were running outside the unit-test bypass.
      *
      * `PreventRequestForgery::handle()` skips its checks when the framework
-     * detects it is running under PHPUnit. We rebind the app's `runningInConsole`
-     * detector by toggling the protected `$app` reference on a clone of the
-     * middleware, so the same handle() method executes the real CSRF flow.
+     * detects it is running under PHPUnit. We use an anonymous subclass that
+     * overrides `runningUnitTests()` to return `false`, ensuring the real CSRF
+     * logic executes even during a unit test.
      */
-    private function callMiddlewareDirectly(PreventRequestForgery $middleware, Request $request): Response
+    private function callMiddlewareDirectly(Request $request): Response
     {
         $next = static fn (Request $r): Response => new Response('ok');
 


### PR DESCRIPTION
Harden `PreventRequestForgeryConfigTest` by removing brittle reflection-based assertions and replacing them with robust behavioral tests that exercise the middleware's real CSRF flow.

- Removed `ReflectionClass` usage on protected properties (`allowSameSite`) and methods (`hasValidOrigin`).
- Implemented an anonymous subclass in `callMiddlewareDirectly` to override `runningUnitTests()`, allowing behavioral testing of CSRF logic during unit tests.
- Ensured requests have a session attached to satisfy the middleware's requirements.
- Verified that tests still pass on the current configuration and correctly fail if `allowSameSite` is disabled.

---
*PR created automatically by Jules for task [2339968770236191574](https://jules.google.com/task/2339968770236191574) started by @GarethClarridge*