### PR TITLE
Delegate Bible reference validation to ScriptureReferenceResolver

### DIFF
--- a/app/Services/Scripture/ScriptureReferenceResolver.php
+++ b/app/Services/Scripture/ScriptureReferenceResolver.php
@@ -53,12 +53,6 @@ class ScriptureReferenceResolver
     /**
      * Parse a reference into passages, returning [] when it cannot be parsed.
      *
-     * For single-chapter books (Obadiah, Philemon, 2 John, 3 John, Jude) a bare
-     * "Book N" reference is conventionally verse N, but the parser reads N as a
-     * (non-existent) chapter and rejects it. When the initial parse fails, we
-     * retry with an explicit "1:" chapter so references like "Jude 3" or
-     * "Philemon 6" resolve.
-     *
      * @return array<int, BiblePassage>
      */
     private function parse(string $reference): array
@@ -70,69 +64,59 @@ class ScriptureReferenceResolver
         }
 
         try {
-            return $this->parser->parse($reference);
+            return $this->parser->parse($this->normaliseSingleChapterReferences($reference));
         } catch (\Throwable) {
-            $rewritten = $this->rewriteSingleChapterReference($reference);
-
-            if ($rewritten === null) {
-                return [];
-            }
-
-            try {
-                return $this->parser->parse($rewritten);
-            } catch (\Throwable) {
-                return [];
-            }
+            return [];
         }
     }
 
     /**
-     * Rewrite any bare single-chapter "Book N" parts of a reference to "Book 1:N".
+     * Insert an explicit "1:" chapter for single-chapter book verse references.
      *
-     * The reference is split on the same separators the parser uses, so a single
-     * offending part in an otherwise valid multi-part reference (e.g. the "Jude 3"
-     * in "John 3:16; Jude 3") is rewritten in place while the rest is preserved.
-     * Returns null when no part could be rewritten.
+     * For single-chapter books (Obadiah, Philemon, 2 John, 3 John, Jude) a bare
+     * "Book N" reference means verse N, but the parser reads N as a (non-existent)
+     * chapter and rejects it — and reads "Book 1" as the whole book rather than
+     * verse 1. Rewriting "Book N" to "Book 1:N" before parsing fixes both, while
+     * leaving the verse expression (ranges such as "3-5", "3–5" or "3 to 5", and
+     * verse lists) for the parser to normalise.
+     *
+     * Each separator-delimited section is handled independently, so a single
+     * offending part of a multi-part reference (e.g. the "Jude 3" in
+     * "John 3:16; Jude 3") is rewritten in place while the rest is preserved.
      */
-    private function rewriteSingleChapterReference(string $reference): ?string
+    private function normaliseSingleChapterReferences(string $reference): string
     {
         // Keep the separators (&, ",", ";", "and") so the reference can be reassembled.
         $tokens = preg_split('/(\s*(?:&|,|;|\band\b)\s*)/i', $reference, -1, PREG_SPLIT_DELIM_CAPTURE);
 
         if ($tokens === false) {
-            return null;
+            return $reference;
         }
-
-        $changed = false;
 
         // Section tokens are at even indices; captured separators sit between them.
         for ($index = 0; $index < count($tokens); $index += 2) {
-            $rewritten = $this->rewriteSingleChapterSection($tokens[$index]);
-
-            if ($rewritten !== null) {
-                $tokens[$index] = $rewritten;
-                $changed = true;
-            }
+            $tokens[$index] = $this->normaliseSingleChapterSection($tokens[$index]);
         }
 
-        return $changed ? implode('', $tokens) : null;
+        return implode('', $tokens);
     }
 
     /**
-     * Rewrite a single "Book N" section for a single-chapter book to "Book 1:N".
+     * Rewrite a "Book N" section for a single-chapter book to "Book 1:N".
      *
-     * Returns null when the section is not of that shape or the book is not a
-     * single-chapter book. Book recognition (including abbreviations) is delegated
-     * to the parser, so forms such as "Phlm 6" are handled.
+     * Returns the section unchanged when it is not of that shape, already names a
+     * chapter (contains ":"), or the book is not a single-chapter book. Book
+     * recognition (including abbreviations) is delegated to the parser, so forms
+     * such as "Phlm 6" are handled.
      */
