### PR TITLE
🏛️ Warden: Harden SermonScriptureFilter validation

### DIFF
--- a/app/Models/SermonScriptureFilter.php
+++ b/app/Models/SermonScriptureFilter.php
@@ -52,9 +52,9 @@ class SermonScriptureFilter extends Model
     public static function validationRules(): array
     {
         return [
-            'sermon_id' => ['required', 'integer', 'exists:sermons,id'],
+            'sermon_id' => ['required', 'integer', 'min:1', 'max:4294967295', 'exists:sermons,id'],
             'bible_book' => ['required', 'string', 'max:50'],
-            'bible_chapter' => ['required', 'integer', 'min:1'],
+            'bible_chapter' => ['required', 'integer', 'min:1', 'max:65535'],
         ];
     }
 

--- a/tests/Feature/DataIntegrity/SermonScriptureFilterIntegrityTest.php
+++ b/tests/Feature/DataIntegrity/SermonScriptureFilterIntegrityTest.php
@@ -21,12 +21,12 @@ class SermonScriptureFilterIntegrityTest extends TestCase
         $rules = SermonScriptureFilter::validationRules();
 
         // sermon_id: unsignedInteger (max: 4294967295)
-        $this->assertContains('max:' . self::UNSIGNED_INTEGER_MAX, $rules['sermon_id']);
+        $this->assertContains('max:'.self::UNSIGNED_INTEGER_MAX, $rules['sermon_id']);
         $this->assertValidationPasses($rules['sermon_id'], 'sermon_id', self::UNSIGNED_INTEGER_MAX);
         $this->assertValidationFails($rules['sermon_id'], 'sermon_id', self::UNSIGNED_INTEGER_MAX + 1);
 
         // bible_chapter: unsignedSmallInteger (max: 65535)
-        $this->assertContains('max:' . self::UNSIGNED_SMALL_INTEGER_MAX, $rules['bible_chapter']);
+        $this->assertContains('max:'.self::UNSIGNED_SMALL_INTEGER_MAX, $rules['bible_chapter']);
         $this->assertValidationPasses($rules['bible_chapter'], 'bible_chapter', self::UNSIGNED_SMALL_INTEGER_MAX);
         $this->assertValidationFails($rules['bible_chapter'], 'bible_chapter', self::UNSIGNED_SMALL_INTEGER_MAX + 1);
 

--- a/tests/Feature/DataIntegrity/SermonScriptureFilterIntegrityTest.php
+++ b/tests/Feature/DataIntegrity/SermonScriptureFilterIntegrityTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\DataIntegrity;
+
+use App\Models\SermonScriptureFilter;
+use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SermonScriptureFilterIntegrityTest extends TestCase
+{
+    private const UNSIGNED_INTEGER_MAX = 4294967295;
+
+    private const UNSIGNED_SMALL_INTEGER_MAX = 65535;
+
+    #[Test]
+    public function validation_rules_mirror_database_column_types(): void
+    {
+        $rules = SermonScriptureFilter::validationRules();
+
+        // sermon_id: unsignedInteger (max: 4294967295)
+        $this->assertContains('max:' . self::UNSIGNED_INTEGER_MAX, $rules['sermon_id']);
+        $this->assertValidationPasses($rules['sermon_id'], 'sermon_id', self::UNSIGNED_INTEGER_MAX);
+        $this->assertValidationFails($rules['sermon_id'], 'sermon_id', self::UNSIGNED_INTEGER_MAX + 1);
+
+        // bible_chapter: unsignedSmallInteger (max: 65535)
+        $this->assertContains('max:' . self::UNSIGNED_SMALL_INTEGER_MAX, $rules['bible_chapter']);
+        $this->assertValidationPasses($rules['bible_chapter'], 'bible_chapter', self::UNSIGNED_SMALL_INTEGER_MAX);
+        $this->assertValidationFails($rules['bible_chapter'], 'bible_chapter', self::UNSIGNED_SMALL_INTEGER_MAX + 1);
+
+        // bible_book: varchar(50)
+        $this->assertContains('max:50', $rules['bible_book']);
+        $this->assertValidationPasses($rules['bible_book'], 'bible_book', str_repeat('a', 50));
+        $this->assertValidationFails($rules['bible_book'], 'bible_book', str_repeat('a', 51));
+    }
+
+    /**
+     * @param  list<mixed>  $rules
+     */
+    private function assertValidationPasses(array $rules, string $field, mixed $value): void
+    {
+        $validator = Validator::make([$field => $value], [$field => $this->rulesWithoutExists($rules)]);
+
+        $this->assertTrue($validator->passes(), $validator->errors()->first($field));
+    }
+
+    /**
+     * @param  list<mixed>  $rules
+     */
+    private function assertValidationFails(array $rules, string $field, mixed $value): void
+    {
+        $validator = Validator::make([$field => $value], [$field => $this->rulesWithoutExists($rules)]);
+
+        $this->assertTrue($validator->fails());
+    }
+
+    /**
+     * @param  list<mixed>  $rules
+     * @return list<mixed>
+     */
+    private function rulesWithoutExists(array $rules): array
+    {
+        return array_values(array_filter(
+            $rules,
+            static fn (mixed $rule): bool => ! is_string($rule) || ! str_starts_with($rule, 'exists:')
+        ));
+    }
+}


### PR DESCRIPTION
💡 **What:** Hardened validation rules for `SermonScriptureFilter` model to match database constraints.
🎯 **Why:** Prevents "Out of range" database errors by catching invalid input at the application layer.
🗄️ **Migration:** No schema changes; purely additive model-layer validation.
✅ **Verification:** Added `SermonScriptureFilterIntegrityTest` and ran full suite.
⚠️ **Rollback:** Revert model changes.

---
*PR created automatically by Jules for task [10257442339930505925](https://jules.google.com/task/10257442339930505925) started by @GarethClarridge*