### PR TITLE
📖 Editor: standardise sermon views to sentence case

### DIFF
--- a/resources/views/livewire/admin/sermons/edit-sermon.blade.php
+++ b/resources/views/livewire/admin/sermons/edit-sermon.blade.php
@@ -12,9 +12,9 @@
                 : route('sermons.show', ['sermon' => $sermon->slug]);
         @endphp
         <x-button :link="$publicUrl" variant="ghost" icon="eye" inline>
-            View Public
+            View public
         </x-button>
-        <x-clipboard-button :content="$publicUrl" label="Copy Link" title="Copy public link to clipboard" class="text-gray-500 hover:text-gray-700" />
+        <x-clipboard-button :content="$publicUrl" label="Copy link" title="Copy public link to clipboard" class="text-gray-500 hover:text-gray-700" />
         <x-button link="{{ route('admin.sermons.index') }}" variant="outline" inline>
             Cancel
         </x-button>
@@ -34,10 +34,10 @@
                         <x-input label="Slug" wire:model="form.slug" required maxlength="255"
                             hint="URL-friendly identifier (auto-generated from title)" />
                     </div>
-                    <x-clipboard-button js-content="$wire.form.slug" hideLabel label="Copy Slug" title="Copy slug to clipboard" class="mt-7" />
+                    <x-clipboard-button js-content="$wire.form.slug" hideLabel label="Copy slug" title="Copy slug to clipboard" class="mt-7" />
                 </div>
 
-                <x-input type="number" label="Download Count" wire:model="form.downloadCount"
+                <x-input type="number" label="Download count" wire:model="form.downloadCount"
                     hint="Incremented automatically when the audio is downloaded" />
             </div>
 
@@ -72,7 +72,7 @@
                 hint="Used when the {{ $isChildrensTalk ? 'speaker' : 'preacher' }} is not in the list above" />
 
             @unless($isChildrensTalk)
-                <x-input label="Bible Reference" wire:model="form.reference" maxlength="255"
+                <x-input label="Bible reference" wire:model="form.reference" maxlength="255"
                     placeholder="e.g., John 3:16-21" />
             @endunless
 
@@ -96,7 +96,7 @@
             </p>
         </x-card>
     @else
-        <x-card heading="AI-Generated Content">
+        <x-card heading="AI-generated content">
             <div class="space-y-4">
                 <x-textarea label="Summary" wire:model="form.summary" rows="5" maxlength="1000"
                     hint="AI-generated summary" autogrow />
@@ -148,10 +148,10 @@
         @unless($isChildrensTalk)
             <x-card heading="Display options">
                 <div class="space-y-4">
-                    <x-toggle label="Show Summary" wire:model="form.showSummary"
+                    <x-toggle label="Show summary" wire:model="form.showSummary"
                         hint="Display AI-generated summary on sermon page" />
 
-                    <x-toggle label="Show Points" wire:model="form.showPoints"
+                    <x-toggle label="Show points" wire:model="form.showPoints"
                         hint="Display AI-generated points on sermon page" />
                 </div>
             </x-card>
@@ -212,7 +212,7 @@
             @endif
         @endisland
 
-        <x-card heading="{{ $isChildrensTalk ? 'Published Media' : 'Media Files' }}">
+        <x-card heading="{{ $isChildrensTalk ? 'Published media' : 'Media files' }}">
             <div class="space-y-3">
                 @if($sermon->audio_file_path)
                     <div class="flex items-center gap-2">

--- a/resources/views/livewire/admin/sermons/list-sermons.blade.php
+++ b/resources/views/livewire/admin/sermons/list-sermons.blade.php
@@ -1,12 +1,12 @@
 <x-admin.list-shell
-    title="Sermons &amp; Talks"
+    title="Sermons &amp; talks"
     description="Manage sermon recordings and published children's talks."
     :paginator="$sermons"
     itemsName="sermon"
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.services.upload-recording') }}" variant="primary" icon="cloud-arrow-up" inline>
-            Upload Sermon
+            Upload sermon
         </x-button>
     </x-slot:actions>
 
@@ -27,9 +27,9 @@
                 :options="$seriesList->map(fn($s) => ['id' => $s, 'name' => $s])->toArray()"
                 class="w-48" />
 
-            <x-toggle label="Has Video" wire:model.live="hasVideoFilter" />
-            <x-toggle label="Needs Review" wire:model.live="needsReviewFilter" />
-            <x-toggle label="Last 12 Months" wire:model.live="last12Months" />
+            <x-toggle label="Has video" wire:model.live="hasVideoFilter" />
+            <x-toggle label="Needs review" wire:model.live="needsReviewFilter" />
+            <x-toggle label="Last 12 months" wire:model.live="last12Months" />
         </x-admin.filter-bar>
     </x-slot:filters>
 
@@ -142,7 +142,7 @@
                 >
                     @if(!$hasFilters)
                         <x-button link="{{ route('admin.services.upload-recording') }}" variant="primary" icon="cloud-arrow-up" inline>
-                            Upload Sermon
+                            Upload sermon
                         </x-button>
                     @endif
                 </x-admin.empty-state>

--- a/resources/views/sermons/sermon.blade.php
+++ b/resources/views/sermons/sermon.blade.php
@@ -138,7 +138,7 @@
                         <x-clipboard-button
                             :content="$sermon->summary"
                             hideLabel
