### PR TITLE
📝 Scribe: Add unit tests for MediaInterludeCueDetector

### DIFF
--- a/.Jules/scribe.md
+++ b/.Jules/scribe.md
@@ -21,3 +21,7 @@
 ## 2026-06-18 - [Logic-Dense Service Unit Testing]
 **Learning:** Testing services like `SectionItemAlignmentScorer` that perform complex scoring and string manipulation (tokenization) is most effective when done via isolated unit tests using unpersisted models (`new Model()`). This avoids database overhead and ensures the tests focus purely on the algorithmic logic.
 **Action:** Prefer `new Model()` over `factory()->create()` for unit tests of services that do not require database persistence or complex relationship resolution.
+
+## 2026-06-19 - [Pure Logic Service Testing]
+**Learning:** Unit testing a pure-logic service like `MediaInterludeCueDetector` that performs simple keyword matching is straightforward but essential for ensuring the robust detection of media interludes during structural section alignment.
+**Action:** Use descriptive test names that reflect the business rules (e.g., case-insensitivity, embedded phrases) and prefer `new Class` instantiation for services with no dependencies.

--- a/tests/Unit/Services/ChurchService/MediaInterludeCueDetectorTest.php
+++ b/tests/Unit/Services/ChurchService/MediaInterludeCueDetectorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\ChurchService;
+
+use App\Services\ChurchService\MediaInterludeCueDetector;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MediaInterludeCueDetectorTest extends TestCase
+{
+    private MediaInterludeCueDetector $detector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->detector = new MediaInterludeCueDetector;
+    }
+
+    #[Test]
+    public function it_returns_false_for_null_or_empty_transcript(): void
+    {
+        $this->assertFalse($this->detector->hasCue(null));
+        $this->assertFalse($this->detector->hasCue(''));
+        $this->assertFalse($this->detector->hasCue('   '));
+    }
+
+    #[Test]
+    public function it_returns_true_for_exact_cue_phrases(): void
+    {
+        $this->assertTrue($this->detector->hasCue('watch a video'));
+        $this->assertTrue($this->detector->hasCue('mission update'));
+        $this->assertTrue($this->detector->hasCue('take a look at this'));
+        $this->assertTrue($this->detector->hasCue('short film'));
+    }
+
+    #[Test]
+    public function it_is_case_insensitive(): void
+    {
+        $this->assertTrue($this->detector->hasCue('WATCH A VIDEO'));
+        $this->assertTrue($this->detector->hasCue('Mission Update'));
+        $this->assertTrue($this->detector->hasCue('Take A Look At This'));
+    }
+
+    #[Test]
+    public function it_detects_cue_phrases_embedded_in_text(): void
+    {
+        $this->assertTrue($this->detector->hasCue("Now we're going to watch a video together."));
+        $this->assertTrue($this->detector->hasCue('Please take a look at this video on the screen.'));
+        $this->assertTrue($this->detector->hasCue('And here is a short clip from the mission field.'));
+    }
+
+    #[Test]
+    public function it_returns_false_for_transcript_without_cues(): void
+    {
+        $this->assertFalse($this->detector->hasCue('Let us pray together.'));
+        $this->assertFalse($this->detector->hasCue('The reading is from John chapter 3.'));
+        $this->assertFalse($this->detector->hasCue('We will now sing our next hymn.'));
+    }
+}


### PR DESCRIPTION
🎯 **Coverage:** `App\Services\ChurchService\MediaInterludeCueDetector` is now fully tested.
📋 **Tests added:**
- `it_returns_false_for_null_or_empty_transcript`: Verifies rejection of blank input.
- `it_returns_true_for_exact_cue_phrases`: Verifies detection of primary cue phrases.
- `it_is_case_insensitive`: Ensures detection works regardless of case.
- `it_detects_cue_phrases_embedded_in_text`: Confirms phrases are found within prose.
- `it_returns_false_for_transcript_without_cues`: Verifies negative cases.
🔍 **Why:** This service is used for structural section alignment during livestream processing; ensuring its detection logic is robust is critical for accurate OoS-to-audio mapping.
✅ **Results:** All tests pass, PHPStan clean, Pint formatted.

---
*PR created automatically by Jules for task [7553376877055439510](https://jules.google.com/task/7553376877055439510) started by @GarethClarridge*