### PR TITLE
🧪 Steward: Harden media job logs and remove reflection in validation tests

### DIFF
--- a/tests/Integration/Jobs/AnalyzeSegmentsVisualTest.php
+++ b/tests/Integration/Jobs/AnalyzeSegmentsVisualTest.php
@@ -666,7 +666,7 @@ class AnalyzeSegmentsVisualTest extends TestCase
         $mockService->expects($this->never())->method('analyzeSegments');
         $mockService->expects($this->never())->method('calibratePerSongThreshold');
 
-        Log::shouldReceive('info')->once()->with('AnalyzeSegments job skipped: processing cancelled', Mockery::any());
+        Log::shouldReceive('info')->once()->withArgs(fn ($msg) => str_contains($msg, 'job skipped: processing cancelled'));
 
         $job = new AnalyzeSegments($log);
         $job->handle($mockService);

--- a/tests/Integration/Jobs/ExtractAudioFromVideoTest.php
+++ b/tests/Integration/Jobs/ExtractAudioFromVideoTest.php
@@ -211,7 +211,7 @@ class ExtractAudioFromVideoTest extends TestCase
         $mockExtractor = $this->createMock(VideoExtractionService::class);
         $mockExtractor->expects($this->never())->method('extractOptimizedAudio');
 
-        Log::shouldReceive('info')->once()->with('ExtractAudioFromVideo job skipped: processing cancelled', \Mockery::any());
+        Log::shouldReceive('info')->once()->withArgs(fn ($msg) => str_contains($msg, 'job skipped: processing cancelled'));
 
         $job = new ExtractAudioFromVideo($log);
         $job->handle($mockExtractor);

--- a/tests/Integration/Jobs/ExtractSermonTest.php
+++ b/tests/Integration/Jobs/ExtractSermonTest.php
@@ -46,7 +46,7 @@ class ExtractSermonTest extends TestCase
 
         $mockStorage = $this->createStub(VideoStorageService::class);
 
-        Log::shouldReceive('info')->once()->with('ExtractSermon job skipped: processing cancelled', \Mockery::any());
+        Log::shouldReceive('info')->once()->withArgs(fn ($msg) => str_contains($msg, 'job skipped: processing cancelled'));
 
         $job = new ExtractSermon($log);
         $this->runJob($job, $mockExtractor, $mockStorage);

--- a/tests/Integration/Jobs/GenerateRmsLogTest.php
+++ b/tests/Integration/Jobs/GenerateRmsLogTest.php
@@ -184,7 +184,7 @@ class GenerateRmsLogTest extends TestCase
         $mockService = $this->createMock(VideoSegmentationService::class);
         $mockService->expects($this->never())->method('generateRmsLog');
 
-        Log::shouldReceive('info')->once()->with('GenerateRmsLog job skipped: processing cancelled', \Mockery::any());
+        Log::shouldReceive('info')->once()->withArgs(fn ($msg) => str_contains($msg, 'job skipped: processing cancelled'));
 
         $job = new GenerateRmsLog($log);
         $job->handle($mockService);

--- a/tests/Integration/Jobs/SendCompletionNotificationTest.php
+++ b/tests/Integration/Jobs/SendCompletionNotificationTest.php
@@ -169,7 +169,7 @@ class SendCompletionNotificationTest extends TestCase
 
         $log = MediaProcessingLog::factory()->cancelled()->create();
 
-        Log::shouldReceive('info')->once()->with('SendCompletionNotification job skipped: processing cancelled', \Mockery::any());
+        Log::shouldReceive('info')->once()->withArgs(fn ($msg) => str_contains($msg, 'job skipped: processing cancelled'));
 
         $job = new SendCompletionNotification($log);
         $job->handle();

--- a/tests/Integration/Jobs/ValidateAudioFileTest.php
+++ b/tests/Integration/Jobs/ValidateAudioFileTest.php
@@ -241,7 +241,7 @@ class ValidateAudioFileTest extends TestCase
         $mockExtractor = $this->createMock(AudioExtractionService::class);
         $mockExtractor->expects($this->never())->method('validateAudioFile');
 
-        Log::shouldReceive('info')->once()->with('ValidateAudioFile job skipped: processing cancelled', \Mockery::any());
+        Log::shouldReceive('info')->once()->withArgs(fn ($msg) => str_contains($msg, 'job skipped: processing cancelled'));
 
         $job = new ValidateAudioFile($log);
         $job->handle($mockExtractor, app(StorageAdapterHelper::class));

--- a/tests/Integration/Jobs/ValidateVideoFileTest.php
+++ b/tests/Integration/Jobs/ValidateVideoFileTest.php
@@ -201,7 +201,7 @@ class ValidateVideoFileTest extends TestCase
         $mockValidation = $this->createMock(MediaValidationService::class);
         $mockValidation->expects($this->never())->method('validateLocalFile');
 
-        Log::shouldReceive('info')->once()->with('ValidateVideoFile job skipped: processing cancelled', \Mockery::any());
+        Log::shouldReceive('info')->once()->withArgs(fn ($msg) => str_contains($msg, 'job skipped: processing cancelled'));
 
         $job = new ValidateVideoFile($log);
         $job->handle($mockValidation);

