### PR TITLE
🪦 Mortician: Possibly dead — icon-button component

### DIFF
--- a/docs/issues/2026-06-29-unused-icon-button.md
+++ b/docs/issues/2026-06-29-unused-icon-button.md
@@ -1,0 +1,16 @@
+# 🪦 Mortician: Possibly dead — `<x-icon-button>` Blade Component
+
+**Path:** `resources/views/components/icon-button.blade.php`
+
+**What:** Reusable icon button component intended as a design primitive.
+
+**Evidence:**
+- Project-wide grep for `<x-icon-button` excluding the component gallery (`resources/views/dev/components.blade.php`) returns **zero** production hits.
+- Grep for `@component('icon-button')` and `Blade::component('icon-button', ...)` returns **zero** hits.
+- Grep for dynamic view resolution `view('components.icon-button')` returns **zero** hits.
+- The component is only referenced in the local-only component gallery: `resources/views/dev/components.blade.php`.
+- Standard UI actions in admin lists (Preachers, Users) have standardized on `<x-button variant="ghost" ...>` instead of this component.
+
+**Risk:** Low — isolated UI primitive with no production callers.
+
+**Recommendation:** Safe to remove. The design system has standard alternatives via `<x-button>`, and this component remains an unadopted "to-do" from March 2026.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -86,6 +86,20 @@ and `TempDiskSpace` respectively.
 
 ---
 
+### O10 · Unused icon button primitive (`<x-icon-button>`)
+
+**Artefact:** `resources/views/components/icon-button.blade.php`
+
+A primitive component added in March 2026 that has zero production callers outside
+the component gallery. The rest of the UI has standardized on `<x-button variant="ghost">`
+for icon-only actions.
+
+**Risk:** Low — isolated UI component.
+
+**Action:** Safe to remove from the codebase and the component gallery.
+
+---
+
 ## ✅ Recently resolved (2026-06-18 unless noted)
 
 - **O1 — Dead mailable `App\Mail\LivestreamProcessingCompleted`** — removed (class, view, test, `AGENTS.md` reference).


### PR DESCRIPTION
I have identified the `<x-icon-button>` Blade component (`resources/views/components/icon-button.blade.php`) as dead code.

### Evidence
- Project-wide grep for `<x-icon-button` excluding the component gallery (`resources/views/dev/components.blade.php`) returned **zero** production hits.
- Search for `@component('icon-button')`, `Blade::component('icon-button', ...)`, and `view('components.icon-button')` also returned no results.
- The UI has standardized on `<x-button variant="ghost" ...>` for icon-only actions in admin lists.

### Changes
- Created `docs/issues/2026-06-29-unused-icon-button.md` with detailed evidence.
- Updated `docs/issues/README.md` (Item O10) to include this finding in the open tracker.
- Cleaned up diagnostic artifacts (`route_list.json`) used during investigation.

Verification: Full test suite passed (5798 tests).

---
*PR created automatically by Jules for task [11097506670344303959](https://jules.google.com/task/11097506670344303959) started by @GarethClarridge*