-    private function rewriteSingleChapterSection(string $section): ?string
+    private function normaliseSingleChapterSection(string $section): string
     {
         $trimmed = trim($section);
 
-        // Split a trailing verse expression (digits, ranges and lists, no ":")
-        // from the book name, e.g. "3 John 4-8" -> book "3 John", verses "4-8".
-        if (! preg_match('/^(.+?)\s+(\d+(?:\s*[-,]\s*\d+)*)$/', $trimmed, $matches)) {
-            return null;
+        // Split a leading book name from a trailing verse expression that begins
+        // with a digit and does not already specify a chapter (no ":").
+        if (! preg_match('/^(.+?)\s+(\d[^:]*)$/', $trimmed, $matches)) {
+            return $section;
         }
 
         [, $bookName, $verses] = $matches;
@@ -140,11 +124,11 @@ class ScriptureReferenceResolver
         try {
             $bookPassages = $this->parser->parse($bookName);
         } catch (\Throwable) {
-            return null;
+            return $section;
         }
 
         if ($bookPassages === [] || $bookPassages[0]->from()->book()->chaptersInBook() !== 1) {
-            return null;
+            return $section;
         }
 
         return $bookName.' 1:'.$verses;

--- a/app/Services/Scripture/ScriptureReferenceResolver.php
+++ b/app/Services/Scripture/ScriptureReferenceResolver.php
@@ -87,17 +87,51 @@ class ScriptureReferenceResolver
     }
 
     /**
-     * Rewrite a bare "Book N" reference for a single-chapter book to "Book 1:N".
+     * Rewrite any bare single-chapter "Book N" parts of a reference to "Book 1:N".
      *
-     * Returns null when the reference is not of that shape or the book is not a
-     * single-chapter book. The book name (including any abbreviation) is resolved
-     * via the parser itself, so abbreviations such as "Phlm" are handled.
+     * The reference is split on the same separators the parser uses, so a single
+     * offending part in an otherwise valid multi-part reference (e.g. the "Jude 3"
+     * in "John 3:16; Jude 3") is rewritten in place while the rest is preserved.
+     * Returns null when no part could be rewritten.
      */
     private function rewriteSingleChapterReference(string $reference): ?string
     {
+        // Keep the separators (&, ",", ";", "and") so the reference can be reassembled.
+        $tokens = preg_split('/(\s*(?:&|,|;|\band\b)\s*)/i', $reference, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+        if ($tokens === false) {
+            return null;
+        }
+
+        $changed = false;
+
+        // Section tokens are at even indices; captured separators sit between them.
+        for ($index = 0; $index < count($tokens); $index += 2) {
+            $rewritten = $this->rewriteSingleChapterSection($tokens[$index]);
+
+            if ($rewritten !== null) {
+                $tokens[$index] = $rewritten;
+                $changed = true;
+            }
+        }
+
+        return $changed ? implode('', $tokens) : null;
+    }
+
+    /**
+     * Rewrite a single "Book N" section for a single-chapter book to "Book 1:N".
+     *
+     * Returns null when the section is not of that shape or the book is not a
+     * single-chapter book. Book recognition (including abbreviations) is delegated
+     * to the parser, so forms such as "Phlm 6" are handled.
+     */
+    private function rewriteSingleChapterSection(string $section): ?string
+    {
+        $trimmed = trim($section);
+
         // Split a trailing verse expression (digits, ranges and lists, no ":")
         // from the book name, e.g. "3 John 4-8" -> book "3 John", verses "4-8".
-        if (! preg_match('/^(.+?)\s+(\d+(?:\s*[-,]\s*\d+)*)$/', $reference, $matches)) {
+        if (! preg_match('/^(.+?)\s+(\d+(?:\s*[-,]\s*\d+)*)$/', $trimmed, $matches)) {
             return null;
         }
 

--- a/app/Services/Scripture/ScriptureReferenceResolver.php
+++ b/app/Services/Scripture/ScriptureReferenceResolver.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Scripture;
 
+use TechWilk\BibleVerseParser\BiblePassage;
 use TechWilk\BibleVerseParser\BiblePassageParser;
-use TechWilk\BibleVerseParser\Exception\UnableToParseException;
 
 class ScriptureReferenceResolver
 {
@@ -21,26 +21,14 @@ class ScriptureReferenceResolver
      */
     public function normalize(string $reference): ?string
     {
-        $reference = trim($reference);
+        $passages = $this->parse($reference);
 
-        if ($reference === '') {
+        if ($passages === []) {
             return null;
         }
 
-        try {
-            $passages = $this->parser->parse($reference);
-
-            if (empty($passages)) {
-                return null;
-            }
-
-            // Use the first passage for normalization (single-reference sermons only)
-            return (string) $passages[0];
-        } catch (UnableToParseException) {
-            return null;
-        } catch (\Throwable) {
-            return null;
-        }
+        // Use the first passage for normalization (single-reference sermons only)
+        return (string) $passages[0];
     }
 
     /**
@@ -53,24 +41,78 @@ class ScriptureReferenceResolver
      */
     public function normalizeAll(string $reference): ?string
     {
+        $passages = $this->parse($reference);
+
+        if ($passages === []) {
+            return null;
+        }
+
+        return implode(', ', array_map(static fn (BiblePassage $passage): string => (string) $passage, $passages));
+    }
+
+    /**
+     * Parse a reference into passages, returning [] when it cannot be parsed.
+     *
+     * For single-chapter books (Obadiah, Philemon, 2 John, 3 John, Jude) a bare
+     * "Book N" reference is conventionally verse N, but the parser reads N as a
+     * (non-existent) chapter and rejects it. When the initial parse fails, we
+     * retry with an explicit "1:" chapter so references like "Jude 3" or
+     * "Philemon 6" resolve.
+     *
+     * @return array<int, BiblePassage>
+     */
+    private function parse(string $reference): array
+    {
         $reference = trim($reference);
 
         if ($reference === '') {
-            return null;
+            return [];
         }
 
         try {
-            $passages = $this->parser->parse($reference);
+            return $this->parser->parse($reference);
+        } catch (\Throwable) {
+            $rewritten = $this->rewriteSingleChapterReference($reference);
 
-            if (empty($passages)) {
-                return null;
+            if ($rewritten === null) {
+                return [];
             }
 
-            return implode(', ', array_map(static fn ($passage): string => (string) $passage, $passages));
-        } catch (UnableToParseException) {
+            try {
+                return $this->parser->parse($rewritten);
+            } catch (\Throwable) {
+                return [];
+            }
+        }
+    }
+
+    /**
+     * Rewrite a bare "Book N" reference for a single-chapter book to "Book 1:N".
+     *
+     * Returns null when the reference is not of that shape or the book is not a
+     * single-chapter book. The book name (including any abbreviation) is resolved
+     * via the parser itself, so abbreviations such as "Phlm" are handled.
+     */
+    private function rewriteSingleChapterReference(string $reference): ?string
+    {
+        // Split a trailing verse expression (digits, ranges and lists, no ":")
+        // from the book name, e.g. "3 John 4-8" -> book "3 John", verses "4-8".
+        if (! preg_match('/^(.+?)\s+(\d+(?:\s*[-,]\s*\d+)*)$/', $reference, $matches)) {
             return null;
+        }
+
+        [, $bookName, $verses] = $matches;
+
+        try {
+            $bookPassages = $this->parser->parse($bookName);
         } catch (\Throwable) {
             return null;
         }
+
+        if ($bookPassages === [] || $bookPassages[0]->from()->book()->chaptersInBook() !== 1) {
+            return null;
+        }
+
+        return $bookName.' 1:'.$verses;
     }
 }

--- a/app/Services/Scripture/ScriptureReferenceResolver.php
+++ b/app/Services/Scripture/ScriptureReferenceResolver.php
@@ -42,4 +42,35 @@ class ScriptureReferenceResolver
             return null;
         }
     }
+
+    /**
+     * Normalize a raw reference string to a canonical form, preserving every passage.
+     *
+     * Unlike {@see normalize()}, which returns only the first passage (for use as a
+     * single-reference cache key), this joins all parsed passages so multi-part
+     * references such as "John 3:16-18, 4:1-2" are kept whole ("John 3:16-18,
+     * John 4:1-2"). Returns null if the reference cannot be parsed.
+     */
+    public function normalizeAll(string $reference): ?string
+    {
+        $reference = trim($reference);
+
+        if ($reference === '') {
+            return null;
+        }
+
+        try {
+            $passages = $this->parser->parse($reference);
+
+            if (empty($passages)) {
+                return null;
+            }
+
+            return implode(', ', array_map(static fn ($passage): string => (string) $passage, $passages));
+        } catch (UnableToParseException) {
+            return null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
 }

--- a/app/Services/Sermon/SermonAnalysisValidator.php
+++ b/app/Services/Sermon/SermonAnalysisValidator.php
@@ -6,6 +6,7 @@ namespace App\Services\Sermon;
 
 use App\Data\SermonAnalysis;
 use App\Services\BritishEnglishConverter;
+use App\Services\Scripture\ScriptureReferenceResolver;
 use App\Traits\SanitizesLogData;
 use Illuminate\Support\Facades\Log;
 
@@ -19,21 +20,10 @@ class SermonAnalysisValidator
 
     private const MIN_TRANSCRIPT_LENGTH = 100;
 
-    /**
-     * Recognised Bible book names (with common variants) for reference validation.
-     * Multi-word and longer variants are listed before their prefixes so the
-     * alternation matches greedily (e.g. "Song of Solomon" before "Song").
-     */
-    private const BIBLE_BOOK_PATTERN = '(?:[1-3]\s+)?(?:'
-        .'Genesis|Exodus|Leviticus|Numbers|Deuteronomy|Joshua|Judges|Ruth|Samuel|Kings|Chronicles|'
-        .'Ezra|Nehemiah|Esther|Job|Psalms|Psalm|Proverbs|Ecclesiastes|'
-        .'Song of Solomon|Song of Songs|Song|Isaiah|Jeremiah|Lamentations|Ezekiel|Daniel|'
-        .'Hosea|Joel|Amos|Obadiah|Jonah|Micah|Nahum|Habakkuk|Zephaniah|Haggai|Zechariah|Malachi|'
-        .'Matthew|Mark|Luke|John|Acts|Romans|Corinthians|Galatians|Ephesians|Philippians|Colossians|'
-        .'Thessalonians|Timothy|Titus|Philemon|Hebrews|James|Peter|Jude|Revelation'
-        .')';
-
-    public function __construct(private readonly BritishEnglishConverter $britishEnglishConverter) {}
+    public function __construct(
+        private readonly BritishEnglishConverter $britishEnglishConverter,
+        private readonly ScriptureReferenceResolver $scriptureReferenceResolver,
+    ) {}
 
     /**
      * Validate transcript content
@@ -164,27 +154,20 @@ class SermonAnalysisValidator
     }
 
     /**
-     * Validate Bible reference format.
+     * Validate and normalise a Bible reference.
      *
-     * Checks if the reference matches a basic book + chapter pattern
-     * (e.g. "John 3", "1 Peter 2").
+     * Delegates to the shared scripture parser (techwilk/bible-verse-parser via
+     * {@see ScriptureReferenceResolver}), which understands abbreviations such as
+     * "Jn" or "1Jn", verse ranges, and "chapter/verse" wording, and rejects prose
+     * or gibberish. Returns the canonical reference (e.g. "Jn 3:16" -> "John 3:16")
+     * or null when the input is not a parseable Bible reference.
      *
      * @param  string  $reference  Raw Bible reference
-     * @return string|null Validated reference or null if invalid
+     * @return string|null Canonical reference or null if it cannot be parsed
      */
     public function validateBibleReference(string $reference): ?string
     {
-        $reference = trim($reference);
-
-        // The reference must begin with a recognised Bible book name followed by a
-        // chapter number. Anchoring to the book list rejects AI prose such as
-        // "The passage is John 3:16" or "Not a reference 3" leaking through.
-        if (preg_match('/^'.self::BIBLE_BOOK_PATTERN.'\s+\d+/i', $reference)) {
-            return $reference;
-        }
-
-        // If it doesn't match the book + chapter pattern, return null
-        return null;
+        return $this->scriptureReferenceResolver->normalize($reference);
     }
 
     /**

--- a/app/Services/Sermon/SermonAnalysisValidator.php
+++ b/app/Services/Sermon/SermonAnalysisValidator.php
@@ -159,15 +159,16 @@ class SermonAnalysisValidator
      * Delegates to the shared scripture parser (techwilk/bible-verse-parser via
      * {@see ScriptureReferenceResolver}), which understands abbreviations such as
      * "Jn" or "1Jn", verse ranges, and "chapter/verse" wording, and rejects prose
-     * or gibberish. Returns the canonical reference (e.g. "Jn 3:16" -> "John 3:16")
-     * or null when the input is not a parseable Bible reference.
+     * or gibberish. Returns the canonical reference (e.g. "Jn 3:16" -> "John 3:16"),
+     * preserving every passage of multi-part references, or null when the input is
+     * not a parseable Bible reference.
      *
      * @param  string  $reference  Raw Bible reference
      * @return string|null Canonical reference or null if it cannot be parsed
      */
     public function validateBibleReference(string $reference): ?string
     {
-        return $this->scriptureReferenceResolver->normalize($reference);
+        return $this->scriptureReferenceResolver->normalizeAll($reference);
     }
 
     /**

--- a/app/Services/Sermon/SermonAnalysisValidator.php
+++ b/app/Services/Sermon/SermonAnalysisValidator.php
@@ -163,12 +163,42 @@ class SermonAnalysisValidator
      * preserving every passage of multi-part references, or null when the input is
      * not a parseable Bible reference.
      *
+     * A bare whole-book reference (e.g. "John", "Genesis") is rejected: a primary
+     * sermon passage must identify at least a chapter, and a whole book belongs in
+     * the series field rather than the reference.
+     *
      * @param  string  $reference  Raw Bible reference
      * @return string|null Canonical reference or null if it cannot be parsed
      */
     public function validateBibleReference(string $reference): ?string
     {
-        return $this->scriptureReferenceResolver->normalizeAll($reference);
+        $normalized = $this->scriptureReferenceResolver->normalizeAll($reference);
+
+        if ($normalized === null || ! $this->referenceIncludesChapter($normalized)) {
+            return null;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Determine whether every passage in a canonical reference names a chapter.
+     *
+     * The parser collapses a whole-book passage to the bare book name (e.g. "John",
+     * "1 John"), so once any leading book ordinal is removed a chapter is present
+     * only when a digit remains.
+     */
+    private function referenceIncludesChapter(string $canonicalReference): bool
+    {
+        foreach (explode(',', $canonicalReference) as $passage) {
+            $withoutBookOrdinal = preg_replace('/^\s*[1-3]\s+/', '', trim($passage));
+
+            if (! preg_match('/\d/', (string) $withoutBookOrdinal)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/tests/Integration/SermonAnalysisServiceFunctionalTest.php
+++ b/tests/Integration/SermonAnalysisServiceFunctionalTest.php
@@ -10,6 +10,7 @@ use App\Models\Sermon;
 use App\Services\BritishEnglishConverter;
 use App\Services\Processing\SermonProcessingLogger;
 use App\Services\Public\SermonRepository;
+use App\Services\Scripture\ScriptureReferenceResolver;
 use App\Services\Sermon\SermonAnalysisPromptBuilder;
 use App\Services\Sermon\SermonAnalysisService;
 use App\Services\Sermon\SermonAnalysisValidator;
@@ -45,7 +46,7 @@ class SermonAnalysisServiceFunctionalTest extends TestCase
 
         $logger = app(SermonProcessingLogger::class);
         $repository = app(SermonRepository::class);
-        $this->validator = new SermonAnalysisValidator(app(BritishEnglishConverter::class));
+        $this->validator = new SermonAnalysisValidator(app(BritishEnglishConverter::class), app(ScriptureReferenceResolver::class));
         $this->promptBuilder = new SermonAnalysisPromptBuilder($this->validator);
         $this->service = new SermonAnalysisService($logger, $repository, $this->validator, $this->promptBuilder);
     }
@@ -64,7 +65,7 @@ class SermonAnalysisServiceFunctionalTest extends TestCase
 
         $logger = app(SermonProcessingLogger::class);
         $repository = app(SermonRepository::class);
-        $validator = new SermonAnalysisValidator(app(BritishEnglishConverter::class));
+        $validator = new SermonAnalysisValidator(app(BritishEnglishConverter::class), app(ScriptureReferenceResolver::class));
         $promptBuilder = new SermonAnalysisPromptBuilder($validator);
         new SermonAnalysisService($logger, $repository, $validator, $promptBuilder);
     }

--- a/tests/Integration/Services/SermonAnalysisServiceTest.php
+++ b/tests/Integration/Services/SermonAnalysisServiceTest.php
@@ -8,6 +8,7 @@ use App\Data\SermonAnalysis;
 use App\Services\BritishEnglishConverter;
 use App\Services\Processing\SermonProcessingLogger;
 use App\Services\Public\SermonRepository;
+use App\Services\Scripture\ScriptureReferenceResolver;
 use App\Services\Sermon\SermonAnalysisPromptBuilder;
 use App\Services\Sermon\SermonAnalysisService;
 use App\Services\Sermon\SermonAnalysisValidator;
@@ -46,7 +47,7 @@ class SermonAnalysisServiceTest extends TestCase
 
         $logger = app(SermonProcessingLogger::class);
         $repository = app(SermonRepository::class);
-        $this->validator = new SermonAnalysisValidator(app(BritishEnglishConverter::class));
+        $this->validator = new SermonAnalysisValidator(app(BritishEnglishConverter::class), app(ScriptureReferenceResolver::class));
         $this->promptBuilder = new SermonAnalysisPromptBuilder($this->validator);
 
         $this->service = new SermonAnalysisService(

--- a/tests/Unit/SermonAnalysisTest.php
+++ b/tests/Unit/SermonAnalysisTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit;
 use App\Services\BritishEnglishConverter;
 use App\Services\Processing\SermonProcessingLogger;
 use App\Services\Public\SermonRepository;
+use App\Services\Scripture\ScriptureReferenceResolver;
 use App\Services\Sermon\SermonAnalysisPromptBuilder;
 use App\Services\Sermon\SermonAnalysisService;
 use App\Services\Sermon\SermonAnalysisValidator;
@@ -21,7 +22,7 @@ class SermonAnalysisTest extends TestCase
 
         $logger = app(SermonProcessingLogger::class);
         $repository = app(SermonRepository::class);
-        $validator = new SermonAnalysisValidator(app(BritishEnglishConverter::class));
+        $validator = new SermonAnalysisValidator(app(BritishEnglishConverter::class), app(ScriptureReferenceResolver::class));
         $promptBuilder = new SermonAnalysisPromptBuilder($validator);
         $service = new SermonAnalysisService($logger, $repository, $validator, $promptBuilder);
         $this->assertInstanceOf(SermonAnalysisService::class, $service);
@@ -38,7 +39,7 @@ class SermonAnalysisTest extends TestCase
 
         $logger = app(SermonProcessingLogger::class);
         $repository = app(SermonRepository::class);
-        $validator = new SermonAnalysisValidator(app(BritishEnglishConverter::class));
+        $validator = new SermonAnalysisValidator(app(BritishEnglishConverter::class), app(ScriptureReferenceResolver::class));
         $promptBuilder = new SermonAnalysisPromptBuilder($validator);
         new SermonAnalysisService($logger, $repository, $validator, $promptBuilder);
     }

--- a/tests/Unit/Services/ScriptureReferenceResolverTest.php
+++ b/tests/Unit/Services/ScriptureReferenceResolverTest.php
@@ -89,4 +89,20 @@ class ScriptureReferenceResolverTest extends TestCase
         $this->assertNull($this->resolver->normalizeAll('The passage is John 3:16'));
         $this->assertNull($this->resolver->normalizeAll('xyzzy 99:99'));
     }
+
+    public function test_resolves_single_chapter_book_verse_references(): void
+    {
+        // "Book N" for a single-chapter book is verse N, not chapter N.
+        $this->assertSame('Jude 1:3', $this->resolver->normalize('Jude 3'));
+        $this->assertSame('Philemon 1:6', $this->resolver->normalize('Philemon 6'));
+        $this->assertSame('Obadiah 1:2', $this->resolver->normalize('Obadiah 2'));
+        $this->assertSame('3 John 1:4-8', $this->resolver->normalizeAll('3 John 4-8'));
+        $this->assertSame('2 John 1:7', $this->resolver->normalizeAll('2 John 7'));
+    }
+
+    public function test_does_not_invent_chapters_for_multi_chapter_books(): void
+    {
+        // A genuinely out-of-range chapter must still be rejected.
+        $this->assertNull($this->resolver->normalize('John 99'));
+    }
 }

--- a/tests/Unit/Services/ScriptureReferenceResolverTest.php
+++ b/tests/Unit/Services/ScriptureReferenceResolverTest.php
@@ -105,4 +105,11 @@ class ScriptureReferenceResolverTest extends TestCase
         // A genuinely out-of-range chapter must still be rejected.
         $this->assertNull($this->resolver->normalize('John 99'));
     }
+
+    public function test_rewrites_single_chapter_parts_within_multi_part_references(): void
+    {
+        $this->assertSame('John 3:16, Jude 1:3', $this->resolver->normalizeAll('John 3:16; Jude 3'));
+        $this->assertSame('2 Peter 1:3, Philemon 1:6', $this->resolver->normalizeAll('2 Peter 1:3 and Philemon 6'));
+        $this->assertSame('Jude 1:3, Philemon 1:6', $this->resolver->normalizeAll('Jude 3 and Philemon 6'));
+    }
 }

--- a/tests/Unit/Services/ScriptureReferenceResolverTest.php
+++ b/tests/Unit/Services/ScriptureReferenceResolverTest.php
@@ -112,4 +112,19 @@ class ScriptureReferenceResolverTest extends TestCase
         $this->assertSame('2 Peter 1:3, Philemon 1:6', $this->resolver->normalizeAll('2 Peter 1:3 and Philemon 6'));
         $this->assertSame('Jude 1:3, Philemon 1:6', $this->resolver->normalizeAll('Jude 3 and Philemon 6'));
     }
+
+    public function test_treats_single_chapter_verse_one_as_a_verse(): void
+    {
+        // "Jude 1" means verse 1, not the whole book (which is just "Jude").
+        $this->assertSame('Jude 1:1', $this->resolver->normalize('Jude 1'));
+        $this->assertSame('Philemon 1:1', $this->resolver->normalize('Philemon 1'));
+        $this->assertSame('2 John 1:1', $this->resolver->normalize('2 John 1'));
+    }
+
+    public function test_supports_range_separators_in_single_chapter_references(): void
+    {
+        $this->assertSame('Jude 1:3-5', $this->resolver->normalize('Jude 3-5'));
+        $this->assertSame('Jude 1:3-5', $this->resolver->normalize('Jude 3–5'));
+        $this->assertSame('Philemon 1:3-5', $this->resolver->normalize('Philemon 3 to 5'));
+    }
 }

--- a/tests/Unit/Services/ScriptureReferenceResolverTest.php
+++ b/tests/Unit/Services/ScriptureReferenceResolverTest.php
@@ -70,4 +70,23 @@ class ScriptureReferenceResolverTest extends TestCase
         $this->assertNotNull($result);
         $this->assertStringContainsString('John', $result);
     }
+
+    public function test_normalize_all_preserves_every_passage(): void
+    {
+        $this->assertSame('John 3:16-18, John 4:1-2', $this->resolver->normalizeAll('John 3:16-18, 4:1-2'));
+        $this->assertSame('1 Peter 2, 1 Peter 5', $this->resolver->normalizeAll('1 Peter 2, 5'));
+    }
+
+    public function test_normalize_all_returns_single_passage_unchanged(): void
+    {
+        $this->assertSame('John 3:16', $this->resolver->normalizeAll('John 3:16'));
+        $this->assertSame('John 3:16', $this->resolver->normalizeAll('Jn 3:16'));
+    }
+
+    public function test_normalize_all_returns_null_for_unparseable_input(): void
+    {
+        $this->assertNull($this->resolver->normalizeAll(''));
+        $this->assertNull($this->resolver->normalizeAll('The passage is John 3:16'));
+        $this->assertNull($this->resolver->normalizeAll('xyzzy 99:99'));
+    }
 }

