### PR TITLE
📖 Editor: [copy improvement]

### DIFF
--- a/resources/views/admin/calendar/uncategorized.blade.php
+++ b/resources/views/admin/calendar/uncategorized.blade.php
@@ -25,7 +25,7 @@
                 <x-calendar-event-card
                     :event="$event"
                     variant="admin"
-                    date-format="l, F j, Y"
+                    date-format="l, j F Y"
                     description-limit="200"
                 >
                     <div class="flex-shrink-0 ml-6">


### PR DESCRIPTION
Standardised the date format in the admin calendar uncategorised events view to use British English (j F Y).

No functional changes — copy only.

📍 resources/views/admin/calendar/uncategorized.blade.php

---
*PR created automatically by Jules for task [10994855987387445069](https://jules.google.com/task/10994855987387445069) started by @GarethClarridge*