### PR TITLE
♿ Aria: [a11y improvement] fix filter toggle and add duration context

### DIFF
--- a/resources/views/components/sermon-card.blade.php
+++ b/resources/views/components/sermon-card.blade.php
@@ -75,6 +75,7 @@
         @if ($formattedDuration)
           <span class="flex items-center text-xs font-medium text-gray-500 bg-gray-50 px-2 py-0.5 rounded-full border border-gray-100 ml-2" title="Sermon duration">
             <x-heroicon-o-play-circle class="h-3.5 w-3.5 mr-1" aria-hidden="true" />
+            <span class="sr-only">Duration: </span>
             {{ $formattedDuration }}
           </span>
         @endif

--- a/resources/views/livewire/sermons/browse-sermons.blade.php
+++ b/resources/views/livewire/sermons/browse-sermons.blade.php
@@ -42,7 +42,7 @@
                     size="sm"
                     class="w-full justify-center sm:w-auto"
                     @click="expanded = !expanded"
-                    ::aria-expanded="expanded.toString()"
+                    x-bind:aria-expanded="expanded.toString()"
                     aria-controls="sermon-filters"
                 >
                     <span class="inline-flex items-center gap-2">


### PR DESCRIPTION
This PR improves accessibility on the sermon browse page and sermon cards:

1.  **Sermon Browse Page**: Fixed a typo in the filter toggle button where `:aria-expanded` was being misinterpreted by Blade (leading to 'Undefined constant' errors or no binding). Changed to `x-bind:aria-expanded` to correctly toggle the accessibility state for screen readers when filters are expanded/collapsed.
2.  **Sermon Cards**: Added a visually hidden `<span class="sr-only">Duration: </span>` before the duration value. This ensures screen reader users hear "Duration: 30 minutes" instead of just "30 minutes", providing essential context for the data point.

These changes follow the project's accessibility standards by prioritizing semantic HTML and standard ARIA patterns, ensuring a better experience for keyboard-only and screen-reader users.

---
*PR created automatically by Jules for task [11254541071249671749](https://jules.google.com/task/11254541071249671749) started by @GarethClarridge*