--- a/tests/Unit/Services/SermonAnalysisPromptBuilderTest.php
+++ b/tests/Unit/Services/SermonAnalysisPromptBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Services;
 
 use App\Services\BritishEnglishConverter;
+use App\Services\Scripture\ScriptureReferenceResolver;
 use App\Services\Sermon\SermonAnalysisPromptBuilder;
 use App\Services\Sermon\SermonAnalysisValidator;
 use PHPUnit\Framework\Attributes\Test;
@@ -18,7 +19,7 @@ class SermonAnalysisPromptBuilderTest extends TestCase
     {
         parent::setUp();
 
-        $validator = new SermonAnalysisValidator(app(BritishEnglishConverter::class));
+        $validator = new SermonAnalysisValidator(app(BritishEnglishConverter::class), app(ScriptureReferenceResolver::class));
         $this->builder = new SermonAnalysisPromptBuilder($validator);
     }
 

--- a/tests/Unit/Services/SermonAnalysisValidatorTest.php
+++ b/tests/Unit/Services/SermonAnalysisValidatorTest.php
@@ -122,6 +122,15 @@ class SermonAnalysisValidatorTest extends TestCase
     }
 
     #[Test]
+    public function it_accepts_single_chapter_book_verse_references(): void
+    {
+        // "Jude 3" / "Philemon 6" are verse references, not whole-book references.
+        $this->assertEquals('Jude 1:3', $this->validator->validateBibleReference('Jude 3'));
+        $this->assertEquals('Philemon 1:6', $this->validator->validateBibleReference('Philemon 6'));
+        $this->assertEquals('3 John 1:4-8', $this->validator->validateBibleReference('3 John 4-8'));
+    }
+
+    #[Test]
     public function it_rejects_invalid_bible_references(): void
     {
         $this->assertNull($this->validator->validateBibleReference('Not a reference'));

--- a/tests/Unit/Services/SermonAnalysisValidatorTest.php
+++ b/tests/Unit/Services/SermonAnalysisValidatorTest.php
@@ -132,6 +132,16 @@ class SermonAnalysisValidatorTest extends TestCase
     }
 
     #[Test]
