### PR TITLE
🔗 Pathfinder: [1] broken [links] on [footer]

### DIFF
--- a/docs/issues/2026-06-27-misleading-footer-link-for-evening-sermons.md
+++ b/docs/issues/2026-06-27-misleading-footer-link-for-evening-sermons.md
@@ -1,0 +1,43 @@
+# 🔗 Pathfinder: [1] broken [links] on [footer]
+
+## Summary
+The link labeled "Listen to evening sermons" in the site footer currently points to the general sermons archive (`/christ/sermons`) rather than the intended filtered view for evening services (`/christ/sermons/evening`).
+
+## Affected items
+- **Surface:** `resources/views/components/layout/footer.blade.php` (Line 15)
+- **Label:** "Listen to evening sermons"
+- **Current URL:** `/christ/sermons`
+- **Expected URL:** `/christ/sermons/evening`
+
+## Verification
+1. **Manual Check:**
+   - Navigating to `/christ/sermons` shows all sermons (Morning, Evening, and Other).
+   - Navigating to `/christ/sermons/evening` correctly filters to only show "Sunday Evening Services".
+2. **Commands:**
+   ```bash
+   # Confirm valid route exists
+   curl -I http://127.0.0.1:8000/christ/sermons/evening
+   # Confirm current link target
+   grep -C 2 "Listen to evening sermons" resources/views/components/layout/footer.blade.php
+   ```
+
+## Likely cause
+Likely a copy-paste error or a placeholder link that was never updated after the service-specific routes were implemented.
+
+## Suggested action
+Update the `href` attribute in the footer Blade component to point to the more specific route.
+
+```blade
+<<<<<<< SEARCH
+        <a class="{{ $linkClasses }}" href="/christ/sermons" wire:navigate>
+          Listen to evening sermons
+        </a>
+=======
+        <a class="{{ $linkClasses }}" href="/christ/sermons/evening" wire:navigate>
+          Listen to evening sermons
+        </a>
+>>>>>>> REPLACE
+```
+
+## Risk note
+Minimal. This is a UX improvement that fulfills a "broken promise" to the user. Both routes exist and are functioning.


### PR DESCRIPTION
I have identified and documented a misleading link in the site footer that represents a "broken promise" to users. 

### Finding
The link labeled **"Listen to evening sermons"** currently points to `/christ/sermons` (the general sermons index) instead of the more appropriate and existing filtered route `/christ/sermons/evening`.

### Diagnostics & Evidence
- **Route Verification:** I verified that `/christ/sermons/evening` is a valid, functioning route that correctly displays only evening services.
- **Sitemap & Link Crawl:** I crawled the sitemap and all internal links. While no 404s were found, this misleading link was identified during manual inspection of the footer component.
- **Asset Check:** No missing images or media files were detected in the public areas or database records.

### Action Taken
Following the Pathfinder persona mission, I have opened a detailed diagnostic issue in:
`docs/issues/2026-06-27-misleading-footer-link-for-evening-sermons.md`

This report includes:
- Verification steps and evidence.
- Impact analysis.
- A suggested code fix (rewriting the URL) for a developer to implement.

I have opted for an issue report rather than a PR because Pathfinder's mission limits PRs to simple **removals** of dead links, whereas this requires a **rewrite** to a more specific valid target.

---
*PR created automatically by Jules for task [7646662229146511018](https://jules.google.com/task/7646662229146511018) started by @GarethClarridge*