### PR TITLE
🏛️ Warden: fortify song title integrity

### DIFF
--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -135,7 +135,7 @@ class Song extends Model
         return [
             // Security: Explicit length constraints are enforced on all text fields to provide
             // Defense in Depth against Denial of Service (DoS) attempts with oversized payloads.
-            'title' => ['required', 'string', 'max:255'],
+            'title' => ['required', 'string', 'max:100'],
             'slug' => $slugRule,
             'canonical_key' => ['required', 'string', 'max:255', $uniqueCanonicalKey],
             'alternate_title' => ['nullable', 'string', 'max:255'],

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -135,7 +135,7 @@ class Song extends Model
         return [
             // Security: Explicit length constraints are enforced on all text fields to provide
             // Defense in Depth against Denial of Service (DoS) attempts with oversized payloads.
-            'title' => ['required', 'string', 'max:100'],
+            'title' => ['required', 'string', 'max:255'],
             'slug' => $slugRule,
             'canonical_key' => ['required', 'string', 'max:255', $uniqueCanonicalKey],
             'alternate_title' => ['nullable', 'string', 'max:255'],

--- a/database/migrations/2026_06_27_065159_add_index_to_songs_title.php
+++ b/database/migrations/2026_06_27_065159_add_index_to_songs_title.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -15,11 +14,6 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('songs', function (Blueprint $table) {
-            // Widen title to 255 to match project standards for title columns
-            // and avoid validation/schema mismatch.
-            $table->string('title', 255)->change();
-
-            // Add index for search and sort performance
             $table->index('title');
         });
     }
@@ -31,15 +25,6 @@ return new class extends Migration
     {
         Schema::table('songs', function (Blueprint $table) {
             $table->dropIndex(['title']);
-        });
-
-        // Truncate if necessary before narrowing back to 100
-        DB::table('songs')
-            ->whereRaw('LENGTH(title) > 100')
-            ->update(['title' => DB::raw('LEFT(title, 100)')]);
-
-        Schema::table('songs', function (Blueprint $table) {
-            $table->string('title', 100)->change();
         });
     }
 };

--- a/database/migrations/2026_06_27_065159_add_index_to_songs_title.php
+++ b/database/migrations/2026_06_27_065159_add_index_to_songs_title.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -14,6 +15,12 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('songs', function (Blueprint $table) {
+            // Widen title to 255 to match project standards for title columns
+            // (e.g. sermons table) and support the max:255 model validation.
+            // Note: DB was varchar(100) due to legacy schema artifacts.
+            $table->string('title', 255)->change();
+
+            // Add index for search and sort performance
             $table->index('title');
         });
     }
@@ -25,6 +32,15 @@ return new class extends Migration
     {
         Schema::table('songs', function (Blueprint $table) {
             $table->dropIndex(['title']);
+        });
+
+        // Truncate if necessary before narrowing back to 100
+        DB::table('songs')
+            ->whereRaw('LENGTH(title) > 100')
+            ->update(['title' => DB::raw('LEFT(title, 100)')]);
+
+        Schema::table('songs', function (Blueprint $table) {
+            $table->string('title', 100)->change();
         });
     }
 };

--- a/database/migrations/2026_06_27_065159_add_index_to_songs_title.php
+++ b/database/migrations/2026_06_27_065159_add_index_to_songs_title.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->index('title');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->dropIndex(['title']);
+        });
+    }
+};

--- a/database/migrations/2026_06_27_065159_add_index_to_songs_title.php
+++ b/database/migrations/2026_06_27_065159_add_index_to_songs_title.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -14,6 +15,11 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('songs', function (Blueprint $table) {
+            // Widen title to 255 to match project standards for title columns
+            // and avoid validation/schema mismatch.
+            $table->string('title', 255)->change();
+
+            // Add index for search and sort performance
             $table->index('title');
         });
     }
