### PR TITLE
♿ Aria: Standardise pagination landmarks in public list views

### DIFF
--- a/resources/views/childrens-corner/index.blade.php
+++ b/resources/views/childrens-corner/index.blade.php
@@ -63,9 +63,9 @@
                 </div>
 
                 @if ($talks->hasPages())
-                    <div class="mx-auto mt-8 max-w-2xl">
+                    <nav class="mx-auto mt-8 max-w-2xl" aria-label="Pagination">
                         {{ $talks->links() }}
-                    </div>
+                    </nav>
                 @endif
             </section>
         @endif

--- a/resources/views/livewire/church/songs/browse-songs.blade.php
+++ b/resources/views/livewire/church/songs/browse-songs.blade.php
@@ -186,9 +186,9 @@
                 </div>
 
                 @if ($songs->hasPages())
-                    <div class="mx-auto mt-8 max-w-2xl">
+                    <nav class="mx-auto mt-8 max-w-2xl" aria-label="Pagination">
                         {{ $songs->links(data: ['scrollTo' => '#song-results']) }}
-                    </div>
+                    </nav>
                 @endif
             </section>
         @endif

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -156,9 +156,9 @@
             </div>
 
             @if ($sermons->hasPages())
-                <div class="mx-auto mt-8 max-w-2xl px-6">
+                <nav class="mx-auto mt-8 max-w-2xl px-6" aria-label="Pagination">
                     {{ $sermons->links(data: ['scrollTo' => '#sermon-results']) }}
-                </div>
+                </nav>
             @endif
         @else
             <section class="mx-auto mt-8 max-w-2xl px-6">


### PR DESCRIPTION
💡 **What:** Standardised pagination landmarks by wrapping them in a semantic `<nav>` element with a descriptive `aria-label`.
🎯 **Who:** Screen reader users and keyboard-only users who rely on landmarks for efficient page navigation.
🧪 **How to verify:** Inspected the rendered HTML in the Sermon browser, Song browser, and Children's Corner to confirm the presence of `<nav aria-label="Pagination">` around the pagination links. Verified visually with Playwright.
🔄 **Behavior:** Same visible behaviour — accessibility metadata only.

---
*PR created automatically by Jules for task [11996329326144449120](https://jules.google.com/task/11996329326144449120) started by @GarethClarridge*