### PR TITLE
🔦 Lighthouse: Enhance archive sitemap entries with dynamic metadata

### DIFF
--- a/app/Services/Public/SitemapService.php
+++ b/app/Services/Public/SitemapService.php
@@ -18,6 +18,7 @@ use App\Sitemap\PageSitemapPresenter;
 use App\Sitemap\PreacherSitemapPresenter;
 use App\Sitemap\SermonSitemapPresenter;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Spatie\Sitemap\Sitemap;
@@ -106,7 +107,7 @@ class SitemapService
             $sermonsUrl->setLastModificationDate($latestAll->updated_at);
         }
         $sermonsUrl->addImage(
-            $latestAll ? $this->sermonViewPresenter->thumbnailUrl($latestAll) : $sermonsImage,
+            ($latestAll ? $this->sermonViewPresenter->thumbnailUrl($latestAll) : null) ?: $sermonsImage,
             'Sermons at Crockenhill Baptist Church'
         );
         $sitemap->add($sermonsUrl);
@@ -129,7 +130,7 @@ class SitemapService
             $morningUrl->setLastModificationDate($latestMorning->updated_at);
         }
         $morningUrl->addImage(
-            $latestMorning ? $this->sermonViewPresenter->thumbnailUrl($latestMorning) : $sermonsImage,
+            ($latestMorning ? $this->sermonViewPresenter->thumbnailUrl($latestMorning) : null) ?: $sermonsImage,
             'Sunday Morning Services'
         );
         $sitemap->add($morningUrl);
@@ -142,7 +143,7 @@ class SitemapService
             $eveningUrl->setLastModificationDate($latestEvening->updated_at);
         }
         $eveningUrl->addImage(
-            $latestEvening ? $this->sermonViewPresenter->thumbnailUrl($latestEvening) : $sermonsImage,
+            ($latestEvening ? $this->sermonViewPresenter->thumbnailUrl($latestEvening) : null) ?: $sermonsImage,
             'Sunday Evening Services'
         );
         $sitemap->add($eveningUrl);
@@ -156,7 +157,7 @@ class SitemapService
                 $childrensUrl->setLastModificationDate($latestChildrens->updated_at);
             }
             $childrensUrl->addImage(
-                $latestChildrens ? $this->sermonViewPresenter->thumbnailUrl($latestChildrens) : $sermonsImage,
+                ($latestChildrens ? $this->sermonViewPresenter->thumbnailUrl($latestChildrens) : null) ?: $sermonsImage,
                 "Children's Corner"
             );
             $sitemap->add($childrensUrl);
@@ -170,9 +171,9 @@ class SitemapService
      * sermon for multiple logical groupings in a single database round-trip,
      * ensuring sitemap freshness without incurring N+1 overhead.
      *
-     * @return \Illuminate\Support\Collection<string, Sermon>
+     * @return Collection<string, Sermon>
      */
