### PR TITLE
🔦 Lighthouse: Add max-image-preview:large meta tag

### DIFF
--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -19,6 +19,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="csrf-token" content="{{ csrf_token() }}">
   <meta name="msvalidate.01" content="2EF7ECDA9644EAD5B1B36A960808B8DB" />
+  <meta name="robots" content="max-image-preview:large">
 
   {{-- Meta Description: @push from x-page.shell takes priority; @section is the alternate path for full-width and error views. --}}
   @php $pushedDescription = trim($__env->yieldPushContent('meta_description')); @endphp


### PR DESCRIPTION
### 💡 What:
Added the `<meta name="robots" content="max-image-preview:large">` directive to the `<head>` of the base layout (`main.blade.php`).

### 🎯 Why:
This tells search engines (primarily Google) that they have permission to use high-quality, large image previews when displaying the site's content in search results and on Google Discover.

### 📊 Impact:
This change applies sitewide. It is particularly beneficial for the sermon archive and individual sermon pages, which use visually rich thumbnails. High-quality previews can lead to higher click-through rates and better engagement from search results.

### 🔍 Verification:
1. Checked `resources/views/layouts/main.blade.php` to ensure the tag is correctly placed in the `<head>` section.
2. Ran relevant SEO and metadata tests (`SeoMetaTagsTest`, `SeoMetadataTest`, `SermonSeoTest`, etc.) to ensure layout rendering remains intact. All tests passed.
3. Verified the presence of the tag in the rendered HTML source during local development.

---
*PR created automatically by Jules for task [5949576194037031253](https://jules.google.com/task/5949576194037031253) started by @GarethClarridge*