### PR TITLE
📜 Herald: [doc improvement] Add PHPDoc to AlignmentTriggerCalculator

### DIFF
--- a/app/Services/ChurchService/AlignmentTriggerCalculator.php
+++ b/app/Services/ChurchService/AlignmentTriggerCalculator.php
@@ -57,7 +57,7 @@ class AlignmentTriggerCalculator
      *     song_match_type: string|null,
      *     review_reason: string|null,
      * }>  $beforeState  Array keyed by section ID
-     * @return list<'ambiguous_sermon_detection'|'unmatched_song_sections'|'oos_structure_mismatch'|'late_oos_alignment_changed'|'too_many_low_confidence_sections'|'manual_review_sections'>
+     * @return array<int, 'ambiguous_sermon_detection'|'unmatched_song_sections'|'oos_structure_mismatch'|'late_oos_alignment_changed'|'too_many_low_confidence_sections'|'manual_review_sections'>
      */
     public function calculate(
         EloquentCollection $sections,

--- a/app/Services/ChurchService/AlignmentTriggerCalculator.php
+++ b/app/Services/ChurchService/AlignmentTriggerCalculator.php
@@ -10,6 +10,12 @@ use App\Support\ServiceSectionConfidence;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
 
+/**
+ * Evaluates the post-alignment state of a church service to determine if manual administrative review is required.
+ *
+ * This calculator identifies conditions such as structure mismatches, low confidence detections, or changes
+ * to late-arriving services that necessitate human oversight.
+ */
 class AlignmentTriggerCalculator
 {
     /**
@@ -17,7 +23,15 @@ class AlignmentTriggerCalculator
      * Pass the result to calculate() as $beforeState for late-arrival change detection.
      *
      * @param  EloquentCollection<int, ServiceSection>  $sections
-     * @return array<int, array<string, mixed>>
+     * @return array<int, array{
+     *     church_service_item_id: int|null,
+     *     title: string|null,
+     *     confidence: float,
+     *     reading_reference: string|null,
+     *     song_id: int|null,
+     *     song_match_type: string|null,
+     *     review_reason: string|null,
+     * }>  Array keyed by section ID
      */
     public function captureAlignmentState(EloquentCollection $sections): array
     {
@@ -34,8 +48,16 @@ class AlignmentTriggerCalculator
      *
      * @param  EloquentCollection<int, ServiceSection>  $sections
      * @param  Collection<int, ServiceSection>  $unmatchedSongSections
-     * @param  array<int, array<string, mixed>>  $beforeState
-     * @return array<int, string>
+     * @param  array<int, array{
+     *     church_service_item_id: int|null,
+     *     title: string|null,
+     *     confidence: float,
+     *     reading_reference: string|null,
+     *     song_id: int|null,
+     *     song_match_type: string|null,
+     *     review_reason: string|null,
+     * }>  $beforeState  Array keyed by section ID
+     * @return list<'ambiguous_sermon_detection'|'unmatched_song_sections'|'oos_structure_mismatch'|'late_oos_alignment_changed'|'too_many_low_confidence_sections'|'manual_review_sections'>
      */
     public function calculate(
         EloquentCollection $sections,
@@ -65,6 +87,9 @@ class AlignmentTriggerCalculator
         }
 
         $lowConfidenceSections = $this->lowConfidenceSections($sections);
+
+        // The 20% threshold is a heuristic: if more than a fifth of the service sections are
+        // low-confidence, the overall alignment is considered suspect and requires manual verification.
         if ($sections->count() > 0 && ($lowConfidenceSections->count() / $sections->count()) > 0.20) {
             $reviewTriggers[] = 'too_many_low_confidence_sections';
         }
@@ -110,7 +135,15 @@ class AlignmentTriggerCalculator
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array{
+     *     church_service_item_id: int|null,
+     *     title: string|null,
+     *     confidence: float,
+     *     reading_reference: string|null,
+     *     song_id: int|null,
+     *     song_match_type: string|null,
+     *     review_reason: string|null,
+     * }
      */
     private function sectionAlignmentState(ServiceSection $section): array
     {


### PR DESCRIPTION
I have improved the internal documentation and developer experience for the `AlignmentTriggerCalculator` service. 

Key changes include:
- **Class-level documentation**: Added a PHPDoc block explaining the service's role in the OoS alignment pipeline.
- **Detailed Array Shapes**: Added explicit `@return` and `@param` array shapes for `captureAlignmentState` and `calculate`, allowing PHPStan to better track the structure of section alignment state.
- **Trigger List Documentation**: Documented the specific list of review trigger strings returned by `calculate`.
- **"Why" Comments**: Added an explanation for the 20% low-confidence threshold, clarifying that it serves as a heuristic for suspect alignment results.

No functional changes were made; this is a documentation-only improvement. verified with PHPStan.

---
*PR created automatically by Jules for task [522301834005303706](https://jules.google.com/task/522301834005303706) started by @GarethClarridge*