-    private function getRepresentativeSermonsForStaticUrls(): \Illuminate\Support\Collection
+    private function getRepresentativeSermonsForStaticUrls(): Collection
     {
         $morning = SermonService::Morning->value;
         $evening = SermonService::Evening->value;

--- a/app/Services/Public/SitemapService.php
+++ b/app/Services/Public/SitemapService.php
@@ -227,24 +227,24 @@ class SitemapService
         $results = collect();
 
         // The 'all' group is the latest 'Sermon' regardless of service.
-        $latestSermon = $sermons->where('content_type', SermonContentType::Sermon)->sortByDesc('date')->first();
+        $latestSermon = $sermons->first(fn (Sermon $s) => $s->getAttribute('type_group') === 'all' && (int) $s->getAttribute('type_rank') === 1);
         if ($latestSermon) {
             $results->put('all', $latestSermon);
         }
 
         // Morning and Evening latest sermons.
-        $latestMorning = $sermons->where('content_type', SermonContentType::Sermon)->where('service', SermonService::Morning)->first();
+        $latestMorning = $sermons->first(fn (Sermon $s) => $s->getAttribute('service_group') === 'morning' && (int) $s->getAttribute('service_rank') === 1);
         if ($latestMorning) {
             $results->put('morning', $latestMorning);
         }
 
-        $latestEvening = $sermons->where('content_type', SermonContentType::Sermon)->where('service', SermonService::Evening)->first();
+        $latestEvening = $sermons->first(fn (Sermon $s) => $s->getAttribute('service_group') === 'evening' && (int) $s->getAttribute('service_rank') === 1);
         if ($latestEvening) {
             $results->put('evening', $latestEvening);
         }
 
         // Children's Talk latest.
-        $latestTalk = $sermons->where('content_type', SermonContentType::ChildrensTalk)->first();
+        $latestTalk = $sermons->first(fn (Sermon $s) => $s->getAttribute('type_group') === 'childrens-talk' && (int) $s->getAttribute('type_rank') === 1);
         if ($latestTalk) {
             $results->put('childrens-talk', $latestTalk);
         }

--- a/app/Services/Public/SitemapService.php
+++ b/app/Services/Public/SitemapService.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Services\Public;
 
 use App\Enums\PageArea;
+use App\Enums\SermonContentType;
+use App\Enums\SermonService;
 use App\Models\Meeting;
 use App\Models\Page;
 use App\Models\Preacher;
@@ -67,6 +69,8 @@ class SitemapService
         $homepageImage = asset('/images/homepage/may2024wide.webp');
         $sermonsImage = asset('/images/headings/large/sermons.webp');
 
+        $representatives = $this->getRepresentativeSermonsForStaticUrls();
+
         $sitemap
             ->add(Url::create(route('home'))
                 ->setPriority(1.0)
@@ -91,11 +95,23 @@ class SitemapService
             ->add(Url::create(route('calendar.index'))
                 ->setPriority(0.5)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
-                ->addImage($homepageImage, 'Church Calendar'))
-            ->add(Url::create(route('sermons.index'))
-                ->setPriority(0.8)
-                ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY)
-                ->addImage($sermonsImage, 'Sermons at Crockenhill Baptist Church'))
+                ->addImage($homepageImage, 'Church Calendar'));
+
+        $sermonsUrl = Url::create(route('sermons.index'))
+            ->setPriority(0.8)
+            ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY);
+
+        $latestAll = $representatives->get('all');
+        if ($latestAll?->updated_at && $latestAll->updated_at->year > 0) {
+            $sermonsUrl->setLastModificationDate($latestAll->updated_at);
+        }
+        $sermonsUrl->addImage(
+            $latestAll ? $this->sermonViewPresenter->thumbnailUrl($latestAll) : $sermonsImage,
+            'Sermons at Crockenhill Baptist Church'
+        );
+        $sitemap->add($sermonsUrl);
+
+        $sitemap
             ->add(Url::create(route('sermons.preachers'))
                 ->setPriority(0.7)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
@@ -103,23 +119,136 @@ class SitemapService
             ->add(Url::create(route('sermons.series'))
                 ->setPriority(0.7)
                 ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
-                ->addImage($sermonsImage, 'Sermon Series'))
-            ->add(Url::create(route('sermons.service', 'morning'))
-                ->setPriority(0.7)
-                ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY)
-                ->addImage($sermonsImage, 'Sunday Morning Services'))
-            ->add(Url::create(route('sermons.service', 'evening'))
-                ->setPriority(0.7)
-                ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY)
-                ->addImage($sermonsImage, 'Sunday Evening Services'));
+                ->addImage($sermonsImage, 'Sermon Series'));
+
+        $morningUrl = Url::create(route('sermons.service', 'morning'))
+            ->setPriority(0.7)
+            ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY);
+        $latestMorning = $representatives->get('morning');
+        if ($latestMorning?->updated_at && $latestMorning->updated_at->year > 0) {
+            $morningUrl->setLastModificationDate($latestMorning->updated_at);
+        }
+        $morningUrl->addImage(
+            $latestMorning ? $this->sermonViewPresenter->thumbnailUrl($latestMorning) : $sermonsImage,
+            'Sunday Morning Services'
+        );
+        $sitemap->add($morningUrl);
+
+        $eveningUrl = Url::create(route('sermons.service', 'evening'))
+            ->setPriority(0.7)
+            ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY);
+        $latestEvening = $representatives->get('evening');
+        if ($latestEvening?->updated_at && $latestEvening->updated_at->year > 0) {
+            $eveningUrl->setLastModificationDate($latestEvening->updated_at);
+        }
+        $eveningUrl->addImage(
+            $latestEvening ? $this->sermonViewPresenter->thumbnailUrl($latestEvening) : $sermonsImage,
+            'Sunday Evening Services'
+        );
+        $sitemap->add($eveningUrl);
 
         if ($this->exposurePolicy->childrensTalksArePublic()) {
-            $sitemap->add(
-                Url::create(route('childrens-corner.index'))
-                    ->setPriority(0.7)
-                    ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
+            $childrensUrl = Url::create(route('childrens-corner.index'))
+                ->setPriority(0.7)
+                ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY);
+            $latestChildrens = $representatives->get('childrens-talk');
+            if ($latestChildrens?->updated_at && $latestChildrens->updated_at->year > 0) {
+                $childrensUrl->setLastModificationDate($latestChildrens->updated_at);
+            }
+            $childrensUrl->addImage(
+                $latestChildrens ? $this->sermonViewPresenter->thumbnailUrl($latestChildrens) : $sermonsImage,
+                "Children's Corner"
             );
+            $sitemap->add($childrensUrl);
         }
