### PR TITLE
🪦 Mortician: Document dead SermonValidationService

### DIFF
--- a/docs/issues/2026-06-28-dead-sermon-validation-service.md
+++ b/docs/issues/2026-06-28-dead-sermon-validation-service.md
@@ -1,0 +1,38 @@
+# 🪦 Mortician: Possibly dead — `App\Services\Processing\SermonValidationService`
+
+## What
+**Path:** `app/Services/Processing/SermonValidationService.php`
+**Description:** A service class intended for validating sermon uploads and generating fallback metadata.
+
+## Evidence
+Project-wide grep for the class name and all its public methods returns no results in `app/`, `resources/`, `routes/`, or `config/` (excluding the file itself and documentation/comments).
+
+### Commands run:
+```bash
+# Check for class references
+grep -r "SermonValidationService" app/ resources/ routes/ config/
+
+# Check for public method callers (examples)
+grep -r "validateAudioFile" app/ resources/ routes/
+grep -r "generateFallbackData" app/ resources/ routes/
+```
+
+### Result:
+- **Zero Production Callers:** No active code paths utilize this service.
+- **Superseded:** Its responsibilities have been absorbed by newer, more specific classes:
+    - File validation is now handled by `App\Services\Processing\MediaValidationService`.
+    - Storage headroom checks are handled by `App\Services\Processing\TempDiskSpace`.
+    - Fallback logic is implemented directly in `App\Jobs\ProcessTranscriptWithAI`.
+    - Error and retry states are managed by `App\Services\Processing\ProcessingRunFailureHandler`.
+- **Unbound:** The class is not registered in any Service Provider.
+
+## Reality
+This class is a relic from the early March 2026 media pipeline architecture. It was left behind during the transition to the `UnifiedMediaProcessor` and the granular job chain system. It remains only as a source of confusion for developers auditing the media services.
+
+## Risk
+**Low** — The class is entirely isolated and unreferenced.
+
+## Recommendation
+**Safe to remove.** The removal should also include its associated test files:
+- `tests/Unit/Services/SermonValidationServiceTest.php`
+- `tests/Integration/Services/SermonValidationServiceTest.php`

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -72,6 +72,20 @@ admin forms. Grep search returns zero production callers in `app/`, `resources/`
 
 ---
 
+### O9 · Dead media validation service (`SermonValidationService`)
+
+**Artefact:** `app/Services/Processing/SermonValidationService.php`
+
+Confirmed dead class with zero production callers. Responsibilities for file
+validation and storage checks have been superseded by `MediaValidationService`
+and `TempDiskSpace` respectively.
+
+**Risk:** Low — isolated and unreferenced.
+
+**Action:** Safe to remove, along with Unit and Integration tests for the service.
+
+---
+
 ## ✅ Recently resolved (2026-06-18 unless noted)
 
 - **O1 — Dead mailable `App\Mail\LivestreamProcessingCompleted`** — removed (class, view, test, `AGENTS.md` reference).


### PR DESCRIPTION
I have documented a confirmed dead piece of code: `App\Services\Processing\SermonValidationService`.

- **Finding:** The service has zero production callers in `app/`, `resources/`, `routes/`, or `config/`.
- **Superseded:** Its logic for file validation, storage checks, and fallback generation has been absorbed by more modern classes like `MediaValidationService` and `TempDiskSpace`.
- **Documentation:** Created `docs/issues/2026-06-28-dead-sermon-validation-service.md` and registered it as Issue O9 in `docs/issues/README.md`.

Following the Mortician mission guidelines and `AGENTS.md` constraints, I have not deleted the production code or its associated tests in this PR, but instead provided the evidence for a human-led "burial."

---
*PR created automatically by Jules for task [4997480489507826879](https://jules.google.com/task/4997480489507826879) started by @GarethClarridge*