### PR TITLE
📜 Herald: Add PHPDoc to PublicPageVisibilityGuard

### DIFF
--- a/app/Services/Public/PublicPageVisibilityGuard.php
+++ b/app/Services/Public/PublicPageVisibilityGuard.php
@@ -9,8 +9,27 @@ use App\Models\Page;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 
+/**
+ * Service for enforcing visibility and authentication rules for public-facing pages.
+ *
+ * This guard ensures that administrative pages are restricted to authorized users
+ * and that members-only areas require both authentication and email verification,
+ * providing a centralized layer for page-level access control.
+ */
 class PublicPageVisibilityGuard
 {
+    /**
+     * Enforce visibility rules for the given page.
+     *
+     * Checks if the page requires administrative access or belongs to the
+     * members area. Returns a RedirectResponse if the user must be
+     * redirected to login or verification pages, or null if access is granted.
+     *
+     * @param  Page|null  $page  The page to check visibility for
+     * @return RedirectResponse|null A redirect if requirements aren't met, or null
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException When admin access is denied
+     */
     public function enforce(?Page $page): ?RedirectResponse
     {
         if (! $page instanceof Page) {

--- a/app/Services/Public/PublicPageVisibilityGuard.php
+++ b/app/Services/Public/PublicPageVisibilityGuard.php
@@ -8,6 +8,7 @@ use App\Enums\PageArea;
 use App\Models\Page;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * Service for enforcing visibility and authentication rules for public-facing pages.
@@ -28,7 +29,7 @@ class PublicPageVisibilityGuard
      * @param  Page|null  $page  The page to check visibility for
      * @return RedirectResponse|null A redirect if requirements aren't met, or null
      *
-     * @throws \Symfony\Component\HttpKernel\Exception\HttpException When admin access is denied
+     * @throws HttpException When admin access is denied
      */
     public function enforce(?Page $page): ?RedirectResponse
     {


### PR DESCRIPTION
💡 **What:** Added comprehensive PHPDoc blocks to the `PublicPageVisibilityGuard` class and its `enforce()` method.

🎯 **Why:** The service lacked documentation explaining its responsibility in guarding public-facing pages, specifically regarding administrative access and member-area authentication/verification requirements.

🔄 **Behavior:** No functional changes — documentation only. Verified with `phpstan` and `pint`.

---
*PR created automatically by Jules for task [10454881084648129971](https://jules.google.com/task/10454881084648129971) started by @GarethClarridge*