### PR TITLE
🎨 Palette: [UX improvement] add dynamic state indicators to admin form footer

### DIFF
--- a/resources/views/components/admin/form-shell.blade.php
+++ b/resources/views/components/admin/form-shell.blade.php
@@ -70,7 +70,14 @@
                 <x-content-wrapper class="mx-auto max-w-7xl px-6 md:px-8">
                     <div class="flex items-center justify-between gap-4">
                         <div class="hidden sm:block">
-                            <p class="text-sm font-medium text-gray-500">Unsaved changes on <span class="text-gray-900">{{ $title }}</span></p>
+                            <div wire:dirty.remove class="flex items-center gap-2 text-sm font-medium text-gray-500">
+                                <x-heroicon-o-pencil-square class="h-4 w-4 text-gray-400" aria-hidden="true" />
+                                <span>Editing <span class="text-gray-900">{{ $title }}</span></span>
+                            </div>
+                            <div wire:dirty class="flex items-center gap-2 text-sm font-semibold text-amber-700" role="alert">
+                                <x-heroicon-o-exclamation-triangle class="h-4 w-4 text-amber-500" aria-hidden="true" />
+                                <span>Unsaved changes on <span class="text-gray-900">{{ $title }}</span></span>
+                            </div>
                         </div>
                         <div class="flex flex-1 sm:flex-none items-center justify-end gap-2">
                             {{ $actions }}


### PR DESCRIPTION
I have enhanced the admin form sticky footer to provide more accurate and responsive feedback to administrators. Previously, the footer would always show "Unsaved changes," which was misleading when no changes had actually been made.

Now, the footer uses Livewire's `wire:dirty` logic to:
1.  Display a neutral **"Editing [Title]"** message with a pencil icon when the form is in its original state.
2.  Display a prominent **"Unsaved changes on [Title]"** warning with an amber exclamation icon and bold text as soon as any field is modified.

This micro-UX improvement ensures that the "Unsaved changes" warning carries more weight and provides clear confirmation to the user about whether their changes are currently saved.

I have verified this change visually using a Playwright script and ensured that existing admin form tests continue to pass.

---
*PR created automatically by Jules for task [10601302454764374251](https://jules.google.com/task/10601302454764374251) started by @GarethClarridge*