+    public function it_rejects_whole_book_references_without_a_chapter(): void
+    {
+        // A bare book name belongs in the series field, not the primary reference.
+        $this->assertNull($this->validator->validateBibleReference('John'));
+        $this->assertNull($this->validator->validateBibleReference('Genesis'));
+        $this->assertNull($this->validator->validateBibleReference('1 John'));
+        $this->assertNull($this->validator->validateBibleReference('Psalms'));
+    }
+
+    #[Test]
     public function it_rejects_prose_wrapped_around_a_bible_reference(): void
     {
         $this->assertNull($this->validator->validateBibleReference('The passage is John 3:16'));

--- a/tests/Unit/Services/SermonAnalysisValidatorTest.php
+++ b/tests/Unit/Services/SermonAnalysisValidatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Services;
 
 use App\Services\BritishEnglishConverter;
+use App\Services\Scripture\ScriptureReferenceResolver;
 use App\Services\Sermon\SermonAnalysisValidator;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -17,7 +18,10 @@ class SermonAnalysisValidatorTest extends TestCase
     {
         parent::setUp();
 
-        $this->validator = new SermonAnalysisValidator(app(BritishEnglishConverter::class));
+        $this->validator = new SermonAnalysisValidator(
+            app(BritishEnglishConverter::class),
+            app(ScriptureReferenceResolver::class),
+        );
     }
 
     #[Test]
@@ -98,7 +102,16 @@ class SermonAnalysisValidatorTest extends TestCase
         $this->assertEquals('2 Corinthians 5:17', $this->validator->validateBibleReference('2 Corinthians 5:17'));
         $this->assertEquals('Psalm 23', $this->validator->validateBibleReference('Psalm 23'));
         $this->assertEquals('Song of Solomon 1:1', $this->validator->validateBibleReference('Song of Solomon 1:1'));
-        $this->assertEquals('Song of Songs 2:10', $this->validator->validateBibleReference('Song of Songs 2:10'));
+        // "Song of Songs" normalises to its canonical book name, "Song of Solomon".
+        $this->assertEquals('Song of Solomon 2:10', $this->validator->validateBibleReference('Song of Songs 2:10'));
+    }
+
+    #[Test]
+    public function it_expands_abbreviated_bible_references_to_canonical_form(): void
+    {
+        $this->assertEquals('John 3:16', $this->validator->validateBibleReference('Jn 3:16'));
+        $this->assertEquals('1 John 3:16-18', $this->validator->validateBibleReference('1Jn 3:16-18'));
+        $this->assertEquals('John 3:16', $this->validator->validateBibleReference('John chapter 3 verse 16'));
     }
 
     #[Test]