@@ -25,6 +31,15 @@ return new class extends Migration
     {
         Schema::table('songs', function (Blueprint $table) {
             $table->dropIndex(['title']);
+        });
+
+        // Truncate if necessary before narrowing back to 100
+        DB::table('songs')
+            ->whereRaw('LENGTH(title) > 100')
+            ->update(['title' => DB::raw('LEFT(title, 100)')]);
+
+        Schema::table('songs', function (Blueprint $table) {
+            $table->string('title', 100)->change();
         });
     }
 };

--- a/database/migrations/2026_06_27_065159_add_index_to_songs_title.php
+++ b/database/migrations/2026_06_27_065159_add_index_to_songs_title.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -15,12 +14,6 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('songs', function (Blueprint $table) {
-            // Widen title to 255 to match project standards for title columns
-            // (e.g. sermons table) and support the max:255 model validation.
-            // Note: DB was varchar(100) due to legacy schema artifacts.
-            $table->string('title', 255)->change();
-
-            // Add index for search and sort performance
             $table->index('title');
         });
     }
@@ -32,15 +25,6 @@ return new class extends Migration
     {
         Schema::table('songs', function (Blueprint $table) {
             $table->dropIndex(['title']);
-        });
-
-        // Truncate if necessary before narrowing back to 100
-        DB::table('songs')
-            ->whereRaw('LENGTH(title) > 100')
-            ->update(['title' => DB::raw('LEFT(title, 100)')]);
-
-        Schema::table('songs', function (Blueprint $table) {
-            $table->string('title', 100)->change();
         });
     }
 };

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -945,6 +945,7 @@ CREATE TABLE `songs` (
   UNIQUE KEY `songs_canonical_key_unique` (`canonical_key`),
   KEY `songs_ccli_number_index` (`ccli_number`),
   KEY `songs_deleted_at_index` (`deleted_at`),
+  KEY `songs_title_index` (`title`),
   FULLTEXT KEY `songs_lyrics_plain_fulltext` (`lyrics_plain`),
   CONSTRAINT `songs_alternate_title_check` CHECK (((`alternate_title` is null) or ((cast(`alternate_title` as char charset binary) = trim(`alternate_title`)) and (`alternate_title` <> _utf8mb4'')))),
   CONSTRAINT `songs_canonical_key_check` CHECK (((cast(`canonical_key` as char charset binary) = lower(trim(regexp_replace(`canonical_key`,_utf8mb3'[[:space:]]+',_utf8mb4' ')))) and (`canonical_key` <> _utf8mb3'') and (locate(_utf8mb3'@',`canonical_key`) = 0))),
@@ -1216,3 +1217,4 @@ INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_16_054346_add_i
 INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_18_120000_drop_redundant_church_service_items_livestream_index',76);
 INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_18_130000_drop_redundant_fk_indexes_from_media_processing_logs_and_speaker_samples',76);
 INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_19_054923_add_preacher_id_date_index_to_sermons_table',77);
+INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_27_065159_add_index_to_songs_title',78);

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -945,7 +945,6 @@ CREATE TABLE `songs` (
   UNIQUE KEY `songs_canonical_key_unique` (`canonical_key`),
   KEY `songs_ccli_number_index` (`ccli_number`),
   KEY `songs_deleted_at_index` (`deleted_at`),
-  KEY `songs_title_index` (`title`),
   FULLTEXT KEY `songs_lyrics_plain_fulltext` (`lyrics_plain`),
   CONSTRAINT `songs_alternate_title_check` CHECK (((`alternate_title` is null) or ((cast(`alternate_title` as char charset binary) = trim(`alternate_title`)) and (`alternate_title` <> _utf8mb4'')))),
   CONSTRAINT `songs_canonical_key_check` CHECK (((cast(`canonical_key` as char charset binary) = lower(trim(regexp_replace(`canonical_key`,_utf8mb3'[[:space:]]+',_utf8mb4' ')))) and (`canonical_key` <> _utf8mb3'') and (locate(_utf8mb3'@',`canonical_key`) = 0))),
@@ -1217,4 +1216,3 @@ INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_16_054346_add_i
 INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_18_120000_drop_redundant_church_service_items_livestream_index',76);
 INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_18_130000_drop_redundant_fk_indexes_from_media_processing_logs_and_speaker_samples',76);
 INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_19_054923_add_preacher_id_date_index_to_sermons_table',77);
-INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_27_065159_add_index_to_songs_title',78);

--- a/tests/Feature/Warden/SongTitleIntegrityTest.php
+++ b/tests/Feature/Warden/SongTitleIntegrityTest.php
@@ -30,12 +30,12 @@ class SongTitleIntegrityTest extends TestCase
         $rules = Song::validationRules();
 
         $this->assertArrayHasKey('title', $rules);
-        $this->assertContains('max:255', $rules['title'], 'The song title validation rule should match the widened database column length of 255.');
+        $this->assertContains('max:100', $rules['title'], 'The song title validation rule should match the database column length of 100.');
 
-        $longTitle = str_repeat('a', 256);
+        $longTitle = str_repeat('a', 101);
         $validator = Validator::make(['title' => $longTitle], ['title' => $rules['title']]);
 
-        $this->assertTrue($validator->fails(), 'Validation should fail for titles longer than 255 characters.');
+        $this->assertTrue($validator->fails(), 'Validation should fail for titles longer than 100 characters.');
         $this->assertArrayHasKey('title', $validator->errors()->toArray());
     }
 
@@ -43,18 +43,10 @@ class SongTitleIntegrityTest extends TestCase
     public function it_allows_valid_song_titles(): void
     {
         $rules = Song::validationRules();
-        $validTitle = str_repeat('a', 255);
+        $validTitle = 'A Valid Song Title';
 
         $validator = Validator::make(['title' => $validTitle], ['title' => $rules['title']]);
 
-        $this->assertFalse($validator->fails(), 'Validation should pass for a valid title within 255 characters.');
-    }
-
-    #[Test]
-    public function it_has_a_widen_database_column(): void
-    {
-        $length = DB::selectOne("SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns WHERE table_name = 'songs' AND column_name = 'title' AND table_schema = DATABASE()")->CHARACTER_MAXIMUM_LENGTH;
-
-        $this->assertEquals(255, $length, 'The songs.title column should have been widened to 255 characters.');
+        $this->assertFalse($validator->fails(), 'Validation should pass for a valid title within 100 characters.');
     }
 }

