### PR TITLE
⚡ Bolt: limit columns in UploadChurchService sidebar

### DIFF
--- a/app/Livewire/Admin/ChurchServices/UploadChurchService.php
+++ b/app/Livewire/Admin/ChurchServices/UploadChurchService.php
@@ -83,7 +83,12 @@ class UploadChurchService extends Component
 
     public function render(): View
     {
+        /**
+         * Performance Optimization: Limits retrieved columns for recent services
+         * to required fields for the sidebar listing to reduce memory usage and DB I/O.
+         */
         $recentServices = ChurchService::query()
+            ->select(['id', 'date', 'service', 'original_filename', 'updated_at'])
             ->withCount('items')
             ->orderByDesc('date')
             ->orderByDesc('updated_at')


### PR DESCRIPTION
Optimised the `render()` method in `app/Livewire/Admin/ChurchServices/UploadChurchService.php` to limit retrieved columns to only those needed for the sidebar listing (`id`, `date`, `service`, `original_filename`, `updated_at`), plus the items count. This is a safe performance improvement that reduces memory overhead and database load when navigating to the service upload page.

---
*PR created automatically by Jules for task [3225918310690866386](https://jules.google.com/task/3225918310690866386) started by @GarethClarridge*