### PR TITLE
📖 Editor: Standardise admin button casing and time formats

### DIFF
--- a/resources/views/admin/calendar/uncategorized.blade.php
+++ b/resources/views/admin/calendar/uncategorized.blade.php
@@ -9,7 +9,7 @@
 >
     <x-slot:actions>
         <x-button link="{{ route('admin.calendar.patterns') }}" variant="outline" inline>
-            View Patterns
+            View patterns
         </x-button>
         <form method="POST" action="{{ route('admin.calendar.sync') }}" class="inline">
             @csrf

--- a/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
+++ b/resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php
@@ -51,7 +51,7 @@
                     <td class="px-4 py-3">
                         <p class="font-medium">{{ $event->start_datetime->format('j M Y') }}</p>
                         <p class="text-sm text-gray-500">
-                            {{ $event->start_datetime->format('H:i') }} - {{ $event->end_datetime->format('H:i') }}
+                            {{ $event->start_datetime->format('g:ia') }} - {{ $event->end_datetime->format('g:ia') }}
                         </p>
                     </td>
                     {{-- Meeting --}}

--- a/resources/views/livewire/admin/church-services/show-church-service.blade.php
+++ b/resources/views/livewire/admin/church-services/show-church-service.blade.php
@@ -90,7 +90,7 @@
                             @endif
                             <div>
                                 <p class="text-gray-500">Imported</p>
-                                <p class="font-medium">{{ $churchService->updated_at?->format('j M Y H:i') }}</p>
+                                <p class="font-medium">{{ $churchService->updated_at?->format('j M Y g:ia') }}</p>
                             </div>
                             <div>
                                 <p class="text-gray-500">Review status</p>

--- a/resources/views/livewire/admin/meetings/list-meetings.blade.php
+++ b/resources/views/livewire/admin/meetings/list-meetings.blade.php
@@ -60,9 +60,9 @@
                         <p class="font-medium">{{ $meeting->day }}</p>
                         @if($meeting->start_time)
                             <p class="text-sm text-gray-500">
-                                {{ $meeting->start_time->format('H:i') }}
+                                {{ $meeting->start_time->format('g:ia') }}
                                 @if($meeting->end_time)
-                                    - {{ $meeting->end_time->format('H:i') }}
+                                    - {{ $meeting->end_time->format('g:ia') }}
                                 @endif
                             </p>
                         @endif
@@ -108,7 +108,7 @@
                 >
                     @if(!$hasFilters)
                         <x-button link="{{ route('admin.meetings.create') }}" variant="primary" icon="plus" inline>
-                            Create Meeting
+                            Create meeting
                         </x-button>
                     @endif
                 </x-admin.empty-state>

--- a/resources/views/livewire/admin/preachers/list-preachers.blade.php
+++ b/resources/views/livewire/admin/preachers/list-preachers.blade.php
@@ -81,7 +81,7 @@
                 >
                     @if(!$hasFilters)
                         <x-button link="{{ route('admin.preachers.create') }}" variant="primary" icon="plus" inline>
-                            Add Preacher
+                            Add preacher
                         </x-button>
                     @endif
                 </x-admin.empty-state>


### PR DESCRIPTION
### 💡 What: The copy change
This PR standardises admin-facing copy to match the project's British English and stylistic standards. Specifically:
- Button labels changed from Title Case to Sentence Case in Preachers, Meetings, and Calendar views.
- Time formats updated from 24h (`H:i`) to conversation British style (`g:ia`).
- Relevant test assertions updated.

### 🎯 Why: Typo, Americanism, consistency, clarity
- **Consistency:** Matches the "sentence case" preference for user-facing words.
- **Standards:** Aligns admin views with the project's British English time format convention (`g:ia`).

### 🔄 Behavior:
No functional changes — copy and presentation formatting only.

### 📍 Where:
- `resources/views/livewire/admin/preachers/list-preachers.blade.php`
- `resources/views/livewire/admin/meetings/list-meetings.blade.php`
- `resources/views/livewire/admin/calendar-events/list-calendar-events.blade.php`
- `resources/views/livewire/admin/church-services/show-church-service.blade.php`
- `resources/views/admin/calendar/uncategorized.blade.php`
- `tests/Feature/Livewire/Admin/Meetings/CreateMeetingTest.php`

---
*PR created automatically by Jules for task [17852805155198550092](https://jules.google.com/task/17852805155198550092) started by @GarethClarridge*