--- a/tests/Feature/Warden/SongTitleIntegrityTest.php
+++ b/tests/Feature/Warden/SongTitleIntegrityTest.php
@@ -27,12 +27,12 @@ class SongTitleIntegrityTest extends TestCase
         $rules = Song::validationRules();
 
         $this->assertArrayHasKey('title', $rules);
-        $this->assertContains('max:255', $rules['title'], 'The song title validation rule should match the widened database column length of 255.');
+        $this->assertContains('max:100', $rules['title'], 'The song title validation rule should match the database column length of 100.');
 
-        $longTitle = str_repeat('a', 256);
+        $longTitle = str_repeat('a', 101);
         $validator = Validator::make(['title' => $longTitle], ['title' => $rules['title']]);
 
-        $this->assertTrue($validator->fails(), 'Validation should fail for titles longer than 255 characters.');
+        $this->assertTrue($validator->fails(), 'Validation should fail for titles longer than 100 characters.');
         $this->assertArrayHasKey('title', $validator->errors()->toArray());
     }
 
@@ -40,18 +40,10 @@ class SongTitleIntegrityTest extends TestCase
     public function it_allows_valid_song_titles(): void
     {
         $rules = Song::validationRules();
-        $validTitle = str_repeat('a', 255);
+        $validTitle = 'A Valid Song Title';
 
         $validator = Validator::make(['title' => $validTitle], ['title' => $rules['title']]);
 
-        $this->assertFalse($validator->fails(), 'Validation should pass for a valid title within 255 characters.');
-    }
-
-    #[Test]
-    public function it_has_a_widen_database_column(): void
-    {
-        $length = DB::selectOne("SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns WHERE table_name = 'songs' AND column_name = 'title' AND table_schema = DATABASE()")->CHARACTER_MAXIMUM_LENGTH;
-
-        $this->assertEquals(255, $length, 'The songs.title column should have been widened to 255 characters.');
+        $this->assertFalse($validator->fails(), 'Validation should pass for a valid title within 100 characters.');
     }
 }

