### PR TITLE
🧹 Tidy: Deduplicate array sanitization logic in OpenAIResponseLogger

### DIFF
--- a/app/Services/OpenAIResponseLogger.php
+++ b/app/Services/OpenAIResponseLogger.php
@@ -53,7 +53,7 @@ class OpenAIResponseLogger
             $logData['response_structure_valid'] = true;
         }
 
-        Log::warning('OpenAI API response type analysis', self::sanitizeArray($logData));
+        Log::warning('OpenAI API response type analysis', self::sanitizeArrayForLog($logData));
     }
 
     /**
@@ -86,25 +86,6 @@ class OpenAIResponseLogger
             }
         }
 
-        Log::error('OpenAI API transport layer error', self::sanitizeArray($logData));
-    }
-
-    /**
-     * Recursively sanitize all string values in an array for logging.
-     *
-     * @param  array<mixed>  $data
-     * @return array<mixed>
-     */
-    private static function sanitizeArray(array $data): array
-    {
-        foreach ($data as $key => $value) {
-            if (is_array($value)) {
-                $data[$key] = self::sanitizeArray($value);
-            } elseif (is_string($value)) {
-                $data[$key] = self::sanitizeForLog($value);
-            }
-        }
-
-        return $data;
+        Log::error('OpenAI API transport layer error', self::sanitizeArrayForLog($logData));
     }
 }

--- a/app/Traits/SanitizesLogData.php
+++ b/app/Traits/SanitizesLogData.php
@@ -23,11 +23,11 @@ trait SanitizesLogData
      * @param  array<mixed>  $data
      * @return array<mixed>
      */
-    protected function sanitizeArrayForLog(array $data): array
+    protected static function sanitizeArrayForLog(array $data): array
     {
         foreach ($data as $key => $value) {
             if (is_array($value)) {
-                $data[$key] = $this->sanitizeArrayForLog($value);
+                $data[$key] = self::sanitizeArrayForLog($value);
             } elseif (is_string($value)) {
                 // Security: Avoid double-sanitization of already-sanitized stack traces
                 // which would flatten them and reduce readability.
@@ -35,7 +35,7 @@ trait SanitizesLogData
                     continue;
                 }
 
-                $data[$key] = $this->sanitizeForLog($value);
+                $data[$key] = self::sanitizeForLog($value);
             }
         }
 


### PR DESCRIPTION
Deduplicate array sanitization logic by centralizing it in the SanitizesLogData trait and updating it to be static-callable.

---
*PR created automatically by Jules for task [7940182376512975481](https://jules.google.com/task/7940182376512975481) started by @GarethClarridge*