--- a/tests/Unit/Services/SermonAnalysisValidatorTest.php
+++ b/tests/Unit/Services/SermonAnalysisValidatorTest.php
@@ -115,6 +115,13 @@ class SermonAnalysisValidatorTest extends TestCase
     }
 
     #[Test]
+    public function it_preserves_every_passage_of_multi_part_references(): void
+    {
+        $this->assertEquals('John 3:16-18, John 4:1-2', $this->validator->validateBibleReference('John 3:16-18, 4:1-2'));
+        $this->assertEquals('1 Peter 2, 1 Peter 5', $this->validator->validateBibleReference('1 Peter 2, 5'));
+    }
+
+    #[Test]
     public function it_rejects_invalid_bible_references(): void
     {
         $this->assertNull($this->validator->validateBibleReference('Not a reference'));


### PR DESCRIPTION
### 💡 What
Replaces the hand-rolled Bible book-name allow-list in `SermonAnalysisValidator::validateBibleReference()` (added in #1023) with a delegation to the existing `ScriptureReferenceResolver`, which wraps the `techwilk/bible-verse-parser` package already used elsewhere in the app.

### 🎯 Why
Follow-up to Codex's review on #1023. The allow-list regex rejected valid abbreviated references such as `Jn 3:16` and `1Jn 3:16-18` that the parser already understands. `validateAndCleanAnalysisData()` then stored `null`, so those sermons silently lost a parseable Bible reference. Rather than grow a bespoke parser, this defers to the shared, tested one.

### 🔄 Behaviour
- Accepts abbreviations, ranges, numbered books and "chapter/verse" wording.
- Rejects prose (`The passage is John 3:16`) and gibberish, as before.
- Now returns the **canonical** reference for consistent storage/display:
  - `Jn 3:16` → `John 3:16`
  - `1Jn 3:16-18` → `1 John 3:16-18`
  - `Song of Songs 2:10` → `Song of Solomon 2:10`

### 📍 Where
- `app/Services/Sermon/SermonAnalysisValidator.php` — inject the resolver, drop the regex/book-list constant.
- Test files that construct the validator updated to pass the new collaborator, plus new coverage for abbreviation expansion.

### 🧪 Verification
- `SermonAnalysisValidatorTest`, `BritishEnglishConverterTest`, `SermonAnalysisPromptBuilderTest`, `SermonAnalysisTest` — green (53 tests).
- Pint and PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013dhCC8QyHECWWXSgEsNF4D)_