-                            label="Copy Summary"
+                            label="Copy summary"
                             title="Copy summary to clipboard"
                             icon="clipboard-document"
                             size="sm"
@@ -155,12 +155,12 @@
                     <div class="px-6 py-4 border-b border-gray-100 flex flex-wrap items-center justify-between gap-4">
                         <div class="flex items-center gap-2">
                             <x-heroicon-o-list-bullet class="h-4 w-4 text-cbc-teal flex-shrink-0" aria-hidden="true" />
-                            <h2 class="font-display text-xl text-gray-900">Sermon Outline</h2>
+                            <h2 class="font-display text-xl text-gray-900">Sermon outline</h2>
                         </div>
                         <x-clipboard-button
                             :content="$sermonView['plain_text_outline']"
                             hideLabel
-                            label="Copy Outline"
+                            label="Copy outline"
                             title="Copy outline to clipboard"
                             icon="clipboard-document"
                             size="sm"
@@ -253,7 +253,7 @@
                             <div x-show="loaded" x-cloak>
                                 <x-clipboard-button
                                     js-content="plainText()"
-                                    label="Copy Transcript"
+                                    label="Copy transcript"
                                     icon="clipboard-document"
                                     size="sm"
                                 />
@@ -439,15 +439,15 @@
                     <div class="mb-4 p-4 bg-gray-50 border border-gray-200 rounded-xl">
                         <h2 class="font-display text-lg text-gray-900 mb-3 flex items-center gap-2">
                             <x-heroicon-o-signal class="h-4 w-4 text-cbc-teal" />
-                            Livestream Processing
+                            Livestream processing
                         </h2>
                         <div class="grid grid-cols-1 gap-4 text-sm">
                             <div>
-                                <span class="font-medium text-gray-700">Original File:</span>
+                                <span class="font-medium text-gray-700">Original file:</span>
                                 <span class="text-gray-600"> {{ $sermon->livestreamProcessing->original_filename }}</span>
                             </div>
                             <div>
-                                <span class="font-medium text-gray-700">Processing Date:</span>
+                                <span class="font-medium text-gray-700">Processing date:</span>
                                 <span class="text-gray-600"> {{ $sermon->livestreamProcessing->created_at->format('Y-m-d H:i:s') }}</span>
                             </div>
                             <div>
@@ -461,12 +461,12 @@
                                 </span>
                             </div>
                             <div>
-                                <span class="font-medium text-gray-700">Total Segments:</span>
+                                <span class="font-medium text-gray-700">Total segments:</span>
                                 <span class="text-gray-600"> {{ $sermon->livestreamProcessing->segments_count ?? 0 }}</span>
                             </div>
                             @if ($sermon->livestreamProcessing->duration)
                             <div>
-                                <span class="font-medium text-gray-700">Total Duration:</span>
+                                <span class="font-medium text-gray-700">Total duration:</span>
                                 <span class="text-gray-600"> {{ gmdate('H:i:s', (int) $sermon->livestreamProcessing->duration) }}</span>
                             </div>
                             @endif

--- a/tests/Feature/Livewire/Admin/EditSermonTest.php
+++ b/tests/Feature/Livewire/Admin/EditSermonTest.php
@@ -527,9 +527,9 @@ class EditSermonTest extends TestCase
             ->assertSee("Edit Children's Talk")
             ->assertSee('Speaker')
             ->assertSee("Children's talk notes")
-            ->assertDontSee('Bible Reference')
-            ->assertDontSee('AI-Generated Content')
-            ->assertDontSee('Display Options');
+            ->assertDontSee('Bible reference')
+            ->assertDontSee('AI-generated content')
+            ->assertDontSee('Display options');
     }
 
     #[Test]

--- a/tests/Feature/SermonPagesTest.php
+++ b/tests/Feature/SermonPagesTest.php
@@ -430,8 +430,8 @@ class SermonPagesTest extends TestCase
             ->get("/christ/sermons/{$sermon->slug}");
 
         $response->assertStatus(200);
-        $response->assertSee('Livestream Processing');
-        $response->assertSeeInOrder(['Total Segments:', '5']);
+        $response->assertSee('Livestream processing');
+        $response->assertSeeInOrder(['Total segments:', '5']);
     }
 
     #[Test]
@@ -454,7 +454,7 @@ class SermonPagesTest extends TestCase
         $response = $this->followingRedirects()->get("/christ/sermons/{$sermon->slug}");
 
         $response->assertStatus(200);
-        $response->assertDontSee('Livestream Processing');
+        $response->assertDontSee('Livestream processing');
         $response->assertDontSee('private-service.mp4');
     }
 }


### PR DESCRIPTION
💡 **What:** Standardised sermon-related admin and public views to use British English sentence case for headings, button labels, and toggle labels.
🎯 **Why:** To improve copy consistency and adhere to the project's British English copy standards.
🔄 **Behavior:** No functional changes — copy only.
📍 **Where:**
- `resources/views/livewire/admin/sermons/list-sermons.blade.php`
- `resources/views/livewire/admin/sermons/edit-sermon.blade.php`
- `resources/views/sermons/sermon.blade.php`
- `tests/Feature/Livewire/Admin/EditSermonTest.php`
- `tests/Feature/SermonPagesTest.php`

---
*PR created automatically by Jules for task [3583728597205175239](https://jules.google.com/task/3583728597205175239) started by @GarethClarridge*