### PR TITLE
📜 Herald: Centralize ClassifiedSection type and enhance service documentation

### DIFF
--- a/app/Jobs/ClassifySpeechSections.php
+++ b/app/Jobs/ClassifySpeechSections.php
@@ -9,6 +9,7 @@ use App\Enums\ServiceSectionStatus;
 use App\Enums\ServiceSectionType;
 use App\Models\MediaProcessingLog;
 use App\Models\ServiceSection;
+use App\Services\ChurchService\ServiceSectionClassifier;
 use App\Services\ChurchService\ServiceSectionSyncService;
 use App\Services\ChurchService\SpeechSectionClassificationService;
 use App\Services\Song\SongTitleHintExtractor;
@@ -21,20 +22,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
 /**
- * @phpstan-type SectionPayload array{
- *     church_service_item_id: int|null,
- *     section_type: string,
- *     section_order: int,
- *     title: ?string,
- *     start_time: float,
- *     end_time: float,
- *     duration: float,
- *     confidence: float,
- *     status: string,
- *     needs_manual_review: bool,
- *     source_segment_ids: array<int, int>,
- *     metadata: array<string, mixed>
- * }
+ * @phpstan-import-type ClassifiedSection from ServiceSectionClassifier
  */
 class ClassifySpeechSections extends ProcessingJob implements ShouldQueue
 {
@@ -167,20 +155,7 @@ class ClassifySpeechSections extends ProcessingJob implements ShouldQueue
     }
 
     /**
-     * @return array{
-     *     church_service_item_id: int|null,
-     *     section_type: string,
-     *     section_order: int,
-     *     title: ?string,
-     *     start_time: float,
-     *     end_time: float,
-     *     duration: float,
-     *     confidence: float,
-     *     status: string,
-     *     needs_manual_review: bool,
-     *     source_segment_ids: array<int, int>,
-     *     metadata: array<string, mixed>
-     * }
+     * @return ClassifiedSection
      */
     private function payloadFromExistingSection(ServiceSection $section): array
     {
@@ -211,20 +186,7 @@ class ClassifySpeechSections extends ProcessingJob implements ShouldQueue
      *     needs_manual_review: bool,
      *     metadata: array<string, mixed>
      * }  $classifiedSection