+    }
+
+    /**
+     * Fetch the latest representative sermons for the main archive landing pages.
+     *
+     * Performance Optimization: Uses a window function to retrieve the most recent
+     * sermon for multiple logical groupings in a single database round-trip,
+     * ensuring sitemap freshness without incurring N+1 overhead.
+     *
+     * @return \Illuminate\Support\Collection<string, Sermon>
+     */
+    private function getRepresentativeSermonsForStaticUrls(): \Illuminate\Support\Collection
+    {
+        $morning = SermonService::Morning->value;
+        $evening = SermonService::Evening->value;
+        $sermon = SermonContentType::Sermon->value;
+        $talk = SermonContentType::ChildrensTalk->value;
+
+        $subquery = Sermon::query()
+            ->whereVisibleInSitemap()
+            ->select([
+                'id',
+                'title',
+                'date',
+                'slug',
+                'service',
+                'content_type',
+                'thumbnail_file_path',
+                'thumbnail_generated_at',
+                'thumbnail_metadata',
+                'video_file_path',
+                'video_visibility_override',
+                'video_quality_status',
+                'updated_at',
+                'preacher',
+                'preacher_id',
+            ])
+            ->selectRaw("
+                CASE
+                    WHEN content_type = '{$sermon}' THEN 'all'
+                    WHEN content_type = '{$talk}' THEN 'childrens-talk'
+                    ELSE 'other'
+                END as type_group,
+                CASE
+                    WHEN content_type = '{$sermon}' AND service = '{$morning}' THEN 'morning'
+                    WHEN content_type = '{$sermon}' AND service = '{$evening}' THEN 'evening'
+                    ELSE 'none'
+                END as service_group
+            ")
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY content_type ORDER BY date DESC, id DESC) as type_rank')
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY content_type, service ORDER BY date DESC, id DESC) as service_rank');
+
+        /**
+         * Performance Optimization: Only eager load preacherProfile to avoid N+1
+         * when resolving thumbnails for the representative sermons.
+         */
+        $sermons = Sermon::query()
+            ->fromSub($subquery, 'ranked')
+            ->with(['preacherProfile:id,name,slug,image_path'])
+            ->where(fn ($q) => $q->where('type_rank', 1)->orWhere('service_rank', 1))
+            ->get();
+
+        $results = collect();
+
+        // The 'all' group is the latest 'Sermon' regardless of service.
+        $latestSermon = $sermons->where('content_type', SermonContentType::Sermon)->sortByDesc('date')->first();
+        if ($latestSermon) {
+            $results->put('all', $latestSermon);
+        }
+
+        // Morning and Evening latest sermons.
+        $latestMorning = $sermons->where('content_type', SermonContentType::Sermon)->where('service', SermonService::Morning)->first();
+        if ($latestMorning) {
+            $results->put('morning', $latestMorning);
+        }
+
+        $latestEvening = $sermons->where('content_type', SermonContentType::Sermon)->where('service', SermonService::Evening)->first();
+        if ($latestEvening) {
+            $results->put('evening', $latestEvening);
+        }
+
+        // Children's Talk latest.
+        $latestTalk = $sermons->where('content_type', SermonContentType::ChildrensTalk)->first();
+        if ($latestTalk) {
+            $results->put('childrens-talk', $latestTalk);
+        }
+
+        return $results;
     }
 
     /**


### PR DESCRIPTION
💡 **What:** Enhanced the sitemap with dynamic metadata for main archive landing pages (Sermons, Morning/Evening services, and Children's Corner).

🎯 **Why:** Previously, these high-traffic landing pages used static placeholder images and lacked "last modified" dates in the `sitemap.xml`. Providing dynamic data helps search engines understand content freshness and improves the visual presentation of the site in search results.

📊 **Impact:** Landing page sitemap entries now reflect the date and thumbnail of the most recent relevant sermon.

🔍 **Verification:** 
- Implemented a high-performance `getRepresentativeSermonsForStaticUrls` method using SQL window functions (`ROW_NUMBER() OVER`) to fetch all needed representative sermons in a single database round-trip.
- Verified correct handling of empty states with fallbacks to static assets.
- Passed all sitemap-specific unit, feature, and integration tests.
- Successfully ran the full application test suite (5,769 tests).

---
*PR created automatically by Jules for task [6416917587510458712](https://jules.google.com/task/6416917587510458712) started by @GarethClarridge*