### PR TITLE
🛡️ Sentinel: [security improvement] Hardened log sanitization and improved documentation in Calendar domain

### DIFF
--- a/app/Console/Commands/SyncGoogleCalendarCommand.php
+++ b/app/Console/Commands/SyncGoogleCalendarCommand.php
@@ -36,9 +36,9 @@ class SyncGoogleCalendarCommand extends Command
 
         } catch (Exception $e) {
             $this->error('Sync failed: '.$e->getMessage());
-            Log::error('Calendar sync failed', [
-                'error' => $this->sanitizeForLog($e->getMessage()),
-            ]);
+            Log::error('Calendar sync failed', $this->sanitizeArrayForLog([
+                'error' => $e->getMessage(),
+            ]));
 
             return 1;
         }

--- a/app/Services/Calendar/CalendarService.php
+++ b/app/Services/Calendar/CalendarService.php
@@ -100,6 +100,9 @@ class CalendarService
             ->get();
     }
 
+    /**
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
     public function manuallyCategorizeEvent(int $eventId, string $meetingSlug): CalendarCategorizationResult
     {
         $event = CalendarEvent::query()->findOrFail($eventId);
@@ -109,18 +112,21 @@ class CalendarService
             'is_categorized_automatically' => false,
         ]);
 
-        Log::warning('Calendar event manually categorized', [
+        Log::warning('Calendar event manually categorized', $this->sanitizeArrayForLog([
             'admin_id' => auth()->id(),
             'event_id' => $event->id,
-            'event_title' => $this->sanitizeForLog($event->title),
-            'meeting_slug' => $this->sanitizeForLog($meetingSlug),
-        ]);
+            'event_title' => $event->title,
+            'meeting_slug' => $meetingSlug,
+        ]));
 
         $googleSynced = $this->googleSync->syncCategorizationToGoogle($event->google_event_id, $meetingSlug);
 
         return new CalendarCategorizationResult($event, $googleSynced);
     }
 
+    /**
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
     public function manuallyUnCategorizeEvent(int $eventId): CalendarCategorizationResult
     {
         $event = CalendarEvent::query()->findOrFail($eventId);
@@ -130,11 +136,11 @@ class CalendarService
             'is_categorized_automatically' => false,
         ]);
 
-        Log::warning('Calendar event un-categorized', [
+        Log::warning('Calendar event un-categorized', $this->sanitizeArrayForLog([
             'admin_id' => auth()->id(),
             'event_id' => $event->id,
-            'event_title' => $this->sanitizeForLog($event->title),
-        ]);
+            'event_title' => $event->title,
+        ]));
 
         $googleSynced = $this->googleSync->removeCategorizationFromGoogle($event->google_event_id);
 

--- a/app/Services/Calendar/CalendarService.php
+++ b/app/Services/Calendar/CalendarService.php
@@ -10,6 +10,7 @@ use App\Traits\SanitizesLogData;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Log;
 
 class CalendarService
@@ -101,7 +102,7 @@ class CalendarService
     }
 
     /**
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws ModelNotFoundException
      */
     public function manuallyCategorizeEvent(int $eventId, string $meetingSlug): CalendarCategorizationResult
     {
@@ -125,7 +126,7 @@ class CalendarService
     }
 
     /**
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws ModelNotFoundException
      */
     public function manuallyUnCategorizeEvent(int $eventId): CalendarCategorizationResult
     {

--- a/app/Services/Calendar/GoogleCalendarSyncService.php
+++ b/app/Services/Calendar/GoogleCalendarSyncService.php
@@ -21,6 +21,8 @@ class GoogleCalendarSyncService
 
     /**
      * @return array<string, mixed>
+     *
+     * @throws \Exception
      */
     public function syncFromGoogleCalendar(): array
     {
@@ -30,9 +32,9 @@ class GoogleCalendarSyncService
         try {
             $googleEvents = $this->fetchEventsFromGoogle($startDate, $endDate);
         } catch (\Exception $e) {
-            Log::error('Failed to fetch events from Google Calendar', [
-                'error' => $this->sanitizeForLog($e->getMessage()),
-            ]);
+            Log::error('Failed to fetch events from Google Calendar', $this->sanitizeArrayForLog([
+                'error' => $e->getMessage(),
+            ]));
             throw $e;
         }
 
@@ -53,11 +55,11 @@ class GoogleCalendarSyncService
                 /** @phpstan-ignore-next-line */
                 $processedEventIds[] = $googleEvent->id;
             } catch (\Exception $e) {
-                Log::warning('Failed to sync single event', [
+                Log::warning('Failed to sync single event', $this->sanitizeArrayForLog([
                     /** @phpstan-ignore-next-line */
-                    'event_id' => $this->sanitizeForLog((string) $googleEvent->id),
-                    'error' => $this->sanitizeForLog($e->getMessage()),
-                ]);
+                    'event_id' => (string) $googleEvent->id,
+                    'error' => $e->getMessage(),
+                ]));
             }
         }
 
@@ -70,13 +72,13 @@ class GoogleCalendarSyncService
 
         $skippedEventIds = array_diff($seenUpstreamIds, $processedEventIds);
 
-        Log::info('Google Calendar sync completed', [
+        Log::info('Google Calendar sync completed', $this->sanitizeArrayForLog([
             'processed_events' => count($processedEventIds),
             'skipped_events' => count($skippedEventIds),
             'deleted_events' => count($deletedEventIds),
             'uncategorized_events' => $uncategorizedCount,
             'sync_window' => [$startDate->format('Y-m-d'), $endDate->format('Y-m-d')],
-        ]);
+        ]));
 
         return [
             'processed_events' => count($processedEventIds),
@@ -173,10 +175,10 @@ class GoogleCalendarSyncService
 
             return true;
         } catch (\Exception $e) {
-            Log::warning('Failed to update Google Calendar extended property', [
-                'google_event_id' => $this->sanitizeForLog($googleEventId),
-                'error' => $this->sanitizeForLog($e->getMessage()),
-            ]);
+            Log::warning('Failed to update Google Calendar extended property', $this->sanitizeArrayForLog([
+                'google_event_id' => $googleEventId,
+                'error' => $e->getMessage(),
+            ]));
 
             return false;
         }
@@ -207,10 +209,10 @@ class GoogleCalendarSyncService
 
             return true;
         } catch (\Exception $e) {
-            Log::warning('Failed to clear Google Calendar extended property', [
-                'google_event_id' => $this->sanitizeForLog($googleEventId),
-                'error' => $this->sanitizeForLog($e->getMessage()),
-            ]);
+            Log::warning('Failed to clear Google Calendar extended property', $this->sanitizeArrayForLog([
+                'google_event_id' => $googleEventId,
+                'error' => $e->getMessage(),
+            ]));
 
             return false;
         }


### PR DESCRIPTION
Standardized log sanitization and improved documentation in the Calendar domain.
- Replaced individual `sanitizeForLog` calls with recursive `sanitizeArrayForLog` wrapping.
- Added missing `@throws` annotations to service methods.
- Proactively verified `sanitizeArrayForLog` existence in `SanitizesLogData` trait.
- All tests passed.

---
*PR created automatically by Jules for task [17935616086665205749](https://jules.google.com/task/17935616086665205749) started by @GarethClarridge*