### PR TITLE
📖 Editor: Improve error page microcopy

### DIFF
--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -20,7 +20,7 @@
         <div class="mx-auto w-full max-w-xs">
             <div class="w-full rounded-xl bg-gradient-teal p-[1.5px]">
                 <x-button link="/" variant="featureOutline" size="lg" class="w-full rounded-[11px]">
-                    Go to the homepage
+                    Return to the homepage
                 </x-button>
             </div>
         </div>

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -19,7 +19,7 @@
         <div class="mx-auto w-full max-w-xs">
             <div class="w-full rounded-xl bg-gradient-teal p-[1.5px]">
                 <x-button link="/" variant="featureOutline" size="lg" class="w-full rounded-[11px]">
-                    Go to the homepage
+                    Return to the homepage
                 </x-button>
             </div>
         </div>

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -19,7 +19,7 @@
         <div class="mx-auto w-full max-w-xs">
             <div class="w-full rounded-xl bg-gradient-teal p-[1.5px]">
                 <x-button link="/" variant="featureOutline" size="lg" class="w-full rounded-[11px]">
-                    Go to the homepage
+                    Return to the homepage
                 </x-button>
             </div>
         </div>


### PR DESCRIPTION
### 💡 What:
Replaced the vague button label "Go to the homepage" with "Return to the homepage" in the application's error templates.

### 🎯 Why:
To improve microcopy clarity and align with the project's copy standards which prefer specific action verbs over generic ones. Encountering an error often leaves users feeling lost; "Return" implies a safe backtrack to a known starting point.

### 🔄 Behavior:
No functional changes — copy only.

### 📍 Where:
- `resources/views/errors/403.blade.php`
- `resources/views/errors/404.blade.php`
- `resources/views/errors/500.blade.php`

---
*PR created automatically by Jules for task [12972905614854317094](https://jules.google.com/task/12972905614854317094) started by @GarethClarridge*