-     * @return array{
-     *     church_service_item_id: int|null,
-     *     section_type: string,
-     *     section_order: int,
-     *     title: ?string,
-     *     start_time: float,
-     *     end_time: float,
-     *     duration: float,
-     *     confidence: float,
-     *     status: string,
-     *     needs_manual_review: bool,
-     *     source_segment_ids: array<int, int>,
-     *     metadata: array<string, mixed>
-     * }
+     * @return ClassifiedSection
      */
     private function payloadFromClassifiedSection(
         ServiceSection $originalSection,
@@ -298,20 +260,7 @@ class ClassifySpeechSections extends ProcessingJob implements ShouldQueue
     }
 
     /**
-     * @return array{
-     *     church_service_item_id: int|null,
-     *     section_type: string,
-     *     section_order: int,
-     *     title: ?string,
-     *     start_time: float,
-     *     end_time: float,
-     *     duration: float,
-     *     confidence: float,
-     *     status: string,
-     *     needs_manual_review: bool,
-     *     source_segment_ids: array<int, int>,
-     *     metadata: array<string, mixed>
-     * }
+     * @return ClassifiedSection
      */
     private function fallbackPayload(ServiceSection $section, string $reason): array
     {
@@ -352,8 +301,8 @@ class ClassifySpeechSections extends ProcessingJob implements ShouldQueue
      * After folding, if more than one sermon section remains, keep the longest as the primary
      * and demote any shorter ones (below the configured threshold) to childrens_talk.
      *
-     * @param  array<int, SectionPayload>  $sections
-     * @return array<int, SectionPayload>
+     * @param  array<int, ClassifiedSection>  $sections
+     * @return array<int, ClassifiedSection>
      */
     private function demoteSecondarySermons(array $sections): array
     {
@@ -403,8 +352,8 @@ class ClassifySpeechSections extends ProcessingJob implements ShouldQueue
     }
 
     /**
-     * @param  SectionPayload  $section
-     * @return SectionPayload
+     * @param  ClassifiedSection  $section
+     * @return ClassifiedSection
      */
     private function demoteSectionToChildrensTalk(array $section): array
     {
@@ -430,8 +379,8 @@ class ClassifySpeechSections extends ProcessingJob implements ShouldQueue
     }
 
     /**
-     * @param  SectionPayload  $section
-     * @return SectionPayload
+     * @param  ClassifiedSection  $section
+     * @return ClassifiedSection
      */
     private function flagSectionForMultipleSermonsReview(array $section): array
     {
@@ -454,34 +403,8 @@ class ClassifySpeechSections extends ProcessingJob implements ShouldQueue
     }
 
     /**
-     * @param  array<int, array{
-     *     church_service_item_id: int|null,
-     *     section_type: string,
-     *     section_order: int,
-     *     title: ?string,
-     *     start_time: float,
-     *     end_time: float,
-     *     duration: float,
-     *     confidence: float,
-     *     status: string,
-     *     needs_manual_review: bool,
-     *     source_segment_ids: array<int, int>,
-     *     metadata: array<string, mixed>
-     * }>  $sections
-     * @return array<int, array{
-     *     church_service_item_id: int|null,
-     *     section_type: string,
-     *     section_order: int,
-     *     title: ?string,
-     *     start_time: float,
-     *     end_time: float,
-     *     duration: float,
-     *     confidence: float,
-     *     status: string,
-     *     needs_manual_review: bool,
-     *     source_segment_ids: array<int, int>,
-     *     metadata: array<string, mixed>
-     * }>
+     * @param  array<int, ClassifiedSection>  $sections
+     * @return array<int, ClassifiedSection>
      */
     private function foldShortSongsIntoSermon(array $sections): array
     {
@@ -582,34 +505,8 @@ class ClassifySpeechSections extends ProcessingJob implements ShouldQueue
      * at least one side is short (below the configured threshold). Children's talk sections
      * are always merged regardless of duration.
      *
-     * @param  array<int, array{
-     *     church_service_item_id: int|null,
-     *     section_type: string,
-     *     section_order: int,
-     *     title: ?string,
-     *     start_time: float,
-     *     end_time: float,
-     *     duration: float,
-     *     confidence: float,
-     *     status: string,
-     *     needs_manual_review: bool,
-     *     source_segment_ids: array<int, int>,
-     *     metadata: array<string, mixed>
-     * }>  $sections
-     * @return array<int, array{
-     *     church_service_item_id: int|null,
-     *     section_type: string,
-     *     section_order: int,
-     *     title: ?string,
-     *     start_time: float,
-     *     end_time: float,
-     *     duration: float,
-     *     confidence: float,
-     *     status: string,
-     *     needs_manual_review: bool,
-     *     source_segment_ids: array<int, int>,
-     *     metadata: array<string, mixed>
-     * }>
+     * @param  array<int, ClassifiedSection>  $sections
+     * @return array<int, ClassifiedSection>
      */
     private function mergeAdjacentSameTypeSections(array $sections): array
     {
@@ -660,48 +557,9 @@ class ClassifySpeechSections extends ProcessingJob implements ShouldQueue
      * Merge two same-type sections into one. The longer section is the primary and
      * carries its church_service_item_id, title, confidence, and metadata.
      *
-     * @param  array{
-     *     church_service_item_id: int|null,
-     *     section_type: string,
-     *     section_order: int,
-     *     title: ?string,
-     *     start_time: float,
-     *     end_time: float,
-     *     duration: float,
-     *     confidence: float,
-     *     status: string,
-     *     needs_manual_review: bool,
-     *     source_segment_ids: array<int, int>,
-     *     metadata: array<string, mixed>
-     * }  $a
-     * @param  array{
-     *     church_service_item_id: int|null,
-     *     section_type: string,
-     *     section_order: int,
-     *     title: ?string,
-     *     start_time: float,
-     *     end_time: float,
-     *     duration: float,
-     *     confidence: float,
-     *     status: string,
-     *     needs_manual_review: bool,
-     *     source_segment_ids: array<int, int>,
-     *     metadata: array<string, mixed>
-     * }  $b
-     * @return array{
-     *     church_service_item_id: int|null,
-     *     section_type: string,
-     *     section_order: int,
-     *     title: ?string,
-     *     start_time: float,
-     *     end_time: float,
-     *     duration: float,
-     *     confidence: float,
-     *     status: string,
-     *     needs_manual_review: bool,
-     *     source_segment_ids: array<int, int>,
-     *     metadata: array<string, mixed>
-     * }
+     * @param  ClassifiedSection  $a
+     * @param  ClassifiedSection  $b
+     * @return ClassifiedSection
      */
     private function mergeTwoSections(array $a, array $b): array
     {

--- a/app/Services/ChurchService/ServiceSectionClassifier.php
+++ b/app/Services/ChurchService/ServiceSectionClassifier.php
@@ -15,6 +15,30 @@ use App\Services\Sermon\SermonCandidateConfidenceService;
 use App\Support\ServiceSectionConfidence;
 use Illuminate\Support\Collection;
 
+/**
+ * Orchestrates the initial identification and classification of service sections.
+ *
+ * This service transforms raw livestream segments into a structured sequence of
+ * church service sections (Songs, Sermons, Readings, etc.). It currently implements
+ * an "audio-only" baseline strategy that relies on acoustic segmentation and
+ * preacher identification, which provides the foundation for later refinement
+ * through OoS alignment and visual analysis.
+ *
+ * @phpstan-type ClassifiedSection array{
+ *     church_service_item_id: int|null,
+ *     section_type: string,
+ *     section_order: int,
+ *     title: ?string,
+ *     start_time: float,
+ *     end_time: float,
+ *     duration: float,
+ *     confidence: float,
+ *     status: string,
+ *     needs_manual_review: bool,
+ *     source_segment_ids: array<int, int>,
+ *     metadata: array<string, mixed>
+ * }
+ */
 class ServiceSectionClassifier
 {
     private MediaProcessingIdentityResolver $identityResolver;
@@ -30,23 +54,13 @@ class ServiceSectionClassifier
     }
 
     /**
+     * Identifies and types all audible sections within a processing log.
+     *
+     * @param  MediaProcessingLog  $processingLog  The log to analyze
      * @return array{
      *     skipped: bool,
      *     skip_reason: ?string,
-     *     sections: array<int, array{
-     *         church_service_item_id: int|null,
-     *         section_type: string,
-     *         section_order: int,
-     *         title: ?string,
-     *         start_time: float,
-     *         end_time: float,
-     *         duration: float,
-     *         confidence: float,
-     *         status: string,
-     *         needs_manual_review: bool,
-     *         source_segment_ids: array<int, int>,
-     *         metadata: array<string, mixed>
-     *     }>
+     *     sections: array<int, ClassifiedSection>
      * }
      */
     public function classify(MediaProcessingLog $processingLog): array
@@ -99,21 +113,10 @@ class ServiceSectionClassifier
     }
 
     /**
+     * Maps raw audible segments to their initial section classifications.
+     *
      * @param  Collection<int, LivestreamSegment>  $segments
-     * @return array<int, array{
-     *     church_service_item_id: int|null,
-     *     section_type: string,
-     *     section_order: int,
-     *     title: ?string,
-     *     start_time: float,
-     *     end_time: float,
-     *     duration: float,
-     *     confidence: float,
-     *     status: string,
-     *     needs_manual_review: bool,
-     *     source_segment_ids: array<int, int>,
-     *     metadata: array<string, mixed>
-     * }>
+     * @return array<int, ClassifiedSection>
      */
     private function classifyFromAudioOnlySegments(Collection $segments): array
     {
@@ -176,22 +179,11 @@ class ServiceSectionClassifier
     }
 
     /**
+     * Helper to create a standardized classified section array from a segment.
+     *
      * @param  'high'|'low'|'none'  $confidenceLevel
      * @param  array<string, mixed>  $extraMetadata
-     * @return array{
-     *     church_service_item_id: null,
-     *     section_type: string,
-     *     section_order: int,
-     *     title: null,
-     *     start_time: float,
-     *     end_time: float,
-     *     duration: float,
-     *     confidence: float,
-     *     status: string,
-     *     needs_manual_review: bool,
-     *     source_segment_ids: array<int, int>,
-     *     metadata: array<string, mixed>
-     * }
+     * @return ClassifiedSection
      */
     private function makeAudioOnlySection(
         LivestreamSegment $segment,

--- a/app/Services/ChurchService/ServiceSectionSyncService.php
+++ b/app/Services/ChurchService/ServiceSectionSyncService.php
@@ -16,6 +16,16 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 
+/**
+ * Synchronizes classified section data with the persistent database state.
+ *
+ * This service handles the idempotent upsert of service sections for a processing log,
+ * ensuring that material changes to a section's "signature" (type, timing, item link)
+ * trigger appropriate asset cleanup and publication notifications while preserving
+ * existing manual metadata edits where possible.
+ *
+ * @phpstan-import-type ClassifiedSection from ServiceSectionClassifier
+ */
 class ServiceSectionSyncService
 {
     use SanitizesLogData;
@@ -36,20 +46,9 @@ class ServiceSectionSyncService
     }
 
     /**
-     * @param  array<int, array{
-     *     church_service_item_id: int|null,
-     *     section_type: string,
-     *     section_order: int,
-     *     title: ?string,
-     *     start_time: float,
-     *     end_time: float,
-     *     duration: float,
-     *     confidence?: float|null,
-     *     status: string,
-     *     needs_manual_review: bool,
-     *     source_segment_ids: array<int, int>,
-     *     metadata: array<string, mixed>
-     * }>  $classifiedSections
+     * Perform an idempotent sync of all classified sections for a processing log.
+     *
+     * @param  array<int, ClassifiedSection>  $classifiedSections
      */
     public function sync(MediaProcessingLog $processingLog, array $classifiedSections): void
     {


### PR DESCRIPTION
I have centralized the complex `ClassifiedSection` array shape using `@phpstan-type` and `@phpstan-import-type` across the service section classification pipeline. This eliminates significant duplication and improves type safety. I also added class-level documentation to `ServiceSectionClassifier` and `ServiceSectionSyncService` to provide better architectural context for future developers. All changes have been verified with Pint, PHPStan, and the full test suite.

---
*PR created automatically by Jules for task [9269446290579120802](https://jules.google.com/task/9269446290579120802) started by @GarethClarridge*