### PR TITLE
🛡️ Sentinel: Additive security hardening

### DIFF
--- a/app/Data/VideoProcessingOptions.php
+++ b/app/Data/VideoProcessingOptions.php
@@ -85,6 +85,7 @@ final class VideoProcessingOptions
             'video_processing_mode' => [
                 'sometimes',
                 'string',
+                'max:255',
                 Rule::in([
                     MediaProcessingLog::VIDEO_PROCESSING_MODE_FULL_VIDEO,
                     MediaProcessingLog::VIDEO_PROCESSING_MODE_AUTO_TRIM,

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -25,6 +25,9 @@ class SecurityHeaders
         // Security Header: Prevent Clickjacking (legacy browsers)
         $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
 
+        // Security Header: Prevent Internet Explorer from executing downloads in site's context
+        $response->headers->set('X-Download-Options', 'noopen');
+
         // Security Header: Disable legacy browser XSS filters in favor of CSP
         $response->headers->set('X-XSS-Protection', '0');
 

--- a/app/Http/Requests/SermonIndexRequest.php
+++ b/app/Http/Requests/SermonIndexRequest.php
@@ -32,13 +32,13 @@ class SermonIndexRequest extends FormRequest
     {
         return [
             'search' => ['nullable', 'string', 'max:255'],
-            'service' => ['nullable', 'string', Rule::enum(SermonService::class)],
+            'service' => ['nullable', 'string', 'max:255', Rule::enum(SermonService::class)],
             'preacher' => ['nullable', 'string', 'max:255'],
             // Security: integer bounding guards against malformed input and overflow before the exists lookup runs.
             'preacher_id' => ['nullable', 'integer', 'min:1', 'max:2147483647', 'exists:preachers,id'],
             'series' => ['nullable', 'string', 'max:255'],
-            'sort' => ['nullable', 'string', 'in:date,title,preacher,series,service'],
-            'order' => ['nullable', 'string', 'in:asc,desc'],
+            'sort' => ['nullable', 'string', 'max:255', 'in:date,title,preacher,series,service'],
+            'order' => ['nullable', 'string', 'max:255', 'in:asc,desc'],
             'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
             'with_thumbnail' => ['nullable', 'boolean'],
         ];

--- a/tests/Feature/Security/SecurityHeadersTest.php
+++ b/tests/Feature/Security/SecurityHeadersTest.php
@@ -18,6 +18,7 @@ class SecurityHeadersTest extends TestCase
 
         $response->assertHeader('X-Content-Type-Options', 'nosniff');
         $response->assertHeader('X-Frame-Options', 'SAMEORIGIN');
+        $response->assertHeader('X-Download-Options', 'noopen');
         $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
         $response->assertHeader('X-XSS-Protection', '0');
         $response->assertHeader('Cross-Origin-Opener-Policy', 'same-origin');
@@ -34,6 +35,7 @@ class SecurityHeadersTest extends TestCase
 
         $response->assertHeader('X-Content-Type-Options', 'nosniff');
         $response->assertHeader('X-Frame-Options', 'SAMEORIGIN');
+        $response->assertHeader('X-Download-Options', 'noopen');
         $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
         $response->assertHeader('X-XSS-Protection', '0');
         $response->assertHeader('Cross-Origin-Opener-Policy', 'same-origin');


### PR DESCRIPTION
This PR implements additive security hardening as per the Sentinel persona mission. It includes:
1. Adding the X-Download-Options: noopen security header to prevent IE8+ from opening HTML downloads in the site context.
2. Hardening validation rules by adding explicit length constraints (max:255) to several input fields for defense-in-depth against oversized payloads.
3. Updated feature tests to ensure the new security header is present and verified.

---
*PR created automatically by Jules for task [247315543590176995](https://jules.google.com/task/247315543590176995) started by @GarethClarridge*