--- a/tests/Unit/Security/SermonValidationSecurityTest.php
+++ b/tests/Unit/Security/SermonValidationSecurityTest.php
@@ -10,13 +10,14 @@ use App\Livewire\Forms\SermonFormData;
 use App\Rules\SermonPointElement;
 use Illuminate\Support\Facades\Validator;
 use Livewire\Component;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class SermonValidationSecurityTest extends TestCase
 {
     #[Test]
-    public function update_sermon_request_rejects_oversized_flat_points()
+    public function update_sermon_request_rejects_oversized_flat_points(): void
     {
         $request = new UpdateSermonRequest;
         $rules = $request->rules();
@@ -41,7 +42,7 @@ class SermonValidationSecurityTest extends TestCase
     }
 
     #[Test]
-    public function update_sermon_request_rejects_oversized_nested_points()
+    public function update_sermon_request_rejects_oversized_nested_points(): void
     {
         $request = new UpdateSermonRequest;
         $rules = $request->rules();
@@ -66,7 +67,7 @@ class SermonValidationSecurityTest extends TestCase
     }
 
     #[Test]
-    public function update_sermon_request_rejects_oversized_sub_points()
+    public function update_sermon_request_rejects_oversized_sub_points(): void
     {
         $request = new UpdateSermonRequest;
         $rules = $request->rules();
@@ -91,7 +92,7 @@ class SermonValidationSecurityTest extends TestCase
     }
 
     #[Test]
-    public function update_sermon_request_rejects_non_string_scalar_flat_points()
+    public function update_sermon_request_rejects_non_string_scalar_flat_points(): void
     {
         $request = new UpdateSermonRequest;
         $rules = $request->rules();
@@ -116,7 +117,7 @@ class SermonValidationSecurityTest extends TestCase
     }
 
     #[Test]
-    public function update_sermon_request_accepts_valid_mixed_points()
+    public function update_sermon_request_accepts_valid_mixed_points(): void
     {
         $request = new UpdateSermonRequest;
         $rules = $request->rules();
@@ -142,7 +143,7 @@ class SermonValidationSecurityTest extends TestCase
     }
 
     #[Test]
-    public function confirm_media_segment_request_rejects_overflow_id()
+    public function confirm_media_segment_request_rejects_overflow_id(): void
     {
         $request = new ConfirmMediaSegmentRequest;
         $rules = $request->rules();
@@ -159,13 +160,16 @@ class SermonValidationSecurityTest extends TestCase
     }
 
     #[Test]
-    public function sermon_form_data_rules_contain_points_limit()
+    public function sermon_form_data_rules_contain_points_limit(): void
     {
         // Mock the Livewire component and property name required by the Form constructor
+        /** @var Component&MockInterface $component */
         $component = \Mockery::mock(Component::class);
 
         // We use an anonymous class to expose the protected rules() method without reflection
-        $form = new class($component, 'form') extends SermonFormData {
+        $form = new class($component, 'form') extends SermonFormData
+        {
+            /** @return array<string, mixed> */
             public function getRules(): array
             {
                 return $this->rules();

--- a/tests/Unit/Security/SermonValidationSecurityTest.php
+++ b/tests/Unit/Security/SermonValidationSecurityTest.php
@@ -163,14 +163,16 @@ class SermonValidationSecurityTest extends TestCase
     {
         // Mock the Livewire component and property name required by the Form constructor
         $component = \Mockery::mock(Component::class);
-        $form = new SermonFormData($component, 'form');
 
-        // We use reflection to access the protected rules() method
-        $reflection = new \ReflectionClass($form);
-        $method = $reflection->getMethod('rules');
-        $method->setAccessible(true);
+        // We use an anonymous class to expose the protected rules() method without reflection
+        $form = new class($component, 'form') extends SermonFormData {
+            public function getRules(): array
+            {
+                return $this->rules();
+            }
+        };
 
-        $rules = $method->invoke($form);
+        $rules = $form->getRules();
 
         $this->assertArrayHasKey('points.*', $rules);
         $this->assertContains('nullable', $rules['points.*']);


### PR DESCRIPTION
This PR hardens the test suite against common forms of brittleness.

### Log Assertion Hardening
I identified a pattern where multiple integration tests for media processing jobs (`ExtractSermon`, `ValidateAudioFile`, etc.) were asserting against exact log message strings when a job is skipped due to cancellation. These assertions would break if the wording in the `ChecksCancellation` trait were ever modified. I've replaced these with `withArgs` closures using `str_contains` to focus on the intent rather than the exact markup.

### Reflection Removal
In `SermonValidationSecurityTest.php`, `ReflectionClass` was used to access the protected `rules()` method of the `SermonFormData` Livewire form. I've refactored this to use an anonymous class that extends `SermonFormData` and exposes `rules()` as a public method. This is more robust as it respects the class hierarchy and avoids internal poking.

### Verification
- Individual tests were run and passed.
- The full test suite was run in parallel and passed: `php artisan test --parallel --compact`.
- Code review confirmed the changes align with "Steward" persona best practices.

---
*PR created automatically by Jules for task [17176948299863274746](https://jules.google.com/task/17176948299863274746) started by @GarethClarridge*