### PR TITLE
🔗 Pathfinder: Broken Link & Asset Report

### DIFF
--- a/.Jules/pathfinder.md
+++ b/.Jules/pathfinder.md
@@ -19,3 +19,7 @@
 **Pattern:** Pages in the 'community' area return 404 if no matching Meeting record exists.
 **Cause:** The route `GET /community/{meeting:slug}` in `routes/web.php` uses implicit model binding for the `Meeting` model. Because it is defined before the catch-all `{area}/{slug}` route, any URL starting with `/community/` is intercepted. If the slug doesn't exist in the `meetings` table, Laravel returns a 404 before it can reach the general page controller, even if a `Page` with that slug exists.
 **Action:** When checking community links, verify both `Page` and `Meeting` existence, and prefer using `Meeting` slugs for the `/community/` prefix.
+## 2026-06-28 - Systemic Heading Image Resolution Bug
+**Pattern:** Every public page missing its heading image in sitemap and views despite files existing in `public/images/headings/`.
+**Cause:** `PageImageCacheService` only checks `Storage::disk('public')` (mapping to `storage/app/public/pages/headings/`) but committed assets are in `public/images/headings/`.
+**Action:** Verify against both storage disk and public path in future diagnostics.

--- a/docs/issues/🔗_Pathfinder_Report_Broken_Assets.md
+++ b/docs/issues/🔗_Pathfinder_Report_Broken_Assets.md
@@ -1,0 +1,36 @@
+# 🔗 Pathfinder: 33 missing heading assets and 1 missing sermon audio
+
+## Summary
+Diagnostic crawl has identified a systemic issue with heading image resolution for pages, resulting in 33 missing assets in the sitemap and on public views. Additionally, a seeded sermon is missing its associated audio file.
+
+## Findings
+
+### 1. Systemic Heading Image Resolution Bug
+**Surface:** All public `/{area}/{slug}` pages and `sitemap.xml`.
+**Affected items:** 33 pages (all seeded pages including 'what-we-believe', 'history', 'statement-of-faith', etc.)
+**Verification:**
+- Tinker verification confirmed that `PageImageCacheService` looks for fallback images in `Storage::disk('public')->exists("pages/headings/{$size}/{$page->slug}.webp")`.
+- This maps to `storage/app/public/pages/headings/`, which is empty.
+- However, the actual fallback images are committed to the repository at `public/images/headings/{large|small}/`.
+- Result: `PageImageCacheService::get()` returns `NULL` for all heading URLs, causing the sitemap to omit these images and pages to fall back to the default `Primary.png` or nothing.
+
+### 2. Missing Sermon Audio
+**Surface:** `/christ/sermons/2024/11/the-prodigal-son`
+**Affected item:** Sermon "The Prodigal Son" (slug: `the-prodigal-son`)
+**Verification:**
+- Database entry has `livestream_processing_id` set to `seed-prodigal-son-processing`.
+- Associated `MediaProcessingLog` record points to `sermons/seed/2024-11-24.mp3`.
+- File check confirmed `storage/app/public/sermons/seed/2024-11-24.mp3` does not exist on disk.
+- Result: The audio player on the sermon detail page is non-functional.
+
+## Likely Cause
+- **Heading Images:** The `PageImageCacheService` logic is misaligned with the project's asset organization. It expects images in the `public` storage disk (which is usually for user-uploaded/generated content) rather than the `public/images/` directory for committed assets.
+- **Sermon Audio:** The `SermonSeeder` creates a reference to a seed audio file that is not included in the repository's sample data.
+
+## Suggested Action
+- **Heading Images:** Update `PageImageCacheService::resolveHeadingImageUrl` to also check `public_path("images/headings/{$size}/{$page->slug}.webp")` as a secondary fallback.
+- **Sermon Audio:** Provide the missing mock audio file in `storage/app/public/sermons/seed/` or update the seeder to use an existing test asset.
+
+## Risk Note
+- Missing heading images in the sitemap reduce SEO visibility for these pages' primary visual content.
+- Broken audio on a sermon page provides a poor user experience for site visitors.


### PR DESCRIPTION
I have completed a diagnostic crawl of the website's public surfaces, sitemap, and media assets.

My findings reveal a systemic issue with how heading images are resolved for pages. The `PageImageCacheService` currently looks for images in `storage/app/public/pages/headings/`, but the actual assets are committed to the repository in `public/images/headings/`. This results in all 33 seeded pages missing their heading images in the sitemap and on public views.

Additionally, I found that the "The Prodigal Son" sermon is missing its audio file on disk, which was referenced in the `MediaProcessingLog` created by the seeder.

I have documented these findings in a new issue file: `docs/issues/🔗_Pathfinder_Report_Broken_Assets.md`.

No code changes were made to the application logic as per the Pathfinder persona's instruction to default to issues rather than PRs for diagnostic findings, especially when they involve systemic patterns or SEO-sensitive assets.

---
*PR created automatically by Jules for task [9945052086650797944](https://jules.google.com/task/9945052086650797944) started by @GarethClarridge*