### PR TITLE
🔦 Lighthouse: [SEO improvement] Fix Schema.org Organization type usage

### DIFF
--- a/app/Seo/PreacherItemListPresenter.php
+++ b/app/Seo/PreacherItemListPresenter.php
@@ -22,7 +22,7 @@ class PreacherItemListPresenter
         $orgId = $appUrl.'/#organization';
 
         $worksFor = [
-            '@type' => ['Organization', 'Church'],
+            '@type' => 'Organization',
             'name' => $orgName,
             '@id' => $orgId,
         ];

--- a/app/Seo/SeriesItemListPresenter.php
+++ b/app/Seo/SeriesItemListPresenter.php
@@ -39,7 +39,7 @@ class SeriesItemListPresenter
                         'url' => $seriesUrl,
                         'inLanguage' => 'en-GB',
                         'publisher' => [
-                            '@type' => ['Organization', 'Church'],
+                            '@type' => 'Organization',
                             'name' => $orgName,
                             '@id' => $orgId,
                             'logo' => [

--- a/app/Seo/SermonItemListPresenter.php
+++ b/app/Seo/SermonItemListPresenter.php
@@ -84,7 +84,7 @@ class SermonItemListPresenter
     private function buildPublisher(string $orgName, string $logoUrl, string $orgId): array
     {
         return [
-            '@type' => ['Organization', 'Church'],
+            '@type' => 'Organization',
             'name' => $orgName,
             '@id' => $orgId,
             'logo' => [
@@ -113,7 +113,7 @@ class SermonItemListPresenter
     private function buildWorksFor(string $orgName, string $orgId): array
     {
         return [
-            '@type' => ['Organization', 'Church'],
+            '@type' => 'Organization',
             'name' => $orgName,
             '@id' => $orgId,
         ];

--- a/app/Seo/SongItemListPresenter.php
+++ b/app/Seo/SongItemListPresenter.php
@@ -21,7 +21,7 @@ class SongItemListPresenter
         $orgId = $appUrl.'/#organization';
 
         $publisher = [
-            '@type' => ['Organization', 'Church'],
+            '@type' => 'Organization',
             'name' => $orgName,
             '@id' => $orgId,
             'logo' => [

--- a/resources/views/components/schema/person.blade.php
+++ b/resources/views/components/schema/person.blade.php
@@ -10,7 +10,7 @@
         'name' => $preacher->name,
         'url' => url("/christ/sermons/preachers/{$preacher->slug}"),
         'worksFor' => [
-            '@type' => ['Organization', 'Church'],
+            '@type' => 'Organization',
             'name' => config('organization.name'),
             '@id' => config('app.url').'/#organization',
         ],

--- a/resources/views/components/schema/sermon.blade.php
+++ b/resources/views/components/schema/sermon.blade.php
@@ -23,7 +23,7 @@
         'url' => $sermonView['preacher_url'],
         'jobTitle' => 'Preacher',
         'worksFor' => [
-            '@type' => ['Organization', 'Church'],
+            '@type' => 'Organization',
             'name' => config('organization.name'),
             'url' => config('app.url'),
             '@id' => config('app.url').'/#organization',
@@ -51,7 +51,7 @@
         'genre' => 'Sermon',
         'author' => $author,
         'publisher' => [
-            '@type' => ['Organization', 'Church'],
+            '@type' => 'Organization',
             'name' => config('organization.name'),
             'url' => config('app.url'),
             '@id' => config('app.url').'/#organization',

--- a/resources/views/components/schema/website.blade.php
+++ b/resources/views/components/schema/website.blade.php
@@ -8,7 +8,7 @@
         '@id' => config('app.url').'/#website',
         'url' => config('app.url'),
         'publisher' => [
-            '@type' => ['Organization', 'Church'],
+            '@type' => 'Organization',
             'name' => config('organization.name'),
             '@id' => config('app.url').'/#organization',
             'logo' => [

--- a/resources/views/meetings/show.blade.php
+++ b/resources/views/meetings/show.blade.php
@@ -63,7 +63,7 @@
                         ],
                     ],
                     'organizer' => [
-                        '@type' => ['Organization', 'Church'],
+                        '@type' => 'Organization',
                         'name' => config('organization.name'),
                         'url' => url('/'),
                         '@id' => config('app.url').'/#organization',
@@ -132,7 +132,7 @@
                                 ],
                                 'image' => $headingpicture ?? asset('images/Primary.png'),
                                 'organizer' => [
-                                    '@type' => ['Organization', 'Church'],
+                                    '@type' => 'Organization',
                                     'name' => config('organization.name'),
                                     'url' => url('/'),
                                     '@id' => config('app.url').'/#organization',

--- a/tests/Feature/SermonJsonLdTest.php
+++ b/tests/Feature/SermonJsonLdTest.php
@@ -53,10 +53,8 @@ class SermonJsonLdTest extends TestCase
         $this->assertStringContainsString('"@type": "Article"', $content);
         $this->assertStringContainsString('"headline": "Enhanced JSON-LD Sermon"', $content);
         $this->assertStringContainsString('"publisher":', $content);
-        // The organization node is multi-typed: Organization satisfies schema.org's
-        // publisher/worksFor expectations while Church expresses the church-specific type.
+        // The organization node should use the base Organization type for relationship properties.
         $this->assertStringContainsString('"Organization"', $content);
-        $this->assertStringContainsString('"Church"', $content);
         $this->assertStringContainsString('"name": "Crockenhill Baptist Church"', $content);
         $this->assertStringContainsString('"mainEntityOfPage":', $content);
         $this->assertStringContainsString('"@type": "WebPage"', $content);


### PR DESCRIPTION
### 💡 What:
Standardised the Schema.org `@type` property for all organization-related relationships (`publisher`, `worksFor`, `organizer`) across the site. All these fields now use the single `@type: Organization` instead of the previous multi-type array `['Organization', 'Church']`.

### 🎯 Why:
Following a "CRITICAL SEO learning" in the project's Lighthouse journal, `Church` is correctly classified as a `Place` (specifically `Place > CivicStructure > PlaceOfWorship`) in Schema.org, not an `Organization`. Using a `Place` type (or a multi-type containing it) in fields where an `Organization` is expected can cause rich-result parsers (like Google's) to ignore or flag the data.

### 📊 Impact:
- **Sermon Listings & Pages**: Fixed `publisher` and `worksFor` types.
- **Preacher Profiles**: Fixed `worksFor` type.
- **Meeting Pages**: Fixed `organizer` type.
- **Site-wide**: Standardised `publisher` in the `WebSite` schema.

### 🔍 Verification:
- ✅ **Tests**: Ran relevant SEO and schema integration tests (17 passed).
- ✅ **Browser Verification**: Used a Playwright script to verify the rendered JSON-LD on the live site, confirming that `Organization` is correctly output in the browser.
- ✅ **Code Quality**: Verified with `pint` and `phpstan`.

---
*PR created automatically by Jules for task [11010871421590205891](https://jules.google.com/task/11010871421590205891) started by @GarethClarridge*