### PR TITLE
📜 Herald: Add precise array shapes for loudness metadata

### DIFF
--- a/app/Services/Media/Audio/AudioEnhancementService.php
+++ b/app/Services/Media/Audio/AudioEnhancementService.php
@@ -152,7 +152,7 @@ class AudioEnhancementService
      * FFmpeg prints loudnorm JSON stats to stderr. Returns null if the pass fails
      * or the output cannot be parsed.
      *
-     * @return array<string, float>|null
+     * @return array{input_i: float, input_tp: float, input_lra: float, input_thresh: float, target_offset: float}|null
      */
     public function measureLoudness(string $inputPath, string $processingId, float $targetLufs, float $truePeak, float $lra): ?array
     {
@@ -175,7 +175,7 @@ class AudioEnhancementService
     /**
      * Extract and decode the loudnorm JSON block from FFmpeg stderr.
      *
-     * @return array<string, float>|null
+     * @return array{input_i: float, input_tp: float, input_lra: float, input_thresh: float, target_offset: float}|null
      */
     private function parseLoudnormJson(string $stderr, string $processingId): ?array
     {


### PR DESCRIPTION
💡 **What:** Added precise PHPDoc array shape annotations to `measureLoudness` and `parseLoudnormJson` in `AudioEnhancementService`.

🎯 **Why:** These methods previously returned generic `array<string, float>|null`, obscuring the specific technical metrics (`input_i`, `input_tp`, etc.) returned by the FFmpeg `loudnorm` filter. Documenting these shapes improves clarity for developers and allows PHPStan to perform better static analysis on the dependent filter-chain logic.

🔄 **Behavior:** No functional changes — documentation only. Verified with 5834 passing tests and a clean `phpstan` run.

---
*PR created automatically by Jules for task [8253128517006090357](https://jules.google.com/task/8253128517006090357) started by @GarethClarridge*