### PR TITLE
🎨 Palette: [UX improvement] Add loading spinners to song catalogue range filters

### DIFF
--- a/resources/views/livewire/church/songs/browse-songs.blade.php
+++ b/resources/views/livewire/church/songs/browse-songs.blade.php
@@ -38,6 +38,10 @@
                 ])
                 aria-pressed="{{ $selectedRange === \App\Services\Public\PublicSongCatalogService::RANGE_ALL ? 'true' : 'false' }}"
             >
+                <svg wire:loading wire:target="$set('range', '{{ \App\Services\Public\PublicSongCatalogService::RANGE_ALL }}')" class="animate-spin -ml-1 mr-2 h-4 w-4 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
                 All time
             </button>
             <button
@@ -55,6 +59,10 @@
                 ])
                 aria-pressed="{{ $selectedRange === \App\Services\Public\PublicSongCatalogService::RANGE_RECENT ? 'true' : 'false' }}"
             >
+                <svg wire:loading wire:target="$set('range', '{{ \App\Services\Public\PublicSongCatalogService::RANGE_RECENT }}')" class="animate-spin -ml-1 mr-2 h-4 w-4 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
                 Last 3 years
             </button>
         </div>


### PR DESCRIPTION
💡 **What:** Added `wire:loading` spinners to the "All time" and "Last 3 years" range filter buttons in the public song catalogue.
🎯 **Why:** Provides immediate visual feedback to the user when switching ranges, making the interface feel more responsive during the network request.
♿ **Accessibility:** Added `aria-hidden="true"` to the spinners.
📱 **Responsive:** No layout changes, just internal feedback.

---
*PR created automatically by Jules for task [3641029069622928843](https://jules.google.com/task/3641029069622928843) started by @GarethClarridge*