--- a/tests/Feature/Warden/SongTitleIntegrityTest.php
+++ b/tests/Feature/Warden/SongTitleIntegrityTest.php
@@ -30,7 +30,7 @@ class SongTitleIntegrityTest extends TestCase
         $rules = Song::validationRules();
 
         $this->assertArrayHasKey('title', $rules);
-        $this->assertContains('max:255', $rules['title'], 'The song title validation rule should match the database column length of 255.');
+        $this->assertContains('max:255', $rules['title'], 'The song title validation rule should match the widened database column length of 255.');
 
         $longTitle = str_repeat('a', 256);
         $validator = Validator::make(['title' => $longTitle], ['title' => $rules['title']]);
@@ -43,10 +43,18 @@ class SongTitleIntegrityTest extends TestCase
     public function it_allows_valid_song_titles(): void
     {
         $rules = Song::validationRules();
-        $validTitle = 'A Valid Song Title';
+        $validTitle = str_repeat('a', 255);
 
         $validator = Validator::make(['title' => $validTitle], ['title' => $rules['title']]);
 
         $this->assertFalse($validator->fails(), 'Validation should pass for a valid title within 255 characters.');
+    }
+
+    #[Test]
+    public function it_has_a_widen_database_column(): void
+    {
+        $length = DB::selectOne("SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns WHERE table_name = 'songs' AND column_name = 'title' AND table_schema = DATABASE()")->CHARACTER_MAXIMUM_LENGTH;
+
+        $this->assertEquals(255, $length, 'The songs.title column should have been widened to 255 characters.');
     }
 }

--- a/tests/Feature/Warden/SongTitleIntegrityTest.php
+++ b/tests/Feature/Warden/SongTitleIntegrityTest.php
@@ -27,12 +27,12 @@ class SongTitleIntegrityTest extends TestCase
         $rules = Song::validationRules();
 
         $this->assertArrayHasKey('title', $rules);
-        $this->assertContains('max:100', $rules['title'], 'The song title validation rule should match the database column length of 100.');
+        $this->assertContains('max:255', $rules['title'], 'The song title validation rule should match the widened database column length of 255.');
 
-        $longTitle = str_repeat('a', 101);
+        $longTitle = str_repeat('a', 256);
         $validator = Validator::make(['title' => $longTitle], ['title' => $rules['title']]);
 
-        $this->assertTrue($validator->fails(), 'Validation should fail for titles longer than 100 characters.');
+        $this->assertTrue($validator->fails(), 'Validation should fail for titles longer than 255 characters.');
         $this->assertArrayHasKey('title', $validator->errors()->toArray());
     }
 
@@ -40,10 +40,18 @@ class SongTitleIntegrityTest extends TestCase
     public function it_allows_valid_song_titles(): void
     {
         $rules = Song::validationRules();
-        $validTitle = 'A Valid Song Title';
+        $validTitle = str_repeat('a', 255);
 
         $validator = Validator::make(['title' => $validTitle], ['title' => $rules['title']]);
 
-        $this->assertFalse($validator->fails(), 'Validation should pass for a valid title within 100 characters.');
+        $this->assertFalse($validator->fails(), 'Validation should pass for a valid title within 255 characters.');
+    }
+
+    #[Test]
+    public function it_has_a_widen_database_column(): void
+    {
+        $length = DB::selectOne("SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns WHERE table_name = 'songs' AND column_name = 'title' AND table_schema = DATABASE()")->CHARACTER_MAXIMUM_LENGTH;
+
+        $this->assertEquals(255, $length, 'The songs.title column should have been widened to 255 characters.');
     }
 }

