### PR TITLE
📜 Pathfinder: Diagnostic Report - Community Routing and Seed Assets

### DIFF
--- a/.Jules/pathfinder.md
+++ b/.Jules/pathfinder.md
@@ -14,3 +14,8 @@
 **Pattern:** Sermon records created by seeders point to audio files that do not exist in the environment's storage.
 **Cause:** `SermonSeeder` assumes the presence of `sermons/seed/2024-11-24.mp3` in the public disk, but this file is not bundled with the repository or generated during setup.
 **Action:** Cross-check `audio_file_path` against `Storage::disk('public')->exists()` specifically for seeded records.
+
+## 2026-06-26 - Community route monopolization
+**Pattern:** Pages in the 'community' area return 404 if no matching Meeting record exists.
+**Cause:** The route `GET /community/{meeting:slug}` in `routes/web.php` uses implicit model binding for the `Meeting` model. Because it is defined before the catch-all `{area}/{slug}` route, any URL starting with `/community/` is intercepted. If the slug doesn't exist in the `meetings` table, Laravel returns a 404 before it can reach the general page controller, even if a `Page` with that slug exists.
+**Action:** When checking community links, verify both `Page` and `Meeting` existence, and prefer using `Meeting` slugs for the `/community/` prefix.


### PR DESCRIPTION
Identified a significant routing behavior in the `community` area where the `Meeting` model binding monopolizes the `/community/{slug}` namespace. Any `Page` created in this area must have a corresponding `Meeting` record with the same slug, or it will be unreachable (404).

Key findings:
- **Routing Conflict**: The route `GET /community/{meeting:slug}` takes precedence over the catch-all `{area}/{slug}` route. Laravel's implicit model binding fails and returns a 404 for slugs not in the `meetings` table, even if they exist in the `pages` table.
- **Missing Asset**: Confirmed that `sermons/seed/2024-11-24.mp3` is missing from the public disk, affecting the "The Prodigal Son" sermon record.
- **Sitemap**: Verified that orphaned community pages (if they existed) would be included in the sitemap but would return 404.

Updated the Pathfinder journal with the routing conflict pattern.

---
*PR created automatically by Jules for task [12086438043316567338](https://jules.google.com/task/12086438043316567338) started by @GarethClarridge*