### PR TITLE
🏛️ Warden: Add index to speaker_samples.approved

### DIFF
--- a/database/migrations/2026_06_27_065159_add_index_to_songs_title.php
+++ b/database/migrations/2026_06_27_065159_add_index_to_songs_title.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->index('title');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->dropIndex(['title']);
+        });
+    }
+};

--- a/database/migrations/2026_06_28_192314_add_index_to_speaker_samples_approved.php
+++ b/database/migrations/2026_06_28_192314_add_index_to_speaker_samples_approved.php
@@ -13,8 +13,8 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('songs', function (Blueprint $table) {
-            $table->index('title');
+        Schema::table('speaker_samples', function (Blueprint $table) {
+            $table->index('approved');
         });
     }
 
@@ -23,8 +23,8 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('songs', function (Blueprint $table) {
-            $table->dropIndex(['title']);
+        Schema::table('speaker_samples', function (Blueprint $table) {
+            $table->dropIndex(['approved']);
         });
     }
 };

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -1001,6 +1001,7 @@ CREATE TABLE `speaker_samples` (
   KEY `speaker_samples_speaker_profile_id_index` (`speaker_profile_id`),
   KEY `speaker_samples_sermon_id_index` (`sermon_id`),
   KEY `speaker_samples_profile_approved_index` (`speaker_profile_id`,`approved`),
+  KEY `speaker_samples_approved_index` (`approved`),
   CONSTRAINT `speaker_samples_media_processing_log_id_foreign` FOREIGN KEY (`media_processing_log_id`) REFERENCES `media_processing_logs` (`id`) ON DELETE SET NULL,
   CONSTRAINT `speaker_samples_sermon_id_foreign` FOREIGN KEY (`sermon_id`) REFERENCES `sermons` (`id`) ON DELETE SET NULL,
   CONSTRAINT `speaker_samples_speaker_profile_id_foreign` FOREIGN KEY (`speaker_profile_id`) REFERENCES `speaker_profiles` (`id`) ON DELETE CASCADE,
@@ -1218,3 +1219,4 @@ INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_18_120000_drop_
 INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_18_130000_drop_redundant_fk_indexes_from_media_processing_logs_and_speaker_samples',76);
 INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_19_054923_add_preacher_id_date_index_to_sermons_table',77);
 INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_27_065159_add_index_to_songs_title',78);
+INSERT INTO `migrations` (`migration`, `batch`) VALUES ('2026_06_28_192314_add_index_to_speaker_samples_approved',79);

--- a/tests/Feature/WardenDatabaseIndexTest.php
+++ b/tests/Feature/WardenDatabaseIndexTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class WardenDatabaseIndexTest extends TestCase
 {
+    use RefreshDatabase;
+
     /**
      * Test that the approved index exists on the speaker_samples table.
      */

--- a/tests/Feature/WardenDatabaseIndexTest.php
+++ b/tests/Feature/WardenDatabaseIndexTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class WardenDatabaseIndexTest extends TestCase
+{
+    /**
+     * Test that the approved index exists on the speaker_samples table.
+     */
+    #[Test]
+    public function it_has_index_on_speaker_samples_approved(): void
+    {
+        $this->assertTrue(
+            Schema::hasIndex('speaker_samples', 'speaker_samples_approved_index'),
+            'Index "speaker_samples_approved_index" is missing on "speaker_samples" table.'
+        );
+    }
+}


### PR DESCRIPTION
I have added a database index to the `approved` column of the `speaker_samples` table.

💡 **What:** A new index `speaker_samples_approved_index` on the `approved` column.
🎯 **Why:** To optimize queries that filter speaker samples by approval status (e.g., in `BootstrapSpeakerProfilesCommand` and `SchemaGuardrailAudit`), preventing full table scans as the dataset grows.
🗄️ **Migration:** `2026_06_28_192314_add_index_to_speaker_samples_approved.php`
✅ **Verification:** Verified via `tests/Feature/WardenDatabaseIndexTest.php` and manual database inspection.
⚠️ **Rollback:** `php artisan migrate:rollback --step=1`

---
*PR created automatically by Jules for task [4602402461504625175](https://jules.google.com/task/4602402461504625175) started by @GarethClarridge*