--- a/tests/Feature/Warden/SongTitleIntegrityTest.php
+++ b/tests/Feature/Warden/SongTitleIntegrityTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Warden;
+
+use App\Models\Song;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SongTitleIntegrityTest extends TestCase
+{
+    #[Test]
+    public function it_has_an_index_on_the_songs_title_column(): void
+    {
+        $indices = DB::select('SHOW INDEX FROM songs');
+        $hasTitleIndex = collect($indices)->contains('Column_name', 'title');
+
+        $this->assertTrue($hasTitleIndex, 'The songs table should have an index on the title column.');
+    }
+
+    #[Test]
+    public function it_validates_that_the_song_title_does_not_exceed_the_database_limit(): void
+    {
+        $rules = Song::validationRules();
+
+        $this->assertArrayHasKey('title', $rules);
+        $this->assertContains('max:100', $rules['title'], 'The song title validation rule should match the database column length of 100.');
+
+        $longTitle = str_repeat('a', 101);
+        $validator = Validator::make(['title' => $longTitle], ['title' => $rules['title']]);
+
+        $this->assertTrue($validator->fails(), 'Validation should fail for titles longer than 100 characters.');
+        $this->assertArrayHasKey('title', $validator->errors()->toArray());
+    }
+
+    #[Test]
+    public function it_allows_valid_song_titles(): void
+    {
+        $rules = Song::validationRules();
+        $validTitle = 'A Valid Song Title';
+
+        $validator = Validator::make(['title' => $validTitle], ['title' => $rules['title']]);
+
+        $this->assertFalse($validator->fails(), 'Validation should pass for a valid title within 100 characters.');
+    }
+}

--- a/tests/Feature/Warden/SongTitleIntegrityTest.php
+++ b/tests/Feature/Warden/SongTitleIntegrityTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Warden;
 
 use App\Models\Song;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use PHPUnit\Framework\Attributes\Test;
@@ -12,6 +13,8 @@ use Tests\TestCase;
 
 class SongTitleIntegrityTest extends TestCase
 {
+    use RefreshDatabase;
+
     #[Test]
     public function it_has_an_index_on_the_songs_title_column(): void
     {
@@ -27,12 +30,12 @@ class SongTitleIntegrityTest extends TestCase
         $rules = Song::validationRules();
 
         $this->assertArrayHasKey('title', $rules);
-        $this->assertContains('max:100', $rules['title'], 'The song title validation rule should match the database column length of 100.');
+        $this->assertContains('max:255', $rules['title'], 'The song title validation rule should match the database column length of 255.');
 
-        $longTitle = str_repeat('a', 101);
+        $longTitle = str_repeat('a', 256);
         $validator = Validator::make(['title' => $longTitle], ['title' => $rules['title']]);
 
-        $this->assertTrue($validator->fails(), 'Validation should fail for titles longer than 100 characters.');
+        $this->assertTrue($validator->fails(), 'Validation should fail for titles longer than 255 characters.');
         $this->assertArrayHasKey('title', $validator->errors()->toArray());
     }
 
@@ -44,6 +47,6 @@ class SongTitleIntegrityTest extends TestCase
 
         $validator = Validator::make(['title' => $validTitle], ['title' => $rules['title']]);
 
-        $this->assertFalse($validator->fails(), 'Validation should pass for a valid title within 100 characters.');
+        $this->assertFalse($validator->fails(), 'Validation should pass for a valid title within 255 characters.');
     }
 }


### PR DESCRIPTION
💡 **What:** This PR improves the data integrity and query performance of the `songs` table.

🎯 **Why:** 
1. The `title` column is frequently used for searching and sorting in the admin interface but lacked a database index.
2. The `Song` model was incorrectly validating the `title` at `max:255`, while the underlying database column was constrained to `varchar(100)`, potentially leading to `QueryException` errors on save.

🗄️ **Migration:** 
- `2026_06_27_065159_add_index_to_songs_title.php`: Adds an index to the `title` column.

✅ **Verification:**
- Migration tested for `up` and `down` execution.
- `tests/Feature/Warden/SongTitleIntegrityTest.php` added to programmatically verify the index existence and the new validation constraint.
- Full parallel test suite passed.

⚠️ **Rollback:** `php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [14737466573140645654](https://jules.google.com/task/14737466573140645654) started by @GarethClarridge*